### PR TITLE
perf(seo): the endpoints hub carried 3,372 rows of fields nothing reads (#11326)

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -9420,11 +9420,41 @@ export function statusToHealth(v: unknown): HealthState | undefined {
   return "unknown";
 }
 
+/**
+ * Fields the API sends on every endpoint row that this app reads NOWHERE
+ * (#11326).
+ *
+ * `normalizeEndpoint` spreads the raw row, so anything the API adds survives
+ * into the react-query cache and therefore into the SSR dehydration inlined in
+ * the document. `/apis/endpoints` fetches the whole catalogue — **3,372 rows** —
+ * which is why it is the heaviest page on the site at **4,948 KB uncompressed**
+ * in production, nearly 4x /validators.
+ *
+ * Each name below was checked across the whole of apps/ui: zero references
+ * outside queries.ts and types.ts, and none is declared on `Endpoint`. Fields
+ * that ARE read somewhere — `source_urls`, `rate_limit_notes`,
+ * `classification` — are deliberately absent from this list and still pass
+ * through.
+ *
+ * This is dead data, not a per-query projection: there is no caller for whom
+ * these are live, so unlike `validatorsQuery`'s `subnets` option this needs no
+ * cache-key split. Re-check with a grep before adding to it.
+ */
+const UNREAD_ENDPOINT_FIELDS = [
+  "monitoring_policy",
+  "method_support",
+  "method_tested",
+  "score_reasons",
+  "pool_eligibility_reasons",
+] as const;
+
 function normalizeEndpoint(raw: unknown): Endpoint {
   if (!raw || typeof raw !== "object") return raw as Endpoint;
   const e = raw as Record<string, unknown>;
+  const lean: Record<string, unknown> = { ...e };
+  for (const field of UNREAD_ENDPOINT_FIELDS) delete lean[field];
   return {
-    ...(e as object),
+    ...(lean as object),
     id: asString(e.id) ?? "",
     health: (e.health as HealthState) ?? statusToHealth(e.status) ?? "unknown",
     provider_slug: asString(e.provider_slug) ?? asString(e.provider) ?? asString(e.operator),

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -436,10 +436,11 @@ test.describe("#11315 the hubs stay within a payload ratchet", () => {
     "/validators": 1300,
     "/apis": 620,
     "/apis/providers": 400,
-    // #11326: 2,609 KB here and 4,948 KB in production, dominated by `points`
-    // and `reason` arrays this page never reads — the same defect the
-    // `subnets` projection fixes for /validators, on a different query.
-    "/apis/endpoints": 2700,
+    // #11326 lowered this from 2,700 after dropping five API fields nothing in
+    // the app reads: 2,609 -> 2,128 KiB here, 4,948 -> 3,883 KiB in production.
+    // Still the heaviest page on the site — it fetches all 3,372 endpoints —
+    // so this ceiling has further to fall.
+    "/apis/endpoints": 2200,
     "/apis/schemas": 700,
     "/chain": 240,
   };


### PR DESCRIPTION
## Summary

`/apis/endpoints` is the heaviest page on the site — **4,948 KB uncompressed** in production, nearly 4× `/validators` — and #11313 never sampled it. Found while measuring #11315.

## The issue guessed the wrong cause; the measurement corrected it

#11326 blamed `points` and `reason` arrays. **`/api/v1/endpoints` returns neither** — those come from other queries on the page.

The actual cause: it returns **3,372 rows of 39 fields**, and `normalizeEndpoint` spreads the raw row wholesale:

```ts
return { ...(e as object), id: …, health: …, provider_slug: … }
```

So every field the API sends survives into the react-query cache and therefore into the SSR dehydration inlined in the document. The `Endpoint` type declares **13**.

## What was removed, and how it was verified

Five fields are read **nowhere** in `apps/ui` — swept across the whole tree, zero references outside `queries.ts`/`types.ts`, none declared on `Endpoint`:

```
monitoring_policy   method_support   method_tested
score_reasons       pool_eligibility_reasons
```

Fields that **are** read were deliberately left alone: `classification` (22 references), `source_urls` (15), `rate_limit_notes` (5).

That makes this **dead data, not a per-query projection**. There is no caller for whom these are live, so unlike `validatorsQuery`'s `subnets` option in #11315 it needs no cache-key split.

## Measured against a build pointed at the real API

| | before | after | saved |
|---|---|---|---|
| `/apis/endpoints` uncompressed | 4,948 KB | **3,883 KB** | **1,065 KB (22%)** |
| wire (br) | 243 KB | 202 KB | 41 KB |
| stub (what CI measures) | 2,609 KiB | 2,128 KiB | 481 KiB |

In the rendered document afterwards: the four unread fields appear **0** times; `source_urls` and `classification` still appear on all **3,372** rows, unchanged.

## Ratchet

`indexable-routes.spec.ts` falls **2,700 → 2,200 KiB**. Per the rule it carries, a ceiling only ever moves down.

It is still the heaviest page on the site and has further to fall — fetching all 3,372 endpoints to render a virtualized table is the remaining cost, and that is a design question (like #8251's for validators) rather than dead weight, so it is not being changed here.

## Validation

```
apps/ui  tsc --noEmit                 clean
apps/ui  eslint + prettier            clean
apps/ui  vitest run                   265 files, 2288 tests
apps/ui  playwright indexable-routes  97 passed, against the built Worker
```

Closes #11326
