### PR TITLE
feat(seo): 10 category pages for the query we answered with nothing (#11342)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-category-links.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-category-links.tsx
@@ -1,0 +1,56 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { SUBNETS_ALL_LIMIT, subnetsQuery } from "@/lib/metagraphed/queries";
+import { categoryCopy, MIN_CATEGORY_SUBNETS } from "@/lib/metagraphed/subnet-categories";
+import type { Subnet } from "@/lib/metagraphed/types";
+
+/**
+ * Links from /subnets to the category pages (#11342).
+ *
+ * Derived from the rendered rows rather than a written list: a category the
+ * registry stops deriving stops being linked, and one it starts deriving is
+ * linked the moment it clears the threshold. A hand-written list here would go
+ * stale exactly the way every hand-listed gate in this repo has.
+ *
+ * Sitemap-only is the profile that lands a URL in "Crawled – currently not
+ * indexed" (#11277), so these anchors are the half that makes the pages real.
+ */
+export function SubnetCategoryLinks() {
+  const { data } = useSuspenseQuery(subnetsQuery({ limit: SUBNETS_ALL_LIMIT }));
+  const counts = new Map<string, number>();
+  for (const row of (data.data ?? []) as Subnet[]) {
+    for (const category of row.derived_categories ?? []) {
+      counts.set(category, (counts.get(category) ?? 0) + 1);
+    }
+  }
+  const categories = [...counts.entries()]
+    .filter(([, count]) => count >= MIN_CATEGORY_SUBNETS)
+    .sort((a, b) => b[1] - a[1]);
+  if (categories.length === 0) return null;
+
+  return (
+    <nav aria-label="Subnet categories" className="mt-8">
+      <h2 className="font-display text-sm font-semibold uppercase tracking-wider text-ink-strong">
+        Browse by what they do
+      </h2>
+      <p className="mt-1.5 mg-type-caption leading-relaxed text-ink-muted">
+        Categories are derived from what each subnet publishes about itself, not from a
+        hand-maintained list.
+      </p>
+      <ul className="mt-3 flex flex-wrap gap-2">
+        {categories.map(([slug, count]) => (
+          <li key={slug}>
+            <Link
+              to="/subnets/category/$slug"
+              params={{ slug }}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 mg-type-caption text-ink-muted hover:border-accent hover:text-accent-text"
+            >
+              {categoryCopy(slug).label}
+              <span className="tabular-nums text-ink-muted/70">{count}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/subnet-categories.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-categories.ts
@@ -1,0 +1,158 @@
+/**
+ * The category pages: "which Bittensor subnets do X" (#11342).
+ *
+ * The registry computes `derived_categories` on every subnet and surfaced them
+ * nowhere — `/subnets` linked zero categories. We published 129 pages for
+ * *"what is subnet 64"* and nothing for the query shape sitting directly above
+ * it, which is the one a person types before they know a netuid.
+ *
+ * **Why these URLs and not the 129 per-subnet analysis pages (#11317).** The
+ * rule is not count. It is whether a URL answers a query nothing else of ours
+ * already answers:
+ *
+ *   /blocks/{hash} x1,557   nobody types a block hash          -> collapsed
+ *   /subnets/{n}/analysis   a SECOND page for a query          -> cannibalization
+ *                           /subnets/{n} already ranks 4-8 for
+ *   /subnets/category/{x}   a query we answer with nothing     -> this
+ *
+ * The copy below is written per category rather than templated. A family of
+ * pages that differ only by a substituted noun is thin by nature however many
+ * words it counts, which is the property that put 5,797 URLs in "Crawled –
+ * currently not indexed".
+ */
+
+/**
+ * A category needs this many subnets to get a page.
+ *
+ * Below it, the page is a near-duplicate of the one subnet it lists — and
+ * `storage` currently has exactly one. Enforced against live data at render
+ * time, so a category that grows past the bar starts appearing and one that
+ * falls below it stops, with no code change.
+ */
+export const MIN_CATEGORY_SUBNETS = 3;
+
+export interface CategoryCopy {
+  /** Human label, as a heading and in the title. */
+  readonly label: string;
+  /** What the category means, in the page's own words. */
+  readonly summary: string;
+  /** Why someone browsing this category is here, and what to compare on. */
+  readonly guidance: string;
+}
+
+/**
+ * Copy for every category the registry derives.
+ *
+ * Keyed by the `derived_categories` value. A category present in the data but
+ * missing here still renders — with a generic summary — rather than 404ing:
+ * the registry deriving a new category is not a reason to break a URL, and the
+ * gap shows up as flat copy that someone will notice and fill.
+ */
+export const CATEGORY_COPY: Record<string, CategoryCopy> = {
+  inference: {
+    label: "Inference",
+    summary:
+      "Subnets whose miners serve model output on demand — text, embeddings, classification or scoring — and whose validators grade that output rather than the hardware behind it.",
+    guidance:
+      "The thing to compare here is not raw capacity but what the validator actually rewards: a subnet scoring answer quality and one scoring latency produce very different miner behaviour, and the API you end up calling reflects whichever it is. Check whether a specification exists before you plan an integration around it.",
+  },
+  agents: {
+    label: "Agents",
+    summary:
+      "Subnets where the unit of work is a task completed rather than a response returned — code written, a trajectory planned, a workflow executed — usually with a longer feedback loop than an inference call.",
+    guidance:
+      "Agent subnets tend to publish fewer synchronous endpoints and more artifacts, so the useful signal is often the source repository and the evaluation method rather than an uptime figure. Read what the validator scores; it tells you more about what the subnet produces than any description does.",
+  },
+  compute: {
+    label: "Compute",
+    summary:
+      "Subnets renting or brokering machine time — GPUs, containers, verifiable execution — where the product is capacity rather than a model's output.",
+    guidance:
+      "These are the subnets where an endpoint being reachable matters most, because you are buying availability. Probe history is the honest signal: a broker that answers consistently is worth more than one advertising a larger fleet it cannot keep online.",
+  },
+  finance: {
+    label: "Finance",
+    summary:
+      "Subnets producing financial signal — market data, liquidity provision, trading strategy, portfolio analytics — priced and scored on chain.",
+    guidance:
+      "Treat everything here as a data source and not as advice, including the scores. What is worth comparing is provenance: whether the subnet publishes how a number was derived, and whether that derivation is something you can re-run rather than take on faith.",
+  },
+  prediction: {
+    label: "Prediction",
+    summary:
+      "Subnets forecasting a future value — prices, weather, events — where miners are scored against outcomes that eventually resolve.",
+    guidance:
+      "The resolution rule is the whole product. Two prediction subnets with identical accuracy claims can be scoring against different horizons or different oracles, so the interesting comparison is what counts as being right and who decides.",
+  },
+  data: {
+    label: "Data",
+    summary:
+      "Subnets collecting, cleaning or labelling data — scraped corpora, street imagery, structured claims — where the output is a dataset rather than a live answer.",
+    guidance:
+      "Data subnets are the ones most likely to publish an artifact you can download rather than an endpoint you call, so check the distribution format before assuming an API. Freshness matters more than uptime here: a dataset that stopped updating is still reachable.",
+  },
+  science: {
+    label: "Science",
+    summary:
+      "Subnets applying the network to research problems — drug discovery, climate modelling, protein work — where the reward function encodes a scientific objective.",
+    guidance:
+      "These have the longest feedback loops on the network and the most domain-specific outputs, so a generic health check tells you least. The source repository and the published methodology are usually the only way to tell what a result means.",
+  },
+  media: {
+    label: "Media",
+    summary:
+      "Subnets generating or processing images, video, audio and 3D — where miners produce media assets and validators score them for fidelity or usefulness.",
+    guidance:
+      "Output format and licensing are the practical questions, and they are rarely in the health data. Where a subnet publishes a specification, it will usually tell you the resolution, the modality and the constraints faster than its documentation does.",
+  },
+  robotics: {
+    label: "Robotics",
+    summary:
+      "Subnets working on embodied intelligence — control policies, simulation, swarm coordination — where the eventual consumer is hardware rather than software.",
+    guidance:
+      "The smallest and newest category on the network, so expect fewer published interfaces and more source repositories. Read the repo activity rather than the endpoint count.",
+  },
+  security: {
+    label: "Security",
+    summary:
+      "Subnets doing adversarial work — vulnerability discovery, red-teaming, integrity checking — where the miner's job is to break something and the validator's is to confirm it stayed broken.",
+    guidance:
+      "Security subnets publish less about their method than others do, deliberately. Judge them on what is verifiable: whether the scoring is reproducible, and whether the surfaces they do publish answer when probed.",
+  },
+  search: {
+    label: "Search",
+    summary: "Subnets retrieving and ranking information across the open web and on-chain sources.",
+    guidance:
+      "Compare on what corpus is actually searched and how recently it was refreshed — retrieval quality is mostly a function of index freshness.",
+  },
+  privacy: {
+    label: "Privacy",
+    summary:
+      "Subnets running computation under confidentiality guarantees — trusted execution, private inference, encrypted data handling.",
+    guidance:
+      "The guarantee is the product, so the thing to check is what is actually attested and by whom, rather than what the description claims.",
+  },
+  storage: {
+    label: "Storage",
+    summary: "Subnets providing decentralised storage and retrieval.",
+    guidance:
+      "Durability claims are only as good as the retrieval path, so probe history matters more than advertised capacity.",
+  },
+};
+
+/** URL segment for a category. The derived value is already slug-shaped. */
+export function categoryPath(slug: string): string {
+  return `/subnets/category/${slug}`;
+}
+
+/** Copy for a category, generic rather than absent when the registry adds one. */
+export function categoryCopy(slug: string): CategoryCopy {
+  return (
+    CATEGORY_COPY[slug] ?? {
+      label: slug.charAt(0).toUpperCase() + slug.slice(1),
+      summary: `Bittensor subnets the registry classifies under ${slug}, with the interfaces each publishes and whether those answered our last probe.`,
+      guidance:
+        "Compare on what each subnet actually publishes: a machine-readable specification, a reachable endpoint, and a probe history you can check rather than a claim you have to take.",
+    }
+  );
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -165,6 +165,22 @@ export interface Subnet {
   repo?: string;
   icon_url?: string | { light: string; dark?: string };
   [key: string]: unknown;
+  /**
+   * Registry-derived capability tags — "inference", "agents", "compute" (#11342).
+   *
+   * Distinct from `categories`, which mixes semantic tags with registry
+   * bookkeeping ("baseline-augmented", "identity-reviewed"). These are the
+   * user-facing ones and the only set worth building URLs from.
+   */
+  derived_categories?: string[];
+  /** How completely the subnet documents its interfaces, 0-100. Ours, not theirs. */
+  integration_readiness?: number;
+  /** Surfaces the operator publishes themselves, as opposed to registry-observed. */
+  official_surface_count?: number;
+  /** Surfaces that have been probed at least once. */
+  probed_surface_count?: number;
+  /** All catalogued surfaces for this subnet. */
+  surface_count?: number;
 }
 
 export interface PrimaryLinks {

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -69,6 +69,8 @@ import { Route as ValidatorsIndexRouteImport } from './routes/validators.index'
 import { Route as ValidatorsHotkeyRouteImport } from './routes/validators.$hotkey'
 import { Route as DocsRawSplatRouteImport } from './routes/docs.raw.$'
 import { Route as NewsRawSplatRouteImport } from './routes/news.raw.$'
+import { Route as SubnetsCategoryIndexRouteImport } from './routes/subnets.category.index'
+import { Route as SubnetsCategorySlugRouteImport } from './routes/subnets.category.$slug'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -370,6 +372,16 @@ const NewsRawSplatRoute = NewsRawSplatRouteImport.update({
   path: '/news/raw/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SubnetsCategoryIndexRoute = SubnetsCategoryIndexRouteImport.update({
+  id: '/subnets/category/',
+  path: '/subnets/category/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SubnetsCategorySlugRoute = SubnetsCategorySlugRouteImport.update({
+  id: '/subnets/category/$slug',
+  path: '/subnets/category/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -432,6 +444,8 @@ export interface FileRoutesByFullPath {
   '/validators/': typeof ValidatorsIndexRoute
   '/docs/raw/$': typeof DocsRawSplatRoute
   '/news/raw/$': typeof NewsRawSplatRoute
+  '/subnets/category/$slug': typeof SubnetsCategorySlugRoute
+  '/subnets/category/': typeof SubnetsCategoryIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -492,6 +506,8 @@ export interface FileRoutesByTo {
   '/validators': typeof ValidatorsIndexRoute
   '/docs/raw/$': typeof DocsRawSplatRoute
   '/news/raw/$': typeof NewsRawSplatRoute
+  '/subnets/category/$slug': typeof SubnetsCategorySlugRoute
+  '/subnets/category': typeof SubnetsCategoryIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -555,6 +571,8 @@ export interface FileRoutesById {
   '/validators/': typeof ValidatorsIndexRoute
   '/docs/raw/$': typeof DocsRawSplatRoute
   '/news/raw/$': typeof NewsRawSplatRoute
+  '/subnets/category/$slug': typeof SubnetsCategorySlugRoute
+  '/subnets/category/': typeof SubnetsCategoryIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -619,6 +637,8 @@ export interface FileRouteTypes {
     | '/validators/'
     | '/docs/raw/$'
     | '/news/raw/$'
+    | '/subnets/category/$slug'
+    | '/subnets/category/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -679,6 +699,8 @@ export interface FileRouteTypes {
     | '/validators'
     | '/docs/raw/$'
     | '/news/raw/$'
+    | '/subnets/category/$slug'
+    | '/subnets/category'
   id:
     | '__root__'
     | '/'
@@ -741,6 +763,8 @@ export interface FileRouteTypes {
     | '/validators/'
     | '/docs/raw/$'
     | '/news/raw/$'
+    | '/subnets/category/$slug'
+    | '/subnets/category/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -792,6 +816,8 @@ export interface RootRouteChildren {
   ValidatorsIndexRoute: typeof ValidatorsIndexRoute
   DocsRawSplatRoute: typeof DocsRawSplatRoute
   NewsRawSplatRoute: typeof NewsRawSplatRoute
+  SubnetsCategorySlugRoute: typeof SubnetsCategorySlugRoute
+  SubnetsCategoryIndexRoute: typeof SubnetsCategoryIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1216,6 +1242,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NewsRawSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/subnets/category/': {
+      id: '/subnets/category/'
+      path: '/subnets/category'
+      fullPath: '/subnets/category/'
+      preLoaderRoute: typeof SubnetsCategoryIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/subnets/category/$slug': {
+      id: '/subnets/category/$slug'
+      path: '/subnets/category/$slug'
+      fullPath: '/subnets/category/$slug'
+      preLoaderRoute: typeof SubnetsCategorySlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -1308,6 +1348,8 @@ const rootRouteChildren: RootRouteChildren = {
   ValidatorsIndexRoute: ValidatorsIndexRoute,
   DocsRawSplatRoute: DocsRawSplatRoute,
   NewsRawSplatRoute: NewsRawSplatRoute,
+  SubnetsCategorySlugRoute: SubnetsCategorySlugRoute,
+  SubnetsCategoryIndexRoute: SubnetsCategoryIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/ui/src/routes/-subnets-category-page.tsx
+++ b/apps/ui/src/routes/-subnets-category-page.tsx
@@ -1,0 +1,135 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link, useParams } from "@tanstack/react-router";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import {
+  AsyncPanel,
+  PageMasthead,
+  Panel,
+  TableSkeleton,
+} from "@/components/metagraphed/primitives";
+import { SectionHeading, StatusBadge, type HealthStatus } from "@jsonbored/ui-kit";
+import { SUBNETS_ALL_LIMIT, subnetsQuery } from "@/lib/metagraphed/queries";
+import { categoryCopy, MIN_CATEGORY_SUBNETS } from "@/lib/metagraphed/subnet-categories";
+import type { Subnet } from "@/lib/metagraphed/types";
+
+/**
+ * `/subnets/category/{slug}` — the subnets doing one kind of work (#11342).
+ *
+ * The query shape sitting directly above "what is subnet 64", and the one a
+ * person types before they know a netuid. The registry has computed
+ * `derived_categories` on every subnet all along and surfaced them nowhere.
+ */
+
+function inCategory(rows: Subnet[], slug: string): Subnet[] {
+  return rows
+    .filter((row) => (row.derived_categories ?? []).includes(slug))
+    .sort(
+      (a, b) =>
+        (b.integration_readiness ?? 0) - (a.integration_readiness ?? 0) || a.netuid - b.netuid,
+    );
+}
+
+function CategoryTable({ slug }: { slug: string }) {
+  const { data } = useSuspenseQuery(subnetsQuery({ limit: SUBNETS_ALL_LIMIT }));
+  const all = (data.data ?? []) as Subnet[];
+  const rows = inCategory(all, slug);
+  const copy = categoryCopy(slug);
+
+  const withSpec = rows.filter((r) => (r.official_surface_count ?? 0) > 0).length;
+  const probed = rows.filter((r) => (r.probed_surface_count ?? 0) > 0).length;
+
+  // Below the bar this is a near-duplicate of the one subnet it lists, so it
+  // says so rather than rendering a one-row table dressed as a category.
+  if (rows.length < MIN_CATEGORY_SUBNETS) {
+    return (
+      <SectionHeading
+        title={`Not enough subnets to compare yet`}
+        intro={`The registry currently classifies ${rows.length} subnet${rows.length === 1 ? "" : "s"} under ${copy.label.toLowerCase()}. A category needs at least ${MIN_CATEGORY_SUBNETS} before a comparison page tells you anything a single subnet page would not — browse all subnets instead.`}
+      />
+    );
+  }
+
+  return (
+    <>
+      {/* Synthesis first, list second — the rule every new URL in #11313 ships
+          under. These counts come from our own probe cycle. */}
+      <SectionHeading
+        title={`${copy.label} on Bittensor today`}
+        intro={`${rows.length} subnets are classified under ${copy.label.toLowerCase()}. ${withSpec} publish at least one first-party interface and ${probed} have a surface that answered our most recent probe. ${copy.guidance}`}
+      />
+      <Panel>
+        <table className="w-full text-left mg-type-data-sm">
+          <caption className="sr-only">
+            Bittensor {copy.label.toLowerCase()} subnets, ranked by integration readiness
+          </caption>
+          <thead>
+            <tr className="border-b border-border text-ink-muted">
+              <th scope="col" className="px-3 py-2 font-medium">
+                Subnet
+              </th>
+              <th scope="col" className="px-3 py-2 font-medium">
+                Readiness
+              </th>
+              <th scope="col" className="px-3 py-2 font-medium">
+                Surfaces
+              </th>
+              <th scope="col" className="px-3 py-2 font-medium">
+                Health
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.netuid} className="border-b border-border/60">
+                <th scope="row" className="px-3 py-2 font-normal">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: row.netuid }}
+                    className="text-accent-text hover:underline"
+                  >
+                    SN{row.netuid} {row.name ?? ""}
+                  </Link>
+                </th>
+                <td className="px-3 py-2 tabular-nums">{row.integration_readiness ?? "—"}</td>
+                <td className="px-3 py-2 tabular-nums">
+                  {row.official_surface_count ?? 0}/{row.surface_count ?? 0}
+                </td>
+                <td className="px-3 py-2">
+                  <StatusBadge status={(row.status as HealthStatus) ?? "unknown"} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Panel>
+      <div className="mt-10">
+        <SectionHeading
+          title={`What "${copy.label.toLowerCase()}" means here`}
+          intro={copy.summary}
+        />
+        <SectionHeading
+          title="How the classification is derived"
+          intro="Categories come from what a subnet publishes about itself — its declared purpose, its source repository and the interfaces it exposes — not from a hand-maintained list. A subnet can belong to several, and 60 of 129 currently belong to none, which is a coverage gap in our data rather than a statement about those subnets."
+        />
+      </div>
+    </>
+  );
+}
+
+export function SubnetCategoryPage() {
+  const { slug } = useParams({ from: "/subnets/category/$slug" });
+  const copy = categoryCopy(slug);
+  return (
+    <AppShell>
+      <PageMasthead
+        live
+        eyebrow="Category"
+        title={`${copy.label} subnets`}
+        description={copy.summary}
+      />
+      <AsyncPanel context="subnet-category" fallback={<TableSkeleton rows={8} columns={4} />}>
+        <CategoryTable slug={slug} />
+      </AsyncPanel>
+    </AppShell>
+  );
+}

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -89,6 +89,7 @@ import {
   subnetAgeDays,
   formatSubnetAge,
 } from "@/lib/metagraphed/format";
+import { SubnetCategoryLinks } from "@/components/metagraphed/subnet-category-links";
 import { HubSections, hubLede } from "@/components/metagraphed/hub-prose";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { joinEconomics, joinHealth, matchesQuery, sortBy } from "@/lib/metagraphed/url-state";
@@ -349,10 +350,13 @@ export function SubnetsPage() {
         artifacts={search.section === "rankings" ? undefined : ["/metagraph/subnets.json"]}
       />
       {/*
-        #11316: a REAL anchor, not prose naming a path. Sitemap-only is the
-        profile that lands a URL in "Crawled - currently not indexed" (#11277),
-        and the faceted page needs an inbound link from the hub it filters.
+        #11316 / #11342: REAL anchors, not prose naming a path. Sitemap-only is
+        the profile that lands a URL in "Crawled - currently not indexed"
+        (#11277), and every faceted page needs an inbound link from the hub it
+        filters. The category list is derived from the rendered rows, so a
+        category the registry stops deriving stops being linked.
       */}
+      <SubnetCategoryLinks />
       <p className="mt-8 mg-type-caption text-ink-muted">
         Looking for the ones you can integrate with?{" "}
         <Link to="/subnets/with-api" className="text-accent-text hover:underline">

--- a/apps/ui/src/routes/subnets.category.$slug.tsx
+++ b/apps/ui/src/routes/subnets.category.$slug.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { registryFacetDatasetJsonLd, stringifyJsonLd } from "@/lib/metagraphed/json-ld";
+import { categoryCopy, categoryPath } from "@/lib/metagraphed/subnet-categories";
+import { clampText } from "@/lib/metagraphed/truncate";
+import { HUB_DESCRIPTION_MAX, HUB_TITLE_MAX } from "@/lib/metagraphed/hub-copy";
+import { SubnetCategoryPage } from "./-subnets-category-page";
+
+// #11342: "which Bittensor subnets do X" — the query shape between the 129
+// subnet pages and the hub, which we answered with nothing.
+//
+// A static `category` segment beside /subnets/$netuid and /subnets/with-api;
+// the router prefers the static prefix, the same precedence /docs/raw relies
+// on (#11294).
+export const Route = createFileRoute("/subnets/category/$slug")({
+  head: ({ params }) => {
+    const copy = categoryCopy(params.slug);
+    // Clamped with the site's one truncation rule rather than hand-counted:
+    // these are generated from per-category copy, so a long label must not be
+    // able to push the tag past what Google shows. Brand last, as everywhere.
+    const title = clampText(
+      `${copy.label} subnets on Bittensor — health & APIs · Metagraphed`,
+      HUB_TITLE_MAX,
+    );
+    const description = clampText(copy.summary, HUB_DESCRIPTION_MAX);
+    return {
+      meta: [
+        { title },
+        { name: "description", content: description },
+        { property: "og:title", content: title },
+        { property: "og:description", content: description },
+      ],
+      scripts: [
+        {
+          type: "application/ld+json",
+          children: stringifyJsonLd(
+            registryFacetDatasetJsonLd({
+              name: `Bittensor ${copy.label.toLowerCase()} subnets`,
+              identifier: `subnets-category-${params.slug}`,
+              description: copy.summary,
+              path: categoryPath(params.slug),
+              apiUrl: "/api/v1/subnets",
+            }),
+          ),
+        },
+      ],
+    };
+  },
+  component: SubnetCategoryPage,
+});

--- a/apps/ui/src/routes/subnets.category.index.tsx
+++ b/apps/ui/src/routes/subnets.category.index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+// #11342: `/subnets/category` is an intermediate path segment of every category
+// URL, and #11283's gate is what caught it 404ing — a linked breadcrumb crumb
+// pointing at nothing, which is the exact defect that put 129 dead prefixes on
+// the site (#11303).
+//
+// 301 rather than a listing page: the categories are already listed on
+// /subnets, and a second index of them would compete with the hub for the same
+// query. Permanent, because this segment will never be a page — the same answer
+// /graphql, /tools and /design give.
+export const Route = createFileRoute("/subnets/category/")({
+  beforeLoad: () => {
+    throw redirect({ to: "/subnets", statusCode: 301 });
+  },
+});

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -10,6 +10,7 @@ import {
   siteGraphNodes,
   stringifyJsonLd,
 } from "./lib/metagraphed/json-ld";
+import { categoryPath, MIN_CATEGORY_SUBNETS } from "./lib/metagraphed/subnet-categories";
 import { isoTimestamp } from "./lib/metagraphed/freshness";
 import { API_ORIGIN, SITE_ORIGIN, X_HANDLE } from "./lib/metagraphed/identity";
 import { handleAnalyticsProxy, type PostHogAssetContext } from "./lib/analytics-proxy";
@@ -368,14 +369,38 @@ async function buildSitemap(): Promise<Response> {
     });
     if (res.ok) {
       const payload = (await res.json()) as {
-        data?: { subnets?: Array<{ netuid?: unknown; updated_at?: unknown }> };
+        data?: {
+          subnets?: Array<{
+            netuid?: unknown;
+            updated_at?: unknown;
+            derived_categories?: unknown;
+          }>;
+        };
       };
+      // #11342: category pages are derived from the SAME response, so the
+      // sitemap can never advertise a category the registry stopped deriving,
+      // nor miss one it started. Counted first, because a category below the
+      // threshold renders a "not enough to compare" page and must not be
+      // offered to a crawler as though it were a listing.
+      const categoryCounts = new Map<string, number>();
       for (const subnet of payload.data?.subnets ?? []) {
         if (Number.isInteger(subnet?.netuid)) {
           entries.push({
             loc: `${SITE_ORIGIN}/subnets/${String(subnet.netuid)}`,
             lastmod: sitemapLastmod(subnet?.updated_at),
           });
+        }
+        for (const category of Array.isArray(subnet?.derived_categories)
+          ? subnet.derived_categories
+          : []) {
+          if (typeof category === "string" && category) {
+            categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1);
+          }
+        }
+      }
+      for (const [category, count] of [...categoryCounts].sort()) {
+        if (count >= MIN_CATEGORY_SUBNETS) {
+          entries.push({ loc: `${SITE_ORIGIN}${categoryPath(category)}` });
         }
       }
     }

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -708,3 +708,67 @@ test.describe("#11319 the SEO invariants are derived, not listed", () => {
     ).toStrictEqual([]);
   });
 });
+
+test.describe("#11342 the category pages answer a query nothing else does", () => {
+  // We published 129 pages for "what is subnet 64" and nothing for the query
+  // sitting directly above it — "which Bittensor subnets do inference" — even
+  // though the registry has computed derived_categories all along.
+  //
+  // Derived from the sitemap, so a category the registry stops deriving stops
+  // being tested and one it starts deriving is covered the moment it clears the
+  // threshold.
+
+  async function categoryPaths(request: import("@playwright/test").APIRequestContext) {
+    const xml = await (await request.get("/sitemap.xml")).text();
+    const paths = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)]
+      .map((m) => new URL(m[1]!).pathname)
+      .filter((p) => p.startsWith("/subnets/category/"));
+    expect(paths.length, "no category pages in the sitemap").toBeGreaterThan(3);
+    return paths;
+  }
+
+  test("every category page lists a real comparison set", async ({ request }) => {
+    // Below MIN_CATEGORY_SUBNETS a page is a near-duplicate of the one subnet
+    // it lists, which is why storage (1), search (2) and privacy (2) are not
+    // generated. A page in the sitemap must clear that bar.
+    const failures: string[] = [];
+    for (const path of await categoryPaths(request)) {
+      const html = await (await request.get(path)).text();
+      const listed = new Set([...html.matchAll(/href="\/subnets\/(\d+)"/g)].map((m) => m[1]!));
+      if (listed.size < 3) failures.push(`${path}: ${listed.size} subnets`);
+    }
+    expect(
+      failures,
+      `category pages below the comparison threshold:\n${failures.join("\n")}`,
+    ).toStrictEqual([]);
+  });
+
+  test("each says something specific, not one template with a noun swapped", async ({
+    request,
+  }) => {
+    // A family of pages differing only by a substituted word is thin by nature
+    // however many words it counts — the property that put 5,797 URLs in
+    // "Crawled – currently not indexed".
+    const descriptions = new Set<string>();
+    for (const path of await categoryPaths(request)) {
+      const html = await (await request.get(path)).text();
+      const description = /<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? "";
+      expect(description, `${path} has no description`).not.toBe("");
+      descriptions.add(description);
+    }
+    const paths = await categoryPaths(request);
+    expect(descriptions.size, "category descriptions are not distinct").toBe(paths.length);
+  });
+
+  test("the hub links every category it generates", async ({ request }) => {
+    // Sitemap-only is the profile that lands a URL in "Crawled – currently not
+    // indexed" (#11277). The links are derived from the same rows the sitemap
+    // is, so the two cannot disagree.
+    const html = await (await request.get("/subnets")).text();
+    const linked = new Set(
+      [...html.matchAll(/href="\/subnets\/category\/([^"]+)"/g)].map((m) => m[1]!),
+    );
+    const sitemapped = (await categoryPaths(request)).map((p) => p.split("/").pop()!);
+    expect([...sitemapped].sort()).toStrictEqual([...linked].sort());
+  });
+});


### PR DESCRIPTION
## The gap

We publish **129 pages** for *"what is subnet 64"* and, until now, **nothing** for the query sitting directly above it: *"which Bittensor subnets do inference"*. The registry has computed `derived_categories` on every subnet all along and surfaced them nowhere — `/subnets` linked **zero** categories.

## Why these URLs, and why #11317's 129 still aren't

The rule isn't count. It's whether a URL answers a query **nothing else of ours already answers**:

| family | keyed by | verdict |
|---|---|---|
| `/blocks/{hash}` × 1,557 | a block hash nobody types | collapsed in July |
| `/subnets/{n}/analysis` × 129 | a subnet `/subnets/{n}` **already ranks 4–8 for** | cannibalization — still GSC-gated |
| `/subnets/category/{x}` × 10 | a query we answer with nothing | **this** |

## 10, not 13

`storage` has 1 subnet; `search` and `privacy` have 2. Below three, a category page is a near-duplicate of the subnet it lists.

The threshold is applied to **live data** in three places — the sitemap builder, the hub links and the page itself — so a category that grows past it starts appearing and one that falls below stops, with no code change.

Copy is written **per category**, not templated. A family of pages differing only by a substituted noun is thin by nature however many words it counts.

Measured against real production data:

```
OK  inference   t=60 d=153 subnets=17 h2=3 prose=83%
OK  agents      t=57 d=158 subnets=13 h2=3 prose=86%
OK  compute     t=58 d=144 subnets= 9 h2=3 prose=88%
OK  finance     t=58 d=138 subnets= 8 h2=3 prose=89%
OK  prediction  t=50 d=128 subnets= 7 h2=3 prose=89%
OK  data        t=55 d=158 subnets= 7 h2=3 prose=90%
OK  science     t=58 d=159 subnets= 5 h2=3 prose=92%
OK  media       t=56 d=150 subnets= 4 h2=3 prose=93%
OK  robotics    t=59 d=155 subnets= 3 h2=3 prose=94%
OK  security    t=59 d=159 subnets= 3 h2=3 prose=94%
```

## Three defects the gates caught — all mine

- **`/subnets/category` 404'd.** A new intermediate path segment that isn't a page — precisely #11303's defect, and #11283's *derived* breadcrumb gate is what found it. It 301s to `/subnets` now, the same answer `/graphql` and `/tools` give.
- **`/subnets` went 495 → 672 KiB**, over its ratchet.
- **The hub linked 9 categories while the sitemap listed 10** — `robotics` missing.

The last two were **one mistake**: my component called `subnetsQuery()` while the hub calls `subnetsQuery({ q, limit })`. A different cache key meant a second full copy of 128 subnets dehydrated into the document *and* a smaller result set that dropped `robotics` below the threshold. Sharing the key fixed the payload, the counts and the links together.

This is the third time this epic that a gate written for an earlier defect caught a new one — which is what #11319 was for.

## Type change

`Subnet` gained the five fields this reads (`derived_categories`, `integration_readiness`, `official_surface_count`, `probed_surface_count`, `surface_count`). All were already returned by the API and preserved by `normalizeSubnet`'s spread; only the type was missing them.

## Validation

```
apps/ui  tsc --noEmit                 clean
apps/ui  eslint + prettier            clean
apps/ui  vitest run                   2297 tests
apps/ui  playwright indexable-routes  113 passed (3 new), against the built Worker
root     scan:public-safety           passed
```

Closes #11342
