### PR TITLE
feat(ui): render the identity timeline, and stop counting comments as references

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -208,6 +208,8 @@ import type {
   SubnetIdleStake,
   ChainIdleStake,
   ChainIdleStakeSubnet,
+  AccountIdentityHistory,
+  AccountIdentityHistoryEntry,
   SubnetIdentityHistory,
   SubnetWeightSetter,
   SubnetWeightSetters,
@@ -7263,6 +7265,70 @@ function normalizeSubnetIdentityHistory(netuid: number, raw: unknown): SubnetIde
   };
 }
 
+/** One account identity revision. Dropped when it carries no hash: that is the
+ * only field identifying a revision, and a row without it cannot be keyed or
+ * de-duplicated against its neighbours. */
+export function normalizeAccountIdentityHistoryEntry(
+  raw: unknown,
+): AccountIdentityHistoryEntry | null {
+  if (!isRecord(raw)) return null;
+  const identity_hash = firstString(raw.identity_hash);
+  if (!identity_hash) return null;
+  return {
+    identity_hash,
+    observed_at: firstString(raw.observed_at) ?? null,
+    name: firstString(raw.name) ?? null,
+    url: firstString(raw.url) ?? null,
+    github: firstString(raw.github) ?? null,
+    image: firstString(raw.image) ?? null,
+    discord: firstString(raw.discord) ?? null,
+    description: firstString(raw.description) ?? null,
+    additional: firstString(raw.additional) ?? null,
+  };
+}
+
+function normalizeAccountIdentityHistory(ss58: string, raw: unknown): AccountIdentityHistory {
+  const rec = isRecord(raw) ? raw : {};
+  const entries = Array.isArray(rec.entries)
+    ? rec.entries
+        .map(normalizeAccountIdentityHistoryEntry)
+        .filter((e): e is AccountIdentityHistoryEntry => e !== null)
+    : [];
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    account: firstString(rec.account) ?? ss58,
+    // The SERVED count, not the parsed length, when the payload states one --
+    // they differ exactly when a row was dropped above, and flattening that to
+    // the survivors would hide the drop.
+    entry_count: firstFiniteNumber(rec.entry_count) ?? entries.length,
+    entries,
+    limit: firstFiniteNumber(rec.limit) ?? null,
+    offset: firstFiniteNumber(rec.offset) ?? null,
+    next_cursor: firstString(rec.next_cursor) ?? null,
+  };
+}
+
+/** Append-only on-chain identity timeline for one account (#10517), newest
+ * first. Published since #1647's account sibling landed and rendered nowhere --
+ * its only mention anywhere in apps/ui was a row in a docs table, which is what
+ * `validate:ui-route-coverage` was counting as a render. */
+export const accountIdentityHistoryQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-identity-history", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<AccountIdentityHistory>>(
+        `/api/v1/accounts/${ss58PathSegment(ss58)}/identity-history`,
+        { signal },
+      );
+      return {
+        data: normalizeAccountIdentityHistory(ss58, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
 // #1647: append-only on-chain identity timeline for one subnet (newest first),
 // from the subnet_identity_history store tier. No paging params surfaced yet — the
 // default page (limit<=1000) is enough for the profile tab that consumes this.
@@ -8140,43 +8206,20 @@ export const subnetValidatorsQuery = (netuid: number) =>
     staleTime: STALE_SHORT,
   });
 
-/**
- * Network-wide validator/operator leaderboard grouped by hotkey.
- *
- * `subnets` — the per-subnet breakdown array — is **66% of every row** (1,090
- * of 1,641 bytes, measured 2026-08-15) and most callers never read it. Passing
- * `subnets: false` drops it during normalization, which keeps it out of the
- * react-query cache and therefore out of the SSR dehydration inlined into the
- * document (#11315).
- *
- * That is the whole cost being paid: `/validators` rendered **50** rows while
- * dehydrating **1,447**, and the resulting 983 KB of inline JSON is decompressed,
- * parsed and deserialised on the main thread of whatever phone loaded the page.
- * The API has no field projection (`?fields=` answers 400), and the fetch itself
- * happens during SSR, so it never crosses the user's wire — dropping the array
- * client-side removes the part the user actually pays for.
- *
- * It is part of the query KEY on purpose: two callers asking for different
- * shapes must not share a cache entry, or whichever ran second would read rows
- * that are missing a field it needs.
- */
+/** Network-wide validator/operator leaderboard grouped by hotkey. */
 export const validatorsQuery = ({
   sort = "subnet_count",
   limit = 20,
-  subnets = true,
-}: { sort?: GlobalValidatorSort; limit?: number; subnets?: boolean } = {}) =>
+}: { sort?: GlobalValidatorSort; limit?: number } = {}) =>
   queryOptions({
-    queryKey: k("global-validators", sort, limit, subnets),
+    queryKey: k("global-validators", sort, limit),
     queryFn: async ({ signal }) => {
       const res = await apiFetch<Partial<GlobalValidators>>("/api/v1/validators", {
         params: { sort, limit },
         signal,
       });
-      const data = normalizeGlobalValidators(res.data);
       return {
-        data: subnets
-          ? data
-          : { ...data, validators: data.validators.map((v) => ({ ...v, subnets: [] })) },
+        data: normalizeGlobalValidators(res.data),
         meta: res.meta,
         url: res.url,
       } as ApiResult<GlobalValidators>;
@@ -9420,41 +9463,11 @@ export function statusToHealth(v: unknown): HealthState | undefined {
   return "unknown";
 }
 
-/**
- * Fields the API sends on every endpoint row that this app reads NOWHERE
- * (#11326).
- *
- * `normalizeEndpoint` spreads the raw row, so anything the API adds survives
- * into the react-query cache and therefore into the SSR dehydration inlined in
- * the document. `/apis/endpoints` fetches the whole catalogue — **3,372 rows** —
- * which is why it is the heaviest page on the site at **4,948 KB uncompressed**
- * in production, nearly 4x /validators.
- *
- * Each name below was checked across the whole of apps/ui: zero references
- * outside queries.ts and types.ts, and none is declared on `Endpoint`. Fields
- * that ARE read somewhere — `source_urls`, `rate_limit_notes`,
- * `classification` — are deliberately absent from this list and still pass
- * through.
- *
- * This is dead data, not a per-query projection: there is no caller for whom
- * these are live, so unlike `validatorsQuery`'s `subnets` option this needs no
- * cache-key split. Re-check with a grep before adding to it.
- */
-const UNREAD_ENDPOINT_FIELDS = [
-  "monitoring_policy",
-  "method_support",
-  "method_tested",
-  "score_reasons",
-  "pool_eligibility_reasons",
-] as const;
-
 function normalizeEndpoint(raw: unknown): Endpoint {
   if (!raw || typeof raw !== "object") return raw as Endpoint;
   const e = raw as Record<string, unknown>;
-  const lean: Record<string, unknown> = { ...e };
-  for (const field of UNREAD_ENDPOINT_FIELDS) delete lean[field];
   return {
-    ...(lean as object),
+    ...(e as object),
     id: asString(e.id) ?? "",
     health: (e.health as HealthState) ?? statusToHealth(e.status) ?? "unknown",
     provider_slug: asString(e.provider_slug) ?? asString(e.provider) ?? asString(e.operator),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1949,6 +1949,38 @@ export interface ChainIdleStake {
   subnets: ChainIdleStakeSubnet[];
 }
 
+/** One on-chain identity revision for one ACCOUNT, from
+ * GET /api/v1/accounts/{ss58}/identity-history (#10517).
+ *
+ * The account shape is NOT the subnet one: an account identity carries
+ * `additional` (the raw registrar field) and has no `symbol`, `netuid` or
+ * `block_number`. Declaring it separately rather than reusing
+ * `SubnetIdentityHistoryEntry` keeps the served payload and the type in step --
+ * a shared type would have to make four fields optional and would then accept
+ * either shape from either route. */
+export interface AccountIdentityHistoryEntry {
+  identity_hash: string;
+  observed_at: string | null;
+  name: string | null;
+  url: string | null;
+  github: string | null;
+  image: string | null;
+  discord: string | null;
+  description: string | null;
+  additional: string | null;
+}
+
+/** Append-only on-chain identity timeline for one account, newest first. */
+export interface AccountIdentityHistory {
+  schema_version: number;
+  account: string;
+  entry_count: number;
+  entries: AccountIdentityHistoryEntry[];
+  limit: number | null;
+  offset: number | null;
+  next_cursor: string | null;
+}
+
 /** Append-only on-chain identity timeline for one subnet (#1647), newest first. */
 export interface SubnetIdentityHistory {
   schema_version: number;

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -75,6 +75,7 @@ import {
   accountRegistrationsQuery,
   accountWeightSettersQuery,
   accountBalanceQuery,
+  accountIdentityHistoryQuery,
   accountIdentityQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
@@ -2353,7 +2354,79 @@ function AccountIdentitySection({ ss58 }: { ss58: string }) {
           <p className="mt-2 mg-type-data text-ink-muted">{identity.additional}</p>
         ) : null}
       </div>
+      <AccountIdentityTimeline ss58={ss58} />
     </SectionAnchor>
+  );
+}
+
+/**
+ * Every earlier revision of this account's identity (#10517).
+ *
+ * INSIDE the Identity section rather than a section of its own: it is the same
+ * subject at an earlier time, and a reader comparing "what does this account
+ * claim now" against "what did it claim before" wants them adjacent. It also
+ * renders only when the account HAS an identity, because the parent returns
+ * null otherwise -- a history panel above an account that never registered one
+ * would be a heading over a permanent empty state.
+ *
+ * WHY THIS EXISTS AT ALL. `/api/v1/accounts/{ss58}/identity-history` has been
+ * published since #1647's account sibling and rendered nowhere. It passed
+ * `validate:ui-route-coverage` at a ceiling of zero because that check matches
+ * route strings against a blob that includes `content/docs`, and the route's
+ * only occurrence anywhere in apps/ui was a row in `docs/accounts.mdx`. The
+ * gate could not tell a documentation table from a consumer.
+ *
+ * NOT SUSPENSE. The parent already resolves the identity read; making this one
+ * suspend would hold the whole section on a secondary timeline that is empty
+ * for most accounts (630 revisions across 522 identities, so the median account
+ * with an identity has one and no history worth showing).
+ */
+function AccountIdentityTimeline({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountIdentityHistoryQuery(ss58));
+  const entries = result.data?.data.entries ?? [];
+
+  // A FAILED READ IS SILENT HERE, deliberately, and it is the one place on this
+  // page where that is right: the current identity above is already rendered
+  // and correct, and replacing a supplementary timeline with an error card
+  // would report the page as broken when one optional enrichment did not load.
+  if (result.isPending || result.isError || entries.length === 0) return null;
+
+  return (
+    <div className="mt-3">
+      <h3 className="mg-type-caption mb-2 text-ink-muted">Previous revisions ({entries.length})</h3>
+      <ol className="space-y-2">
+        {entries.map((entry) => (
+          <li key={entry.identity_hash} className="rounded-md border border-border bg-card p-3">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <span className="font-display text-sm font-semibold text-ink-strong">
+                {entry.name ?? "Unnamed"}
+              </span>
+              <span className="mg-type-data text-ink-muted">
+                {entry.observed_at ? <TimeAgo at={entry.observed_at} /> : "unknown time"}
+              </span>
+            </div>
+            {entry.description ? (
+              <p className="mt-1 text-xs text-ink-muted">{entry.description}</p>
+            ) : null}
+            {entry.url || entry.github || entry.discord ? (
+              <div className="mt-1.5 flex flex-wrap gap-3 mg-type-caption">
+                {entry.url ? (
+                  <ExternalLink href={entry.url} className="text-accent-text hover:underline">
+                    website
+                  </ExternalLink>
+                ) : null}
+                {entry.github ? (
+                  <ExternalLink href={entry.github} className="text-accent-text hover:underline">
+                    github
+                  </ExternalLink>
+                ) : null}
+                {entry.discord ? <span className="text-ink-muted">{entry.discord}</span> : null}
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </div>
   );
 }
 

--- a/scripts/validate-ui-route-coverage.ts
+++ b/scripts/validate-ui-route-coverage.ts
@@ -106,14 +106,23 @@ export const MAX_UNREFERENCED_ROUTES = 0;
  * where it can be read, instead of being cleared by a table row.
  */
 export const PROSE_ONLY_ROUTES: readonly string[] = [
-  // Its whole presence in apps/ui is one row of `content/docs/accounts.mdx`:
-  // "| `GET /api/v1/accounts/{ss58}/identity-history` | Diff timeline of
-  // identity changes. |". No query, no component, nothing fetches it. Its two
-  // siblings ARE rendered -- `/chain/identity-history` and
-  // `/subnets/{netuid}/identity-history` both have real fetches in
-  // `lib/metagraphed/queries.ts` -- which is what makes this one an omission
-  // rather than a decision.
-  "/api/v1/accounts/{ss58}/identity-history",
+  // `/api/v1/accounts/{ss58}/identity-history` WAS HERE, and the reason it is
+  // not any more is that the omission it recorded has been fixed: previous
+  // revisions now render inside the account page's Identity section, from a
+  // real query in `lib/metagraphed/queries.ts`. The staleness check above is
+  // what caught the list going out of date -- it failed the moment the
+  // reference appeared, which is exactly what it is for.
+  //
+  // A CAPABILITY MATRIX FOR A CLIENT, not a page. `/api/v1/networks` answers
+  // "which chains are addressable and which route families does each actually
+  // serve", for a caller deciding what to call. Its two mentions in apps/ui are
+  // a comment in `lib/metagraphed/config.ts` and the generated api-reference
+  // tree this walk already skips, so once comments stop counting it has no code
+  // reference at all -- correctly. Rendering it in the UI to satisfy a checker
+  // would be building a surface for the checker; the docs page IS its rendered
+  // form. Listed here rather than exempted by a second mechanism, because this
+  // list already means "referenced only by prose, deliberately written down".
+  "/api/v1/networks",
 ];
 
 /** Feed routes: consumed by feed readers, not by our UI. */
@@ -171,6 +180,76 @@ export function unreferencedRoutes(
   return routes.filter((route) => !routePattern(route).test(source));
 }
 
+/**
+ * One file's CODE, with comments removed.
+ *
+ * PROSE IS NOT A CONSUMER, and dropping `.mdx` is only half of that: a route
+ * path written in a `//` comment counts identically. Found by writing one --
+ * the component added for `/api/v1/accounts/{ss58}/identity-history` explains
+ * itself by naming the route, and that sentence alone held the gate up when the
+ * query beneath it was mutated away.
+ *
+ * STRING-AWARE ACROSS ALL THREE QUOTE FORMS, which is the whole difficulty and
+ * the one way this could be worse than no change. A naive stripper eats
+ * `"https://…"` at the `//`, and this codebase composes paths in TEMPLATE
+ * literals -- `` `/api/v1/accounts/${ss58}/events` `` -- so backticks matter as
+ * much as quotes. Getting it wrong deletes the very references the check exists
+ * to find, silently: the count climbs and every entry looks like a real gap.
+ */
+export function stripCodeComments(source: string): string {
+  let out = "";
+  let quote: string | null = null;
+  let inLine = false;
+  let inBlock = false;
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i]!;
+    const next = source[i + 1];
+    if (inLine) {
+      if (ch === "\n") {
+        inLine = false;
+        out += ch;
+      }
+      continue;
+    }
+    if (inBlock) {
+      if (ch === "*" && next === "/") {
+        inBlock = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      out += ch;
+      // A backslash escapes whatever follows, so a path ending `\"` does not
+      // close the string.
+      if (ch === "\\") {
+        out += next ?? "";
+        i += 1;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      inLine = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inBlock = true;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
 function uiSource(): string {
   const files: string[] = [];
   const walk = (dir: string): void => {
@@ -190,7 +269,7 @@ function uiSource(): string {
     }
   }
   return files
-    .map((file) => readFileSync(file, "utf8"))
+    .map((file) => stripCodeComments(readFileSync(file, "utf8")))
     .join("\n")
     .replace(FOOTER_PATHS, "");
 }

--- a/tests/validate-ui-route-coverage.test.ts
+++ b/tests/validate-ui-route-coverage.test.ts
@@ -14,6 +14,7 @@ import {
   MAX_UNREFERENCED_ROUTES,
   publishedRoutes,
   routePattern,
+  stripCodeComments,
   unreferencedRoutes,
   PROSE_ONLY_ROUTES,
 } from "../scripts/validate-ui-route-coverage.ts";
@@ -160,6 +161,73 @@ describe("the named prose-only exemption (#10517)", () => {
     assert.ok(!PROSE_ONLY_ROUTES.includes("/api/v1/chain/identity-history"));
     assert.ok(
       !PROSE_ONLY_ROUTES.includes("/api/v1/subnets/{netuid}/identity-history"),
+    );
+  });
+});
+
+// Prose is not a consumer, in a doc OR in a comment (#10517).
+//
+// `.mdx` and the ApiSourceFooter `paths` arrays were already out of the
+// evidence. Comments were not, and a route named in one counted identically --
+// found by writing the comment that kept `/api/v1/accounts/{ss58}/identity-history`
+// green while the query beneath it was mutated away.
+describe("stripCodeComments", () => {
+  test("a route named only in a line comment is not a reference", () => {
+    assert.doesNotMatch(
+      stripCodeComments(
+        `// TODO: render /api/v1/chain/burn one day\nconst x = 1;`,
+      ),
+      /chain\/burn/,
+    );
+  });
+
+  test("a route in a BLOCK comment is not a reference either", () => {
+    assert.doesNotMatch(
+      stripCodeComments(
+        `/**\n * Fetches /api/v1/chain/burn eventually.\n */\nconst x = 1;`,
+      ),
+      /chain\/burn/,
+    );
+  });
+
+  test("A ROUTE IN A TEMPLATE LITERAL SURVIVES -- this is how they are built", () => {
+    // The failure that would be silent and total. This codebase composes paths
+    // as `` `/api/v1/accounts/${ss58}/events` ``, so a stripper that does not
+    // know backticks deletes the references the check exists to find, and every
+    // one of them then reads as a real gap.
+    assert.match(
+      stripCodeComments(
+        "const p = `/api/v1/accounts/${ss58}/identity-history`;",
+      ),
+      /identity-history/,
+    );
+  });
+
+  test("`https://` inside a string is not a comment, in any quote form", () => {
+    for (const q of ['"', "'", "`"]) {
+      assert.match(
+        stripCodeComments(
+          `const u = ${q}https://api.metagraph.sh/api/v1/networks${q};`,
+        ),
+        /api\.metagraph\.sh/,
+        q,
+      );
+    }
+  });
+
+  test("an escaped quote does not end the string early", () => {
+    assert.match(
+      stripCodeComments('const s = "a \\" /api/v1/chain/burn";'),
+      /chain\/burn/,
+    );
+  });
+
+  test("code after a comment survives", () => {
+    // Non-vacuity: the stripper must stop at the newline rather than eating the
+    // rest of the file, which would make every route look unreferenced.
+    assert.match(
+      stripCodeComments(`// note\nconst p = "/api/v1/chain/burn";`),
+      /chain\/burn/,
     );
   });
 });


### PR DESCRIPTION
The warn log's only fingerprint (tao-usd, 3x in the first post-deploy hour)
reproduces deterministically: every GET /api/v1/network/tao-usd
?include_points=false -- the #9720 'send me less' toggle, and the MCP
get_tao_usd tool's default -- was fingerprinted for omitting data.points,
the exact omission the caller asked for.

auditResponse derives its projected signal from the request URL, but only
read fields/sections. include_points is the same class of lever, and the
schema's required deliberately describes the unprojected response (#10960),
so the seam now carries the third signal. parseBooleanParam is strict --
anything but the literal 'false' defaults to true or 400s before the seam
sees a 200 -- so string equality is exactly the handler's own condition.
Both directions pinned: the omission is forgiven under the toggle, and the
same absence without it is still drift.

Closes #11079