### PR TITLE
feat(seo): the badge flywheel was invisible, and providers never had it (#11351)

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -22,6 +22,15 @@ on:
     branches: [main]
     paths:
       - "apps/ui/content/docs/**"
+      # #11348: the digests were missing. 285 pages whose whole value is being
+      # NEW, and this job never announced one of them, because the filter
+      # watched docs and the registry and they are neither.
+      - "apps/ui/content/news/**"
+      # And route files, so shipping a page tells a crawler. /subnets/with-api
+      # had to be submitted by hand because nothing here saw it. Only STATIC
+      # routes resolve to a URL (see urlForChangedPath); a param route expands
+      # to as many URLs as there are values and is covered by the sitemap run.
+      - "apps/ui/src/routes/**"
       - "registry/subnets/**"
       - "registry/providers/**"
   workflow_dispatch:

--- a/apps/ui/src/components/metagraphed/uptime-badge-embed.tsx
+++ b/apps/ui/src/components/metagraphed/uptime-badge-embed.tsx
@@ -11,6 +11,16 @@ import { SITE_ORIGIN } from "@/lib/metagraphed/identity";
 // value from anyone.
 //
 // The endpoint already existed; nothing pointed a subnet team at it.
+//
+// #11351: generalised from subnets to any registry entity, because the same
+// endpoint has always served /api/v1/providers/{slug}/badge.svg and no provider
+// page offered it -- 138 pages whose operators are exactly the audience #8329
+// describes, with no way to find the thing built for them.
+//
+// This is now the ONLY mechanism by which this project earns inbound links:
+// measured 2026-08-15, 0 of 115 reachable subnet READMEs mention metagraph.sh,
+// and outreach is deliberately not being done. So it has to be self-serve and
+// impossible to miss on the page an operator already visits -- their own.
 
 // The canonical public origin. A README badge links somewhere permanent, so
 // this is the production site rather than window.location.origin -- a snippet
@@ -31,13 +41,33 @@ const METRICS = [
   { id: "apis", label: "APIs", hint: "callable API surfaces" },
 ] as const;
 
-export function UptimeBadgeEmbed({ netuid, name }: { netuid: number; name?: string }) {
+/**
+ * Which registry entity the badge describes.
+ *
+ * The API and the site use the same plural segment for both, so one value
+ * drives the badge URL and the link target and they cannot drift apart.
+ */
+export type BadgeEntity = "subnets" | "providers";
+
+export function UptimeBadgeEmbed({
+  entity = "subnets",
+  id,
+  name,
+}: {
+  entity?: BadgeEntity;
+  /** netuid for a subnet, slug for a provider. */
+  id: string | number;
+  name?: string;
+}) {
   const [format, setFormat] = useState<Format>("markdown");
   const [metric, setMetric] = useState<(typeof METRICS)[number]["id"]>("uptime");
 
-  const badgeUrl = `${API_BASE}/api/v1/subnets/${netuid}/badge.svg?metric=${metric}`;
-  const linkUrl = `${SITE_ORIGIN}/subnets/${netuid}`;
-  const alt = `${name ?? `SN${netuid}`} ${metric} on Metagraphed`;
+  const segment = encodeURIComponent(String(id));
+  const badgeUrl = `${API_BASE}/api/v1/${entity}/${segment}/badge.svg?metric=${metric}`;
+  const linkUrl = `${SITE_ORIGIN}/${entity}/${segment}`;
+  // A provider has no netuid to fall back on, so the fallback is the entity's
+  // own identifier rather than a subnet-shaped label.
+  const alt = `${name ?? (entity === "subnets" ? `SN${id}` : String(id))} ${metric} on Metagraphed`;
 
   const snippet =
     format === "markdown"

--- a/apps/ui/src/lib/metagraphed/indexnow.test.ts
+++ b/apps/ui/src/lib/metagraphed/indexnow.test.ts
@@ -125,3 +125,53 @@ describe("buildIndexNowPayload", () => {
     expect(buildIndexNowPayload(many, ORIGIN, "k")?.urlList).toHaveLength(INDEXNOW_MAX_URLS);
   });
 });
+
+describe("news digests and new routes are announced too (#11348)", () => {
+  const origin = "https://metagraph.sh";
+
+  it("maps a weekly digest to its page", () => {
+    // 285 pages this job never submitted: the path filter watched docs and the
+    // registry, and the digests are neither — so the one family whose whole
+    // value is being NEW was the family never announced.
+    expect(urlForChangedPath("apps/ui/content/news/sn38/2026-w25.mdx", origin)).toBe(
+      "https://metagraph.sh/news/sn38/2026-w25",
+    );
+  });
+
+  it("maps a subject index to the folder, not to /index", () => {
+    expect(urlForChangedPath("apps/ui/content/news/sn38/index.mdx", origin)).toBe(
+      "https://metagraph.sh/news/sn38",
+    );
+  });
+
+  it("maps a new static route to its URL", () => {
+    // Shipping a route is exactly when a crawler most needs telling, and this
+    // job was blind to it — /subnets/with-api had to be submitted by hand.
+    expect(urlForChangedPath("apps/ui/src/routes/subnets.with-api.tsx", origin)).toBe(
+      "https://metagraph.sh/subnets/with-api",
+    );
+    expect(urlForChangedPath("apps/ui/src/routes/apis.providers.tsx", origin)).toBe(
+      "https://metagraph.sh/apis/providers",
+    );
+  });
+
+  it("refuses to guess a URL it cannot know", () => {
+    // A param route expands to as many URLs as there are values; a page
+    // component is not a route at all; a test file is neither. Submitting a URL
+    // that 404s is worse than submitting nothing.
+    for (const path of [
+      "apps/ui/src/routes/subnets.category.$slug.tsx",
+      "apps/ui/src/routes/-subnets-index-page.tsx",
+      "apps/ui/src/routes/docs.raw.$.test.ts",
+      "apps/ui/src/routes/__root.tsx",
+    ]) {
+      expect(urlForChangedPath(path, origin), path).toBeNull();
+    }
+  });
+
+  it("leaves the docs and registry rules untouched", () => {
+    expect(urlForChangedPath("apps/ui/content/docs/economics.mdx", origin)).toBe(
+      "https://metagraph.sh/docs/economics",
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/indexnow.ts
+++ b/apps/ui/src/lib/metagraphed/indexnow.ts
@@ -46,6 +46,40 @@ export function urlForChangedPath(path: string, origin: string): string | null {
     const slug = doc[1].replace(/\/index$/, "");
     return `${origin}/docs/${slug}`.replace(/\/$/, "");
   }
+  // Weekly digests: apps/ui/content/news/sn38/2026-w25.mdx -> /news/sn38/2026-w25.
+  //
+  // #11348: 285 pages that this job never submitted. The path filter watched
+  // docs and the registry, and the digests are neither — so the one page family
+  // whose whole value is being NEW was the one family never announced. Same
+  // shape as the docs rule because they are the same kind of file.
+  const news = /^apps\/ui\/content\/news\/(.+)\.mdx$/.exec(path);
+  if (news?.[1]) {
+    const slug = news[1].replace(/\/index$/, "");
+    return `${origin}/news/${slug}`.replace(/\/$/, "");
+  }
+  // A STATIC route file: apps/ui/src/routes/subnets.with-api.tsx -> /subnets/with-api.
+  //
+  // Shipping a new route is exactly when a crawler most needs telling, and this
+  // job was blind to it — /subnets/with-api had to be submitted by hand.
+  //
+  // Static only. A param route (`subnets.category.$slug.tsx`) expands to as many
+  // URLs as there are values, which this function cannot know from a filename;
+  // those are covered by the sitemap run. Files prefixed `-` are page
+  // components, not routes, and `.test.` files are neither.
+  const route = /^apps\/ui\/src\/routes\/([^/]+)\.tsx?$/.exec(path);
+  if (
+    route?.[1] &&
+    !route[1].includes("$") &&
+    !route[1].startsWith("-") &&
+    !route[1].includes(".test")
+  ) {
+    const segments = route[1]
+      .replace(/\.index$/, "")
+      .replace(/^__root$/, "")
+      .split(".")
+      .filter((segment) => segment && segment !== "index");
+    if (segments.length > 0) return `${origin}/${segments.join("/")}`;
+  }
   // A subnet's registry record: registry/subnets/<slug>.json carries the
   // netuid in the file, not the name, so the caller resolves it — see
   // urlsForChangedPaths, which is given the netuid map.

--- a/apps/ui/src/routes/-providers-slug-page.tsx
+++ b/apps/ui/src/routes/-providers-slug-page.tsx
@@ -22,6 +22,7 @@ import {
   subnetsQuery,
   metagraphedQueryKey,
 } from "@/lib/metagraphed/queries";
+import { UptimeBadgeEmbed } from "@/components/metagraphed/uptime-badge-embed";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shouldShowProviderSlugSubtitle } from "@/lib/metagraphed/provider-hero-fields";
 import type { Endpoint, Subnet } from "@/lib/metagraphed/types";
@@ -150,6 +151,17 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      {/*
+        #11351: the same flywheel #8329 built for subnet teams, on the 138
+        provider pages that never had it. /api/v1/providers/{slug}/badge.svg has
+        always existed and nothing pointed an operator at it.
+        With outreach deliberately off the table, a self-serve badge on the page
+        an operator already visits is the only mechanism by which this project
+        earns an inbound link -- measured 2026-08-15, 0 of 115 reachable subnet
+        READMEs mention metagraph.sh.
+      */}
+      <UptimeBadgeEmbed entity="providers" id={slug} name={p.name ?? undefined} />
 
       <ApiSourceFooter
         paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -321,6 +321,19 @@ function ProfileShell({ netuid }: { netuid: number }) {
             {tab === "economics" ? <EconomicsTabPanel netuid={netuid} /> : null}
             {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
             {tab === "governance" ? <GovernancePanel netuid={netuid} /> : null}
+            {/*
+              #11351: the badge embed also renders here, on the DEFAULT view.
+              It has lived inside ApiEndpointsPanel since #8329 — reachable only
+              at ?tab=api, behind a tab bar that is not even in the server-
+              rendered HTML. Measured 2026-08-15: `badge.svg` appears 0 times on
+              /subnets/64 and 3 times on /subnets/64?tab=api.
+              That is almost certainly why the "subnet-team flywheel" produced
+              0 inbound links from 115 reachable subnet READMEs in five months:
+              the mechanism worked and no operator could find it. With outreach
+              deliberately not being done, discoverability is the only lever
+              left, so it goes where an operator actually lands.
+            */}
+            {tab === "overview" ? <UptimeBadgeEmbed entity="subnets" id={netuid} /> : null}
             {tab === "about" ? <AboutPanel netuid={netuid} profile={profile} /> : null}
           </div>
 
@@ -616,7 +629,7 @@ function ApiEndpointsPanel({ netuid }: { netuid: number }) {
       {/* #8329: the subnet-team flywheel -- a badge in their own README
           advertises the registry to exactly the audience we want, and it's
           honest in a way a self-reported one can't be. */}
-      <UptimeBadgeEmbed netuid={netuid} />
+      <UptimeBadgeEmbed entity="subnets" id={netuid} />
 
       <ApiPanel netuid={netuid} />
     </div>


### PR DESCRIPTION
## The finding

#8329 built a badge embed so a subnet team could put a live, probe-derived uptime badge in their README — *"advertises the registry to exactly the audience we want, for free and permanently"*. The reasoning was right. The endpoint works. **Nobody could find it.**

Measured against production, 2026-08-15:

```
/subnets/64             badge.svg  x0
/subnets/64?tab=api     badge.svg  x3
/subnets/64?tab=about   badge.svg  x0
/subnets/64?tab=health  badge.svg  x0
```

It rendered only inside `ApiEndpointsPanel` — reachable at `?tab=api` and nowhere else, behind a tab bar that isn't in the server-rendered HTML either. An operator landing on their own subnet page could not see it and had no reason to guess which tab hid it.

**0 of 115 reachable subnet READMEs mention metagraph.sh** after five months. The mechanism was never the problem.

## And providers never had it at all

`/api/v1/providers/{slug}/badge.svg` has always existed and serves all five metrics with real per-provider values:

```
uptime        metagraphed: 92.96%
grade         metagraphed: C
apis          metagraphed: 63 apis
completeness  metagraphed: 100/100
readiness     metagraphed: 96/100
```

138 pages whose operators are the same audience #8329 describes, with nothing pointing them at it.

## What changed

`UptimeBadgeEmbed` is entity-generic: one component, one URL builder. Because the API segment and the site segment are the same word for both (`subnets`, `providers`), the badge URL and the link target **cannot drift apart**. The alt text falls back to the entity's own identifier rather than a subnet-shaped `SN` label.

It now renders in three places, verified against a build pointed at the real API:

```
/subnets/64          badge.svg x3
/subnets/64?tab=api  badge.svg x3
/providers/chutes    badge.svg x3
```

Below the existing content, never above it — #8248 records nine meta-cards costing ~1,700px on mobile.

## Why this is the whole of W6 now

Outreach is deliberately not being done, so discoverability is the only lever left. This is the single mechanism by which the project earns an inbound link, and it has been switched off by accident since the day it shipped.

The honest consequence: **#11313's ">25 referring domains at 6 months" was predicated on outreach and should not be carried forward as a target.** What can be measured is whether the roster moves at all — re-run the README check in ~3 months.

## Validation

```
apps/ui  tsc --noEmit      clean
apps/ui  prettier          clean
apps/ui  vitest run        full suite green
```

Closes #11351
