### PR TITLE
fix(seo): IndexNow never announced the digests, or any new route (#11348)

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -22,6 +22,15 @@ on:
     branches: [main]
     paths:
       - "apps/ui/content/docs/**"
+      # #11348: the digests were missing. 285 pages whose whole value is being
+      # NEW, and this job never announced one of them, because the filter
+      # watched docs and the registry and they are neither.
+      - "apps/ui/content/news/**"
+      # And route files, so shipping a page tells a crawler. /subnets/with-api
+      # had to be submitted by hand because nothing here saw it. Only STATIC
+      # routes resolve to a URL (see urlForChangedPath); a param route expands
+      # to as many URLs as there are values and is covered by the sitemap run.
+      - "apps/ui/src/routes/**"
       - "registry/subnets/**"
       - "registry/providers/**"
   workflow_dispatch:

--- a/apps/ui/src/lib/metagraphed/indexnow.test.ts
+++ b/apps/ui/src/lib/metagraphed/indexnow.test.ts
@@ -125,3 +125,53 @@ describe("buildIndexNowPayload", () => {
     expect(buildIndexNowPayload(many, ORIGIN, "k")?.urlList).toHaveLength(INDEXNOW_MAX_URLS);
   });
 });
+
+describe("news digests and new routes are announced too (#11348)", () => {
+  const origin = "https://metagraph.sh";
+
+  it("maps a weekly digest to its page", () => {
+    // 285 pages this job never submitted: the path filter watched docs and the
+    // registry, and the digests are neither — so the one family whose whole
+    // value is being NEW was the family never announced.
+    expect(urlForChangedPath("apps/ui/content/news/sn38/2026-w25.mdx", origin)).toBe(
+      "https://metagraph.sh/news/sn38/2026-w25",
+    );
+  });
+
+  it("maps a subject index to the folder, not to /index", () => {
+    expect(urlForChangedPath("apps/ui/content/news/sn38/index.mdx", origin)).toBe(
+      "https://metagraph.sh/news/sn38",
+    );
+  });
+
+  it("maps a new static route to its URL", () => {
+    // Shipping a route is exactly when a crawler most needs telling, and this
+    // job was blind to it — /subnets/with-api had to be submitted by hand.
+    expect(urlForChangedPath("apps/ui/src/routes/subnets.with-api.tsx", origin)).toBe(
+      "https://metagraph.sh/subnets/with-api",
+    );
+    expect(urlForChangedPath("apps/ui/src/routes/apis.providers.tsx", origin)).toBe(
+      "https://metagraph.sh/apis/providers",
+    );
+  });
+
+  it("refuses to guess a URL it cannot know", () => {
+    // A param route expands to as many URLs as there are values; a page
+    // component is not a route at all; a test file is neither. Submitting a URL
+    // that 404s is worse than submitting nothing.
+    for (const path of [
+      "apps/ui/src/routes/subnets.category.$slug.tsx",
+      "apps/ui/src/routes/-subnets-index-page.tsx",
+      "apps/ui/src/routes/docs.raw.$.test.ts",
+      "apps/ui/src/routes/__root.tsx",
+    ]) {
+      expect(urlForChangedPath(path, origin), path).toBeNull();
+    }
+  });
+
+  it("leaves the docs and registry rules untouched", () => {
+    expect(urlForChangedPath("apps/ui/content/docs/economics.mdx", origin)).toBe(
+      "https://metagraph.sh/docs/economics",
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/indexnow.ts
+++ b/apps/ui/src/lib/metagraphed/indexnow.ts
@@ -46,6 +46,40 @@ export function urlForChangedPath(path: string, origin: string): string | null {
     const slug = doc[1].replace(/\/index$/, "");
     return `${origin}/docs/${slug}`.replace(/\/$/, "");
   }
+  // Weekly digests: apps/ui/content/news/sn38/2026-w25.mdx -> /news/sn38/2026-w25.
+  //
+  // #11348: 285 pages that this job never submitted. The path filter watched
+  // docs and the registry, and the digests are neither — so the one page family
+  // whose whole value is being NEW was the one family never announced. Same
+  // shape as the docs rule because they are the same kind of file.
+  const news = /^apps\/ui\/content\/news\/(.+)\.mdx$/.exec(path);
+  if (news?.[1]) {
+    const slug = news[1].replace(/\/index$/, "");
+    return `${origin}/news/${slug}`.replace(/\/$/, "");
+  }
+  // A STATIC route file: apps/ui/src/routes/subnets.with-api.tsx -> /subnets/with-api.
+  //
+  // Shipping a new route is exactly when a crawler most needs telling, and this
+  // job was blind to it — /subnets/with-api had to be submitted by hand.
+  //
+  // Static only. A param route (`subnets.category.$slug.tsx`) expands to as many
+  // URLs as there are values, which this function cannot know from a filename;
+  // those are covered by the sitemap run. Files prefixed `-` are page
+  // components, not routes, and `.test.` files are neither.
+  const route = /^apps\/ui\/src\/routes\/([^/]+)\.tsx?$/.exec(path);
+  if (
+    route?.[1] &&
+    !route[1].includes("$") &&
+    !route[1].startsWith("-") &&
+    !route[1].includes(".test")
+  ) {
+    const segments = route[1]
+      .replace(/\.index$/, "")
+      .replace(/^__root$/, "")
+      .split(".")
+      .filter((segment) => segment && segment !== "index");
+    if (segments.length > 0) return `${origin}/${segments.join("/")}`;
+  }
   // A subnet's registry record: registry/subnets/<slug>.json carries the
   // netuid in the file, not the name, so the caller resolves it — see
   // urlsForChangedPaths, which is given the netuid map.


### PR DESCRIPTION
## Summary

The IndexNow workflow tells Bing/Yandex which pages changed within minutes of a merge. Its core design is right and untouched: the change signal is the **git diff**, not the registry changelog — one publish reports ~2,837 modified artifacts because the 15-minute probe rewrites nearly everything, and submitting unchanged URLs is what gets a host discounted.

But its path filter watched docs and the registry, and missed two of the three things that create a page:

| missing | pages | consequence |
|---|---|---|
| `apps/ui/content/news/**` | **285** | the one family whose entire value is being *new* has never been announced, once |
| `apps/ui/src/routes/**` | every new route | `/subnets/with-api` shipped and nothing submitted it — you had to request it by hand |

## The refusals are the load-bearing part

Static routes only:

```
subnets.with-api.tsx           -> /subnets/with-api
apis.providers.tsx             -> /apis/providers
content/news/sn38/2026-w25.mdx -> /news/sn38/2026-w25
content/news/sn38/index.mdx    -> /news/sn38

subnets.category.$slug.tsx     -> null   param route: as many URLs as values
-subnets-index-page.tsx        -> null   a page component, not a route
docs.raw.$.test.ts             -> null   a test file
__root.tsx                     -> null   not a page
```

A param route expands to as many URLs as there are values, which a filename cannot tell you — those stay covered by the existing `--sitemap` run. Every refusal has a test, because **submitting a URL that 404s is worse than submitting nothing**, which is the rule this script already ships under for a subnet whose netuid will not resolve.

The docs and registry rules are unchanged, pinned by a test.

## Validation

```
apps/ui  tsc --noEmit        clean
apps/ui  prettier            clean
apps/ui  vitest run          2302 tests (5 new)
```

All eight mapping cases verified against the real function before the tests were written.

Closes #11348
