### PR TITLE
fix(alarm): a watchdog's own verdict row needs a cadence floor, or it alarms at birth

### DIFF
--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -70,6 +70,26 @@ export const PRODUCER_CADENCE_SECS = {
   /** The top-holders flow materialization, rebuilt daily. */
   top_holders_flow: 86_400,
   /**
+   * The top-holders WATCHDOG's own tick -- TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
+   * twice hourly.
+   *
+   * A WATCHDOG IS THE PRODUCER OF ITS OWN VERDICT ROW, and that is the sense
+   * this table is keyed in: `laneSilenceCadenceMs` asks "how often does this
+   * lane_health row get written", and for `top-holders-flow-staleness` /
+   * `top-holders-holdings-staleness` the answer is the watchdog's cron, not the
+   * cadence of the artifact it judges. The two are different numbers -- the
+   * flow artifact is daily and the holdings half three-hourly, while both
+   * verdicts are written every 30 minutes.
+   *
+   * WITHOUT THIS THE BOUND IS THE OBSERVED SAMPLE ALONE, and a lane's FIRST
+   * hours are a sample of one or two. `top-holders-holdings-staleness` alarmed
+   * once at 14:29Z on 2026-08-15, 66 minutes after its first row, against a
+   * bound derived from the only gap it had seen -- and then never again,
+   * because by the third row the sample was stable. Every new watchdog lane
+   * gets that birth alarm; a declared floor is what removes it.
+   */
+  top_holders_staleness_watchdog: 1_800,
+  /**
    * The STORE-backed half of that same artifact, republished three-hourly by
    * TOP_HOLDERS_HOLDINGS_REFRESH_CRON (#9632).
    *
@@ -169,6 +189,7 @@ export const WORKER_CRON_LANES: Readonly<
 > = {
   top_holders_flow: "TOP_HOLDERS_FLOW_CRON",
   top_holders_holdings: "TOP_HOLDERS_HOLDINGS_REFRESH_CRON",
+  top_holders_staleness_watchdog: "TOP_HOLDERS_STALENESS_WATCHDOG_CRON",
 } as const;
 
 /**
@@ -298,6 +319,12 @@ export const LANE_PRODUCER: Readonly<Record<string, ProducerLane>> = {
   "neon:account-identity": "account_identity",
   "subnet-hyperparams": "subnet_hyperparams",
   "neon:subnet-hyperparams": "subnet_hyperparams",
+  // The top-holders watchdog's own two verdict rows. Mapped to the WATCHDOG's
+  // cadence rather than to either artifact's: these rows are written by the
+  // watchdog cron, so that is the interval a silence is measured against. Their
+  // STALENESS bounds are separate and live in the watchdog itself.
+  "top-holders-flow-staleness": "top_holders_staleness_watchdog",
+  "top-holders-holdings-staleness": "top_holders_staleness_watchdog",
   "self-stake": "self_stake",
   "neon:self-stake": "self_stake",
   "subnet-identity": "subnet_identity",

--- a/tests/producer-cadence.test.ts
+++ b/tests/producer-cadence.test.ts
@@ -14,6 +14,7 @@ import {
   LANE_PRODUCER,
   PRODUCER_CADENCE_SECS,
   cadenceMs,
+  laneSilenceCadenceMs,
   missedTicksMs,
   passWindowMs,
   type ProducerLane,
@@ -212,10 +213,43 @@ describe("a worker lane's declared cadence matches the cron it runs on", () => {
 
   // The map is the thing that can silently shrink: dropping a lane from it
   // removes the check rather than failing it.
-  test("both worker-cron lanes are still named", () => {
+  // A PROMPT TO THINK, not to widen: dropping a lane from the map removes its
+  // check rather than failing it, so the set is pinned and every addition is
+  // deliberate. `top_holders_staleness_watchdog` is the WATCHDOG's own tick --
+  // a watchdog is the producer of its verdict row, and that row's cadence is
+  // the watchdog cron rather than the cadence of anything it judges.
+  // The birth alarm this mapping removes: `top-holders-holdings-staleness`
+  // fired once at 14:29Z on 2026-08-15, 66 minutes after its first row, against
+  // a silence bound derived from the only gap it had seen. Its verdict rows
+  // have landed every 30 minutes since with no gap at all -- lane_health shows
+  // 13:23, 13:53, 14:23, 14:53, 15:23 -- so the alarm was about the sample, not
+  // the lane. A declared floor is what makes a new lane's first hours quiet.
+  test("both top-holders verdict rows are floored at the watchdog's own tick", () => {
+    for (const lane of [
+      "top-holders-flow-staleness",
+      "top-holders-holdings-staleness",
+    ]) {
+      assert.equal(LANE_PRODUCER[lane], "top_holders_staleness_watchdog", lane);
+    }
+    // A sample of one 30-minute gap can no longer bound the lane below the
+    // watchdog's real cadence.
+    assert.equal(
+      laneSilenceCadenceMs("top-holders-holdings-staleness", 30 * MINUTE),
+      30 * MINUTE,
+    );
+    // And with NO sample at all -- the state a lane is in on its first tick --
+    // the floor answers instead of nothing.
+    assert.equal(
+      laneSilenceCadenceMs("top-holders-holdings-staleness", null),
+      30 * MINUTE,
+    );
+  });
+
+  test("the worker-cron lanes are still named", () => {
     assert.deepEqual(Object.keys(WORKER_CRON_LANES).sort(), [
       "top_holders_flow",
       "top_holders_holdings",
+      "top_holders_staleness_watchdog",
     ]);
   });
 });


### PR DESCRIPTION
## The lane was never silent

`top-holders-holdings-staleness` fired the lane-silence alarm once, at **14:29Z** today:

```
lane top-holders-holdings-staleness is stale: 1.1h (producer cadence 30 min)
```

It is not. `lane_health` shows its verdicts landing every thirty minutes since the lane was born, with no gap:

```
13:23:00Z  stale    <- first row, 2 minutes after the #11333 deploy
13:53:00Z  stale
14:23:00Z  stale    <- 6 minutes before the alarm
14:53:00Z  stale
15:23:00Z  stale
```

(The `stale` verdicts are correct and separate — the published artifact's holdings half is 13 h old because the first refresh tick has not run yet. That is #11347, and it self-clears at 15:49Z.)

## It was about the sample

`laneSilenceCadenceMs` floors the **observed** maximum gap with the lane's **declared** producer cadence:

```ts
const floor = declared ? cadenceMs(declared) : null;
if (observed === null) return floor;
return floor === null ? observed : Math.max(observed, floor);
```

An unmapped lane has no floor, so the bound is whatever the observations happen to show. In a lane's first hour that is a **sample of one**, and any measurement wider than that single gap trips it.

`PRODUCER_CADENCE_SECS`'s own header already records this failure in the other direction — `self-stake` alarmed at "20.2h (producer cadence 3.1h)" because its bound came from intra-pass minutes. This is the same defect at a lane's birth rather than in its steady state, and **every new watchdog lane gets it**. Neither top-holders verdict row was mapped; the flow one only escaped because its sample has been stable for weeks.

## A watchdog is the producer of its own verdict row

That is the sense the table is keyed in: `laneSilenceCadenceMs` asks *how often does this lane_health row get written*, and for these two the answer is `TOP_HOLDERS_STALENESS_WATCHDOG_CRON` — **not** the cadence of either artifact they judge. The flow artifact is daily and the holdings half three-hourly, while both verdicts are written every thirty minutes. Their **staleness** bounds are a different number and stay in the watchdog.

## #11353's gate covered the new entry for free

Adding `top_holders_staleness_watchdog: 1_800` needed no new assertion — the agreement gate that merged an hour ago checks it against `"22,52 * * * *"`, so the cadence is verified rather than claimed in a comment.

Its map-contents pin also did its job: it **failed the moment the third lane was added**, which is what a prompt-to-think is for. Widened deliberately, with the reason written down.

## Why the existing test does not reach this

`tests/lane-silence-cadence.test.ts` already asserts that a `<lane>-staleness-watchdog.ts` and `LANE_PRODUCER` cannot disagree — but it matches on the watchdog's **file name** (`top-holders`), and these rows are written under different lane names (`top-holders-flow-staleness`, `top-holders-holdings-staleness`). That test is correct as written; it simply cannot see this case, and the new one names both rows explicitly.

## Validation

```
tsc --noEmit                                     clean
eslint + prettier                                clean
validate:unreferenced-exports, lane-topology,
  contract-drift                                 pass
vitest producer-cadence, lane-silence-cadence,
  top-holders-staleness-watchdog                 79 passed (1 new)
```
