### PR TITLE
feat(seo): 1,023 validator pages carried a breadcrumb and no record (#11335)

### DIFF
--- a/apps/ui/src/lib/metagraphed/json-ld.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.ts
@@ -425,6 +425,47 @@ export function registryFacetDatasetJsonLd(input: RegistryFacetDatasetInput) {
   });
 }
 
+export interface ValidatorDatasetInput {
+  /** The hotkey ss58 — the validator's stable on-chain identifier. */
+  hotkey: string;
+  /** Operator's self-declared coldkey identity, when the chain carries one. */
+  name?: string | null;
+  /** Subnets this hotkey validates on, when known. */
+  subnetCount?: number | null;
+  dateModified?: string | null;
+}
+
+/**
+ * schema.org Dataset for one validator's registry record (#11313).
+ *
+ * These are **1,023 URLs — 53% of the sitemap** — and every one of them carried
+ * a BreadcrumbList and nothing else: no node saying what the page is about, no
+ * link to the machine-readable form, no place in the catalog. The biggest
+ * structured-data gap on the site, and the one nobody had measured because the
+ * audit that found it (#11230) sampled subnets and providers.
+ *
+ * Dataset for the same reason the subnet records are: what this page publishes
+ * is OUR measured record of a hotkey's participation — stake, take, the subnets
+ * it validates on — not the validator's software, and not an endorsement of it.
+ */
+export function validatorDatasetJsonLd(input: ValidatorDatasetInput) {
+  const label = input.name?.trim();
+  return registryDatasetJsonLd({
+    name: label ? `${label} — Bittensor validator` : "Bittensor validator record",
+    identifier: input.hotkey,
+    description: label
+      ? `Registry record for ${label}: the subnets this Bittensor validator operates on, its stake, take and probe-derived participation.`
+      : "Registry record for a Bittensor validator hotkey: the subnets it operates on, its stake, take and probe-derived participation.",
+    url: `${SITE_ORIGIN}/validators/${encodeURIComponent(input.hotkey)}`,
+    apiUrl: `${API_ORIGIN}/api/v1/validators/${encodeURIComponent(input.hotkey)}`,
+    // No per-validator generated artifact exists; the API route is the
+    // machine-readable form, named once rather than duplicated into a second
+    // DataDownload pointing at the same bytes.
+    artifactUrl: `${API_ORIGIN}/api/v1/validators/${encodeURIComponent(input.hotkey)}`,
+    dateModified: input.dateModified ?? null,
+  });
+}
+
 interface RegistryDatasetInput {
   name: string;
   identifier: string;

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -11,6 +11,8 @@ import {
   isMissingEntityError,
   isNotFoundMatch,
 } from "@/lib/metagraphed/entity-not-found-meta";
+import { recordModifiedAt } from "@/lib/metagraphed/freshness";
+import { stringifyJsonLd, validatorDatasetJsonLd } from "@/lib/metagraphed/json-ld";
 import { formatTao } from "@/lib/metagraphed/format";
 import { logoHostFrom, ogImageMeta } from "@/lib/metagraphed/og-card";
 import { validatorDetailQuery } from "@/lib/metagraphed/queries";
@@ -50,11 +52,13 @@ export const Route = createFileRoute("/validators/$hotkey")({
   // truncated-hotkey form.
   loader: async ({ context, params }) => {
     try {
-      const { data } = await context.queryClient.ensureQueryData(
+      const { data, meta } = await context.queryClient.ensureQueryData(
         validatorDetailQuery(params.hotkey),
       );
       const identity = data.coldkey_identity;
       return {
+        // #11313: same publish timestamp the subnet and provider records use.
+        dateModified: recordModifiedAt(meta) ?? null,
         name: identity?.name ?? null,
         // Same candidate ladder the site's BrandIcon uses for a validator.
         logoHost: logoHostFrom(identity?.image, identity?.url, identity?.github),
@@ -123,6 +127,28 @@ export const Route = createFileRoute("/validators/$hotkey")({
               : []),
           ],
         }),
+      ],
+      // #11313: these are 1,023 URLs -- 53% of the sitemap -- and every one of
+      // them carried a BreadcrumbList and nothing else. No node saying what the
+      // page is about, no link to the machine-readable form, no place in the
+      // catalog. The largest structured-data gap on the site, missed because
+      // #11230's audit sampled subnets and providers.
+      //
+      // Emitted only on the resolved path: a Dataset built for a hotkey that is
+      // not a validator would assert a record that does not exist, which is the
+      // same reason the feed links and the OG card are withheld there.
+      scripts: [
+        {
+          type: "application/ld+json",
+          children: stringifyJsonLd(
+            validatorDatasetJsonLd({
+              hotkey: params.hotkey,
+              name: loaderData?.name ?? null,
+              subnetCount: loaderData?.subnetCount ?? null,
+              dateModified: loaderData?.dateModified ?? null,
+            }),
+          ),
+        },
       ],
     };
   },

--- a/apps/ui/src/server.seo.test.ts
+++ b/apps/ui/src/server.seo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildOgImageUrl, routeOwnsOgImage } from "./lib/metagraphed/og-card";
-import { subnetDatasetJsonLd } from "./lib/metagraphed/json-ld";
+import { subnetDatasetJsonLd, validatorDatasetJsonLd } from "./lib/metagraphed/json-ld";
 import {
   buildJsonLd,
   handleArtifactHostRedirect,
@@ -284,5 +284,40 @@ describe("registry records assert their own freshness (#11314)", () => {
       }),
     );
     expect(node.dateModified).toBe(sitemapLastmod(value));
+  });
+});
+
+describe("validator records are typed, not just breadcrumbed (#11313)", () => {
+  it("names the operator when the chain carries an identity", () => {
+    // 1,023 URLs -- 53% of the sitemap -- carried a BreadcrumbList and nothing
+    // else. The largest structured-data gap on the site.
+    const node = validatorDatasetJsonLd({
+      hotkey: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      name: "Datura",
+      subnetCount: 12,
+      dateModified: "2026-08-14T12:14:17.177Z",
+    }) as Record<string, unknown>;
+    expect(node["@type"]).toBe("Dataset");
+    expect(node.name).toBe("Datura — Bittensor validator");
+    expect(node.identifier).toBe("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    expect(node.url).toBe(
+      "https://metagraph.sh/validators/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    );
+    expect(node.dateModified).toBe("2026-08-14T12:14:17.177Z");
+  });
+
+  it("does not invent a name for a hotkey with no declared identity", () => {
+    // 424 of 1,022 have no coldkey_identity.name. Naming them anything is a
+    // claim about someone's business that the chain does not support.
+    const node = validatorDatasetJsonLd({ hotkey: "5Grwva" }) as Record<string, unknown>;
+    expect(node.name).toBe("Bittensor validator record");
+    expect(node).not.toHaveProperty("dateModified");
+  });
+
+  it("puts the record in the same catalog as every other registry record", () => {
+    // What makes 1,023 Datasets one catalog rather than 1,023 loose files.
+    const node = validatorDatasetJsonLd({ hotkey: "5Grwva" }) as Record<string, unknown>;
+    expect(node.includedInDataCatalog).toBeTruthy();
+    expect(node.publisher).toBeTruthy();
   });
 });


### PR DESCRIPTION
## The gap

A fresh JSON-LD audit across every page family, 2026-08-15:

| page family | JSON-LD beyond the site graph |
|---|---|
| `/subnets/{netuid}` | `Dataset`, `BreadcrumbList` |
| `/providers/{slug}` | `Dataset`, `BreadcrumbList` |
| `/docs/*` | `TechArticle`, `BreadcrumbList` |
| `/news/*` | `Article`, `BreadcrumbList` |
| `/subnets/with-api` | `Dataset`, `BreadcrumbList` |
| **`/validators/{hotkey}`** | **`BreadcrumbList` only** |

**1,023 URLs — 53% of the sitemap** — saying where they sit in the hierarchy and nothing about what they are. No node naming the record, no `distribution` pointing at the machine-readable form, no `includedInDataCatalog` tying them to the catalog the other 267 entity pages belong to.

#11230's audit missed them because it sampled subnets and providers.

## Two judgment calls

**No fabricated names.** 424 of 1,022 hotkeys have no `coldkey_identity.name`. Those get `"Bittensor validator record"`, never a name derived from the hotkey or the subnet — labelling them would be a claim about someone's business the chain does not support.

**`Dataset`, not `SoftwareApplication`.** What the page publishes is *our measured record* of a hotkey's participation — the subnets it operates on, its stake and take — not the validator's software and not an endorsement of the operator. Same reasoning the subnet records ship under.

## Reuse

`validatorDatasetJsonLd` delegates to `registryDatasetJsonLd`, so the `creator`/`publisher`/`includedInDataCatalog` wiring is not re-typed per entity kind. That duplication is what once minted a second, unrelated publisher on all 129 subnet pages. `dateModified` comes from the same `recordModifiedAt` rule as #11314.

Emitted only on the resolved path — a Dataset for a hotkey that is not a validator asserts a record that does not exist, the same reason the feed links and OG card are withheld there.

## No new e2e assertion, deliberately

#11319's derived gate already samples one page per family from the sitemap and checks **every `Dataset` it finds** for `dateModified`. This family is now one of them, so it is covered without a hand-written case — which is the property that gate exists for.

## Also found, deliberately not fixed here

Hub pages (`/`, `/subnets`, `/validators`, `/apis`, `/chain`, `/accounts`) emit the site graph and no page-level node. An `ItemList`/`CollectionPage` would describe the listing — but a wrong one claims an order and a completeness the page may not have, so it needs its own issue and its own verification.

## Validation

```
apps/ui  tsc --noEmit                 clean
apps/ui  eslint + prettier            clean
apps/ui  vitest run                   2297 tests (3 new)
apps/ui  playwright indexable-routes  110 passed, against the built Worker
```

Closes #11335
