### PR TITLE
refactor(lakehouse): name the rows four identity reads return, and drop the ratchet to 25

### DIFF
--- a/scripts/validate-untyped-lakehouse-reads.ts
+++ b/scripts/validate-untyped-lakehouse-reads.ts
@@ -50,7 +50,7 @@ import { sourceFiles } from "./validate-untyped-db-reads.ts";
  */
 // Annotated `number` rather than left as the literal so the "none left" branch
 // below stays reachable code as the ceiling falls to zero.
-export const MAX_UNTYPED_LAKEHOUSE_READS: number = 30;
+export const MAX_UNTYPED_LAKEHOUSE_READS: number = 25;
 
 /** Where a read can live. `scripts/` is excluded: it does not serve traffic. */
 const SOURCE_DIRS = ["src", "workers"];

--- a/src/account-identity-cold-tier.ts
+++ b/src/account-identity-cold-tier.ts
@@ -11,6 +11,10 @@
 
 import { buildAccountIdentity, IDENTITY_FIELDS } from "./account-identity.ts";
 import { buildAccountIdentityHistory } from "./account-identity-history.ts";
+import type {
+  AccountIdentityHistoryRow,
+  AccountIdentityRow,
+} from "../generated/lakehouse/types.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
@@ -38,7 +42,11 @@ export async function loadAccountIdentityColdTier(
   // SS58 guard -- refused rather than escaped.
   const addr = safeSs58Literal(ss58);
   if (addr === null) return null;
-  const rows = await r2SqlQuery(
+  // TYPED, because the SELECT list IS the generated row. `LATEST_COLUMNS` is
+  // `account` + the seven identity fields + `captured_at`, which is every column
+  // `AccountIdentityRow` declares -- so naming it here is a restatement of what
+  // the catalog already says rather than a guess about it.
+  const rows = await r2SqlQuery<AccountIdentityRow>(
     env,
     `SELECT ${LATEST_COLUMNS} FROM chain.account_identity WHERE account = '${addr}'`,
   );
@@ -76,7 +84,11 @@ export async function loadAccountIdentityHistoryColdTier(
   // Cursor pages never carry an offset, mirroring data-api.
   const paged = cursor ? 0 : offset;
 
-  const rows = await r2SqlQuery(
+  // The history frame swaps `account`/`captured_at` for `id`/`observed_at` and
+  // adds the diff hash, which is `AccountIdentityHistoryRow` minus `account` --
+  // and the read is already scoped to one account, so that column would be a
+  // constant. `Omit` states which one and why, rather than widening the type.
+  const rows = await r2SqlQuery<Omit<AccountIdentityHistoryRow, "account">>(
     env,
     `SELECT ${HISTORY_COLUMNS} FROM chain.account_identity_history` +
       ` WHERE ${where.join(" AND ")}` +

--- a/src/subnet-identity-cold-tier.ts
+++ b/src/subnet-identity-cold-tier.ts
@@ -18,6 +18,7 @@ import {
   CHAIN_IDENTITY_HISTORY_LIMIT_DEFAULT,
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
 } from "./chain-identity-history.ts";
+import type { SubnetIdentityHistoryRow } from "../generated/lakehouse/types.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. The network feed adds netuid up front, exactly as
@@ -59,7 +60,10 @@ export async function loadSubnetIdentityHistoryColdTier(
   // Cursor pages never carry an offset, mirroring data-api.
   const paged = cursor ? 0 : offset;
 
-  const rows = await r2SqlQuery(
+  // `IDENTITY_COLUMNS` is every column of the generated row except `netuid`,
+  // and this read is already scoped to one -- so that column would be a
+  // constant in every row. `Omit` names which one is missing and why.
+  const rows = await r2SqlQuery<Omit<SubnetIdentityHistoryRow, "netuid">>(
     env,
     `SELECT ${IDENTITY_COLUMNS} FROM chain.subnet_identity_history` +
       ` WHERE ${where.join(" AND ")}` +
@@ -100,7 +104,9 @@ export async function loadChainIdentityHistoryColdTier(
   if (cap === null || cap <= 0 || cap > CHAIN_IDENTITY_HISTORY_LIMIT_MAX)
     return null;
 
-  const rows = await r2SqlQuery(
+  // The network feed puts `netuid` back, so this one is the whole generated
+  // row -- the same list, differing by exactly the column the scoped read drops.
+  const rows = await r2SqlQuery<SubnetIdentityHistoryRow>(
     env,
     `SELECT netuid, ${IDENTITY_COLUMNS} FROM chain.subnet_identity_history` +
       // data-api's exact feed order: newest block first, netuid as a stable


### PR DESCRIPTION
The warn log's only fingerprint (tao-usd, 3x in the first post-deploy hour)
reproduces deterministically: every GET /api/v1/network/tao-usd
?include_points=false -- the #9720 'send me less' toggle, and the MCP
get_tao_usd tool's default -- was fingerprinted for omitting data.points,
the exact omission the caller asked for.

auditResponse derives its projected signal from the request URL, but only
read fields/sections. include_points is the same class of lever, and the
schema's required deliberately describes the unprojected response (#10960),
so the seam now carries the third signal. parseBooleanParam is strict --
anything but the literal 'false' defaults to true or 400s before the seam
sees a 200 -- so string equality is exactly the handler's own condition.
Both directions pinned: the omission is forgiven under the toggle, and the
same absence without it is still drift.

Closes #11079