### PR TITLE
test(cron): a lane's declared cadence must be the cron it runs on

### DIFF
--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -127,6 +127,126 @@ export const PRODUCER_CADENCE_SECS = {
 export type ProducerLane = keyof typeof PRODUCER_CADENCE_SECS;
 
 /**
+ * Which of those cadences belong to a WORKER CRON in this repo, and to which
+ * `workers/config.ts` constant (#10709).
+ *
+ * ## The drift this closes
+ *
+ * Most entries above are transcribed from metagraphed-infra's ansible defaults
+ * — this repo cannot check those, and the header says so. But two of them are
+ * OURS: the lane runs on a cron declared a few files away, so its interval is
+ * stated TWICE, in two languages, with nothing comparing them.
+ *
+ * That is not hypothetical. #9632 added `top_holders_holdings: 10_800` beside
+ * `TOP_HOLDERS_HOLDINGS_REFRESH_CRON = "49 *\/3 * * *"` in the same change, and
+ * nothing would have failed if one had said three hours and the other six.
+ *
+ * ## Why the consequence is an alarm rather than a stale lane
+ *
+ * The number here is what every staleness watchdog sizes its bound from —
+ * `missedTicksMs(lane, n)`. A cadence that disagrees with the cron does not
+ * make the producer late; it makes the ALARM wrong, in whichever direction the
+ * error points:
+ *
+ *   - declared too LONG  → the bound never fires, and a dead lane is silent.
+ *     That is #10566's shape.
+ *   - declared too SHORT → a healthy lane reads `stale` for most of every
+ *     cycle. That is #10329 (`account_identity` bounded at half a tick) and
+ *     #9301, both of which cost a real alarm and the trust in it.
+ *
+ * Both are invisible from either side, because each file is internally correct.
+ *
+ * ## Deliberately partial
+ *
+ * Only the lanes whose producer is a cron in THIS repo can be checked, so this
+ * map names them explicitly rather than deriving the set. An infra-poller
+ * cadence has no local expression to compare against, and inventing one would
+ * be a second copy of the thing this exists to stop.
+ * tests/producer-cadence.test.ts asserts the agreement.
+ */
+export const WORKER_CRON_LANES: Readonly<
+  Partial<Record<ProducerLane, string>>
+> = {
+  top_holders_flow: "TOP_HOLDERS_FLOW_CRON",
+  top_holders_holdings: "TOP_HOLDERS_HOLDINGS_REFRESH_CRON",
+} as const;
+
+/**
+ * How often a cron expression fires, in seconds — or null where the shape is
+ * not one this can reason about.
+ *
+ * NULL RATHER THAN A GUESS. A list expression (`3,13,23,...`) has no single
+ * interval unless the values are evenly spaced, and `*\/n` inside an hour field
+ * only divides evenly when n divides 24. Returning a number for a shape it
+ * cannot actually measure would put a wrong bound under a watchdog, which is
+ * the failure this whole module exists to prevent — so an unrecognised shape is
+ * reported as unmeasurable and the caller decides.
+ *
+ * Handles the shapes this repo's lane crons actually use:
+ *   `M H * * *`      once a day
+ *   `M *\/N * * *`    every N hours
+ *   `M * * * *`      hourly
+ *   `M1,M2,... * * * *`  evenly-spaced minutes within an hour
+ */
+export function cronIntervalSecs(expression: string): number | null {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+  const [minute, hour, dom, month, dow] = fields as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+  // Anything narrowing the DAY is not a fixed interval in seconds.
+  if (dom !== "*" || month !== "*" || dow !== "*") return null;
+
+  const minutes = evenlySpaced(minute, 60);
+  if (minutes === null) return null;
+
+  if (hour === "*") return minutes * 60;
+  const hourStep = /^\*\/(\d+)$/.exec(hour);
+  if (hourStep) {
+    const step = Number(hourStep[1]);
+    // 24 % step !== 0 means the last window of the day is short, so the
+    // interval is not constant.
+    if (!Number.isInteger(step) || step <= 0 || 24 % step !== 0) return null;
+    // A step within the hour AND across hours is two cadences, not one.
+    if (minutes !== 60) return null;
+    return step * 3_600;
+  }
+  // A single fixed hour: once a day, and only when the minute is fixed too.
+  if (/^\d+$/.test(hour)) return minutes === 60 ? 86_400 : null;
+  return null;
+}
+
+/** The interval a minute field describes, in minutes, or null when its values
+ * are not evenly spaced. `*` and `*\/n` are spaced by construction; a list is
+ * only if every gap matches, INCLUDING the wrap back to the first value. */
+function evenlySpaced(field: string, period: number): number | null {
+  if (field === "*") return 1;
+  const step = /^\*\/(\d+)$/.exec(field);
+  if (step) {
+    const n = Number(step[1]);
+    return Number.isInteger(n) && n > 0 && period % n === 0 ? n : null;
+  }
+  const values = field.split(",").map(Number);
+  if (values.some((v) => !Number.isInteger(v) || v < 0 || v >= period)) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 1) return period;
+  const gap = sorted[1]! - sorted[0]!;
+  for (let i = 1; i < sorted.length; i += 1) {
+    if (sorted[i]! - sorted[i - 1]! !== gap) return null;
+  }
+  // The wrap: the last value back round to the first must be the same gap, or
+  // the lane has a long window once a period.
+  if (period - sorted[sorted.length - 1]! + sorted[0]! !== gap) return null;
+  return gap;
+}
+
+/**
  * Which `lane_health` lane names are written by a producer we know the cadence
  * of (#10333).
  *

--- a/tests/producer-cadence.test.ts
+++ b/tests/producer-cadence.test.ts
@@ -36,6 +36,11 @@ import {
 } from "../src/nominator-positions-staleness-watchdog.ts";
 import { VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS } from "../src/top-holders-staleness-watchdog.ts";
+import {
+  WORKER_CRON_LANES,
+  cronIntervalSecs,
+} from "../src/producer-cadence.ts";
+import * as CONFIG from "../workers/config.ts";
 
 const HOUR = 60 * 60 * 1000;
 const MINUTE = 60 * 1000;
@@ -153,5 +158,135 @@ describe("the cadence table", () => {
   test("passWindowMs is a fraction of the same cadence", () => {
     assert.equal(passWindowMs("hotkey_alpha", 1 / 4), 6 * HOUR);
     assert.equal(passWindowMs("metagraph", 1 / 3), 5 * MINUTE);
+  });
+});
+
+// #10709: a lane whose producer is a cron in THIS repo states its interval
+// TWICE -- once as a cron expression, once as a number here -- and nothing
+// compared them.
+//
+// THE CONSEQUENCE IS A WRONG ALARM, NOT A LATE LANE. This number is what every
+// staleness watchdog sizes its bound from, so a disagreement does not make the
+// producer slow; it makes the alarm wrong in whichever direction the error
+// points. Declared too long and a dead lane is silent (#10566); too short and a
+// healthy lane reads `stale` for most of every cycle (#10329, #9301). Both are
+// invisible from either file, because each is internally correct.
+describe("a worker lane's declared cadence matches the cron it runs on", () => {
+  /** The exported cron string for a constant name, or null. workers/config.ts
+   * exports functions and objects too, so this is a type TEST rather than a
+   * cast over the whole namespace. */
+  const cronFor = (constant: string): string | null => {
+    const value = (CONFIG as unknown as Record<string, unknown>)[constant];
+    return typeof value === "string" ? value : null;
+  };
+
+  test("every named lane resolves to a real cron constant", () => {
+    for (const [lane, constant] of Object.entries(WORKER_CRON_LANES)) {
+      assert.notEqual(
+        cronFor(constant),
+        null,
+        `${lane} names ${constant}, which workers/config.ts does not export as a cron string`,
+      );
+    }
+  });
+
+  test("the declared seconds ARE the cron's interval", () => {
+    for (const [lane, constant] of Object.entries(WORKER_CRON_LANES)) {
+      const expression = cronFor(constant)!;
+      const measured = cronIntervalSecs(expression);
+      assert.notEqual(
+        measured,
+        null,
+        `${constant} = "${expression}" is a shape cronIntervalSecs cannot ` +
+          `measure, so this lane's cadence cannot be checked -- widen the ` +
+          `parser or give the lane a shape that has one interval`,
+      );
+      assert.equal(
+        measured,
+        PRODUCER_CADENCE_SECS[lane as keyof typeof PRODUCER_CADENCE_SECS],
+        `${lane} declares ${PRODUCER_CADENCE_SECS[lane as keyof typeof PRODUCER_CADENCE_SECS]}s ` +
+          `but ${constant} = "${expression}" fires every ${measured}s`,
+      );
+    }
+  });
+
+  // The map is the thing that can silently shrink: dropping a lane from it
+  // removes the check rather than failing it.
+  test("both worker-cron lanes are still named", () => {
+    assert.deepEqual(Object.keys(WORKER_CRON_LANES).sort(), [
+      "top_holders_flow",
+      "top_holders_holdings",
+    ]);
+  });
+});
+
+describe("cronIntervalSecs", () => {
+  test("measures the shapes this repo's lanes use", () => {
+    assert.equal(cronIntervalSecs("34 1 * * *"), 86_400);
+    assert.equal(cronIntervalSecs("49 */3 * * *"), 10_800);
+    assert.equal(cronIntervalSecs("26 * * * *"), 3_600);
+    assert.equal(cronIntervalSecs("11,41 * * * *"), 1_800);
+    assert.equal(cronIntervalSecs("3,13,23,33,43,53 * * * *"), 600);
+    assert.equal(cronIntervalSecs("*/15 * * * *"), 900);
+    assert.equal(cronIntervalSecs("* * * * *"), 60);
+  });
+
+  // NULL, NEVER A GUESS. Returning a number for a shape with no single interval
+  // would put a wrong bound under a watchdog -- the exact failure this file is
+  // about, arriving through the tool meant to prevent it.
+  test("an unevenly-spaced list has no single interval", () => {
+    // 1,16,31,46 IS even (15 apart, wrapping); 1,16,31,47 is not.
+    assert.equal(cronIntervalSecs("1,16,31,46 * * * *"), 900);
+    assert.equal(cronIntervalSecs("1,16,31,47 * * * *"), null);
+    // Evenly spaced within the hour but NOT across the wrap: 0,1,2 leaves a
+    // 57-minute gap once an hour, which is not a cadence.
+    assert.equal(cronIntervalSecs("0,1,2 * * * *"), null);
+  });
+
+  // A fixed hour with a STEPPED minute fires several times inside one hour and
+  // then not for twenty-three. Reading the minute step as the cadence would
+  // bound a daily lane at ten minutes -- the #10329 direction, and the worst of
+  // the two because it alarms on a lane that is working.
+  test("a stepped minute inside a fixed hour is not that step's cadence", () => {
+    assert.equal(cronIntervalSecs("*/10 1 * * *"), null);
+    assert.equal(cronIntervalSecs("0,30 1 * * *"), null);
+    // The same hour with a single fixed minute IS once a day.
+    assert.equal(cronIntervalSecs("34 1 * * *"), 86_400);
+  });
+
+  // An hour RANGE or list is a common cron shape and has no single interval --
+  // it must fall through rather than be measured by whichever branch is nearest.
+  test("an hour range or list is unmeasurable, not approximated", () => {
+    assert.equal(cronIntervalSecs("0 1-5 * * *"), null);
+    assert.equal(cronIntervalSecs("0 1,13 * * *"), null);
+    assert.equal(cronIntervalSecs("0 ? * * *"), null);
+  });
+
+  test("an hour step that does not divide the day has no single interval", () => {
+    assert.equal(cronIntervalSecs("0 */5 * * *"), null);
+    assert.equal(cronIntervalSecs("0 */6 * * *"), 21_600);
+  });
+
+  test("a day-narrowing field is not a fixed interval at all", () => {
+    assert.equal(cronIntervalSecs("0 0 1 * *"), null);
+    assert.equal(cronIntervalSecs("0 0 * * 1"), null);
+    assert.equal(cronIntervalSecs("0 0 * 3 *"), null);
+  });
+
+  test("two step fields at once are two cadences, not one", () => {
+    assert.equal(cronIntervalSecs("*/10 */2 * * *"), null);
+  });
+
+  test("a malformed expression is unmeasurable rather than a throw", () => {
+    for (const bad of [
+      "",
+      "  ",
+      "* * * *",
+      "* * * * * *",
+      "x * * * *",
+      "*/0 * * * *",
+    ]) {
+      assert.equal(cronIntervalSecs(bad), null, JSON.stringify(bad));
+    }
   });
 });


### PR DESCRIPTION
## A lane declares its interval twice, and nothing compared them

A lane whose producer is a cron in this repo states how often it runs in two places:

```ts
// workers/config.ts
export const TOP_HOLDERS_HOLDINGS_REFRESH_CRON = "49 */3 * * *";

// src/producer-cadence.ts
top_holders_holdings: 10_800,
```

I added both, in the same change (#9632), this afternoon. **Nothing would have failed if one had said three hours and the other six.**

## The consequence is a wrong alarm, not a late lane

`PRODUCER_CADENCE_SECS` is what every staleness watchdog sizes its bound from — `missedTicksMs(lane, n)`. A cadence that disagrees with the cron does not make the producer slow. It makes the **alarm** wrong, in whichever direction the error points:

| drift | result | precedent |
|---|---|---|
| declared **too long** | the bound never fires; a dead lane is silent | #10566 |
| declared **too short** | a healthy lane reads `stale` for most of every cycle | #10329, #9301 |

Both are invisible from either file, because each one is internally correct. #10329 is exactly this: `account_identity` bounded at twelve hours against a twenty-four-hour poller — half a tick, so the lane read `stale` for the back half of every cycle. That cost a real alarm and the trust in it.

## `cronIntervalSecs` returns null rather than a guess

The parser handles the shapes this repo's lane crons actually use, and refuses everything else:

```
"34 1 * * *"                → 86400     "1,16,31,47 * * * *"  → null  (uneven)
"49 */3 * * *"              → 10800     "0,1,2 * * * *"       → null  (uneven across the wrap)
"26 * * * *"                →  3600     "0 */5 * * *"         → null  (5 ∤ 24)
"11,41 * * * *"             →  1800     "*/10 */2 * * *"      → null  (two cadences)
"3,13,23,33,43,53 * * * *"  →   600     "0 0 * * 1"           → null  (narrows the day)
```

The wrap case is the one worth naming: `0,1,2 * * * *` is evenly spaced *within* the hour and leaves a 57-minute gap once an hour. A parser that only checked consecutive gaps would call that a one-minute cadence and put a one-minute bound under a watchdog — the failure this exists to prevent, arriving through the tool meant to prevent it. So an unmeasurable shape is reported as unmeasurable and the caller decides.

## Deliberately partial, and it says so

`WORKER_CRON_LANES` names its two lanes explicitly rather than deriving the set. Most of `PRODUCER_CADENCE_SECS` is transcribed from metagraphed-infra's ansible defaults — the module header already says this repo cannot check those — and inventing a local expression for them would be a second copy of the thing this stops. A test pins the map's contents, so dropping a lane from it removes the check **loudly** rather than quietly.

## Proved it can fail before landing it

A gate that has only ever passed is not evidence. Setting the cadence to `21_600` against the 3-hourly cron:

```
AssertionError: top_holders_holdings declares 21600s but
TOP_HOLDERS_HOLDINGS_REFRESH_CRON = "49 */3 * * *" fires every 10800s
```

Restored, 22 tests pass.

## Relationship to #10709

That issue proposes replacing 75 `if (cron === X)` branches with a lane registry keyed on declared cadence. This is not that, and does not pre-empt it — it closes one live drift the current design cannot see, and it makes the registry's job smaller by establishing that a lane's cadence and its schedule must agree. Commented there separately with a correction to that issue's free-minute count: the scarce unit is the literal **string**, not the minute, so the space is larger than "one slot".

Not building the dispatcher in this session, on that issue's own advice — getting it wrong stops 39 producers with no error anywhere.

## Validation

```
tsc --noEmit           clean
eslint + prettier      clean
validate:boundary-casts, unreferenced-exports/-modules,
  lane-topology, contract-drift                       pass
vitest  producer-cadence, lane-silence-cadence,
  top-holders-staleness-watchdog, api-crons-have-handlers   84 passed (15 new)
gate proven to fail on a real drift, then restored
```

Refs #10709
