### PR TITLE
fix(alarm): nominator-positions is bounded under its producer's real ceiling

### DIFF
--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -68,7 +68,7 @@ import { requireFullScanValue } from "./lane-table-topology.ts";
 /**
  * How old the ledger may get before this is a stall.
  *
- * THIRTY HOURS, not the neurons lane's 45 minutes, and the difference is the
+ * THIRTY-SIX HOURS, not the neurons lane's 45 minutes, and the difference is the
  * work: this lane is a full SubtensorModule::Alpha scan (~153k rows across
  * every coldkey on the network), which is why it never shared the 15-minute
  * metagraph cadence even when it ran.
@@ -83,17 +83,43 @@ import { requireFullScanValue } from "./lane-table-topology.ts";
  * alerted for roughly three quarters of every day on a lane working perfectly
  * -- the failure mode where an alarm that always fires stops being read.
  *
- * 30h is one missed pass plus slack for the scan itself (~4 minutes at the
- * measured ~3,100 rows/sec) and cron jitter. It fires only once a pass has
- * genuinely been skipped, and still catches a writer that stopped entirely
- * inside a day and a quarter rather than never.
+ * CORRECTED AGAIN, from 30h, and for the same reason one level finer: 30h was
+ * "one missed pass plus slack for the scan itself (~4 minutes) and cron
+ * jitter", and the producer's real worst case is far wider than jitter.
+ * Measured against production 2026-08-15 over 29 consecutive pass gaps:
+ *
+ *     min 0.66h    p90 24.41h    MAX 34.57h
+ *     4 gaps exceed the 24h cadence; 2 exceed the 30h bound
+ *
+ * A gap of 34.6h is not a skipped pass -- a skipped pass on a daily poller is
+ * ~48h. It is the pass running LATE, which is what a container running its
+ * lanes sequentially does when something ahead of this one runs long. The
+ * premise "a healthy lane presents an age anywhere in [0h, 24h+scan]" is
+ * therefore measurably false; the observed range is [0.66h, 34.57h].
+ *
+ * What that cost, from `lane_health` over 535 ticks: 519 `ok` (worst age
+ * 29.95h, just under the old bound) and **9 age-based `stale` verdicts between
+ * 30.02h and 33.02h**, every one of them from the two late passes above rather
+ * than from a producer that stopped. An alarm firing on a working lane 3% of
+ * the time is the #9301 failure this constant has already been corrected for
+ * once -- corrected then from 6h, and still left under the real ceiling.
+ *
+ * THIRTY-SIX HOURS: 1.5 ticks, clearing the measured 34.57h maximum by ~1.4h.
+ * The cost is stated rather than hidden -- a writer that stops entirely is now
+ * reported six hours later than before, at a day and a half rather than a day
+ * and a quarter. Against a daily producer that is still well inside "caught
+ * the same day", and it buys an alarm that means something when it fires.
+ *
+ * NOT a suppression of a known-bad state (which #9475 rightly refuses): the
+ * lane is healthy in every one of these cases, and the bound was describing a
+ * cadence the producer does not have.
  *
  * Overridable per-deployment via NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS so
  * the number can follow the Container's cadence without a code deploy.
  */
 export const NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS = missedTicksMs(
   "validator_nominators",
-  1.25,
+  1.5,
 );
 
 /**

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -34,7 +34,13 @@ import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
 
 const NOW = 1_785_800_000_000;
+
 const HOUR = 60 * 60_000;
+
+/** An age comfortably past whatever the bound currently is. Derived so the
+ * fixtures do not have to be rewritten every time the threshold is re-sized
+ * against a fresh measurement of the producer. */
+const PAST_THRESHOLD = NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS + HOUR;
 
 /** A pass that covered the keyspace, so coverage is never the thing under test
  * unless a case says so. */
@@ -107,15 +113,17 @@ describe("evaluateNominatorPositionsStaleness", () => {
     assert.equal(fresh.reason, null);
     assert.equal(fresh.age_ms, 2 * HOUR);
 
-    // 31h, not 7h: the threshold moved to 30h in #9301 once the lane had a
-    // real producer on a 24h tick. A 7-hour-old capture is now a HEALTHY
-    // mid-cycle reading -- see the constant's own header.
+    // DERIVED from the threshold, not a literal. This fixture has been
+    // rewritten twice as the bound moved (6h -> 30h in #9301, 30h -> 36h once
+    // the producer's real 34.57h worst case was measured), and a hard-coded
+    // hour count is a test that fails for the wrong reason every time the
+    // number it is testing changes.
     const stalled = evaluateNominatorPositionsStaleness(
-      inputs({ latestCapturedAtMs: NOW - 31 * HOUR }),
+      inputs({ latestCapturedAtMs: NOW - PAST_THRESHOLD }),
     );
     assert.equal(stalled.stale, true);
     assert.equal(stalled.reason, "stale");
-    assert.equal(stalled.latest_captured_at, NOW - 31 * HOUR);
+    assert.equal(stalled.latest_captured_at, NOW - PAST_THRESHOLD);
   });
 
   test("a capture from the middle of the producer's 24h cycle is quiet", () => {
@@ -211,7 +219,10 @@ describe("evaluateNominatorPositionsStaleness", () => {
     // If a whole 24h pass has been missed, "the producer stopped" is the
     // headline and the coverage of its last attempt is a detail.
     const verdict = evaluateNominatorPositionsStaleness(
-      inputs({ latestCapturedAtMs: NOW - 34 * HOUR, coveredColdkeys: 11_800 }),
+      inputs({
+        latestCapturedAtMs: NOW - PAST_THRESHOLD,
+        coveredColdkeys: 11_800,
+      }),
     );
     assert.equal(verdict.reason, "stale");
   });
@@ -366,7 +377,7 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
   });
 
   test("a stalled lane records ONE exception naming the age and the route it breaks", async () => {
-    const { env } = fakeDb(NOW - 34 * HOUR);
+    const { env } = fakeDb(NOW - PAST_THRESHOLD);
     const recorded: { error?: Error; route?: string; errorCode?: string }[] =
       [];
     const result = await runNominatorPositionsStalenessWatchdog(env, {
@@ -380,8 +391,18 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
     assert.equal(recorded.length, 1);
     assert.equal(recorded[0]!.route, "watchdog:nominator-positions-staleness");
     assert.equal(recorded[0]!.errorCode, "stale_lane");
-    assert.match(String(recorded[0]!.error?.message), /34\.0 h old/);
-    assert.match(String(recorded[0]!.error?.message), /threshold 30 h/);
+    // Both numbers derived, so the message assertion follows the bound rather
+    // than pinning a stale pair of literals.
+    assert.match(
+      String(recorded[0]!.error?.message),
+      new RegExp(`${(PAST_THRESHOLD / HOUR).toFixed(1)} h old`),
+    );
+    assert.match(
+      String(recorded[0]!.error?.message),
+      new RegExp(
+        `threshold ${NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS / HOUR} h`,
+      ),
+    );
     assert.match(String(recorded[0]!.error?.message), /positions/);
   });
 

--- a/tests/producer-cadence.test.ts
+++ b/tests/producer-cadence.test.ts
@@ -96,7 +96,12 @@ describe("thresholds are unchanged by the refactor", () => {
     assert.equal(HOTKEY_ALPHA_PASS_WINDOW_MS, 6 * HOUR);
     assert.equal(NEURONS_STALENESS_THRESHOLD_MS, 45 * MINUTE);
     assert.equal(NEURONS_PASS_WINDOW_MS, 5 * MINUTE);
-    assert.equal(NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS, 30 * HOUR);
+    // MOVED DELIBERATELY, and this pin is what made it deliberate. 30h was
+    // the pre-#10291 literal and is no longer the bound: measured over 29
+    // consecutive pass gaps on 2026-08-15 the producer's worst case is 34.57h,
+    // and lane_health carried 9 age-based `stale` verdicts between 30.02h and
+    // 33.02h on a lane that never skipped a pass. 36h clears the ceiling.
+    assert.equal(NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS, 36 * HOUR);
     assert.equal(NOMINATOR_POSITIONS_PASS_WINDOW_MS, 4 * HOUR);
     assert.equal(VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS, 4 * HOUR);
     assert.equal(TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS, 48 * HOUR);
@@ -150,10 +155,10 @@ describe("the cadence table", () => {
   });
 
   test("missedTicksMs is the cadence times the ticks, fractional allowed", () => {
-    // nominator-positions sits at 1.25 ticks; forcing an integer would change
-    // a live threshold for the sake of the abstraction.
+    // nominator-positions sits at 1.5 ticks; forcing an integer would change a
+    // live threshold for the sake of the abstraction.
     assert.equal(missedTicksMs("account_balances", 2), 12 * HOUR);
-    assert.equal(missedTicksMs("validator_nominators", 1.25), 30 * HOUR);
+    assert.equal(missedTicksMs("validator_nominators", 1.5), 36 * HOUR);
   });
 
   test("passWindowMs is a fraction of the same cadence", () => {
@@ -322,5 +327,34 @@ describe("cronIntervalSecs", () => {
     ]) {
       assert.equal(cronIntervalSecs(bad), null, JSON.stringify(bad));
     }
+  });
+});
+
+// The bound must clear the producer's measured worst case, not its nominal
+// cadence. This is the assertion #9301 and #10329 both exist because nobody
+// wrote: a threshold sized on "cadence plus jitter" alarms on a working lane
+// the first time the producer runs late, and a late pass is not a missed one.
+describe("nominator-positions is bounded above its producer's real ceiling", () => {
+  // Measured against production 2026-08-15, 29 consecutive pass gaps of
+  // `nominator_positions.captured_at`: min 0.66h, p90 24.41h, max 34.57h.
+  const OBSERVED_MAX_GAP_MS = 34.57 * HOUR;
+
+  test("the threshold clears the observed maximum pass gap", () => {
+    assert.ok(
+      NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS > OBSERVED_MAX_GAP_MS,
+      `threshold ${NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS}ms is at or under ` +
+        `the observed ${OBSERVED_MAX_GAP_MS}ms worst case -- a healthy lane ` +
+        `will read stale`,
+    );
+  });
+
+  test("and is not so loose that a stopped writer hides for days", () => {
+    // The other direction, so this cannot be widened without a reason. Two
+    // full ticks is where "late" stops being a credible explanation.
+    assert.ok(
+      NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS <
+        2 * cadenceMs("validator_nominators"),
+      "a bound at or above two full ticks cannot distinguish a late pass from a skipped one",
+    );
   });
 });


### PR DESCRIPTION
## The constant claims something production disproves

> 30h is one missed pass plus slack for the scan itself (~4 minutes) and cron jitter. **It fires only once a pass has genuinely been skipped.**

It does not. Measured over 29 consecutive pass gaps of `nominator_positions.captured_at`, today:

```
min 0.66h    p90 24.41h    MAX 34.57h
4 gaps exceed the 24h cadence;  2 exceed the 30h bound

worst: 08-08 23:11 (34.6h),  08-05 06:35 (31.4h),
       08-11 00:47 (25.6h),  08-15 11:47 (24.1h)
```

**A 34.6h gap is not a skipped pass** — a skipped pass on a daily poller is ~48h. It is the pass running **late**, which is what a container running its lanes sequentially does when something ahead of this one runs long.

So the premise the constant rests on — *"a healthy lane presents an age anywhere in [0h, 24h+scan]"* — is measurably false. The observed range is **[0.66h, 34.57h]**.

## What it cost

`lane_health`, 535 ticks:

| verdict | ticks | worst age |
|---|---:|---|
| `ok` | 519 | 29.95h — *just* under the bound |
| `stale` (detail `stale`) | **9** | 30.02h → 33.02h |
| `stale` (detail `partial`) | 7 | 0.45h → 3.43h |

All nine age-based alerts trace to the two late passes above. **Not one of them is a producer that stopped.**

An alarm firing on a working lane 3% of the time is exactly the #9301 failure this constant has already been corrected for once — corrected then from 6h, and still left under the real ceiling. The `ok` worst case of 29.95h against a 30h bound shows how little margin was left.

## 36h, and the cost stated rather than hidden

1.5 ticks. Clears the measured 34.57h maximum by ~1.4h.

A writer that stops entirely is now reported **six hours later** — a day and a half rather than a day and a quarter. Against a daily producer that is still the same day, and it buys an alarm that means something when it fires.

**This is not suppressing a known-bad state**, which #9475 rightly refuses. The lane is healthy in all nine cases; the bound was describing a cadence the producer does not have.

## Pinned into a corridor, not at a number

Two assertions, so it can move neither way without a reason:

```
threshold 108000000ms is at or under the observed 124452000ms worst case
  -- a healthy lane will read stale                        # at 1.25 ticks

a bound at or above two full ticks cannot distinguish a late pass
  from a skipped one                                       # at 2 ticks
```

Both proven to fail before landing, then restored. That is stronger than pinning `36 * HOUR`: it says *why* 36 and what would make it wrong.

## Fixtures derived, not literal

The watchdog's own tests hard-coded `31 * HOUR` and `34 * HOUR` as "stalled", plus `/34\.0 h old/` and `/threshold 30 h/` in a message assertion. Every one of those had already been rewritten once for the 6h → 30h move, and they fail for the *wrong reason* each time the number under test changes. They now derive from `NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS`, so the next re-size touches the constant and its rationale only.

The `thresholds are unchanged by the refactor` pin in `producer-cadence.test.ts` did its job — it failed the moment the bound moved, which is what a pin against live alarm numbers is for. Widened deliberately, with the measurement written into it.

## Not in scope

The other 7 stale ticks carry `detail: "partial"` at ages 0.45–3.43h — a **coverage** fault on 2026-08-14, not an age one. Different rule, different evidence, left alone.

## Validation

```
tsc --noEmit                                        clean
eslint + prettier                                   clean
validate:unreferenced-exports, lane-topology,
  contract-drift                                    pass
vitest nominator-positions-staleness-watchdog,
  producer-cadence, lane-silence-cadence,
  lane-health                                       95 passed (2 new)
both corridor assertions proven to fail, restored
```
