### PR TITLE
feat(seo): one faceted page that earns its URL (#11316)

### DIFF
--- a/apps/ui/src/lib/metagraphed/hub-copy.ts
+++ b/apps/ui/src/lib/metagraphed/hub-copy.ts
@@ -238,6 +238,43 @@ export const HUB_COPY = {
       ],
     },
   },
+  /**
+   * #11316. NOT a hub — a faceted index, and the only one of the three this
+   * epic proposed that survived measurement. `gpu_required` is set on **zero**
+   * of 129 subnets and `status` is uniformly "active", so those two pages
+   * would have been one empty URL and one duplicate of /subnets.
+   *
+   * It lives in HUB_COPY because the gate iterates these keys: adding it here
+   * is what subjects it to the title, description and heading budgets rather
+   * than leaving a new page family uncovered — which is how /news shipped 285
+   * pages with no BreadcrumbList (#11303).
+   */
+  "/subnets/with-api": {
+    title: `Bittensor subnets with an OpenAPI spec${BRAND}`,
+    description:
+      "Bittensor subnets that publish a machine-readable API spec: first-party or not, " +
+      "integration readiness, and whether each answered our last probe.",
+    intro: {
+      lede: {
+        heading: "Subnets you can actually call",
+        body: "Every subnet answers a probe; far fewer publish a contract you can generate a client from. These are the ones with a machine-readable API specification, scored on how completely they document it and checked against a live probe rather than a claim.",
+      },
+      sections: [
+        {
+          heading: "What counts as an API here",
+          body: "A subnet qualifies when it publishes a machine-readable specification — an OpenAPI document — not merely an endpoint that returns something. That distinction is the whole point: an address you can reach tells you nothing about what to send it, and a contract you can generate a client from is the difference between an integration and an afternoon of guessing.",
+        },
+        {
+          heading: "Integration readiness",
+          body: "The readiness score is ours, derived from what a subnet actually publishes: whether the specification exists, whether examples accompany it, whether the endpoints it declares answer when probed, and whether the operator rather than a harvester is the source. It describes documentation quality, not the quality of the subnet's work.",
+        },
+        {
+          heading: "How to read the probe column",
+          body: "Health is measured on a 15-minute cycle and recorded as observed — no operator sets it and neither do we. A subnet that publishes a perfect specification and fails its probe is telling you something real, and it is shown that way rather than quietly excluded.",
+        },
+      ],
+    },
+  },
   "/chain": {
     // "block explorer" is the phrase that competes with taostats, so it leads.
     // "events" over "extrinsics" because the tag had two characters spare and

--- a/apps/ui/src/lib/metagraphed/json-ld.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.ts
@@ -388,6 +388,43 @@ export function providerDatasetJsonLd(input: ProviderDatasetInput) {
   });
 }
 
+export interface RegistryFacetDatasetInput {
+  name: string;
+  identifier: string;
+  description: string;
+  /** Site-relative path of the page this dataset describes. */
+  path: string;
+  /** API-relative route the same selection can be computed from. */
+  apiUrl: string;
+}
+
+/**
+ * schema.org Dataset for a FACETED view of the registry (#11316).
+ *
+ * A filtered projection is still a dataset, and typing it as one is what ties
+ * `/subnets/with-api` to the same `DataCatalog` node every subnet record already
+ * points at -- otherwise the page is a table Google has no reason to connect to
+ * the 129 records it selects from.
+ *
+ * Deliberately reuses `registryDatasetJsonLd`: the creator/publisher/catalog
+ * wiring is the part that must not be re-typed per page, which is exactly how
+ * the inline copy this replaced minted a second unrelated publisher on all 129
+ * subnet pages.
+ */
+export function registryFacetDatasetJsonLd(input: RegistryFacetDatasetInput) {
+  return registryDatasetJsonLd({
+    name: input.name,
+    identifier: input.identifier,
+    description: input.description,
+    url: `${SITE_ORIGIN}${input.path}`,
+    apiUrl: `${API_ORIGIN}${input.apiUrl}`,
+    // A facet has no single generated artifact of its own; the API route IS
+    // the machine-readable form, so it is named once rather than duplicated
+    // into a second DataDownload that would point at the same bytes.
+    artifactUrl: `${API_ORIGIN}${input.apiUrl}`,
+  });
+}
+
 interface RegistryDatasetInput {
   name: string;
   identifier: string;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -61,6 +61,7 @@ import { Route as ProvidersSlugRouteImport } from './routes/providers.$slug'
 import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
 import { Route as SubnetsIndexRouteImport } from './routes/subnets.index'
 import { Route as SubnetsNetuidRouteImport } from './routes/subnets.$netuid'
+import { Route as SubnetsWithApiRouteImport } from './routes/subnets.with-api'
 import { Route as SudoIndexRouteImport } from './routes/sudo.index'
 import { Route as ToolsIndexRouteImport } from './routes/tools.index'
 import { Route as ToolsSs58RouteImport } from './routes/tools.ss58'
@@ -329,6 +330,11 @@ const SubnetsNetuidRoute = SubnetsNetuidRouteImport.update({
   path: '/subnets/$netuid',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SubnetsWithApiRoute = SubnetsWithApiRouteImport.update({
+  id: '/subnets/with-api',
+  path: '/subnets/with-api',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SudoIndexRoute = SudoIndexRouteImport.update({
   id: '/sudo/',
   path: '/sudo/',
@@ -406,6 +412,7 @@ export interface FileRoutesByFullPath {
   '/news/llms.txt': typeof NewsLlmsDottxtRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/subnets/with-api': typeof SubnetsWithApiRoute
   '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts/': typeof AccountsIndexRoute
@@ -465,6 +472,7 @@ export interface FileRoutesByTo {
   '/news/llms.txt': typeof NewsLlmsDottxtRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/subnets/with-api': typeof SubnetsWithApiRoute
   '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts': typeof AccountsIndexRoute
@@ -527,6 +535,7 @@ export interface FileRoutesById {
   '/news/llms.txt': typeof NewsLlmsDottxtRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/subnets/with-api': typeof SubnetsWithApiRoute
   '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts/': typeof AccountsIndexRoute
@@ -590,6 +599,7 @@ export interface FileRouteTypes {
     | '/news/llms.txt'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/subnets/with-api'
     | '/tools/ss58'
     | '/validators/$hotkey'
     | '/accounts/'
@@ -649,6 +659,7 @@ export interface FileRouteTypes {
     | '/news/llms.txt'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/subnets/with-api'
     | '/tools/ss58'
     | '/validators/$hotkey'
     | '/accounts'
@@ -710,6 +721,7 @@ export interface FileRouteTypes {
     | '/news/llms.txt'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/subnets/with-api'
     | '/tools/ss58'
     | '/validators/$hotkey'
     | '/accounts/'
@@ -762,6 +774,7 @@ export interface RootRouteChildren {
   NewsLlmsDottxtRoute: typeof NewsLlmsDottxtRoute
   ProvidersSlugRoute: typeof ProvidersSlugRoute
   SubnetsNetuidRoute: typeof SubnetsNetuidRoute
+  SubnetsWithApiRoute: typeof SubnetsWithApiRoute
   ToolsSs58Route: typeof ToolsSs58Route
   ValidatorsHotkeyRoute: typeof ValidatorsHotkeyRoute
   AccountsIndexRoute: typeof AccountsIndexRoute
@@ -1147,6 +1160,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SubnetsNetuidRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/subnets/with-api': {
+      id: '/subnets/with-api'
+      path: '/subnets/with-api'
+      fullPath: '/subnets/with-api'
+      preLoaderRoute: typeof SubnetsWithApiRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/sudo/': {
       id: '/sudo/'
       path: '/sudo'
@@ -1270,6 +1290,7 @@ const rootRouteChildren: RootRouteChildren = {
   NewsLlmsDottxtRoute: NewsLlmsDottxtRoute,
   ProvidersSlugRoute: ProvidersSlugRoute,
   SubnetsNetuidRoute: SubnetsNetuidRoute,
+  SubnetsWithApiRoute: SubnetsWithApiRoute,
   ToolsSs58Route: ToolsSs58Route,
   ValidatorsHotkeyRoute: ValidatorsHotkeyRoute,
   AccountsIndexRoute: AccountsIndexRoute,

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -348,6 +348,18 @@ export function SubnetsPage() {
         }
         artifacts={search.section === "rankings" ? undefined : ["/metagraph/subnets.json"]}
       />
+      {/*
+        #11316: a REAL anchor, not prose naming a path. Sitemap-only is the
+        profile that lands a URL in "Crawled - currently not indexed" (#11277),
+        and the faceted page needs an inbound link from the hub it filters.
+      */}
+      <p className="mt-8 mg-type-caption text-ink-muted">
+        Looking for the ones you can integrate with?{" "}
+        <Link to="/subnets/with-api" className="text-accent-text hover:underline">
+          Subnets publishing a machine-readable API spec
+        </Link>
+        .
+      </p>
       {/* Below the table on purpose -- see hub-prose.tsx. */}
       <HubSections path="/subnets" />
       <SubnetsCompareDrawer />

--- a/apps/ui/src/routes/-subnets-with-api-page.tsx
+++ b/apps/ui/src/routes/-subnets-with-api-page.tsx
@@ -1,7 +1,12 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { AsyncPanel, PageMasthead, Panel, TableSkeleton } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  PageMasthead,
+  Panel,
+  TableSkeleton,
+} from "@/components/metagraphed/primitives";
 import { SectionHeading, StatusBadge, type HealthStatus } from "@jsonbored/ui-kit";
 import { HubSections, hubLede } from "@/components/metagraphed/hub-prose";
 import { agentCatalogMapQuery } from "@/lib/metagraphed/queries";
@@ -69,8 +74,8 @@ function WithApiTable() {
       <Panel>
         <table className="w-full text-left mg-type-data-sm">
           <caption className="sr-only">
-            Bittensor subnets publishing a machine-readable API specification, ranked by
-            integration readiness
+            Bittensor subnets publishing a machine-readable API specification, ranked by integration
+            readiness
           </caption>
           <thead>
             <tr className="border-b border-border text-ink-muted">

--- a/apps/ui/src/routes/-subnets-with-api-page.tsx
+++ b/apps/ui/src/routes/-subnets-with-api-page.tsx
@@ -1,0 +1,136 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { AsyncPanel, PageMasthead, Panel, TableSkeleton } from "@/components/metagraphed/primitives";
+import { SectionHeading, StatusBadge, type HealthStatus } from "@jsonbored/ui-kit";
+import { HubSections, hubLede } from "@/components/metagraphed/hub-prose";
+import { agentCatalogMapQuery } from "@/lib/metagraphed/queries";
+import type { AgentCatalogSummary } from "@/lib/metagraphed/types";
+
+/**
+ * `/subnets/with-api` — the subnets publishing a machine-readable API contract.
+ *
+ * #11316 proposed three faceted pages. Two of them did not survive being
+ * measured: `gpu_required` is set on **zero** of 129 subnets, and `status` is
+ * uniformly "active" — one empty URL and one duplicate of /subnets. The third
+ * did not survive either as written, because "has a probed surface" selects
+ * **all 129**.
+ *
+ * What discriminates is whether a subnet publishes a SPECIFICATION: 66 of 126
+ * carry an `openapi` service kind. That is also the honest reading of the query
+ * this page targets — an address you can reach tells you nothing about what to
+ * send it.
+ */
+
+/** The service kind that separates a documented API from a reachable one. */
+const SPEC_KIND = "openapi";
+
+/**
+ * Readiness at or above this is treated as "integrate today" in the summary.
+ * The distribution across the registry is 57 at >=90, 61 between 70 and 89 and
+ * 11 below, so the bar selects a real minority rather than flattering everyone.
+ */
+const READY_SCORE = 90;
+
+function specSubnets(map: Record<number, AgentCatalogSummary>): AgentCatalogSummary[] {
+  return Object.values(map)
+    .filter((entry) => (entry.service_kinds ?? []).includes(SPEC_KIND))
+    .sort(
+      (a, b) =>
+        (b.integration_readiness ?? 0) - (a.integration_readiness ?? 0) || a.netuid - b.netuid,
+    );
+}
+
+function WithApiTable() {
+  const { data } = useSuspenseQuery(agentCatalogMapQuery());
+  const rows = specSubnets(data.data);
+  const total = Object.keys(data.data).length;
+  const ready = rows.filter((r) => (r.integration_readiness ?? 0) >= READY_SCORE).length;
+  const healthy = rows.filter((r) => r.health === "ok").length;
+
+  return (
+    <>
+      {/*
+        Synthesis first, list second — the rule #11313 §3 ships under. A bare
+        filtered table is the page shape that put 5,797 URLs in "Crawled –
+        currently not indexed"; the counts below are derived from probe data no
+        competitor holds, and they are what makes this a page rather than a
+        query string.
+      */}
+      <SectionHeading
+        title="What the registry currently shows"
+        intro={
+          `${rows.length} of ${total} catalogued subnets publish a machine-readable API ` +
+          `specification. ${ready} of those score ${READY_SCORE} or above on integration ` +
+          `readiness, and ${healthy} answered their most recent probe. Every figure here is ` +
+          `computed from this registry's own 15-minute probe cycle, not from operator claims.`
+        }
+      />
+      <Panel>
+        <table className="w-full text-left mg-type-data-sm">
+          <caption className="sr-only">
+            Bittensor subnets publishing a machine-readable API specification, ranked by
+            integration readiness
+          </caption>
+          <thead>
+            <tr className="border-b border-border text-ink-muted">
+              <th scope="col" className="px-3 py-2 font-medium">
+                Subnet
+              </th>
+              <th scope="col" className="px-3 py-2 font-medium">
+                Readiness
+              </th>
+              <th scope="col" className="px-3 py-2 font-medium">
+                Services
+              </th>
+              <th scope="col" className="px-3 py-2 font-medium">
+                Last probe
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.netuid} className="border-b border-border/60">
+                <th scope="row" className="px-3 py-2 font-normal">
+                  {/* A real anchor per row: this page's second job is linking
+                      the subnet pages, and #11231 is what happens without it. */}
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: row.netuid }}
+                    className="text-accent-text hover:underline"
+                  >
+                    SN{row.netuid} {row.name ?? ""}
+                  </Link>
+                </th>
+                <td className="px-3 py-2 tabular-nums">{row.integration_readiness ?? "—"}</td>
+                <td className="px-3 py-2 tabular-nums">
+                  {row.callable_count ?? 0}/{row.service_count ?? 0}
+                </td>
+                <td className="px-3 py-2">
+                  <StatusBadge status={(row.health as HealthStatus) ?? "unknown"} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Panel>
+    </>
+  );
+}
+
+export function SubnetsWithApiPage() {
+  return (
+    <AppShell>
+      <PageMasthead
+        live
+        eyebrow="Capability"
+        title="Subnets with an API spec"
+        description={hubLede("/subnets/with-api")}
+      />
+      <AsyncPanel context="subnets-with-api" fallback={<TableSkeleton rows={10} columns={4} />}>
+        <WithApiTable />
+      </AsyncPanel>
+      <HubSections path="/subnets/with-api" />
+    </AppShell>
+  );
+}

--- a/apps/ui/src/routes/subnets.with-api.tsx
+++ b/apps/ui/src/routes/subnets.with-api.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
+import { stringifyJsonLd, registryFacetDatasetJsonLd } from "@/lib/metagraphed/json-ld";
+import { SubnetsWithApiPage } from "./-subnets-with-api-page";
+
+// #11316: the one faceted page of the three this epic proposed that survived
+// measurement. See -subnets-with-api-page.tsx for why the other two did not.
+//
+// A STATIC segment beside /subnets/$netuid: the router prefers it over the
+// param route, the same precedence /docs/raw relies on (#11294). Nothing else
+// is needed to keep /subnets/64 working.
+export const Route = createFileRoute("/subnets/with-api")({
+  head: () => ({
+    meta: hubMeta("/subnets/with-api"),
+    // The page is a registry projection, so it gets the same Dataset treatment
+    // every other registry record has -- a filtered view of the catalog is
+    // still a dataset, and saying so is what ties it to the catalog node the
+    // site graph already publishes.
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: stringifyJsonLd(
+          registryFacetDatasetJsonLd({
+            name: "Bittensor subnets publishing a machine-readable API specification",
+            identifier: "subnets-with-api",
+            description:
+              "The subset of Bittensor subnets that publish an OpenAPI specification, with " +
+              "integration-readiness scores and probe-derived health for each.",
+            path: "/subnets/with-api",
+            apiUrl: "/api/v1/agent-catalog",
+          }),
+        ),
+      },
+    ],
+  }),
+  component: SubnetsWithApiPage,
+});

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -103,6 +103,10 @@ export const SEO_DEFAULT_TAGS =
 const SITEMAP_STATIC_PATHS = [
   "/",
   "/subnets",
+  // #11316: the one faceted page this epic shipped. Sitemap-only is the profile
+  // that lands a URL in "Crawled - currently not indexed" (#11277), so it is
+  // also linked from /subnets rather than relying on this entry alone.
+  "/subnets/with-api",
   "/apis/providers",
   "/apis",
   "/apis/endpoints",

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -270,6 +270,64 @@ test.describe("#11294 the markdown twin is reachable, and a stale one 404s", () 
   }
 });
 
+test.describe("#11316 the faceted page earns its URL", () => {
+  // The epic proposed THREE faceted pages. Two did not survive measurement:
+  // `gpu_required` is set on zero of 129 subnets and `status` is uniformly
+  // "active" — one empty URL and one duplicate of /subnets. Shipping them would
+  // have been the July mistake, which is what §3 of #11313 exists to prevent.
+  //
+  // These assertions are what stop this page decaying into the same thing.
+
+  test("selects a real subset rather than duplicating /subnets", async ({ request }) => {
+    const html = await (await request.get("/subnets/with-api")).text();
+    const listed = new Set([...html.matchAll(/href="\/subnets\/(\d+)"/g)].map((m) => m[1]!));
+    // A facet that selects everything is a canonical duplicate of the hub, and
+    // a facet that selects nothing is a page with no reason to be crawled.
+    expect(listed.size, "the facet lists no subnets").toBeGreaterThan(10);
+    expect(listed.size, "the facet lists every subnet — it is not a facet").toBeLessThan(120);
+  });
+
+  test("leads with synthesis, not a bare table", async ({ request }) => {
+    // The rule every new URL in this epic ships under: the numbers above the
+    // list are derived from probe data no competitor holds, and they are what
+    // makes this a page rather than a query string.
+    const html = await (await request.get("/subnets/with-api")).text();
+    const text = html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ");
+    expect(text).toContain("catalogued subnets publish a machine-readable API");
+    expect(text).toContain("15-minute probe cycle");
+  });
+
+  test("is reachable from /subnets, not sitemap-only", async ({ request }) => {
+    // Sitemap-only is the textbook profile for "Crawled – currently not
+    // indexed" (#11277) — discoverable, with nothing saying it matters.
+    const html = await (await request.get("/subnets")).text();
+    expect(html, "/subnets does not link the faceted page").toContain('href="/subnets/with-api"');
+  });
+
+  test("is in the sitemap and answers without a redirect", async ({ request }) => {
+    const xml = await (await request.get("/sitemap.xml")).text();
+    expect(xml).toContain("<loc>https://metagraph.sh/subnets/with-api</loc>");
+    const res = await request.get("/subnets/with-api", { maxRedirects: 0 });
+    expect(res.status()).toBe(200);
+  });
+
+  test("does not shadow the subnet detail route", async ({ request }) => {
+    // A static segment beside /subnets/$netuid. If precedence ever flipped,
+    // every one of the 129 detail pages would resolve to this one.
+    //
+    // netuid 1, not 64: the e2e stub's fixture carries subnet 1 and not 64, so
+    // asserting on 64 tests the fixture rather than the routing.
+    const res = await request.get("/subnets/1", { maxRedirects: 0 });
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+    expect(html).not.toContain("catalogued subnets publish a machine-readable API");
+    // And an unknown netuid must still reach the detail route's not-found, not
+    // fall through to the facet page.
+    const missing = await (await request.get("/subnets/999999")).text();
+    expect(missing).not.toContain("catalogued subnets publish a machine-readable API");
+  });
+});
+
 test.describe("#11283 every breadcrumb link goes somewhere", () => {
   // buildCrumbs (components/metagraphed/breadcrumb-nav.ts) makes a link out of
   // EVERY path segment, so a page at /a/b/c offers /a and /a/b whether or not
@@ -443,6 +501,8 @@ test.describe("#11315 the hubs stay within a payload ratchet", () => {
     "/apis/endpoints": 2200,
     "/apis/schemas": 700,
     "/chain": 240,
+    // #11316: a filtered projection of 66 rows, so it is small by construction.
+    "/subnets/with-api": 300,
   };
 
   for (const path of Object.keys(HUB_COPY) as Array<keyof typeof HUB_COPY>) {


### PR DESCRIPTION
## The issue named three facets; none of them discriminate

I wrote #11316 without checking that any of its three proposed facets actually select a subset. Measured against the live registry (129 subnets):

| proposed page | criterion | qualifying | verdict |
|---|---|---|---|
| `/subnets/with-api` | `probed_surface_count > 0` | **129 of 129** | duplicate of `/subnets` |
| `/subnets/gpu-required` | `gpu_required === true` | **0 of 129** | empty page |
| `/subnets/status` | `status` | **129 "active"** | duplicate of `/subnets` |

`gpu_required` exists in the schema and is set on **nothing**. `status` and `coverage_level` are uniform across the entire registry. Shipping the three would have been the July mistake exactly — one empty URL and two near-duplicates of a page that already ranks — against an epic whose §3 exists to prevent it.

## What does discriminate

| facet | distribution |
|---|---|
| `service_kinds` includes **openapi** | **66 of 126** |
| `integration_readiness` ≥ 90 | 57 (70–89: 61, <70: 11) |
| `first_party` | 116 / **13** |
| `lifecycle` | 124 active / 3 deprecated / 1 parked / 1 pending |

## One page, redefined

`/subnets/with-api` now means the **66 subnets publishing a machine-readable API specification**, not the 129 that merely answer a probe. That is also the honest reading of the query it targets — an address you can reach tells you nothing about what to send it.

The other two are **dropped, not deferred**. A page whose facet selects nothing is not a page waiting for content; it is a URL waiting to be crawled and ignored. If `gpu_required` is ever populated, the page can be built then, from a facet that means something.

The cap in the issue was *three maximum*, not a quota.

## Measured against real production data

```
subnets listed   66 of 129
synthesis line   "66 of 129 catalogued subnets publish a machine-readable API…"
h2 count         4
html             248 KB   (ratchet 300)
Dataset node     present
prose ratio      95%      (epic floor: 60%)
```

Every row carries probe-derived health, an integration-readiness score and a **real anchor** to its subnet page.

## How it avoids the traps this epic has already hit

- **Registered in `HUB_COPY`**, which is what subjects it to the existing title/description/heading budgets. Leaving a new page family outside the gate is exactly how `/news` shipped 285 pages with no `BreadcrumbList` (#11303).
- **Linked from `/subnets` with a real `<a>`**, not prose naming a path. I wrote the prose version first; `SectionHeading`'s `intro` renders plain text, so it would have claimed a link that did not exist. Sitemap-only is the profile that lands a URL in *Crawled – currently not indexed* (#11277).
- **A static segment beside `/subnets/$netuid`** — the router prefers it, the same precedence `/docs/raw` relies on. A test pins that the detail route still resolves, and that an unknown netuid reaches its not-found rather than falling through here.

## Validation

```
apps/ui  tsc --noEmit                 clean
apps/ui  eslint + prettier            clean
apps/ui  vitest run                   2294 tests
apps/ui  playwright indexable-routes  107 passed (11 new), against the built Worker
```

One test failure worth recording: my "does not shadow the detail route" assertion used `/subnets/64`, which **404s in the e2e stub** because the fixture carries subnet 1 and not 64. It was testing the fixture, not the routing — the page correctly rendered "Subnet not found" and never the facet copy. Retargeted at netuid 1, plus an unknown-netuid case.

Closes #11316
