### PR TITLE
Revert "fix(ui): remove an argument no query and no route accepts (#11340)"

### DIFF
--- a/apps/ui/src/components/metagraphed/home-watched-module.tsx
+++ b/apps/ui/src/components/metagraphed/home-watched-module.tsx
@@ -283,8 +283,8 @@ function WatchedValidators({ hotkeys }: { hotkeys: string[] }) {
   // Same sort + limit as the /validators index, so this shares that query's
   // cache key instead of firing a second 2000-row fetch.
   const validators =
-    useQuery(validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT })).data?.data
-      ?.validators ?? [];
+    useQuery(validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false }))
+      .data?.data?.validators ?? [];
   const watched = new Set(hotkeys);
 
   const { flashed, flash } = useRowFlash();

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -93,7 +93,8 @@ export function ValidatorsPage() {
         context="validators"
         fallback={<TableSkeleton rows={10} columns={8} />}
         retryQueryKeys={[
-          validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }).queryKey,
+          validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false })
+            .queryKey,
         ]}
       >
         <ValidatorsDirectory density={density} onDensityChange={onDensityChange} />
@@ -127,7 +128,7 @@ function ValidatorsDirectory({
   // key never changes with UI state, so sorting/searching re-uses the cached
   // full set instead of refetching.
   const res = useSuspenseQuery(
-    validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }),
+    validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false }),
   ).data;
   const all = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
@@ -215,7 +216,8 @@ function ValidatorsDirectory({
         <StaleBanner
           generatedAt={generatedAt}
           refreshQueryKeys={[
-            validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }).queryKey,
+            validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false })
+              .queryKey,
           ]}
         />
       ) : null}


### PR DESCRIPTION
The warn log's only fingerprint (tao-usd, 3x in the first post-deploy hour)
reproduces deterministically: every GET /api/v1/network/tao-usd
?include_points=false -- the #9720 'send me less' toggle, and the MCP
get_tao_usd tool's default -- was fingerprinted for omitting data.points,
the exact omission the caller asked for.

auditResponse derives its projected signal from the request URL, but only
read fields/sections. include_points is the same class of lever, and the
schema's required deliberately describes the unprojected response (#10960),
so the seam now carries the third signal. parseBooleanParam is strict --
anything but the literal 'false' defaults to true or 400s before the seam
sees a 200 -- so string equality is exactly the handler's own condition.
Both directions pinned: the omission is forgiven under the toggle, and the
same absence without it is still drift.

Closes #11079