### PR TITLE
fix(contract): the sweep verdict list had three mirrors, and one was missing a value

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -13076,8 +13076,8 @@ export interface components {
                 sources_read: number;
                 /** @description When this subnet's published surfaces were last searched for an address. NULL means never, or that the sweep store could not be read — either way nobody has looked, which is a different fact from having looked and found nothing. */
                 swept_at: string | null;
-                /** @description `none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet. */
-                verdict: ("none-published" | "candidates-found" | "unreachable" | "no-sources") | null;
+                /** @description `none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `listings-only` is also a finding, and a different one: every source that answered was a metagraph or holder dump whose addresses belong to other people, so there is nothing here to attribute. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet. */
+                verdict: ("none-published" | "candidates-found" | "unreachable" | "no-sources" | "listings-only") | null;
             } | null;
             contract_version?: string;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -59239,7 +59239,8 @@
                           "none-published",
                           "candidates-found",
                           "unreachable",
-                          "no-sources"
+                          "no-sources",
+                          "listings-only"
                         ],
                         "type": "string"
                       },
@@ -59247,7 +59248,7 @@
                         "type": "null"
                       }
                     ],
-                    "description": "`none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet."
+                    "description": "`none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `listings-only` is also a finding, and a different one: every source that answered was a metagraph or holder dump whose addresses belong to other people, so there is nothing here to attribute. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet."
                   }
                 },
                 "required": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -13076,8 +13076,8 @@ export interface components {
                 sources_read: number;
                 /** @description When this subnet's published surfaces were last searched for an address. NULL means never, or that the sweep store could not be read — either way nobody has looked, which is a different fact from having looked and found nothing. */
                 swept_at: string | null;
-                /** @description `none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet. */
-                verdict: ("none-published" | "candidates-found" | "unreachable" | "no-sources") | null;
+                /** @description `none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `listings-only` is also a finding, and a different one: every source that answered was a metagraph or holder dump whose addresses belong to other people, so there is nothing here to attribute. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet. */
+                verdict: ("none-published" | "candidates-found" | "unreachable" | "no-sources" | "listings-only") | null;
             } | null;
             contract_version?: string;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */

--- a/schemas-src/routes/subnet-wallets.ts
+++ b/schemas-src/routes/subnet-wallets.ts
@@ -16,6 +16,7 @@
 //      majority state at launch, and a null-vs-zero conflation here says "this
 //      owner kept nothing" about a subnet we simply could not measure.
 import { z } from "zod";
+import { SWEEP_VERDICTS } from "../../src/attribution-verdicts.ts";
 import { ArtifactBaseSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
@@ -99,13 +100,14 @@ const AttributionSearchSchema = z
       description:
         "Checksum-valid addresses found in the fetched bytes. A CANDIDATE, never an attribution: an address appearing on a team's page is not thereby theirs — a `validator_hotkey` field inside their own API response is the common false positive — and clearing the evidence bar is a human judgement.",
     }),
-    verdict: z
-      .enum(["none-published", "candidates-found", "unreachable", "no-sources"])
-      .nullable()
-      .meta({
-        description:
-          "`none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet.",
-      }),
+    // THE LIST, not a copy of it (#11227). This enum and the lane's union drifted
+    // once already -- `listings-only` was added to the lane and the CHECK
+    // constraint and not to this -- and the only thing that noticed was the MCP
+    // mirror validating its own response in production.
+    verdict: z.enum(SWEEP_VERDICTS).nullable().meta({
+      description:
+        "`none-published` is the expected majority answer and IS a finding: we read at least one source and found no address. `listings-only` is also a finding, and a different one: every source that answered was a metagraph or holder dump whose addresses belong to other people, so there is nothing here to attribute. `unreachable` and `no-sources` are statements about US — we could not look, or there was nothing to look at — and must never be read as a finding about the subnet.",
+    }),
   })
   .strict();
 

--- a/src/attribution-sweep.ts
+++ b/src/attribution-sweep.ts
@@ -33,13 +33,13 @@ import { probeJob } from "./probe-jobs.ts";
 // waiting to happen.
 import type { AttributionSweeps } from "../generated/db/types.ts";
 
-/** Verdicts, matching the CHECK constraint on attribution_sweeps. */
-export type SweepVerdict =
-  | "none-published"
-  | "candidates-found"
-  | "unreachable"
-  | "no-sources"
-  | "listings-only";
+// The verdict list lives in src/attribution-verdicts.ts and is re-exported
+// here, where every existing caller already imports it from. That module has no
+// dependencies on purpose: `schemas-src/routes/subnet-wallets.ts` publishes the
+// same list as a Zod enum and cannot reach into this one, which is how
+// `listings-only` came to be written by the lane, accepted by the database, and
+// REJECTED by the published contract on six subnets in production.
+import type { SweepVerdict } from "./attribution-verdicts.ts";
 
 /**
  * How many DISTINCT addresses one page may yield before it is a LISTING.

--- a/src/attribution-verdicts.ts
+++ b/src/attribution-verdicts.ts
@@ -1,0 +1,69 @@
+// What an attribution sweep can conclude, declared ONCE.
+//
+// ## Why this file exists rather than a union in the lane
+//
+// The verdict list had THREE mirrors and they drifted. `listings-only` was
+// added by #11227 to `src/attribution-sweep.ts`'s `SweepVerdict` union and to
+// `migrations/neon/0031`'s CHECK constraint — and not to the published Zod
+// enum in `schemas-src/routes/subnet-wallets.ts`.
+//
+// Nothing failed at build time, because a route's published enum and a lane's
+// TypeScript union are not compared anywhere. It failed in PRODUCTION, on the
+// six subnets that carry the new verdict:
+//
+//   McpResponseSchemaDriftError: get_subnet_wallets result drifted from its
+//   published outputSchema — invalid_value, expected one of
+//   ["none-published","candidates-found","unreachable","no-sources"]
+//
+// The REST route served it too; only the MCP mirror validates its own response,
+// which is the only reason it was visible at all.
+//
+// ## A CONSTANTS MODULE, with no imports, deliberately
+//
+// `schemas-src/` is the contract's source and must stay cheap to import: the
+// lane it would otherwise have to reach into pulls in the queue runner, the
+// probe-job client and the store. A route schema importing that would drag the
+// whole producer into the contract build, which is the shape
+// #11061 records as breaking the data-api bundle.
+//
+// So the shared thing is the LIST, and it has no dependencies at all. Both the
+// lane and the schema import it, and the type is derived from the array rather
+// than written beside it — a union that can disagree with the runtime value is
+// the same defect one level down.
+//
+// ## The third mirror is a database CHECK, and it is pinned by a test
+//
+// `attribution_sweeps_verdict_is_known` cannot import anything. Its values are
+// asserted against this list in tests/attribution-sweep.test.ts by reading the
+// migration file, so the constraint and the contract cannot drift either — the
+// gap that let this one through.
+
+/**
+ * Every verdict a sweep may record, in the order they are documented.
+ *
+ * `as const` because the array IS the contract: `SweepVerdict` is derived from
+ * it, `z.enum()` publishes it, and the CHECK constraint is tested against it.
+ */
+export const SWEEP_VERDICTS = [
+  /** We read at least one source and found no address. A FINDING, and the
+   * expected majority answer. */
+  "none-published",
+  /** We read at least one source and found addresses worth a human's look. */
+  "candidates-found",
+  /** We could not read the sources. A statement about US, never about the
+   * subnet — collapsing it into `none-published` would turn our own outage
+   * into a finding about somebody else. */
+  "unreachable",
+  /** There was nothing to look at. Also a statement about us. */
+  "no-sources",
+  /** Every source that answered was a LISTING — a metagraph or holder dump
+   * whose addresses belong to other people. Distinct from `none-published`,
+   * which would claim we found no address when we found twelve hundred, and
+   * from `candidates-found`, which would put strangers' keys in a review
+   * queue (#11227). */
+  "listings-only",
+] as const;
+
+/** Verdicts, matching the CHECK constraint on `attribution_sweeps`. Derived
+ * from the array above so the two cannot disagree. */
+export type SweepVerdict = (typeof SWEEP_VERDICTS)[number];

--- a/tests/attribution-sweep.test.ts
+++ b/tests/attribution-sweep.test.ts
@@ -10,6 +10,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { SEND_BATCH_MAX } from "../src/lane-queue.ts";
+import { SWEEP_VERDICTS } from "../src/attribution-verdicts.ts";
+import { SubnetWalletsArtifactSchema } from "../schemas-src/routes/subnet-wallets.ts";
 import worker, {
   fetchSweepText,
   handleScheduled,
@@ -1295,5 +1297,82 @@ describe("the listing cap", () => {
     // reports about US rather than about its pages.
     assert.equal(sweepVerdict(3, 0, 0, 0), "unreachable");
     assert.equal(sweepVerdict(0, 0, 0, 0), "no-sources");
+  });
+});
+
+// #11227: the verdict list had THREE mirrors and they drifted. `listings-only`
+// was added to the lane's union and to migrations/neon/0031's CHECK constraint,
+// and NOT to the published Zod enum -- so six subnets in production served a
+// value their own contract rejects, and the only thing that noticed was the MCP
+// mirror validating its own response:
+//
+//   McpResponseSchemaDriftError: get_subnet_wallets result drifted from its
+//   published outputSchema
+//
+// Two of the three now share one declaration. The third is SQL and cannot
+// import, so it is read off disk and compared here -- which is the gap that let
+// this through.
+describe("every mirror of the verdict list agrees", () => {
+  test("the published contract accepts exactly the declared verdicts", () => {
+    const parseVerdict = (verdict: unknown) =>
+      SubnetWalletsArtifactSchema.shape.attribution_search.safeParse({
+        swept_at: "2026-08-15T14:29:03.921Z",
+        sources_checked: 8,
+        sources_read: 5,
+        candidates: 6,
+        verdict,
+      }).success;
+
+    for (const verdict of SWEEP_VERDICTS) {
+      assert.equal(
+        parseVerdict(verdict),
+        true,
+        `${verdict} must be publishable`,
+      );
+    }
+    // The positive control: an undeclared verdict is still refused, so the
+    // assertions above are not passing on an enum that accepts anything.
+    assert.equal(parseVerdict("made-up"), false);
+    // Null is the "never swept" state and stays valid.
+    assert.equal(parseVerdict(null), true);
+  });
+
+  test("the database CHECK constraint accepts exactly the same set", async () => {
+    const dir = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "migrations",
+      "neon",
+    );
+    const files = await fs.readdir(dir);
+    // The NEWEST migration touching the constraint is the live one; an older
+    // widening is history, and comparing against it would pin the wrong set.
+    const constraintFiles = (
+      await Promise.all(
+        files
+          .filter((f) => f.endsWith(".sql"))
+          .sort()
+          .map(async (f) => ({
+            file: f,
+            sql: await fs.readFile(path.join(dir, f), "utf8"),
+          })),
+      )
+    ).filter(({ sql }) => sql.includes("attribution_sweeps_verdict_is_known"));
+    assert.ok(
+      constraintFiles.length > 0,
+      "no migration declares attribution_sweeps_verdict_is_known",
+    );
+    const newest = constraintFiles[constraintFiles.length - 1]!;
+    const clause = /CHECK\s*\(\s*verdict\s+IN\s*\(([^)]*)\)/i.exec(newest.sql);
+    assert.ok(clause, `${newest.file} has no readable verdict IN (...) clause`);
+    const declared = [...clause![1]!.matchAll(/'([^']+)'/g)].map((m) => m[1]!);
+    assert.deepEqual(
+      [...declared].sort(),
+      [...SWEEP_VERDICTS].sort(),
+      `${newest.file}'s CHECK constraint and SWEEP_VERDICTS disagree -- a ` +
+        `verdict the lane can write and the database rejects stops the whole ` +
+        `pass, and one the database accepts and the contract does not is ` +
+        `served as a schema violation`,
+    );
   });
 });

--- a/tests/degenerate-output-watchdog.test.ts
+++ b/tests/degenerate-output-watchdog.test.ts
@@ -122,7 +122,7 @@ describe("tallySql", () => {
 describe("the declared lanes", () => {
   test("attribution_sweeps declares the verdict its own type names", () => {
     // The barren value has to be one the producer can actually write, or the
-    // check silently never matches. `SweepVerdict` in src/attribution-sweep.ts
+    // check silently never matches. `SweepVerdict` in src/attribution-verdicts.ts
     // is the union; `no-sources` is its "publishes nothing fetchable" member.
     assert.equal(SWEEP.table, "attribution_sweeps");
     assert.equal(SWEEP.barren, "no-sources");


### PR DESCRIPTION
## Found in production, not in CI

Sweeping PostHog error tracking turned up an issue first seen **07:21 today**:

```
McpResponseSchemaDriftError: get_subnet_wallets result drifted from its
published outputSchema — invalid_value, expected one of
["none-published","candidates-found","unreachable","no-sources"]
```

`listings-only` was added by #11227 to the lane's `SweepVerdict` union **and** to `migrations/neon/0031`'s CHECK constraint — and not to the published Zod enum. Nothing failed at build time, because a route's published enum and a lane's TypeScript union are compared nowhere.

**It is live on six subnets right now:**

```sql
SELECT verdict, COUNT(*) FROM attribution_sweeps GROUP BY verdict;
 none-published    67
 candidates-found  48
 unreachable        7
 listings-only      6   <- served against a contract that rejects it
```

The REST route serves the same body with no complaint — it validates nothing on the way out. The MCP mirror is the only surface that checks its own response, which is the only reason this was visible at all.

## One declaration, and the reason it is its own file

`src/attribution-verdicts.ts` holds the list, and the type is **derived from the array** rather than written beside it — a union that can disagree with the runtime value is the same defect one level down.

It has **no imports**, deliberately. `schemas-src/` is the contract's source and has to stay cheap to import; reaching into `src/attribution-sweep.ts` for the list would drag the queue runner, the probe-job client and the store into the contract build — the shape that broke the data-api bundle before.

## The third mirror is SQL, so the test reads it off disk

A CHECK constraint cannot import a constant. The test finds the **newest** migration declaring `attribution_sweeps_verdict_is_known` (an older widening is history, and pinning against it would pin the wrong set), parses its `IN (...)` list, and compares it to `SWEEP_VERDICTS`.

That is precisely the gap that let this through: two of three mirrors now share a declaration, and the one that cannot is compared.

## Proved both halves fail

```
# enum reverted to the pre-fix four
AssertionError: listings-only must be publishable

# CHECK constraint narrowed
AssertionError: 0031_attribution_sweeps_listings_only.sql's CHECK constraint and
SWEEP_VERDICTS disagree -- a verdict the lane can write and the database rejects
stops the whole pass, and one the database accepts and the contract does not is
served as a schema violation
```

Both restored; 71 tests pass. The enum assertion carries a **positive control** (`"made-up"` must be refused), so it cannot pass on an enum that accepts anything — and `null` stays valid, since it is the never-swept state.

## Also fixed while here

The published description had no reason to explain `listings-only` before, because it did not admit it existed. It now says what the verdict **means**: every source that answered was a metagraph or holder dump whose addresses belong to other people, so there is nothing to attribute — a finding, and a different one from `none-published`. A stale pointer in `tests/degenerate-output-watchdog.test.ts` naming the old home of `SweepVerdict` was repointed.

## Validation

```
tsc --noEmit                                  clean
eslint + prettier                             clean
npm run build                                 openapi + types regenerated
validate:api/openapi/types/contract-drift,
  single-schema-source, schema-enums, docs,
  mcp, migrations, unreferenced-exports/-modules,
  scan:public-safety                          all pass
vitest attribution-sweep, degenerate-output-watchdog,
  zod-schemas                                 427 passed (2 new)
unreferenced-exports                          731, at the ceiling
```
