### PR TITLE
feat(top-holders): the holdings half republishes on its own cadence (#9632)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -13450,6 +13450,7 @@ export interface components {
                 delegated_tao: number | null;
                 /** @description Genuine free TAO from the System::Account chain-state scan. NULL when the tier that answered has no balance source for this row -- a page ranked by net_flow_* is served from the live flow lane, which carries no holdings columns at all (#9469). Null is never a zero balance: 0 is a measured zero. */
                 free_tao: number | null;
+                /** @description When THIS ROW's figures for the requested sort were measured. Which measurement that is depends on the sort, because the two halves of the leaderboard have different producers (#9632): free_tao/delegated_tao/total_tao are refreshed from the store every three hours and report the newest COMPLETE input pass behind them, while net_flow_7d/30d/90d are recomputed daily from the lakehouse and report that scan. Null when the answering tier carries no stamp for the row. */
                 last_updated: string | null;
                 /** @description As net_flow_7d, over the trailing 30 days. */
                 net_flow_30d: number | null;
@@ -13461,6 +13462,7 @@ export interface components {
                 /** @description free_tao + delegated_tao. Both addends are TAO, so the sum is a real TAO quantity; it inherits delegated_tao's ~24h price staleness. Default sort. NULL whenever either addend is null, rather than summing the half that is known -- a partial total would understate the account silently (#9469). */
                 total_tao: number | null;
             }[];
+            /** @description How old THIS RANKING is: the newest last_updated across the accounts served, for the leg that backs the requested sort. A holdings-sorted page therefore reports its store refresh and a net_flow_*-sorted page its daily lakehouse scan -- one number for both would have to be wrong about one of them (#9632). Null when no row carries a usable stamp, which includes the cold/empty leaderboard. */
             captured_at?: string | null;
             limit: number;
             schema_version: number;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -61183,7 +61183,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "When THIS ROW's figures for the requested sort were measured. Which measurement that is depends on the sort, because the two halves of the leaderboard have different producers (#9632): free_tao/delegated_tao/total_tao are refreshed from the store every three hours and report the newest COMPLETE input pass behind them, while net_flow_7d/30d/90d are recomputed daily from the lakehouse and report that scan. Null when the answering tier carries no stamp for the row."
                 },
                 "net_flow_30d": {
                   "anyOf": [
@@ -61256,7 +61257,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "How old THIS RANKING is: the newest last_updated across the accounts served, for the leg that backs the requested sort. A holdings-sorted page therefore reports its store refresh and a net_flow_*-sorted page its daily lakehouse scan -- one number for both would have to be wrong about one of them (#9632). Null when no row carries a usable stamp, which includes the cold/empty leaderboard."
           },
           "limit": {
             "maximum": 100,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -13450,6 +13450,7 @@ export interface components {
                 delegated_tao: number | null;
                 /** @description Genuine free TAO from the System::Account chain-state scan. NULL when the tier that answered has no balance source for this row -- a page ranked by net_flow_* is served from the live flow lane, which carries no holdings columns at all (#9469). Null is never a zero balance: 0 is a measured zero. */
                 free_tao: number | null;
+                /** @description When THIS ROW's figures for the requested sort were measured. Which measurement that is depends on the sort, because the two halves of the leaderboard have different producers (#9632): free_tao/delegated_tao/total_tao are refreshed from the store every three hours and report the newest COMPLETE input pass behind them, while net_flow_7d/30d/90d are recomputed daily from the lakehouse and report that scan. Null when the answering tier carries no stamp for the row. */
                 last_updated: string | null;
                 /** @description As net_flow_7d, over the trailing 30 days. */
                 net_flow_30d: number | null;
@@ -13461,6 +13462,7 @@ export interface components {
                 /** @description free_tao + delegated_tao. Both addends are TAO, so the sum is a real TAO quantity; it inherits delegated_tao's ~24h price staleness. Default sort. NULL whenever either addend is null, rather than summing the half that is known -- a partial total would understate the account silently (#9469). */
                 total_tao: number | null;
             }[];
+            /** @description How old THIS RANKING is: the newest last_updated across the accounts served, for the leg that backs the requested sort. A holdings-sorted page therefore reports its store refresh and a net_flow_*-sorted page its daily lakehouse scan -- one number for both would have to be wrong about one of them (#9632). Null when no row carries a usable stamp, which includes the cold/empty leaderboard. */
             captured_at?: string | null;
             limit: number;
             schema_version: number;

--- a/schemas-src/routes/top-holders.ts
+++ b/schemas-src/routes/top-holders.ts
@@ -1,14 +1,16 @@
 // GET /api/v1/accounts/top-holders (types-epic B batch 4, #8058). Modeled on
 // account_balances + nominator_positions/neurons tier data -- no static file.
-// TWO TIERS SINCE #9469: `net_flow_7d/30d/90d` are recomputed daily from
-// chain.account_events and are live; `free_tao`/`delegated_tao`/`total_tao`
-// still come from the fixed 2026-08-02 materialization, because neither has a
-// live source (src/top-holders-flow-tier.ts's header measures both gaps). Each
-// tier answers only the sorts it can rank, so the three holdings columns are
-// now NULLABLE -- a net_flow_*-ranked page carries rows the frozen snapshot
-// has never seen, and zeroing them there would assert a balance nothing
-// measured. Modeled from src/top-holders.ts's buildTopHoldersList(), cross-
-// checked against the hand-edited TopHoldersArtifact component it replaces.
+// TWO LEGS SINCE #9469, ON TWO CADENCES SINCE #9632: `net_flow_7d/30d/90d` are
+// recomputed daily from chain.account_events; `free_tao`/`delegated_tao`/
+// `total_tao` are composed from the store and republished every three hours.
+// (Both were frozen 2026-08-02 materializations when this file was written --
+// #9502 gave the holdings columns a live source and #9632 gave them their own
+// producer, so the sentence that used to be here is gone rather than edited.)
+// Each leg answers only the sorts it can rank, so the three holdings columns
+// are NULLABLE -- a net_flow_*-ranked page carries rows the holdings leg has
+// never seen, and zeroing them there would assert a balance nothing measured.
+// Modeled from src/top-holders.ts's buildTopHoldersList(), cross-checked
+// against the hand-edited TopHoldersArtifact component it replaces.
 //
 // Real finding (bucket b): the hand-edited `sort` enum only listed
 // ["total_tao","free_tao","delegated_tao"] -- TOP_HOLDERS_SORTS also allows
@@ -32,6 +34,26 @@ export const TOP_HOLDERS_SORT_VALUES = [
   "net_flow_7d",
   "net_flow_30d",
   "net_flow_90d",
+] as const;
+
+/**
+ * Which of those sorts the STORE-backed holdings leg answers (#9632).
+ *
+ * The two legs are published on different cadences now -- the flow ranking
+ * daily from the lakehouse, these three every three hours from the store -- so
+ * a page's `captured_at` depends on which leg backs the sort it was ranked by,
+ * and src/top-holders.ts needs to know the split to answer that.
+ *
+ * Declared HERE, beside the enum it partitions, rather than imported from
+ * src/top-holders-holdings.ts: that module reaches the Postgres read path, and
+ * pulling it into the formatter would drag the driver into every build that
+ * only wanted to shape a row. tests/top-holders-holdings-refresh.test.ts pins
+ * this against the lane's own three constants, so the copy cannot drift.
+ */
+export const TOP_HOLDERS_HOLDINGS_SORT_VALUES = [
+  "free_tao",
+  "delegated_tao",
+  "total_tao",
 ] as const;
 
 const TopHoldersEntrySchema = z
@@ -72,7 +94,12 @@ const TopHoldersEntrySchema = z
       .number()
       .nullable()
       .describe("As net_flow_7d, over the trailing 90 days."),
-    last_updated: z.string().nullable(),
+    last_updated: z
+      .string()
+      .nullable()
+      .describe(
+        "When THIS ROW's figures for the requested sort were measured. Which measurement that is depends on the sort, because the two halves of the leaderboard have different producers (#9632): free_tao/delegated_tao/total_tao are refreshed from the store every three hours and report the newest COMPLETE input pass behind them, while net_flow_7d/30d/90d are recomputed daily from the lakehouse and report that scan. Null when the answering tier carries no stamp for the row.",
+      ),
   })
   .strict();
 
@@ -81,7 +108,13 @@ export const TopHoldersArtifactSchema = z
     schema_version: z.int(),
     sort: z.enum(TOP_HOLDERS_SORT_VALUES),
     limit: z.int().min(1).max(100),
-    captured_at: z.string().nullable().optional(),
+    captured_at: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "How old THIS RANKING is: the newest last_updated across the accounts served, for the leg that backs the requested sort. A holdings-sorted page therefore reports its store refresh and a net_flow_*-sorted page its daily lakehouse scan -- one number for both would have to be wrong about one of them (#9632). Null when no row carries a usable stamp, which includes the cold/empty leaderboard.",
+      ),
     account_count: z.int().min(0),
     accounts: z.array(TopHoldersEntrySchema),
   })

--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -70,6 +70,17 @@ export const PRODUCER_CADENCE_SECS = {
   /** The top-holders flow materialization, rebuilt daily. */
   top_holders_flow: 86_400,
   /**
+   * The STORE-backed half of that same artifact, republished three-hourly by
+   * TOP_HOLDERS_HOLDINGS_REFRESH_CRON (#9632).
+   *
+   * Two entries for one object, because it has two writers on two cadences and
+   * a single number could only bound one of them. Faster than its own slowest
+   * input on purpose -- `account_balances` is declared at 21,600 s above and
+   * lands irregularly inside it, so a consumer on the producer's period is at
+   * the mercy of the phase between them.
+   */
+  top_holders_holdings: 10_800,
+  /**
    * ACCOUNT_IDENTITY_POLL_SECS. Twenty-four hours, and its absence from this
    * table is what let `TABLE_FRESHNESS` bound the table it writes at TWELVE --
    * half a tick, so a healthy lane read `stale` for the back half of every

--- a/src/top-holders-flow-tier.ts
+++ b/src/top-holders-flow-tier.ts
@@ -11,6 +11,15 @@
 // -- lexicographic address order -- while the envelope echoed
 // `"sort": "net_flow_30d"`. A ranking that is not a ranking, announced as one.
 //
+// THIS LANE NO LONGER OWNS THE HOLDINGS CADENCE (#9632). It still WRITES both
+// halves -- a daily run refreshes everything at once -- but
+// src/top-holders-holdings-refresh.ts rewrites the store-backed columns over
+// this lane's row set every three hours in between, on the same artifact key.
+// Two writers, one object, and the two vintages are carried separately:
+// `generated_at` / a row's `captured_at` are the SCAN's, `holdings_generated_at`
+// / a row's `holdings_captured_at` are the store's. Nothing here may stamp the
+// latter from this lane's clock on a row it did not recompute.
+//
 // THE HOLDINGS COLUMNS ARE COMPOSED HERE TOO (#9502), beside the flow ones:
 // free_tao, delegated_tao and total_tao come from src/top-holders-holdings.ts,
 // which prices `nominator_positions` against the `hotkey_alpha` pool totals
@@ -214,7 +223,18 @@ export function buildTopHoldersFlowRows(
     // HoldingsCells names its three optional keys rather than carrying an index
     // signature, which is the stricter and more useful shape everywhere else;
     // `add` takes the open record every other caller hands it.
-    add(ss58, cells as Record<string, unknown>);
+    //
+    // STAMPED SEPARATELY FROM `captured_at`, because after #9632 the two halves
+    // of a row have genuinely different vintages: the flow cells are as old as
+    // the daily lakehouse scan and the holdings cells as old as their last
+    // store refresh, which is hours fresher. One stamp could only be a lie
+    // about one of them. A row the holdings leg never named carries no
+    // `holdings_captured_at` at all -- absent, not zero, the same rule its
+    // cells follow.
+    add(ss58, {
+      ...(cells as Record<string, unknown>),
+      holdings_captured_at: holdings?.capturedAt,
+    });
   }
 
   const candidates = [...byColdkey.values()];
@@ -270,6 +290,21 @@ export async function computeTopHoldersFlow(
     // reader below is the frozen reader's twin rather than a second dialect.
     schema_version: 1,
     generated_at: new Date(generatedAt).toISOString(),
+    // WHEN THE HOLDINGS HALF LAST RAN, which after #9632 is not the same tick:
+    // src/top-holders-holdings-refresh.ts rewrites these columns every three
+    // hours over the row set this scan produced. Written here too -- by the
+    // daily lane, which refreshes both halves at once -- so the field is
+    // present on every body a live lane wrote and its ABSENCE means the lane
+    // that wrote this predates the split.
+    //
+    // The LANE CLOCK, deliberately, unlike the per-row `holdings_captured_at`
+    // beside it: this one answers "is the refresh lane alive" for
+    // src/top-holders-staleness-watchdog.ts, and that question must not be
+    // answerable by a producer that stopped. The data's own age is the row
+    // stamp.
+    ...(holdings
+      ? { holdings_generated_at: new Date(generatedAt).toISOString() }
+      : {}),
     row_count: shaped.length,
     // WHICH SORTS THIS BODY CAN RANK, declared by the writer rather than
     // assumed by the reader. The legs fail independently and each holdings

--- a/src/top-holders-holdings-refresh.ts
+++ b/src/top-holders-holdings-refresh.ts
@@ -1,0 +1,226 @@
+// The HOLDINGS half of the top-holders leaderboard, republished on its own
+// cadence (#9632).
+//
+// ## What was wrong
+//
+// One daily cron published two things with very different natural cadences.
+// `net_flow_7d/30d/90d` are 7/30/90-day windows over the lakehouse -- daily is
+// genuinely right for those, and the scan costs 1.65 GB, so running it more
+// often is a 79 GB/day mistake. `free_tao`/`delegated_tao`/`total_tao` are
+// composed from store tables that move several times a day, and they inherited
+// the flow leg's cadence for no reason except sharing a lane.
+//
+// Measured on the served route, the same top holder, three times:
+//
+//   2026-08-06   ~225 TAO behind, 3 h after a complete pass had landed
+//   2026-08-09   ~321 TAO behind, 19.3 h old
+//   2026-08-15   ~792 TAO behind, 6 h 10 m behind a complete pass
+//
+// Growing, on a public leaderboard, on the headline account.
+//
+// ## Why the deferral ended
+//
+// The cadence was left alone twice on the argument that `account_events` was
+// about to move to Neon, turning the 1.65 GB `GROUP BY` into an indexed query
+// and removing the cost that forced one combined pass -- so a split would be
+// machinery thrown away at cutover. Checked again 2026-08-15: Neon's
+// `chain_detail_account_events` holds a rolling **24.2 hours** (1,141,787 rows,
+// oldest 2026-08-14T12:27Z). It has grown four-fold since the last check and is
+// still a seventh of the SHORTEST window the flow legs need. The cutover is not
+// close, and the error is compounding while it is waited for.
+//
+// ## Why this is contained, which the deferral's phrasing understated
+//
+// The recorded blocker was that `buildTopHoldersFlowRows` keeps the top-N per
+// key across the UNION of both legs' sorts, so the retained row set depends on
+// both. True -- and it does not require re-running the scan, because the flow
+// leg's contribution to that union is already sitting in the published
+// artifact. Re-ranking FLOW needs the scan; re-ranking HOLDINGS does not.
+// `topHoldersHoldings` selects its own top-N over the FULL store tables, so a
+// refresh is not a subset of a stale set -- it is the same holdings ranking a
+// full run would compute, merged onto flow columns that did not move.
+//
+// Priced against production before it was written, per the same rule the flow
+// lane's own header follows. `EXPLAIN (ANALYZE, BUFFERS)` on the real
+// statement, 2026-08-15: **1,974 rows in 1.37 s, zero lakehouse bytes** --
+// three sequential scans and a hash join over `account_balances` (367,462),
+// `nominator_positions` (143,121) and `hotkey_alpha` (34,508). Against the
+// flow scan's 7.1 s and 1.65 GB, at 8 ticks a day, this is roughly 11 seconds
+// of Neon compute daily and nothing at all on the lakehouse bill.
+//
+// ## The one caveat, stated because it is easy to mistake for a regression
+//
+// The refreshed row set is the union of the flow scan's coldkeys and the
+// holdings leg's own top-N. An account that belongs in the holdings top-N is
+// therefore included on its own merit -- the cap is not inherited from the
+// stale flow set. What IS inherited is the flow ranking itself, which is the
+// point: those columns did not move, and claiming they did is the thing this
+// module refuses to do (see the two stamps below).
+//
+// ## Failure posture
+//
+// It reuses runProjectionLane, so it inherits that runner's all-or-nothing
+// contract verbatim: a decline leaves the published artifact exactly as it is
+// and records one counted `compute_declined`. Every reason to decline below is
+// a reason the CURRENT object is still the best answer available --
+// specifically including "there is no artifact yet", which is the daily lane's
+// job to fix and not this one's. A refresh must never be able to CREATE the
+// leaderboard, only to update its store-backed half; a bug that let it would
+// publish a body with no flow ranking and un-rank three sorts.
+
+import type { ChainNetworkId } from "./chain-network.ts";
+import { DEFAULT_CHAIN_NETWORK, projectionKey } from "./chain-network.ts";
+import type { ProjectionLane } from "./projection-lanes.ts";
+import {
+  buildTopHoldersFlowRows,
+  TOP_HOLDERS_FLOW_PROJECTION_KEY,
+  TOP_HOLDERS_FLOW_ROW_CAP,
+  TOP_HOLDERS_FLOW_SORTS,
+  topHoldersFlowRows,
+} from "./top-holders-flow-tier.ts";
+import { topHoldersHoldings } from "./top-holders-holdings.ts";
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/**
+ * A published body's rows, projected back to the shape the row builder takes
+ * as its lakehouse aggregate.
+ *
+ * The rename is the whole reason this exists and is not a spread:
+ * `buildTopHoldersFlowRows` reads `coldkey` on the way in and writes `ss58` on
+ * the way out, so feeding a written row straight back drops every one of them
+ * on the `!coldkey` guard -- silently, producing a holdings-only artifact with
+ * three un-ranked sorts.
+ *
+ * Only the flow cells are carried. The holdings cells are about to be replaced
+ * wholesale, and passing the old ones through would let a column the fresh leg
+ * DECLINED survive as a stale value under a fresh stamp.
+ */
+export function topHoldersFlowCellsFromRows(
+  rows: readonly Record<string, unknown>[],
+): Array<Record<string, unknown>> {
+  const projected: Array<Record<string, unknown>> = [];
+  for (const row of rows) {
+    const ss58 = typeof row?.ss58 === "string" ? row.ss58 : null;
+    if (!ss58) continue;
+    const cells: Record<string, unknown> = { coldkey: ss58 };
+    for (const key of TOP_HOLDERS_FLOW_SORTS) {
+      if (typeof row[key] === "number") cells[key] = row[key];
+    }
+    projected.push(cells);
+  }
+  return projected;
+}
+
+/**
+ * The published flow vintage -- the ISO string as written, and the epoch ms it
+ * parses to -- or null when the body cannot say.
+ *
+ * Null is a DECLINE upstream rather than a fallback to `Date.now()`: stamping a
+ * rebuilt row with the refresh clock would advance `net_flow_*`'s own age
+ * without recomputing a single one of them.
+ *
+ * Returns the STRING as well as the number so the rewritten body can carry the
+ * original forward byte-for-byte. Re-serialising a parsed instant is a
+ * round-trip that has to be right for the watchdog reading it to stay right,
+ * and there is no reason to take that risk on a field this lane does not own.
+ */
+export function publishedFlowGeneratedAt(
+  body: unknown,
+): { iso: string; ms: number } | null {
+  const raw = (body as { generated_at?: unknown } | null)?.generated_at;
+  if (typeof raw !== "string") return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? { iso: raw, ms } : null;
+}
+
+export interface HoldingsRefreshDeps {
+  /** The store read, injectable so the merge rules can be tested without a
+   * Postgres double. Defaults to the real leg. */
+  holdings?: typeof topHoldersHoldings;
+  /** Clock for `holdings_generated_at`. */
+  now?: () => number;
+}
+
+/**
+ * The refreshed artifact body, or null to leave the published one alone.
+ *
+ * MAINNET ONLY, for the reason the flow lane's holdings call already gives:
+ * the store tables are one chain's, and pricing a testnet leaderboard from
+ * them would mislabel another network's accounts. A testnet tick is a decline,
+ * not a failure.
+ */
+export async function computeTopHoldersHoldingsRefresh(
+  env: Env,
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+  deps: HoldingsRefreshDeps = {},
+): Promise<Record<string, unknown> | null> {
+  if (network !== DEFAULT_CHAIN_NETWORK) return null;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return null;
+
+  let body: unknown;
+  try {
+    const object = await bucket.get(
+      projectionKey(TOP_HOLDERS_FLOW_PROJECTION_KEY, network),
+    );
+    if (!object) return null;
+    body = await object.json();
+  } catch {
+    return null;
+  }
+
+  // Judged by the READ PATH's own test, not a looser one. A body this refresh
+  // accepted and the route rejects would be rewritten under a fresh stamp and
+  // still serve an empty leaderboard -- with the watchdog now reporting it
+  // healthy, because the lane is writing.
+  const published = topHoldersFlowRows(body);
+  if (published === null || published.length === 0) return null;
+  const flow = publishedFlowGeneratedAt(body);
+  if (flow === null) return null;
+
+  const holdings = await (deps.holdings ?? topHoldersHoldings)(env);
+  // Nothing proven means nothing to publish. Rewriting the artifact WITHOUT the
+  // holdings columns would be a strictly worse object than the one already
+  // there -- it would drop three live sorts to make a stamp move.
+  if (holdings === null) return null;
+
+  const flowCells = topHoldersFlowCellsFromRows(published);
+  const shaped = buildTopHoldersFlowRows(
+    flowCells,
+    // THE PUBLISHED FLOW VINTAGE, not now(). Every row's `captured_at` is the
+    // flow half's age and it did not change here; the holdings half carries its
+    // own `holdings_captured_at`, which the merge above stamps from the input
+    // passes the leg actually read.
+    flow.ms,
+    TOP_HOLDERS_FLOW_ROW_CAP,
+    holdings,
+  );
+  if (shaped.length === 0) return null;
+
+  return {
+    schema_version: 1,
+    // Carried forward VERBATIM. This is the sole field the flow watchdog bounds,
+    // so re-deriving it from anything but the published string is a way to make
+    // a dead daily lane look alive.
+    generated_at: flow.iso,
+    holdings_generated_at: new Date((deps.now ?? Date.now)()).toISOString(),
+    row_count: shaped.length,
+    sorts: [...TOP_HOLDERS_FLOW_SORTS, ...holdings.sorts],
+    rows: shaped,
+  };
+}
+
+/** The lane, in the shape runProjectionLane consumes. Deliberately NOT in
+ * PROJECTION_LANES: those share the twice-hourly tick and read the lakehouse,
+ * and this one reads neither. It writes the SAME key the flow lane writes --
+ * one artifact with two writers on two cadences, which is what makes the
+ * reader and every downstream consumer unchanged. */
+export const TOP_HOLDERS_HOLDINGS_REFRESH_LANE: ProjectionLane = {
+  name: "top-holders-holdings-refresh",
+  artifactKey: TOP_HOLDERS_FLOW_PROJECTION_KEY,
+  compute: computeTopHoldersHoldingsRefresh,
+};

--- a/src/top-holders-holdings.ts
+++ b/src/top-holders-holdings.ts
@@ -1,6 +1,13 @@
 // The HOLDINGS leg of GET /api/v1/accounts/top-holders: free_tao,
 // delegated_tao and total_tao, composed live beside the flow columns (#9502).
 //
+// TWO CALLERS SINCE #9632, on two cadences: the daily flow lane, which rebuilds
+// the whole artifact, and src/top-holders-holdings-refresh.ts, which runs this
+// alone every three hours and merges the result onto the flow ranking already
+// published. Nothing here changes between them -- this leg selects its own
+// top-N over the FULL tables either way, which is exactly why the refresh is
+// not a subset of a stale row set.
+//
 // WHAT THIS REPLACES. All three came from src/top-holders-artifact.ts's
 // one-shot 2026-08-02 materialization, whose `captured_at` is a fixed date
 // rather than a refresh clock: an account that moved TAO since was misreported
@@ -89,6 +96,22 @@ export interface HoldingsLeg {
   cells: Map<string, HoldingsCells>;
   /** The holdings sorts this leg proved it can rank. */
   sorts: string[];
+  /**
+   * How old these numbers are: the OLDEST input pass they rest on.
+   *
+   * Not the clock at compute time, which is what a lane stamp would be and
+   * would overstate freshness by however long the producer has been quiet --
+   * measured 2026-08-15, `account_balances`' newest complete pass was 5 h old
+   * when read, so a lane-clock stamp would have announced 0 minutes. The
+   * refresh lane exists precisely to make this number small, so it has to be
+   * the number that can fail to get smaller.
+   *
+   * OLDEST rather than newest because the columns are consumed together and
+   * `total_tao` -- the default sort -- is a sum of both legs: a total is
+   * exactly as current as its stalest addend. When only one leg is proven
+   * there is only one stamp to take.
+   */
+  capturedAt: number;
 }
 
 /**
@@ -313,5 +336,18 @@ export async function topHoldersHoldings(
       (entry) => typeof entry[key as keyof HoldingsCells] === "number",
     ),
   );
-  return sorts.length ? { cells, sorts } : null;
+  // No `sorts.length` guard here, and that is not an omission: an entry reaches
+  // `cells` only when at least one of its three keys is a number, so a non-empty
+  // map always declares at least one sort and the `cells.size === 0` return
+  // above IS that check. A second one would be a branch nothing can reach.
+  //
+  // Only the passes that actually backed a column count. `mayRankAccountBalances`
+  // / `mayPriceHotkeyAlpha` are the same predicates that decided whether the leg
+  // ran at all, so an unproven leg contributes no stamp rather than a null one
+  // that Math.min would read as 0 and report as 1970.
+  const stamps = [
+    ...(free ? [balances.capturedAt as number] : []),
+    ...(delegated ? [alpha.capturedAt as number] : []),
+  ];
+  return { cells, sorts, capturedAt: Math.min(...stamps) };
 }

--- a/src/top-holders-staleness-watchdog.ts
+++ b/src/top-holders-staleness-watchdog.ts
@@ -74,6 +74,24 @@ export const TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS = missedTicksMs(
   2,
 );
 
+/**
+ * The same rule for the HOLDINGS half, which has its own producer now (#9632).
+ *
+ * SIX HOURS -- two missed ticks of the three-hourly
+ * TOP_HOLDERS_HOLDINGS_REFRESH_CRON, by the identical arithmetic one cadence
+ * down. Without it the split is invisible when it breaks: the flow leg would
+ * keep writing `generated_at` on schedule, this watchdog would keep reporting
+ * `ok`, and free_tao/delegated_tao/total_tao would quietly drift back to being
+ * a day stale -- which is precisely the state #9632 was filed about, restored
+ * with an alarm now saying it is fine.
+ *
+ * Overridable per-deployment via TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS.
+ */
+export const TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS = missedTicksMs(
+  "top_holders_holdings",
+  2,
+);
+
 export type TopHoldersStalenessReason =
   "absent" | "unreadable" | "empty" | "stale" | null;
 
@@ -83,7 +101,25 @@ export type TopHoldersStalenessReason =
  * different repairs even though the route serves the same empty page for both. */
 export type TopHoldersArtifactState =
   | { present: false; reason: "absent" | "unreadable" }
-  | { present: true; generatedAt: string | null; rowCount: number };
+  | {
+      present: true;
+      generatedAt: string | null;
+      /**
+       * When the HOLDINGS half was last written (#9632).
+       *
+       * Falls back to `generated_at` when the body does not carry its own, and
+       * that is a reading rather than a suppression: before the split the
+       * holdings columns were written by the daily lane at exactly that
+       * instant, so for such a body the two vintages are genuinely equal. The
+       * same rule topHoldersArtifactSorts applies to a body with no `sorts`.
+       *
+       * The consequence is deliberate: on the first tick after this deploys,
+       * the published artifact's holdings half really is up to 24 h old, and
+       * this leg really should fire until the first refresh lands.
+       */
+      holdingsGeneratedAt: string | null;
+      rowCount: number;
+    };
 
 export interface TopHoldersStalenessVerdict {
   stale: boolean;
@@ -93,11 +129,22 @@ export interface TopHoldersStalenessVerdict {
   threshold_ms: number;
 }
 
-/** The rule alone, testable without a bucket or a clock. */
+/** Which of the artifact's two vintages a verdict is about (#9632). One
+ * object, two writers on two cadences: the daily lakehouse scan stamps `flow`
+ * and the three-hourly store refresh stamps `holdings`. */
+export type TopHoldersVintage = "flow" | "holdings";
+
+/** The rule alone, testable without a bucket or a clock.
+ *
+ * `vintage` selects the stamp, not the rule: absent/unreadable/empty mean the
+ * same repair for either leg, because all three are properties of the ONE
+ * object both write. Only "how old is it" differs, which is the whole reason
+ * the split needs a second verdict rather than a second threshold. */
 export function evaluateTopHoldersStaleness(input: {
   artifact: TopHoldersArtifactState;
   nowMs: number;
   thresholdMs: number;
+  vintage?: TopHoldersVintage;
 }): TopHoldersStalenessVerdict {
   const { artifact, nowMs, thresholdMs } = input;
   if (!artifact.present) {
@@ -112,7 +159,11 @@ export function evaluateTopHoldersStaleness(input: {
       threshold_ms: thresholdMs,
     };
   }
-  const { generatedAt, rowCount } = artifact;
+  const { rowCount } = artifact;
+  const generatedAt =
+    input.vintage === "holdings"
+      ? artifact.holdingsGeneratedAt
+      : artifact.generatedAt;
   const at = generatedAt == null ? NaN : Date.parse(generatedAt);
   if (!Number.isFinite(at)) {
     // A body whose timestamp cannot be read is worse than a missing one: the
@@ -188,10 +239,21 @@ export async function readTopHoldersArtifactState(
   }
   const rows = readRows(body);
   if (rows === null) return { present: false, reason: "unreadable" };
-  const generatedAt = (body as { generated_at?: unknown } | null)?.generated_at;
+  const stamps = body as {
+    generated_at?: unknown;
+    holdings_generated_at?: unknown;
+  } | null;
+  const generatedAt =
+    typeof stamps?.generated_at === "string" ? stamps.generated_at : null;
   return {
     present: true,
-    generatedAt: typeof generatedAt === "string" ? generatedAt : null,
+    generatedAt,
+    // See TopHoldersArtifactState for why the fallback is a reading of an older
+    // body rather than a hole in the alarm.
+    holdingsGeneratedAt:
+      typeof stamps?.holdings_generated_at === "string"
+        ? stamps.holdings_generated_at
+        : generatedAt,
     rowCount: rows.length,
   };
 }
@@ -214,10 +276,24 @@ export async function runTopHoldersStalenessWatchdog(
   const flowThresholdMs =
     Number(env?.TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS) ||
     TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS;
+  const holdingsThresholdMs =
+    Number(env?.TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS) ||
+    TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS;
+  // ONE read, two verdicts. Both legs write the same object, so a second get
+  // would only add a window in which they could disagree about which body they
+  // judged.
+  const artifact = await readTopHoldersArtifactState(bucket);
+  const nowMs = now();
   const flow = evaluateTopHoldersStaleness({
-    artifact: await readTopHoldersArtifactState(bucket),
-    nowMs: now(),
+    artifact,
+    nowMs,
     thresholdMs: flowThresholdMs,
+  });
+  const holdings = evaluateTopHoldersStaleness({
+    artifact,
+    nowMs,
+    thresholdMs: holdingsThresholdMs,
+    vintage: "holdings",
   });
 
   if (flow.stale) {
@@ -238,27 +314,63 @@ export async function runTopHoldersStalenessWatchdog(
     }).catch(() => false);
   }
 
+  // REPORTED SEPARATELY, not folded into the leg above, because the repairs are
+  // different people's: a stale flow leg is the daily lakehouse scan, a stale
+  // holdings leg is the three-hourly store refresh or the `account_balances` /
+  // `hotkey_alpha` producer under it. Collapsing them into one alert would name
+  // the wrong lane half the time. Both firing at once is the artifact being
+  // absent, unreadable or empty, which is genuinely one fault reported twice --
+  // and that is the case where a duplicate costs nothing to read.
+  if (holdings.stale) {
+    const age =
+      holdings.age_ms === null
+        ? "age unknown"
+        : `${(holdings.age_ms / 3_600_000).toFixed(1)} h old`;
+    await record(env as never, {
+      error: new Error(
+        `top-holders holdings refresh ${holdings.reason}: free_tao, ` +
+          `delegated_tao and total_tao are ${age} (threshold ` +
+          `${(holdingsThresholdMs / 3_600_000).toFixed(1)} h) -- the ` +
+          `leaderboard still RANKS on them, so this is a wrong ordering ` +
+          `served with a 200 rather than a missing column (#9632)`,
+      ),
+      route: "watchdog:top-holders-holdings-staleness",
+      errorCode: "stale_lane",
+    }).catch(() => false);
+  }
+
   // #9330/#9340: the DURABLE record, written every tick rather than only when
   // stale. PostHog stays the notification path; it is no longer the record,
   // because a dropped `$exception` is indistinguishable from a lane that was
   // fine, and writing on every tick is also what makes "the watchdog stopped
   // running" visible at all. Never throws -- see recordLaneVerdict.
-  await recordLaneVerdict(laneHealthStore(env, deps.laneHealthDb), {
+  const store = laneHealthStore(env, deps.laneHealthDb);
+  await recordLaneVerdict(store, {
     lane: "top-holders-flow-staleness",
     verdict: flow.stale ? "stale" : "ok",
     age_ms: flow.age_ms,
     detail: flow.reason,
-    checked_at: now(),
+    checked_at: nowMs,
+  });
+  // Its OWN lane row, for the reason the alert above is its own alert: the two
+  // halves fail independently and a single row could only record one of them.
+  await recordLaneVerdict(store, {
+    lane: "top-holders-holdings-staleness",
+    verdict: holdings.stale ? "stale" : "ok",
+    age_ms: holdings.age_ms,
+    detail: holdings.reason,
+    checked_at: nowMs,
   });
 
   // `ok` describes whether the TICK ran, not whether the lane is fresh. The
-  // verdict is flat now that there is one artifact rather than two; `flow` is
-  // kept alongside it so a reader written against the two-artifact shape still
-  // finds the field it was reading.
+  // top-level spread stays the FLOW verdict, unchanged, so a reader written
+  // against the one-artifact shape finds exactly the fields it was reading;
+  // `holdings` is additive beside it.
   return {
     ok: true,
-    alerted: flow.stale,
+    alerted: flow.stale || holdings.stale,
     ...flow,
     flow,
+    holdings,
   };
 }

--- a/src/top-holders.ts
+++ b/src/top-holders.ts
@@ -5,7 +5,10 @@ import {
   TOP_HOLDERS_LIMIT_DEFAULT,
   TOP_HOLDERS_LIMIT_MAX,
 } from "./route-limits.ts";
-import { TOP_HOLDERS_SORT_VALUES } from "../schemas-src/routes/top-holders.ts";
+import {
+  TOP_HOLDERS_HOLDINGS_SORT_VALUES,
+  TOP_HOLDERS_SORT_VALUES,
+} from "../schemas-src/routes/top-holders.ts";
 export { TOP_HOLDERS_LIMIT_DEFAULT, TOP_HOLDERS_LIMIT_MAX };
 // Balance-based top-holder leaderboard (#6741/#6743) -- the coldkey/balance-
 // centric counterpart to src/accounts-list.ts (hotkey/neuron-centric,
@@ -29,8 +32,10 @@ export { TOP_HOLDERS_LIMIT_DEFAULT, TOP_HOLDERS_LIMIT_MAX };
 //                        outflow is negative -- so it gets its own signed
 //                        guard below.
 //   free_tao             COMPOSED LIVE by src/top-holders-holdings.ts (#9502),
-//   delegated_tao        in the same daily lane and from D1: free_tao out of
-//   total_tao            `account_balances`, delegated_tao by pricing
+//   delegated_tao        and republished every three hours on its OWN cron
+//   total_tao            since #9632 (src/top-holders-holdings-refresh.ts):
+//                        free_tao out of
+//                        `account_balances`, delegated_tao by pricing
 //                        `nominator_positions` against the `hotkey_alpha` pool
 //                        totals, total_tao as their sum ranked across the full
 //                        tables. That module's header carries the pricing rule
@@ -48,6 +53,11 @@ export { TOP_HOLDERS_LIMIT_DEFAULT, TOP_HOLDERS_LIMIT_MAX };
 //                        cell here is a statement about an input, not about
 //                        this route: see src/account-balances-completeness.ts
 //                        and src/hotkey-alpha-completeness.ts.
+//
+// SO ONE ROW CARRIES TWO VINTAGES, and `captured_at`/`last_updated` report the
+// one belonging to the sort that was requested -- see topHoldersStampKey. A
+// single number for both would have to be wrong about one of them, and the
+// number a caller of a RANKING wants is the age of the column it was ranked by.
 //
 // A tier answers only the sorts it can genuinely rank and declines the rest,
 // so neither tier's gaps drive an ordering. The holdings cells are therefore
@@ -107,7 +117,36 @@ interface TopHoldersEntry {
   [key: string]: unknown;
 }
 
-function buildTopHoldersEntry(row: Row): TopHoldersEntry {
+/**
+ * Which stamp on a row answers "how old is this ranking" for a given sort
+ * (#9632).
+ *
+ * ONE ROW, TWO VINTAGES, since the holdings leg got its own cadence: the
+ * `net_flow_*` cells are as old as the daily lakehouse scan and the holdings
+ * cells as old as their last three-hourly store refresh. Reporting one number
+ * for both would have to be wrong about one of them, and the number a caller
+ * wants is the age of the column they ranked by.
+ *
+ * Exported for the tests that pin the mapping, and because "which leg backs
+ * this sort" is the same question src/top-holders-flow-tier.ts's per-body
+ * `sorts` answers -- worth stating once rather than re-deriving from a prefix.
+ */
+export function topHoldersStampKey(sort: string): string {
+  return (TOP_HOLDERS_HOLDINGS_SORT_VALUES as readonly string[]).includes(sort)
+    ? "holdings_captured_at"
+    : "captured_at";
+}
+
+/** The stamp for one row under one sort, falling back to the row's own
+ * `captured_at`. The fallback is what a body written before #9632 needs -- it
+ * carries no `holdings_captured_at` at all -- and it is also the right answer
+ * for a flow-only row on a holdings-sorted page: that row has no holdings
+ * cells, ranks last on nulls, and its vintage is the only one it has. */
+function rowStamp(row: Row, stampKey: string): unknown {
+  return row?.[stampKey] ?? row?.captured_at;
+}
+
+function buildTopHoldersEntry(row: Row, stampKey: string): TopHoldersEntry {
   const freeTao = nonNegativeOrNull(row?.free_tao);
   const delegatedTao = nonNegativeOrNull(row?.delegated_tao);
   return {
@@ -122,9 +161,7 @@ function buildTopHoldersEntry(row: Row): TopHoldersEntry {
     net_flow_7d: numberOrNullSigned(row?.net_flow_7d),
     net_flow_30d: numberOrNullSigned(row?.net_flow_30d),
     net_flow_90d: numberOrNullSigned(row?.net_flow_90d),
-    last_updated: toIso(
-      row?.captured_at == null ? null : Number(row.captured_at),
-    ),
+    last_updated: toIso(rowStamp(row, stampKey)),
   };
 }
 
@@ -174,18 +211,21 @@ export function buildTopHoldersList(
     TOP_HOLDERS_LIMIT_MAX,
   );
 
+  // The stamp that answers for THIS page's sort -- see topHoldersStampKey.
+  const stampKey = topHoldersStampKey(normalizedSort);
+
   let latestCapturedAt: number | null = null;
   const accounts = (Array.isArray(rows) ? rows : [])
     .filter((row) => typeof row?.ss58 === "string" && row.ss58.length > 0)
     .map((row) => {
-      const capturedAt =
-        row?.captured_at == null ? null : Number(row.captured_at);
+      const stamp = rowStamp(row, stampKey);
+      const capturedAt = stamp == null ? null : Number(stamp);
       if (capturedAt != null && Number.isFinite(capturedAt) && capturedAt > 0) {
         if (latestCapturedAt == null || capturedAt > latestCapturedAt) {
           latestCapturedAt = capturedAt;
         }
       }
-      return buildTopHoldersEntry(row);
+      return buildTopHoldersEntry(row, stampKey);
     })
     .sort((a, b) => compareTopHoldersSort(a, b, normalizedSort));
 

--- a/tests/top-holders-flow-tier.test.ts
+++ b/tests/top-holders-flow-tier.test.ts
@@ -36,6 +36,11 @@ import {
 } from "../src/top-holders-flow-tier.ts";
 
 const GENERATED_AT = Date.parse("2026-08-05T01:34:00.000Z");
+/** The holdings leg's vintage, deliberately a DIFFERENT instant from the flow
+ * lane's stamp -- that difference is the whole subject of #9632, and equal
+ * fixtures would let a row carrying one stamp pass an assertion about the
+ * other. */
+const HOLDINGS_CAPTURED_AT = Date.parse("2026-08-05T00:50:48.000Z");
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** An aggregate row as the lakehouse hands it back. */
@@ -76,9 +81,14 @@ function bucketWith(
 function holdings(
   cells: Record<string, Record<string, number>>,
   sorts?: string[],
+  /** The leg's own vintage -- the OLDEST input pass it rests on (#9632).
+   * Distinct from GENERATED_AT by default so a test asserting one stamp cannot
+   * pass by reading the other. */
+  capturedAt: number = HOLDINGS_CAPTURED_AT,
 ) {
   const entries = Object.entries(cells);
   return {
+    capturedAt,
     cells: new Map(entries),
     sorts:
       sorts ??

--- a/tests/top-holders-holdings-refresh.test.ts
+++ b/tests/top-holders-holdings-refresh.test.ts
@@ -1,0 +1,530 @@
+// The three-hourly holdings refresh (#9632).
+//
+// EVERY TEST HERE IS ABOUT ONE OF TWO FAILURES, because a bug in this lane is
+// never a crash:
+//
+//   1. It publishes a WORSE artifact than the one already there. The lane
+//      rewrites the object the route serves, so any path that drops the flow
+//      ranking, drops a holdings column, or invents a row set replaces a
+//      correct leaderboard with a plausible wrong one and reports success.
+//   2. It publishes a FRESHER-LOOKING artifact than the data justifies.
+//      `generated_at` is what the staleness watchdog bounds; advancing it here
+//      would make a dead daily lane read healthy forever.
+//
+// The decline cases are therefore not error handling -- they are the contract.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  computeTopHoldersHoldingsRefresh,
+  publishedFlowGeneratedAt,
+  TOP_HOLDERS_HOLDINGS_REFRESH_LANE,
+  topHoldersFlowCellsFromRows,
+} from "../src/top-holders-holdings-refresh.ts";
+import {
+  TOP_HOLDERS_FLOW_PROJECTION_KEY,
+  TOP_HOLDERS_HOLDINGS_SORTS,
+  topHoldersArtifactSorts,
+} from "../src/top-holders-flow-tier.ts";
+import type { HoldingsLeg } from "../src/top-holders-holdings.ts";
+import { TOP_HOLDERS_HOLDINGS_SORT_VALUES } from "../schemas-src/routes/top-holders.ts";
+import { buildTopHoldersList } from "../src/top-holders.ts";
+import {
+  TOP_HOLDERS_FLOW_CRON,
+  TOP_HOLDERS_HOLDINGS_REFRESH_CRON,
+} from "../workers/config.ts";
+
+/** The published flow vintage: 01:34 UTC, the daily lane's slot. */
+const FLOW_AT = "2026-08-15T01:34:47.000Z";
+/** The newest COMPLETE account_balances pass at refresh time -- the real one
+ * from 2026-08-15, which is what makes the numbers below the measured ones. */
+const BALANCES_AT = Date.parse("2026-08-15T07:44:48.000Z");
+/** When the refresh lane ran. Deliberately hours after BALANCES_AT: the whole
+ * point of the row stamp is that it reports the DATA's age, not the lane's. */
+const REFRESH_AT = Date.parse("2026-08-15T12:49:00.000Z");
+
+/** The headline account from the issue, at both vintages. */
+const TOP = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+const SERVED_FREE = 5_403_692.792802455;
+const LIVE_FREE = 5_404_484.759152642;
+
+function leg(
+  cells: Record<string, Record<string, number>>,
+  sorts?: string[],
+  capturedAt = BALANCES_AT,
+): HoldingsLeg {
+  const entries = Object.entries(cells);
+  return {
+    cells: new Map(entries),
+    capturedAt,
+    sorts:
+      sorts ??
+      ["free_tao", "delegated_tao", "total_tao"].filter((key) =>
+        entries.some(([, cell]) => typeof cell[key] === "number"),
+      ),
+  };
+}
+
+/** The artifact as the daily lane wrote it this morning. */
+function publishedBody(
+  rows: unknown[] = [
+    {
+      ss58: TOP,
+      net_flow_7d: -1_200.5,
+      net_flow_30d: 4_000,
+      net_flow_90d: 9_000,
+      free_tao: SERVED_FREE,
+      delegated_tao: 10,
+      total_tao: SERVED_FREE + 10,
+      captured_at: Date.parse(FLOW_AT),
+      holdings_captured_at: Date.parse(FLOW_AT),
+    },
+  ],
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    schema_version: 1,
+    generated_at: FLOW_AT,
+    row_count: rows.length,
+    sorts: ["net_flow_7d", "net_flow_30d", "net_flow_90d", "free_tao"],
+    rows,
+    ...extra,
+  };
+}
+
+function envWith(
+  body: unknown,
+  opts: { missing?: boolean; throwOnGet?: boolean; throwOnJson?: boolean } = {},
+) {
+  return {
+    METAGRAPH_ARCHIVE: {
+      async get(key: string) {
+        assert.equal(key, TOP_HOLDERS_FLOW_PROJECTION_KEY);
+        if (opts.throwOnGet) throw new Error("r2 unreachable");
+        if (opts.missing) return null;
+        return {
+          async json() {
+            if (opts.throwOnJson) throw new Error("not json");
+            return body;
+          },
+        };
+      },
+    },
+  } as unknown as Env;
+}
+
+function refresh(
+  env: Env,
+  holdings: HoldingsLeg | null,
+  network?: Parameters<typeof computeTopHoldersHoldingsRefresh>[1],
+) {
+  return computeTopHoldersHoldingsRefresh(env, network, {
+    holdings: async () => holdings,
+    now: () => REFRESH_AT,
+  });
+}
+
+describe("topHoldersFlowCellsFromRows", () => {
+  // The rename is the bug this function exists to prevent, and it fails
+  // SILENTLY: buildTopHoldersFlowRows reads `coldkey` and writes `ss58`, so
+  // feeding written rows straight back drops every one on the `!coldkey`
+  // guard and publishes a holdings-only artifact with three un-ranked sorts.
+  test("renames ss58 back to coldkey", () => {
+    const [cells] = topHoldersFlowCellsFromRows([
+      { ss58: "5A", net_flow_7d: 3 },
+    ]);
+    assert.equal(cells!.coldkey, "5A");
+    assert.equal("ss58" in cells!, false);
+  });
+
+  // The stale holdings values must NOT ride along. If they did, a column the
+  // fresh leg declined would survive as yesterday's number under today's
+  // stamp -- the one shape worse than declining the column outright.
+  test("carries the flow cells and nothing else", () => {
+    const [cells] = topHoldersFlowCellsFromRows([
+      {
+        ss58: "5A",
+        net_flow_7d: 1,
+        net_flow_30d: 2,
+        net_flow_90d: 3,
+        free_tao: 999,
+        total_tao: 999,
+        captured_at: 1,
+        holdings_captured_at: 2,
+      },
+    ]);
+    assert.deepEqual(cells, {
+      coldkey: "5A",
+      net_flow_7d: 1,
+      net_flow_30d: 2,
+      net_flow_90d: 3,
+    });
+  });
+
+  test("drops rows with no usable ss58, and non-numeric flow cells", () => {
+    assert.deepEqual(
+      topHoldersFlowCellsFromRows([
+        { ss58: 17, net_flow_7d: 1 },
+        { net_flow_7d: 1 },
+        { ss58: "", net_flow_7d: 1 },
+        { ss58: "5A", net_flow_7d: "3" },
+      ]),
+      [{ coldkey: "5A" }],
+    );
+  });
+});
+
+describe("publishedFlowGeneratedAt", () => {
+  test("returns the string as written alongside the parsed instant", () => {
+    assert.deepEqual(publishedFlowGeneratedAt({ generated_at: FLOW_AT }), {
+      iso: FLOW_AT,
+      ms: Date.parse(FLOW_AT),
+    });
+    // A microsecond fraction is what the flow lane's own fixtures carry, and
+    // it must survive verbatim rather than being normalised on the way through.
+    const micro = "2026-08-02T22:38:17.501738+00:00";
+    assert.equal(publishedFlowGeneratedAt({ generated_at: micro })?.iso, micro);
+  });
+
+  test("a missing, non-string or unparseable stamp is a decline", () => {
+    for (const body of [
+      null,
+      {},
+      { generated_at: 17 },
+      { generated_at: "not a timestamp" },
+    ]) {
+      assert.equal(publishedFlowGeneratedAt(body), null, JSON.stringify(body));
+    }
+  });
+});
+
+describe("computeTopHoldersHoldingsRefresh", () => {
+  test("republishes the holdings columns and leaves the flow ones alone", async () => {
+    const body = await refresh(
+      envWith(publishedBody()),
+      leg({
+        [TOP]: {
+          free_tao: LIVE_FREE,
+          delegated_tao: 12,
+          total_tao: LIVE_FREE + 12,
+        },
+      }),
+    );
+    assert.ok(body);
+    const [row] = body.rows as Record<string, unknown>[];
+    // The measured drift from the issue, now gone.
+    assert.equal(row!.free_tao, LIVE_FREE);
+    assert.equal(row!.delegated_tao, 12);
+    // Every flow cell survives, values AND vintage.
+    assert.equal(row!.net_flow_7d, -1_200.5);
+    assert.equal(row!.net_flow_30d, 4_000);
+    assert.equal(row!.net_flow_90d, 9_000);
+    assert.equal(row!.captured_at, Date.parse(FLOW_AT));
+  });
+
+  // The #2 failure at the top of this file. `generated_at` is the field the
+  // staleness watchdog bounds; if this lane advanced it, a daily lane that
+  // stopped running would read healthy for as long as the refresh kept ticking.
+  test("carries generated_at forward verbatim and never advances it", async () => {
+    const body = await refresh(
+      envWith(publishedBody()),
+      leg({ [TOP]: { free_tao: LIVE_FREE } }),
+    );
+    assert.equal(body!.generated_at, FLOW_AT);
+    assert.equal(
+      body!.holdings_generated_at,
+      new Date(REFRESH_AT).toISOString(),
+    );
+  });
+
+  // The row stamp is the DATA's age, not the lane's. A lane-clock stamp would
+  // have announced these numbers as 0 minutes old when the balance scan behind
+  // them was already five hours stale.
+  test("stamps rows with the input pass, not the refresh clock", async () => {
+    const body = await refresh(
+      envWith(publishedBody()),
+      leg({ [TOP]: { free_tao: LIVE_FREE } }),
+    );
+    const [row] = body!.rows as Record<string, unknown>[];
+    assert.equal(row!.holdings_captured_at, BALANCES_AT);
+    assert.notEqual(row!.holdings_captured_at, REFRESH_AT);
+  });
+
+  // A column the fresh leg could not prove must vanish, not persist at
+  // yesterday's value: `sorts` is what the reader trusts, so a surviving cell
+  // under a dropped sort is a number nothing will ever correct.
+  test("a column the fresh leg declined does not survive from the old body", async () => {
+    const body = await refresh(
+      envWith(publishedBody()),
+      leg({ [TOP]: { free_tao: LIVE_FREE } }, ["free_tao"]),
+    );
+    const [row] = body!.rows as Record<string, unknown>[];
+    assert.equal(row!.free_tao, LIVE_FREE);
+    assert.equal("delegated_tao" in row!, false);
+    assert.equal("total_tao" in row!, false);
+    assert.deepEqual(body!.sorts, [
+      "net_flow_7d",
+      "net_flow_30d",
+      "net_flow_90d",
+      "free_tao",
+    ]);
+  });
+
+  // An account the flow scan never saw still belongs on a holdings-ranked page
+  // -- the leg picks its own top-N over the full store tables, so the row set
+  // is not capped by the stale flow one.
+  test("an account only the holdings leg names is added", async () => {
+    const body = await refresh(
+      envWith(publishedBody()),
+      leg({ "5Exchange": { free_tao: 900_000 } }),
+    );
+    const names = (body!.rows as Record<string, unknown>[]).map((r) => r.ss58);
+    assert.ok(names.includes("5Exchange"));
+    assert.ok(names.includes(TOP), "the flow-ranked row is still there");
+  });
+
+  test("the row set is not capped by the previous artifact's holdings", async () => {
+    const body = await refresh(
+      envWith(publishedBody()),
+      leg({
+        "5A": { free_tao: 3 },
+        "5B": { free_tao: 2 },
+        "5C": { free_tao: 1 },
+      }),
+    );
+    assert.equal(body!.row_count, 4);
+  });
+
+  describe("declines, which all leave the published artifact in place", () => {
+    const holdings = () => leg({ [TOP]: { free_tao: LIVE_FREE } });
+
+    test("on a network other than mainnet", async () => {
+      assert.equal(
+        await refresh(envWith(publishedBody()), holdings(), "testnet"),
+        null,
+      );
+    });
+
+    test("without a bucket binding", async () => {
+      assert.equal(await refresh({} as Env, holdings()), null);
+      assert.equal(
+        await refresh({ METAGRAPH_ARCHIVE: {} } as unknown as Env, holdings()),
+        null,
+      );
+    });
+
+    // THE ONE THAT MATTERS MOST. A refresh must never be able to CREATE the
+    // leaderboard: with no flow scan behind it, the body it would write has no
+    // net_flow_* ranking at all, so three sorts would go from live to declined
+    // and the watchdog would report a lane that had just written.
+    test("when there is no artifact yet", async () => {
+      assert.equal(
+        await refresh(envWith(undefined, { missing: true }), holdings()),
+        null,
+      );
+    });
+
+    test("when the get or the parse throws", async () => {
+      assert.equal(
+        await refresh(envWith(undefined, { throwOnGet: true }), holdings()),
+        null,
+      );
+      assert.equal(
+        await refresh(envWith(undefined, { throwOnJson: true }), holdings()),
+        null,
+      );
+    });
+
+    // Judged by the READ PATH's own test. A body this lane accepted and the
+    // route rejects would be rewritten under a fresh stamp and still serve an
+    // empty leaderboard -- with the watchdog now calling it healthy.
+    test("on a body the route itself would not serve", async () => {
+      for (const bad of [
+        { schema_version: 2, generated_at: FLOW_AT, rows: [{ ss58: "5A" }] },
+        { schema_version: 1, generated_at: FLOW_AT, rows: "nope" },
+        { schema_version: 1, generated_at: FLOW_AT, rows: [] },
+      ]) {
+        assert.equal(await refresh(envWith(bad), holdings()), null);
+      }
+    });
+
+    test("when the published body cannot say how old its flow half is", async () => {
+      const body = publishedBody();
+      assert.equal(
+        await refresh(
+          envWith({ ...body, generated_at: undefined }),
+          holdings(),
+        ),
+        null,
+      );
+    });
+
+    // Rewriting WITHOUT the holdings columns would drop three live sorts to
+    // make a stamp move -- strictly worse than the object already published.
+    test("when the holdings leg proves nothing", async () => {
+      assert.equal(await refresh(envWith(publishedBody()), null), null);
+    });
+
+    // A published body whose rows carry no readable flow cell projects to
+    // nothing, and the merge would then publish holdings-only rows under a
+    // `sorts` list claiming three flow rankings.
+    test("when the merge would produce no rows at all", async () => {
+      const body = publishedBody([{ ss58: TOP, free_tao: 1, captured_at: 1 }]);
+      assert.equal(
+        await refresh(envWith(body), {
+          cells: new Map(),
+          sorts: ["free_tao"],
+          capturedAt: BALANCES_AT,
+        }),
+        null,
+      );
+    });
+  });
+
+  // The seams have real defaults, and a test that only ever injects never
+  // proves it: an unwired `deps.holdings` would read as a permanent decline in
+  // production and as a passing suite here.
+  describe("the injected seams default to the real ones", () => {
+    test("with no holdings dep it calls the store leg, which declines unbound", async () => {
+      assert.equal(
+        await computeTopHoldersHoldingsRefresh(
+          envWith(publishedBody()),
+          undefined,
+          { now: () => REFRESH_AT },
+        ),
+        null,
+      );
+    });
+
+    test("with no clock dep it stamps from the real one", async () => {
+      const before = Date.now();
+      const body = await computeTopHoldersHoldingsRefresh(
+        envWith(publishedBody()),
+        undefined,
+        { holdings: async () => leg({ [TOP]: { free_tao: LIVE_FREE } }) },
+      );
+      const at = Date.parse(body!.holdings_generated_at as string);
+      assert.ok(
+        at >= before && at <= Date.now(),
+        String(body!.holdings_generated_at),
+      );
+    });
+  });
+
+  // The reader is unchanged by this lane, which is the design: one artifact,
+  // two writers. If the refreshed body did not satisfy the same reader, the
+  // route would decline every sort the moment a refresh landed.
+  test("the refreshed body still reads back through the served reader", async () => {
+    const body = await refresh(
+      envWith(publishedBody()),
+      leg({
+        [TOP]: {
+          free_tao: LIVE_FREE,
+          delegated_tao: 12,
+          total_tao: LIVE_FREE + 12,
+        },
+      }),
+    );
+    assert.deepEqual(topHoldersArtifactSorts(body), [
+      "net_flow_7d",
+      "net_flow_30d",
+      "net_flow_90d",
+      "free_tao",
+      "delegated_tao",
+      "total_tao",
+    ]);
+    // And the two vintages reach the envelope: a holdings-sorted page reports
+    // the balance pass, a flow-sorted page reports the daily scan.
+    const rows = body!.rows as Record<string, unknown>[];
+    assert.equal(
+      buildTopHoldersList(rows, { sort: "total_tao" }).captured_at,
+      new Date(BALANCES_AT).toISOString(),
+    );
+    assert.equal(
+      buildTopHoldersList(rows, { sort: "net_flow_30d" }).captured_at,
+      FLOW_AT,
+    );
+  });
+});
+
+describe("the lane and its cron", () => {
+  test("writes the SAME key the flow lane writes", () => {
+    assert.equal(
+      TOP_HOLDERS_HOLDINGS_REFRESH_LANE.artifactKey,
+      TOP_HOLDERS_FLOW_PROJECTION_KEY,
+    );
+    assert.equal(
+      TOP_HOLDERS_HOLDINGS_REFRESH_LANE.name,
+      "top-holders-holdings-refresh",
+    );
+  });
+
+  // Two silent wiring failures this repo has hit before: a cron constant with
+  // no wrangler entry never fires, and a cron whose literal collides with
+  // another's routes one lane's tick into the other's branch.
+  test("has its own cron string, registered in wrangler.jsonc", async () => {
+    const config = (await import("../workers/config.ts")) as Record<
+      string,
+      unknown
+    >;
+    const others = Object.entries(config)
+      .filter(
+        ([name]) =>
+          name.endsWith("_CRON") &&
+          name !== "TOP_HOLDERS_HOLDINGS_REFRESH_CRON",
+      )
+      .map(([, value]) => value);
+    assert.equal(
+      others.includes(TOP_HOLDERS_HOLDINGS_REFRESH_CRON),
+      false,
+      "dispatch keys on the literal",
+    );
+    assert.notEqual(TOP_HOLDERS_HOLDINGS_REFRESH_CRON, TOP_HOLDERS_FLOW_CRON);
+    // Three-hourly on a fixed minute: faster than the six-hourly producer it
+    // consumes, so the phase between them cannot cost a full producer interval.
+    assert.match(TOP_HOLDERS_HOLDINGS_REFRESH_CRON, /^\d+ \*\/3 \* \* \*$/);
+
+    const { readFile } = await import("node:fs/promises");
+    const wrangler = await readFile("wrangler.jsonc", "utf8");
+    assert.ok(
+      wrangler.includes(`"${TOP_HOLDERS_HOLDINGS_REFRESH_CRON}"`),
+      "the cron constant must match a triggers.crons entry",
+    );
+  });
+
+  test("handleScheduled routes it to the lane, not the health prober", async () => {
+    const { handleScheduled } = await import("../workers/api.ts");
+    const puts: string[] = [];
+    const result = (await handleScheduled(
+      { cron: TOP_HOLDERS_HOLDINGS_REFRESH_CRON } as never,
+      {
+        METAGRAPH_ARCHIVE: {
+          async get() {
+            return null;
+          },
+          async put(key: string) {
+            puts.push(key);
+          },
+        },
+      } as never,
+      {} as never,
+    )) as Record<string, unknown>;
+    // No published artifact here, so the compute declines and NOTHING is
+    // written -- the all-or-nothing posture that keeps the existing object.
+    assert.equal(result.name, "top-holders-holdings-refresh");
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "compute_declined");
+    assert.deepEqual(puts, []);
+  });
+});
+
+// The copy that exists so the row formatter does not have to import the
+// Postgres read path. tests/read-store-tables-match-the-sql.test.ts is the
+// same idea for a different copy: state it once, then pin it.
+describe("the holdings sort list is single-sourced in effect", () => {
+  test("the schema's partition matches the lane's own three constants", () => {
+    assert.deepEqual(
+      [...TOP_HOLDERS_HOLDINGS_SORT_VALUES].sort(),
+      [...TOP_HOLDERS_HOLDINGS_SORTS].sort(),
+    );
+  });
+});

--- a/tests/top-holders-holdings.test.ts
+++ b/tests/top-holders-holdings.test.ts
@@ -321,6 +321,23 @@ describe("topHoldersHoldings ranks total_tao across the full tables", () => {
 });
 
 describe("topHoldersHoldings declines rather than ranking on unproven inputs", () => {
+  // #9632: the leg's vintage is the OLDEST input it rests on, not the newest
+  // and not the clock. `total_tao` -- the default sort -- is a sum of both
+  // legs, and a total is exactly as current as its stalest addend.
+  test("with both legs proven the vintage is the older pass", async () => {
+    pass("account_balances_passes", BAL_AT, true);
+    pass("hotkey_alpha_passes", ALPHA_AT, true);
+    balance("5Whale", 900_000);
+    position("5Whale", "5Hot", 7, 1);
+    pool("5Hot", 7, 100);
+    price(7, 1);
+
+    const leg = await holdings(runner());
+    assert.deepEqual(leg?.sorts, ["free_tao", "delegated_tao", "total_tao"]);
+    assert.ok(BAL_AT < ALPHA_AT, "the fixture must actually differ");
+    assert.equal(leg?.capturedAt, BAL_AT);
+  });
+
   test("declines when neither pass has completed", async () => {
     balance("5Whale", 900_000);
     position("5Holder", "5Hot", 7, 1);
@@ -343,6 +360,11 @@ describe("topHoldersHoldings declines rather than ranking on unproven inputs", (
     assert.deepEqual(leg?.sorts, ["delegated_tao"]);
     assert.equal(leg?.cells.has("5Whale"), false);
     assert.equal(leg?.cells.get("5Holder")?.delegated_tao, 100);
+    // #9632: only a pass that BACKED a column contributes a stamp. The
+    // balances pass did not complete, so its captured_at must not be the
+    // vintage -- Math.min over a null would report 1970 and read as an
+    // eternally stale leg.
+    assert.equal(leg?.capturedAt, ALPHA_AT);
   });
 
   test("an in-flight pool pass leaves delegated_tao and total_tao out", async () => {
@@ -356,6 +378,7 @@ describe("topHoldersHoldings declines rather than ranking on unproven inputs", (
     const leg = await holdings(runner());
     assert.deepEqual(leg?.sorts, ["free_tao"]);
     assert.equal(leg?.cells.get("5Whale")?.free_tao, 900_000);
+    assert.equal(leg?.capturedAt, BAL_AT);
   });
 
   test("declines on an unbound DB and on an unreadable table", async () => {

--- a/tests/top-holders-staleness-watchdog.test.ts
+++ b/tests/top-holders-staleness-watchdog.test.ts
@@ -9,6 +9,7 @@ import { describe, test } from "vitest";
 import {
   evaluateTopHoldersStaleness,
   TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS,
+  TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS,
   readTopHoldersArtifactState,
   runTopHoldersStalenessWatchdog,
   type TopHoldersArtifactState,
@@ -28,12 +29,18 @@ const NOW = Date.parse("2026-08-05T02:00:00.000Z");
  * alarm quiet on the live defect. Here it is only a fixture. */
 const FROZEN_GENERATED_AT = "2026-08-02T22:38:17.501738+00:00";
 
-/** A present artifact carrying `rows` rows, generated at `generatedAt`. */
+/** A present artifact carrying `rows` rows, generated at `generatedAt`.
+ *
+ * `holdingsGeneratedAt` defaults to the flow stamp, which is what
+ * readTopHoldersArtifactState produces for a body written before #9632 and for
+ * one the daily lane wrote whole -- so every assertion below that predates the
+ * split keeps asking exactly the question it was asking. */
 function present(
   generatedAt: string | null,
   rowCount = 2_965,
+  holdingsGeneratedAt: string | null = generatedAt,
 ): TopHoldersArtifactState {
-  return { present: true, generatedAt, rowCount };
+  return { present: true, generatedAt, holdingsGeneratedAt, rowCount };
 }
 
 function verdictFor(
@@ -191,6 +198,10 @@ describe("readTopHoldersArtifactState", () => {
     assert.deepEqual(await readTopHoldersArtifactState(bucket(frozenBody)), {
       present: true,
       generatedAt: FROZEN_GENERATED_AT,
+      // A body with no `holdings_generated_at` is one written before #9632
+      // split the lane, and for such a body the holdings columns really were
+      // written at `generated_at` -- so it reads as that, not as null.
+      holdingsGeneratedAt: FROZEN_GENERATED_AT,
       rowCount: 1,
     });
   });
@@ -232,7 +243,12 @@ describe("readTopHoldersArtifactState", () => {
       await readTopHoldersArtifactState(
         bucket({ schema_version: 1, generated_at: 17, rows: [] }),
       ),
-      { present: true, generatedAt: null, rowCount: 0 },
+      {
+        present: true,
+        generatedAt: null,
+        holdingsGeneratedAt: null,
+        rowCount: 0,
+      },
     );
   });
 });
@@ -264,14 +280,33 @@ describe("runTopHoldersStalenessWatchdog", () => {
     };
   }
 
+  /** One leg's alerts / lane rows. Every assertion below is scoped to a leg
+   * rather than to a total, because #9632 gave this ONE object a second writer
+   * on a second cadence and therefore a second verdict: a bare `length === 1`
+   * would now pass or fail on which legs happened to be stale together, which
+   * is not what any of these tests are about. */
+  const forRoute = <T extends { route?: string }>(events: T[], route: string) =>
+    events.filter((e) => e.route === route);
+  const forLane = (rows: Record<string, unknown>[], lane: string) =>
+    rows.filter((r) => r.lane === lane);
+
+  const FLOW_ROUTE = "watchdog:top-holders-flow-staleness";
+  const HOLDINGS_ROUTE = "watchdog:top-holders-holdings-staleness";
+  const FLOW_LANE = "top-holders-flow-staleness";
+  const HOLDINGS_LANE = "top-holders-holdings-staleness";
+
   /** The object the route actually serves: the daily flow projection, which
    * has carried all six sortable keys since its holdings leg started proving.
    * There is no second artifact under it any more. */
   function flowBody(
     generatedAt: string,
     rows: unknown[] = [{ ss58: "5A", net_flow_7d: 1 }],
+    /** #9632: the holdings half's own stamp. Omitted by default, which is what
+     * a body written before the split looks like -- and what the daily lane
+     * writes when its holdings leg declines. */
+    extra: Record<string, unknown> = {},
   ) {
-    return { schema_version: 1, generated_at: generatedAt, rows };
+    return { schema_version: 1, generated_at: generatedAt, rows, ...extra };
   }
 
   function envWith(body: unknown, extra: Record<string, unknown> = {}) {
@@ -303,7 +338,16 @@ describe("runTopHoldersStalenessWatchdog", () => {
         return true;
       }) as never,
     }).then((result) => ({
-      result: result as Record<string, unknown>,
+      result: result as Record<string, unknown> & {
+        // #9632 added a second verdict beside the flow one. Named here so the
+        // assertions below read it without a cast apiece.
+        holdings: {
+          stale: boolean;
+          reason: string | null;
+          age_ms: number | null;
+          threshold_ms: number;
+        };
+      },
       events,
       rows: spy.rows,
     }));
@@ -329,17 +373,24 @@ describe("runTopHoldersStalenessWatchdog", () => {
   // not age -- it was a fixed answer to a query whose inputs were gone. That
   // artifact has a live producer now and was deleted, so a tick that recorded
   // two rows recording one `ok` and one permanent `stale` records one.
-  test("writes exactly one lane row, for the object that is served", async () => {
+  test("writes one lane row per leg of the object that is served", async () => {
     const { result, rows, events } = await run(
       flowBody(new Date(NOW - HOUR).toISOString()),
     );
     assert.equal(result.ok, true);
     assert.equal(result.stale, false);
     assert.equal(result.alerted, false);
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0]!.lane, "top-holders-flow-staleness");
-    assert.equal(rows[0]!.verdict, "ok");
-    assert.equal(rows[0]!.checked_at, NOW);
+    // TWO rows for ONE object, which is the #9632 shape: the flow half and the
+    // holdings half are written by different crons and fail independently, so
+    // one row could only ever record one of them.
+    assert.deepEqual(
+      rows.map((r) => r.lane),
+      [FLOW_LANE, HOLDINGS_LANE],
+    );
+    assert.deepEqual([...new Set(rows.map((r) => r.verdict))], ["ok"]);
+    // ONE read, so both verdicts are stamped from the same clock -- two gets
+    // would leave a window in which the legs judged different bodies.
+    assert.deepEqual([...new Set(rows.map((r) => r.checked_at))], [NOW]);
     assert.deepEqual(events, [], "a healthy lane pages nobody");
   });
 
@@ -353,12 +404,13 @@ describe("runTopHoldersStalenessWatchdog", () => {
     assert.equal(result.stale, true);
     assert.equal(result.alerted, true);
     assert.equal(result.reason, "stale");
-    assert.equal(events.length, 1, "a stalled lane must page");
-    assert.equal(events[0]!.route, "watchdog:top-holders-flow-staleness");
-    assert.equal(events[0]!.errorCode, "stale_lane");
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0]!.verdict, "stale");
-    assert.equal(rows[0]!.detail, "stale");
+    const flow = forRoute(events, FLOW_ROUTE);
+    assert.equal(flow.length, 1, "a stalled lane must page");
+    assert.equal(flow[0]!.errorCode, "stale_lane");
+    const flowRows = forLane(rows, FLOW_LANE);
+    assert.equal(flowRows.length, 1);
+    assert.equal(flowRows[0]!.verdict, "stale");
+    assert.equal(flowRows[0]!.detail, "stale");
   });
 
   // The message must not promise a fallback that no longer exists. It used to
@@ -368,7 +420,9 @@ describe("runTopHoldersStalenessWatchdog", () => {
     const { events } = await run(
       flowBody(new Date(NOW - 72 * HOUR).toISOString()),
     );
-    const message = String(events[0]!.error?.message ?? "");
+    const message = String(
+      forRoute(events, FLOW_ROUTE)[0]!.error?.message ?? "",
+    );
     assert.match(message, /serve an EMPTY leaderboard/);
     assert.match(message, /no second tier under it/);
     assert.doesNotMatch(message, /frozen artifact/);
@@ -380,8 +434,8 @@ describe("runTopHoldersStalenessWatchdog", () => {
     const stale = flowBody(new Date(NOW - 72 * HOUR).toISOString());
     const first = await run(stale);
     const second = await run(stale);
-    assert.equal(first.events.length, 1);
-    assert.equal(second.events.length, 1);
+    assert.equal(forRoute(first.events, FLOW_ROUTE).length, 1);
+    assert.equal(forRoute(second.events, FLOW_ROUTE).length, 1);
   });
 
   test("an absent artifact pages, because the route then serves an empty list", async () => {
@@ -389,13 +443,16 @@ describe("runTopHoldersStalenessWatchdog", () => {
     assert.equal(result.stale, true);
     assert.equal(result.reason, "absent");
     assert.equal(result.age_ms, null);
-    assert.equal(events.length, 1);
-    assert.equal(rows[0]!.detail, "absent");
-    assert.equal(
-      rows[0]!.age_ms,
-      null,
-      "an absent object has no measurable age",
-    );
+    // BOTH legs page here, and that is the one duplicate worth having: an
+    // absent object is genuinely both lanes' problem, and neither operator
+    // should have to infer it from the other's alert.
+    assert.equal(forRoute(events, FLOW_ROUTE).length, 1);
+    assert.equal(forRoute(events, HOLDINGS_ROUTE).length, 1);
+    for (const lane of [FLOW_LANE, HOLDINGS_LANE]) {
+      const [row] = forLane(rows, lane);
+      assert.equal(row!.detail, "absent", lane);
+      assert.equal(row!.age_ms, null, "an absent object has no measurable age");
+    }
   });
 
   test("an empty artifact is reported as empty, not stale", async () => {
@@ -424,6 +481,106 @@ describe("runTopHoldersStalenessWatchdog", () => {
     );
     assert.equal(result.stale, true);
     assert.equal(result.threshold_ms, HOUR);
+  });
+
+  // #9632. THE CASE THE WHOLE SPLIT EXISTS TO MAKE VISIBLE: the daily lane is
+  // writing on schedule, so the flow leg is healthy and the old single-verdict
+  // watchdog would have reported `ok` -- while the store-backed columns the
+  // leaderboard ranks by have quietly drifted back to a day stale, which is
+  // exactly the state #9632 was filed about.
+  test("a healthy flow leg does not vouch for a stalled holdings leg", async () => {
+    const { result, events, rows } = await run(
+      flowBody(new Date(NOW - HOUR).toISOString(), undefined, {
+        holdings_generated_at: new Date(NOW - 24 * HOUR).toISOString(),
+      }),
+    );
+    assert.equal(result.stale, false, "the flow half really is fresh");
+    assert.equal(result.alerted, true, "and the tick still pages");
+    assert.equal(result.holdings.stale, true);
+    assert.equal(result.holdings.reason, "stale");
+    assert.equal(result.holdings.age_ms, 24 * HOUR);
+    assert.deepEqual(forRoute(events, FLOW_ROUTE), []);
+    assert.equal(forRoute(events, HOLDINGS_ROUTE).length, 1);
+    assert.equal(forLane(rows, FLOW_LANE)[0]!.verdict, "ok");
+    assert.equal(forLane(rows, HOLDINGS_LANE)[0]!.verdict, "stale");
+  });
+
+  // And the converse, so the two bounds cannot be silently collapsed into one:
+  // the refresh keeps ticking while the daily lakehouse scan dies.
+  test("a healthy holdings leg does not vouch for a stalled flow leg", async () => {
+    const { result, events } = await run(
+      flowBody(new Date(NOW - 72 * HOUR).toISOString(), undefined, {
+        holdings_generated_at: new Date(NOW - HOUR).toISOString(),
+      }),
+    );
+    assert.equal(result.stale, true);
+    assert.equal(result.holdings.stale, false);
+    assert.equal(forRoute(events, FLOW_ROUTE).length, 1);
+    assert.deepEqual(forRoute(events, HOLDINGS_ROUTE), []);
+  });
+
+  // The bound is two missed ticks of a three-hourly cron. A twelve-hour-old
+  // holdings half is well past it, and a two-hour-old one is not -- the
+  // asymmetry with the flow leg's 48 h is the point, and a single shared
+  // threshold would lose it.
+  test("the holdings bound is six hours, not the flow leg's forty-eight", async () => {
+    const at = async (hours: number) =>
+      (
+        await run(
+          flowBody(new Date(NOW - HOUR).toISOString(), undefined, {
+            holdings_generated_at: new Date(NOW - hours * HOUR).toISOString(),
+          }),
+        )
+      ).result.holdings.stale;
+    assert.equal(TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS, 6 * HOUR);
+    assert.equal(await at(2), false);
+    assert.equal(await at(5.9), false);
+    assert.equal(await at(12), true);
+    // The same age the flow leg calls perfectly healthy.
+    assert.equal(await at(24), true);
+  });
+
+  test("the holdings threshold is overridable per-deployment", async () => {
+    const { result } = await run(
+      flowBody(new Date(NOW - HOUR).toISOString(), undefined, {
+        holdings_generated_at: new Date(NOW - 2 * HOUR).toISOString(),
+      }),
+      { TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS: String(HOUR) },
+    );
+    assert.equal(result.holdings.stale, true);
+    assert.equal(result.holdings.threshold_ms, HOUR);
+  });
+
+  // A body written before the split carries no `holdings_generated_at`, and
+  // reading it as `generated_at` is the CORRECT reading rather than a hole: the
+  // daily lane wrote both halves at that instant. The consequence is deliberate
+  // -- on the first tick after this deploys, the holdings half really is a day
+  // old and this really should fire until the first refresh lands.
+  test("a pre-split body is judged on its flow stamp, and that is not a suppression", async () => {
+    const { result } = await run(
+      flowBody(new Date(NOW - 24 * HOUR).toISOString()),
+    );
+    assert.equal(result.stale, false, "24 h is inside the flow bound");
+    assert.equal(result.holdings.stale, true, "and outside the holdings one");
+    assert.equal(result.holdings.age_ms, 24 * HOUR);
+  });
+
+  // The message has to name the lane an operator would go and look at. A
+  // holdings alert that read like the flow one would send them to the daily
+  // lakehouse scan, which is working.
+  test("the holdings page names the columns and says the ranking is wrong, not missing", async () => {
+    const { events } = await run(
+      flowBody(new Date(NOW - HOUR).toISOString(), undefined, {
+        holdings_generated_at: new Date(NOW - 24 * HOUR).toISOString(),
+      }),
+    );
+    const message = String(
+      forRoute(events, HOLDINGS_ROUTE)[0]!.error?.message ?? "",
+    );
+    assert.match(message, /free_tao/);
+    assert.match(message, /delegated_tao/);
+    assert.match(message, /still RANKS on them/);
+    assert.match(message, /24\.0 h old/);
   });
 
   test("`flow` is still on the summary, for a reader written against the old shape", async () => {

--- a/tests/top-holders.test.ts
+++ b/tests/top-holders.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from "vitest";
 import {
   buildTopHoldersList,
   compareTopHoldersSort,
+  topHoldersStampKey,
   TOP_HOLDERS_SORTS,
   DEFAULT_TOP_HOLDERS_SORT,
   TOP_HOLDERS_LIMIT_DEFAULT,
@@ -142,6 +143,93 @@ describe("buildTopHoldersList", () => {
       { ss58: "5B", free_tao: 1, delegated_tao: 0, captured_at: 200 },
     ]) as Row;
     assert.equal(data.captured_at, new Date(200).toISOString());
+  });
+
+  // #9632. ONE ROW, TWO VINTAGES, since the holdings columns got their own
+  // three-hourly producer: `net_flow_*` is as old as the daily lakehouse scan
+  // and the holdings cells as old as their last store refresh. Reporting one
+  // number for both would have to be wrong about one of them, and the number a
+  // caller wants is the age of the column they ranked by.
+  describe("two vintages, one artifact", () => {
+    const FLOW_AT = 1_786_800_000_000;
+    const HOLDINGS_AT = 1_786_818_000_000;
+    const rows = [
+      {
+        ss58: "5A",
+        free_tao: 10,
+        delegated_tao: 1,
+        net_flow_30d: 5,
+        captured_at: FLOW_AT,
+        holdings_captured_at: HOLDINGS_AT,
+      },
+    ];
+
+    test("a holdings-sorted page reports the holdings vintage", () => {
+      for (const sort of ["total_tao", "free_tao", "delegated_tao"]) {
+        const data = buildTopHoldersList(rows, { sort }) as Row;
+        assert.equal(
+          data.captured_at,
+          new Date(HOLDINGS_AT).toISOString(),
+          sort,
+        );
+        assert.equal(
+          (data.accounts as Row[])[0]!.last_updated,
+          new Date(HOLDINGS_AT).toISOString(),
+          sort,
+        );
+      }
+    });
+
+    test("a flow-sorted page reports the flow vintage", () => {
+      for (const sort of ["net_flow_7d", "net_flow_30d", "net_flow_90d"]) {
+        const data = buildTopHoldersList(rows, { sort }) as Row;
+        assert.equal(data.captured_at, new Date(FLOW_AT).toISOString(), sort);
+      }
+    });
+
+    // A body written before the split carries no `holdings_captured_at` at
+    // all. Falling back to `captured_at` is what keeps such an artifact
+    // answering exactly as it did, rather than reporting a null vintage for
+    // three of six sorts the moment this deploys.
+    test("a pre-split row falls back to its one stamp", () => {
+      const data = buildTopHoldersList(
+        [{ ss58: "5A", free_tao: 10, delegated_tao: 1, captured_at: FLOW_AT }],
+        { sort: "total_tao" },
+      ) as Row;
+      assert.equal(data.captured_at, new Date(FLOW_AT).toISOString());
+    });
+
+    // The mapping itself, stated once so it cannot be re-derived from a
+    // string prefix somewhere else.
+    test("every sort maps to exactly one stamp", () => {
+      assert.deepEqual(
+        Object.fromEntries(
+          TOP_HOLDERS_SORTS.map((s) => [s, topHoldersStampKey(s)]),
+        ),
+        {
+          total_tao: "holdings_captured_at",
+          free_tao: "holdings_captured_at",
+          delegated_tao: "holdings_captured_at",
+          net_flow_7d: "captured_at",
+          net_flow_30d: "captured_at",
+          net_flow_90d: "captured_at",
+        },
+      );
+    });
+
+    // The envelope's stamp is a MAX over the rows it actually served, so a
+    // page mixing a refreshed row with a flow-only one reports the freshest
+    // holdings figure rather than being dragged back by a row that has none.
+    test("a flow-only row does not drag a holdings page's vintage back", () => {
+      const data = buildTopHoldersList(
+        [...rows, { ss58: "5B", net_flow_30d: 9, captured_at: FLOW_AT }],
+        { sort: "free_tao" },
+      ) as Row;
+      assert.equal(data.captured_at, new Date(HOLDINGS_AT).toISOString());
+      // ...and that row still reports its own age, which is all it has.
+      const b = (data.accounts as Row[]).find((a) => a.ss58 === "5B");
+      assert.equal(b!.last_updated, new Date(FLOW_AT).toISOString());
+    });
   });
 
   test("skips a row with no ss58", () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -697,6 +697,7 @@ import {
   CHAIN_CONCENTRATION_ROLLUP_CRON,
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   TOP_HOLDERS_FLOW_CRON,
+  TOP_HOLDERS_HOLDINGS_REFRESH_CRON,
   SUBNET_DEREGISTRATION_DAILY_CRON,
   TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
   ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
@@ -832,6 +833,7 @@ import {
   runProjectionLanes,
 } from "../src/projection-lanes.ts";
 import { TOP_HOLDERS_FLOW_LANE } from "../src/top-holders-flow-tier.ts";
+import { TOP_HOLDERS_HOLDINGS_REFRESH_LANE } from "../src/top-holders-holdings-refresh.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
 import type {
   ConsumeResult,
@@ -2889,6 +2891,8 @@ function cronLabel(cron: string): string {
   if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON)
     return "account-balances-staleness-watchdog";
   if (cron === TOP_HOLDERS_FLOW_CRON) return "top-holders-flow";
+  if (cron === TOP_HOLDERS_HOLDINGS_REFRESH_CRON)
+    return "top-holders-holdings-refresh";
   if (cron === SUBNET_DEREGISTRATION_DAILY_CRON)
     return "subnet-deregistration-daily";
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) return "live-economics-refresh";
@@ -3438,6 +3442,7 @@ export const API_HANDLED_CRONS: readonly string[] = [
   CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   SUBNET_DEREGISTRATION_DAILY_CRON,
   TOP_HOLDERS_FLOW_CRON,
+  TOP_HOLDERS_HOLDINGS_REFRESH_CRON,
   TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
   HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
   ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
@@ -3949,6 +3954,15 @@ async function dispatchScheduled(
     // ranking in place and records one exception under
     // projection:top-holders-flow rather than publishing an empty one.
     return runProjectionLane(env, TOP_HOLDERS_FLOW_LANE);
+  }
+  if (cron === TOP_HOLDERS_HOLDINGS_REFRESH_CRON) {
+    // #9632: republish free_tao/delegated_tao/total_tao over the row set the
+    // branch above already produced, three-hourly, WITHOUT touching the
+    // net_flow_* ranking or its vintage. Same runner and therefore the same
+    // all-or-nothing posture: every decline in that module leaves the published
+    // leaderboard exactly as it is, including the one that matters most --
+    // "there is no artifact yet" is the daily lane's job, never this one's.
+    return runProjectionLane(env, TOP_HOLDERS_HOLDINGS_REFRESH_LANE);
   }
   if (cron === TOP_HOLDERS_STALENESS_WATCHDOG_CRON) {
     // The top-holders leaderboard's alarm (#9464). Zero alerts is the correct

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -433,14 +433,24 @@ export const PROJECTION_LANES_CRON = "11,41 * * * *";
 // ~225 TAO off on the top holder, three hours after a complete 364,568-account
 // pass had already landed in D1.
 //
-// The cadence stays daily regardless, because the legs are NOT separable as
-// written: buildTopHoldersFlowRows keeps the top-N per key across the UNION of
-// both legs' sorts, so republishing holdings alone cannot preserve the flow
-// ranking without re-running the 1.65 GB scan. Splitting them is real work and
-// is deliberately deferred: that scan is a lakehouse GROUP BY which becomes an
-// indexed query once account_events is on Neon, removing the cost that forced
-// the daily bound. Doing it now would be building machinery to throw away at
-// cutover.
+// THE FLOW HALF STAYS DAILY AND THE HOLDINGS HALF NO LONGER DOES. This comment
+// used to say the legs were "NOT separable as written", because
+// buildTopHoldersFlowRows keeps the top-N per key across the UNION of both
+// legs' sorts -- and to defer the split until account_events reached Neon and
+// made the 1.65 GB GROUP BY an indexed query. Both halves of that were
+// re-checked on 2026-08-15 and only one survived:
+//
+//   - The cutover is not close. Neon's chain_detail_account_events holds a
+//     rolling 24.2 h, a SEVENTH of the shortest window the flow legs need.
+//   - The union does not require re-running the scan. The flow leg's
+//     contribution to it is already in the published artifact, and
+//     topHoldersHoldings picks its own top-N over the FULL store tables. So a
+//     holdings refresh is not a subset of a stale set.
+//
+// Meanwhile the error compounded: ~225 TAO behind on the top holder when filed,
+// ~321 on 2026-08-09, ~792 on 2026-08-15. TOP_HOLDERS_HOLDINGS_REFRESH_CRON
+// below republishes the store-backed columns over the row set this scan already
+// produced, for 1.37 s of Neon and zero lakehouse bytes.
 //
 // 01:34 UTC puts it ~2.5 h after the
 // nominator-positions producer's nightly pass (last two writes 22:27 and
@@ -448,6 +458,35 @@ export const PROJECTION_LANES_CRON = "11,41 * * * *";
 // on the LITERAL cron string, so this must be unique here as well as matching
 // a wrangler.jsonc `triggers.crons` entry.
 export const TOP_HOLDERS_FLOW_CRON = "34 1 * * *";
+
+/**
+ * The store-backed half of that leaderboard, republished on its own cadence
+ * (#9632). See src/top-holders-holdings-refresh.ts for the lane.
+ *
+ * THREE-HOURLY, against a six-hourly producer, and the factor of two is the
+ * point rather than over-sampling. `account_balances` is declared at 21,600 s
+ * (PRODUCER_CADENCE_SECS) and lands irregularly inside it -- measured across 57
+ * gaps on 2026-08-15: 25 min minimum, 4.2 h mean, 23.5 h maximum. A consumer on
+ * the SAME period as its producer is at the mercy of the phase between them and
+ * can sit a full producer interval behind; halving the period halves that
+ * worst case. The cost that would normally argue against it is not there --
+ * 1.37 s of Neon and no lakehouse bytes, so eight ticks is ~11 s of compute a
+ * day.
+ *
+ * IT ALSO FIXES A SECOND STALENESS THE ISSUE DID NOT NAME. `delegated_tao` is
+ * priced against `hotkey_alpha`'s newest COMPLETE pass, and that producer runs
+ * daily at ~09:40 UTC while the flow lane rebuilds at 01:34 -- so the daily
+ * lane has always read YESTERDAY's pool totals, never fresher than ~15.9 h and
+ * averaging over a day. A three-hourly refresh picks each 09:40 pass up within
+ * three hours of it landing.
+ *
+ * Minute 49 is used by no other cron in this file, hourly ones included, and
+ * dispatch keys on the LITERAL string -- so it must stay unique here AND match
+ * a wrangler.jsonc `triggers.crons` entry. The 00:49 tick sits 45 minutes ahead
+ * of the flow lane's 01:34, which is harmless: that lane rewrites both halves,
+ * and this one declines rather than competing when there is nothing to merge.
+ */
+export const TOP_HOLDERS_HOLDINGS_REFRESH_CRON = "49 */3 * * *";
 
 /**
  * Daily capture of the deregistration ranking's MEASURED inputs (#10296).

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1117,6 +1117,13 @@
       // the twice-hourly cadence would cost 79 GB/day for windows measured in
       // weeks -- see TOP_HOLDERS_FLOW_CRON in workers/config.ts.
       "34 1 * * *",
+      // 49 */3 = the store-backed HALF of that same leaderboard (#9632),
+      // republished eight times a day over the row set the daily scan produced.
+      // It reads no lakehouse at all -- 1.37 s of Neon, measured -- so it is
+      // bounded by its producer's cadence rather than by scan cost. See
+      // TOP_HOLDERS_HOLDINGS_REFRESH_CRON in workers/config.ts; dispatch keys on
+      // this LITERAL string, so it must match that constant exactly.
+      "49 */3 * * *",
       // 05:17 daily = the deregistration-input series (#10296). See
       // SUBNET_DEREGISTRATION_DAILY_CRON in workers/config.ts: dispatch keys on
       // this LITERAL string, so it must match that constant exactly.


### PR DESCRIPTION
## The deferral, re-checked — and only half of it survived

This was left alone twice on two arguments. Both were tested against production on 2026-08-15.

**"The legs are not separable without re-running the 1.65 GB scan."** The recorded blocker is that `buildTopHoldersFlowRows` keeps the top-N per key across the **union** of both legs' sorts, so the retained row set depends on both. True — and it does not need the scan, because **the flow leg's contribution to that union is already in the published artifact**, and `topHoldersHoldings` picks its own top-N over the **full** store tables. A refresh is not a subset of a stale set; it is the same holdings ranking a full run would compute, merged onto flow columns that did not move.

**"account_events is about to reach Neon, so this is machinery to throw away."**

```
chain_detail_account_events   1,141,787 rows
oldest  2026-08-14T12:27Z     newest  2026-08-15T12:41Z     span 24.23 h
```

Four times the 6.2 h measured on 2026-08-09, and still **a seventh of the shortest window the flow legs need**. The cutover is not close, and the error compounds while it is waited for: **~225 TAO** behind on the top holder when filed, **~321** on 08-09, **~792** on 08-15.

## Priced before it was written

`EXPLAIN (ANALYZE, BUFFERS)` on the real statement against production:

| | flow leg (daily) | **holdings leg (this)** |
|---|---|---|
| time | 7.1 s | **1.37 s** |
| lakehouse bytes | 1.65 GB | **0** |
| rows | 32,007 coldkeys | 1,974 |

Three sequential scans and a hash join over `account_balances` (367,462), `nominator_positions` (143,121), `hotkey_alpha` (34,508). Eight ticks a day is **~11 s of Neon compute** and nothing on the lakehouse bill.

## Why three-hourly against a six-hourly producer

`account_balances` is declared at 21,600 s and lands irregularly inside it — 57 gaps measured: **25 min minimum, 4.2 h mean, 23.5 h maximum**. A consumer on its producer's own period is at the mercy of the phase between them and can sit a full producer interval behind; halving the period halves that worst case. The cost that would normally argue against it is not there.

**It also fixes a staleness the issue did not name.** `delegated_tao` is priced against `hotkey_alpha`'s newest complete pass, and that producer runs daily at **~09:40 UTC** while the flow lane rebuilds at **01:34** — so the daily lane has always read *yesterday's* pool totals, never fresher than ~15.9 h and averaging over a day. A three-hourly refresh picks each 09:40 pass up within three hours.

## One artifact, two writers, two vintages

The refresh writes the same key the daily lane writes, so the reader, the route and every downstream consumer are unchanged. What is new is that the object stops pretending its two halves are the same age:

| | flow half | holdings half |
|---|---|---|
| body | `generated_at` | `holdings_generated_at` (lane clock) |
| row | `captured_at` | `holdings_captured_at` (**input pass**) |

The row stamp is the **oldest input pass the leg rests on**, not the lane clock. Measured 2026-08-15, `account_balances`' newest complete pass was 5 h old when read — a lane-clock stamp would have announced those numbers as 0 minutes old. Oldest rather than newest because `total_tao` (the default sort) is a sum of both legs, and a total is as current as its stalest addend.

`captured_at` / `last_updated` on the route now report **the leg backing the requested sort**. One number for both would have to be wrong about one of them, and the number a caller of a *ranking* wants is the age of the column it was ranked by. Both fields had no `describe()` at all; they do now.

## The watchdog, because otherwise the split is invisible when it breaks

Without a second bound, a dead refresh lane looks like this: the daily lane keeps writing `generated_at` on schedule, the alarm keeps reporting `ok`, and the columns drift back to a day stale — **the exact state this issue is about, restored with an alarm vouching for it**. So there is a second verdict at two missed ticks of the new cron (6 h), its own alert route and its own `lane_health` row, from **one** artifact read.

A body with no `holdings_generated_at` is read as `generated_at`. That is a reading, not a suppression: before the split the daily lane wrote both halves at that instant. The consequence is deliberate — on the first tick after this deploys the holdings half really is up to 24 h old, and the alarm really should fire until the first refresh lands.

## Failure posture

Same runner, same all-or-nothing contract. **Every** decline leaves the published artifact exactly as it is, including the one that matters most: a refresh must never be able to *create* the leaderboard. With no flow scan behind it, the body it would write has no `net_flow_*` ranking at all — three sorts would go from live to declined, and the watchdog would report a lane that had just written. `tests/top-holders-holdings-refresh.test.ts` pins each decline: no artifact, a throwing get, a throwing parse, a body the read path itself would reject, an unparseable `generated_at`, an unproven holdings leg, and a merge that would yield no rows.

The refreshed body is judged by the **route's own reader**, not a looser one — a body this lane accepted and the route rejects would be rewritten under a fresh stamp and still serve an empty leaderboard, with the watchdog now calling it healthy.

## One thing removed rather than covered

`topHoldersHoldings` carried a `sorts.length ? … : null` guard that cannot fire: an entry reaches `cells` only when one of its three keys is a number, so a non-empty map always declares a sort and the `cells.size === 0` return above **is** that check. Deleted with the reasoning written down, rather than kept as a branch nothing can reach.

## Validation

```
tsc --noEmit                                   clean
eslint + prettier --check                      clean
npm run build                                  openapi + types + client regenerated
validate, contract-drift, types, openapi,
  single-schema-source, schema-enums,
  schema-vocabularies, query-vocabulary,
  lane-topology, boundary-casts, docs,
  contract-doc-sync, generated-client,
  client-sdk-sync, graphql-types-drift,
  unreferenced-modules/-exports              all pass
vitest  16 adjacent suites                     3,447 passed
vitest  5 top-holders suites                     158 passed (63 new)
patch coverage (git diff -U0 ∩ lcov.info)      61/61 lines, 60/60 branches = 100%
```

Closes #9632
