### PR TITLE
refactor(types): parse the boundary instead of casting past it

### DIFF
--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -504,6 +504,27 @@ export const SubnetEconomicsSchema = z
   .strict();
 export type SubnetEconomics = z.infer<typeof SubnetEconomicsSchema>;
 
+/**
+ * `SubnetEconomics` as a READ path must take it.
+ *
+ * Same partial+catchall contract every lakehouse row schema is declared with,
+ * and for the same two reasons: a read often carries a SUBSET of the columns
+ * (a `fields=` projection, or a tier whose producer has no such field), and it
+ * may carry MORE than the schema names (a producer that shipped a field before
+ * this file learned about it). What stays pinned is the TYPE of any declared
+ * key that IS present -- which is the half that catches a real defect.
+ *
+ * The strict schema above stays the PRODUCER's contract, where an undeclared
+ * key is a genuine drift worth failing on. Reading through it instead would
+ * make the leaderboards go empty the day a producer adds a field, turning a
+ * schema into an availability risk -- and a route that answers nothing is
+ * indistinguishable from one whose data is gone (#11339, closing #10789's
+ * "replace the assertion with a parse").
+ */
+export const SubnetEconomicsReadSchema =
+  SubnetEconomicsSchema.partial().catchall(z.unknown());
+export type SubnetEconomicsRead = z.infer<typeof SubnetEconomicsReadSchema>;
+
 // The block every v440 emission-pipeline read was pinned to (#8744), carried
 // at the artifact's top level because one `state_queryStorageAt` produced the
 // whole network's row set -- two subnets cannot disagree about it.

--- a/src/account-balances-completeness.ts
+++ b/src/account-balances-completeness.ts
@@ -1,4 +1,4 @@
-import type { RowReader } from "./read-store.ts";
+import type { OptionalRowReader } from "./read-store.ts";
 // "Is the account_balances ledger safe to rank from?" (#9511)
 //
 // THE QUESTION A ROW COUNT CANNOT ANSWER. `ORDER BY free_tao DESC LIMIT n` over
@@ -62,7 +62,19 @@ const NONE: AccountBalancesCompleteness = {
  * leaderboard that cannot prove its inputs should fall back, not 500.
  */
 export async function latestCompleteAccountBalancesPass(
-  db: RowReader | null | undefined,
+  /**
+   * OPTIONAL `first`, matching what the body actually does.
+   *
+   * This declared `RowReader` -- `first` REQUIRED -- while the line below
+   * guards `if (!db?.first)` and declines. The two disagreed, so every caller
+   * holding a store whose `first` is optional had to cast, and four of them
+   * did: `db as unknown as Parameters<typeof …>[0]`. That cast asserted the
+   * method was there, past a guard whose whole purpose is that it might not be.
+   *
+   * Widening the parameter is the honest direction. The guard is the contract;
+   * the signature now says so, and the casts are gone rather than justified.
+   */
+  db: OptionalRowReader | null | undefined,
 ): Promise<AccountBalancesCompleteness> {
   if (!db?.first) return { ...NONE, reason: "unavailable" };
   try {

--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -383,7 +383,7 @@ export async function runAccountBalancesStalenessWatchdog(
         verdict.reason === "partial"
           ? `account-balances lane truncated: the newest pass covered only ${verdict.covered_rows} accounts against a floor of ${verdict.coverage_floor_rows} (${verdict.total_rows} rows in the table, newest stamp ${age}) -- the capture is RECENT and PARTIAL, so /accounts/top-holders ranks free_tao over whatever fraction landed and a real top holder the pass never reached is silently absent, not merely stale`
           : `account-balances lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/top-holders is answering from a free_tao column nothing is refreshing`;
-      await record(env as never, {
+      await record(env, {
         error: new Error(message),
         route: "watchdog:account-balances-staleness",
         errorCode: "stale_lane",

--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -97,6 +97,24 @@ import {
   type ReadStoreDb,
 } from "./read-store.ts";
 import type { AccountBalances } from "../generated/db/types.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type AccountBalancesStalenessWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS?: unknown;
+    ACCOUNT_BALANCES_PASS_WINDOW_MS?: unknown;
+    ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS?: unknown;
+  };
 
 /**
  * How old the ledger may get before this is a stall.
@@ -334,7 +352,7 @@ export interface AccountBalancesStalenessDeps {
  * and a cron that throws is a cron nobody can read the result of.
  */
 export async function runAccountBalancesStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: AccountBalancesStalenessWatchdogEnv | null | undefined,
   deps: AccountBalancesStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/account-entities-answer.ts
+++ b/src/account-entities-answer.ts
@@ -36,6 +36,12 @@ import {
   type SubnetOwnerSnapshot,
 } from "./entity-labels.ts";
 import { readArtifact } from "../workers/storage.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { ArtifactEnv } from "../workers/storage.ts";
+
+/** One env, forwarded to both legs: the Neon store and the lakehouse. */
+type ComposerEnv = R2SqlEnv & StoreEnv & ArtifactEnv;
 
 type Row = Record<string, unknown>;
 
@@ -60,7 +66,7 @@ export interface AnswerAccountEntitiesOptions {
  * the same route.
  */
 export async function answerAccountEntities(
-  env: unknown,
+  env: ComposerEnv | null | undefined,
   coldkey: string,
   tierResult: Row | null | undefined,
   {
@@ -78,8 +84,7 @@ export async function answerAccountEntities(
   // half must not disappear just because the transfer half declined.
   const ownerSnapshot = await owners();
 
-  const answered =
-    tierResult ?? ((await coldTier(env as never, coldkey)) as Row | null);
+  const answered = tierResult ?? ((await coldTier(env, coldkey)) as Row | null);
 
   // A tier that answered already shaped its payload from the transfer stream.
   // Its ties are merged with the owned ones rather than rebuilt, so the tier
@@ -127,7 +132,7 @@ function withOwnedTies(
  * `owners_observed_at` publishes.
  */
 async function readSubnetOwners(
-  env: unknown,
+  env: ComposerEnv | null | undefined,
 ): Promise<SubnetOwnerSnapshot | null> {
   // BOTH guards, because they catch different failures. readArtifact reports
   // `{ ok: false }` for a miss or a timeout -- but it THROWS when the binding
@@ -136,7 +141,7 @@ async function readSubnetOwners(
   // into a 500. Every one of those outcomes means the same thing to a caller:
   // we could not read who owns what, which `owners_observed_at: null` says.
   try {
-    const artifact = await readArtifact(env as never, ECONOMICS_ARTIFACT);
+    const artifact = await readArtifact(env, ECONOMICS_ARTIFACT);
     return artifact.ok ? subnetOwnersFromEconomics(artifact.data) : null;
   } catch {
     return null;

--- a/src/account-events-window.ts
+++ b/src/account-events-window.ts
@@ -56,6 +56,7 @@
 // and the summary card share one bound instead of one route having it.
 import { r2SqlQuery } from "./r2-sql.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -165,7 +166,7 @@ export interface WindowedRowReadOptions extends WindowWalkDeps {
  * be a worse answer than the slow one it replaces.
  */
 export async function windowedRowRead<Row>(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   options: WindowedRowReadOptions,
 ): Promise<Row[] | null> {
   const { table, columns, where, order, need, ceiling = null } = options;
@@ -242,7 +243,7 @@ export interface WindowedFloorReadOptions<T> extends WindowWalkDeps {
  * always did.
  */
 export async function windowedFloorRead<T>(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   options: WindowedFloorReadOptions<T>,
 ): Promise<T | null> {
   const { attempt, satisfied } = options;

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -107,6 +107,7 @@ import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
 import { readStore, type OptionalRowQuerier } from "./read-store.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -171,7 +172,7 @@ export interface AccountTransfersQuery {
  * Returns null when the lakehouse cannot answer faithfully.
  */
 export async function loadAccountTransfersColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: AccountTransfersQuery,
 ): Promise<ReturnType<typeof buildAccountTransfers> | null> {
@@ -268,7 +269,7 @@ export async function loadAccountTransfersColdTier(
  * Returns data-api's `{ data, generatedAt }` wrapped shape.
  */
 export async function loadAccountStakeFlowColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { window?: string | null; direction?: unknown } = {},
 ): Promise<{
@@ -342,7 +343,7 @@ export async function loadAccountStakeFlowColdTier(
  * StakeMoved footprint, GROUP BY netuid. Same wrapped shape as stake-flow.
  */
 export async function loadAccountStakeMovesColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { window?: string | null } = {},
 ): Promise<{
@@ -401,7 +402,7 @@ const ACCOUNT_STAKE_MOVES_PRICE_TABLES = ["subnet_snapshots"] as const;
  * this enrichment had no caller at all.
  */
 async function alphaPriceByNetuidDate(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   rows: Array<Record<string, unknown>>,
   cutoff: number,
 ): Promise<Map<string, number>> {
@@ -450,7 +451,7 @@ async function alphaPriceByNetuidDate(
  * shape this request-time module is for; see the header above.
  */
 export async function loadAccountRegistrationsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { window?: string | null } = {},
 ): Promise<{
@@ -485,7 +486,7 @@ export async function loadAccountRegistrationsColdTier(
  * reads (`announcements`).
  */
 export async function loadAccountServingColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { window?: string | null } = {},
 ): Promise<{
@@ -523,7 +524,7 @@ export async function loadAccountServingColdTier(
  * card answered from the same PrometheusServed stream.
  */
 export async function loadAccountPrometheusColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { window?: string | null } = {},
 ): Promise<{
@@ -557,7 +558,7 @@ export async function loadAccountPrometheusColdTier(
  * without them the hotkey-less WeightsSet rows would be silently dropped --
  * a degrade, and this family declines rather than degrades. */
 async function neuronSlots(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   addr: string,
 ): Promise<{ netuid: number; uid: number }[] | null> {
   const db = readStore(env, ["neurons"]) as unknown as
@@ -591,7 +592,7 @@ async function neuronSlots(
  * one disjunction here; see the module header for the equivalence.
  */
 export async function loadAccountWeightSettersColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { window?: string | null } = {},
 ): Promise<{
@@ -694,7 +695,7 @@ export interface ValidatorNominatorsQuery {
  * 2.06 GB at ~4.1s, against a 15s ceiling.
  */
 export async function loadValidatorNominatorsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   hotkey: string,
   query: ValidatorNominatorsQuery,
 ): Promise<{
@@ -811,7 +812,7 @@ type CounterpartyScanRow = Pick<
 >;
 
 async function counterpartyScan(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   predicate: string,
 ): Promise<CounterpartyScanRow[] | null> {
   // BOUNDED (#11131), same reasoning as the transfer feed: the predicate pins
@@ -836,7 +837,7 @@ async function counterpartyScan(
  * the same builder every tier feeds.
  */
 export async function loadAccountCounterpartiesColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { limit?: number } = {},
 ): Promise<ReturnType<typeof buildCounterparties> | null> {
@@ -877,7 +878,7 @@ export interface CounterpartyDrilldownResult {
  * one relationship's fund-flow totals plus the transfer evidence.
  */
 export async function loadCounterpartyRelationshipColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   counterparty: string,
   query: { limit?: number } = {},
@@ -1035,7 +1036,7 @@ export function mergeNewestEvents(
  * the card -- with nothing in the payload to say so.
  */
 async function headProbe(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   options: {
     query: R2SqlReader;
     where: string;
@@ -1055,7 +1056,7 @@ async function headProbe(
 }
 
 export async function loadAccountSummaryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   {
     recentLimit = ACCOUNT_SUMMARY_RECENT_LIMIT,

--- a/src/account-history-cold-tier.ts
+++ b/src/account-history-cold-tier.ts
@@ -39,6 +39,7 @@ import {
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -100,7 +101,7 @@ export interface AccountHistoryQuery {
  * rather than being indistinguishable from a broken tier.
  */
 export async function loadAccountHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: AccountHistoryQuery,
   { queryFn = r2SqlQuery }: { queryFn?: R2SqlReader } = {},
@@ -208,7 +209,7 @@ export async function loadAccountHistoryColdTier(
  * scan the account's entire history to answer a question about no rows.
  */
 async function loadKindsForPage(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   where: string[],
   page: Array<Row & { day: string }>,
   queryFn: R2SqlReader,

--- a/src/account-identity-cold-tier.ts
+++ b/src/account-identity-cold-tier.ts
@@ -18,6 +18,7 @@ import type {
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 // Both SELECT lists are derived from the same exported field set data-api's
 // reads are built on: latest-only is account + the 7 identity fields +
@@ -34,7 +35,7 @@ const CURSOR_ARITY = 2;
  * answer, so the caller keeps its schema-stable "no identity" fallback.
  */
 export async function loadAccountIdentityColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
 ): Promise<ReturnType<typeof buildAccountIdentity> | null> {
   // An unusable address is a decline, not an unfiltered scan: it reaches a
@@ -61,7 +62,7 @@ export async function loadAccountIdentityColdTier(
  * order, columns, cursor token, and OFFSET-only-without-cursor rule.
  */
 export async function loadAccountIdentityHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: { limit: number; offset?: number | null; cursor?: unknown },
 ): Promise<ReturnType<typeof buildAccountIdentityHistory> | null> {

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -57,6 +57,7 @@ import {
   AccountSummaryRecentMapSchema,
   AccountSummaryRecentSchema,
 } from "../schemas-src/artifacts/account-summary-projection.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Objects the producer writes, one per shard. Contract with
  * metagraphed-infra's `services/indexer-rs/account_summary_r2.py`. */
@@ -195,7 +196,7 @@ async function readJson(
  * whose meaning depends on its tier is worse than either.
  */
 export async function loadAccountSummaryProjection(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   account: string,
   {
     now = Date.now,

--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -358,7 +358,7 @@ export async function loadSubnetUptime(
     observedAt,
     rows,
     now: now || new Date().toISOString(),
-  } as unknown as Parameters<typeof formatUptime>[0]);
+  });
 }
 
 // One subnet's 7d/30d uptime + latency trend per operational surface, over the

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -53,6 +53,7 @@ import {
   resolveDecodeWatermark,
   type DecodeWatermarkDeps,
 } from "./decode-watermark.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Floor for the seam, overridable per environment. NOT the seam itself any
  * more: see `resolveBlocksSeam`. */
@@ -253,7 +254,7 @@ export function storeCanServe(query: BlockFeedQuery): boolean {
 /** Rows above the seam, newest first. Bound parameters throughout — D1 had
  * them, so unlike the R2 SQL leg there is no literal-building here. */
 async function storeHeadRows(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: BlockFeedQuery,
   cursor: number[] | null,
   seam: number,
@@ -308,7 +309,7 @@ async function storeHeadRows(
  * can answer, so the caller keeps its schema-stable empty.
  */
 export async function loadBlockFeedColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: BlockFeedQuery,
   /** Which chain to read (#8700). Off mainnet there is no hot tier, so the
    * whole feed comes from that network's lakehouse namespace. */
@@ -407,7 +408,7 @@ export async function loadBlockFeedColdTier(
  * either, so D1 is asked first and the lakehouse answers if it misses.
  */
 export async function loadBlockColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   /** Which chain to read (#8700). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,

--- a/src/capture-state-neon-write.ts
+++ b/src/capture-state-neon-write.ts
@@ -28,6 +28,7 @@ import {
 import { recordNeonWriteVerdict, type NeonWriteResult } from "./neon-write.ts";
 import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 export const BLOCKS_HEAD_NEON_LANE = "blocks-head";
 export const RAW_CAPTURE_STATE_NEON_LANE = "raw-capture-state";
@@ -44,7 +45,7 @@ export interface CaptureStateMirrorDeps {
 
 /** Resolve the runner and lane bookkeeping shared by both mirrors. */
 async function runner(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   lane: string,
   deps: CaptureStateMirrorDeps,
@@ -113,7 +114,7 @@ async function record(
 /** One head row. Never throws: while D1 still serves, a mirror failure costs a
  * lane verdict and nothing the poller can see. */
 export async function mirrorBlocksHeadToNeon(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   row: BlocksHead,
   deps: CaptureStateMirrorDeps = {},
@@ -158,7 +159,7 @@ export async function mirrorBlocksHeadToNeon(
 
 /** The contiguity watermark, one row per network. */
 export async function mirrorRawCaptureStateToNeon(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   network: string,
   lastContiguousBlock: number,

--- a/src/chain-concentration-rollup.ts
+++ b/src/chain-concentration-rollup.ts
@@ -26,6 +26,7 @@
 
 import { buildChainConcentration } from "./concentration.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -89,7 +90,7 @@ export async function rollupChainConcentration(
     nowMs = Date.now(),
     maxDays = CHAIN_CONCENTRATION_ROLLUP_MAX_DAYS_PER_TICK,
     env = null,
-  }: { nowMs?: number; maxDays?: number; env?: unknown } = {},
+  }: { nowMs?: number; maxDays?: number; env?: R2SqlEnv | null } = {},
 ): Promise<Row> {
   if (!db?.query || !db?.run) return { rolled: false, reason: "unavailable" };
 
@@ -100,7 +101,7 @@ export async function rollupChainConcentration(
       .map((r) => r?.day)
       .filter((d): d is string => typeof d === "string" && d.length > 0);
   } catch (error) {
-    await recordExceptionEvent(env as never, {
+    await recordExceptionEvent(env, {
       error,
       route: "chain-concentration-rollup-scan",
     });
@@ -157,7 +158,7 @@ export async function rollupChainConcentration(
       rolled.push(day);
     } catch (error) {
       failed.push(day);
-      await recordExceptionEvent(env as never, {
+      await recordExceptionEvent(env, {
         error,
         route: "chain-concentration-rollup",
       });

--- a/src/chain-detail-neon-write.ts
+++ b/src/chain-detail-neon-write.ts
@@ -24,6 +24,7 @@ import {
   neonWriteRunner,
 } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 // ---------------------------------------------------------------------------
 // Moved here when D1 was deleted (#10179). These describe the TABLE -- its
@@ -188,7 +189,7 @@ function coerceBooleans(rows: Row[], booleans?: readonly string[]): Row[] {
  * and the write order is the point.
  */
 export async function mirrorChainDetailToNeon(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   input: ChainDetailMirrorInput,
   deps: ChainDetailMirrorDeps = {},

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -159,7 +159,7 @@ export async function runChainDetailStalenessWatchdog(
         verdict.age_ms === null
           ? "no blocks at all"
           : `${(verdict.age_ms / 60_000).toFixed(1)} min behind`;
-      await record(env as never, {
+      await record(env, {
         error: new Error(
           `chain-detail lane stalled: the live-follow window is ${age} ` +
             `(threshold ${thresholdMs / 60_000} min, head block ` +

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -30,6 +30,22 @@ import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore, type ReadStoreDb, safeIntOrNull } from "./read-store.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type ChainDetailStalenessWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    CHAIN_DETAIL_STALENESS_THRESHOLD_MS?: unknown;
+  };
 
 /**
  * How far behind the lane may fall before this is a stall.
@@ -100,7 +116,7 @@ export function evaluateChainDetailStaleness(input: {
  * drift silently, since each looks correct on its own.
  */
 export async function readChainDetailHead(
-  env: Record<string, unknown> | null | undefined,
+  env: ChainDetailStalenessWatchdogEnv | null | undefined,
 ): Promise<{ latestObservedAtMs: number | null; headBlock: number | null }> {
   const db = readStore(env, ["chain_detail_blocks"]) as unknown as
     ReadStoreDb | undefined;
@@ -130,7 +146,7 @@ export interface ChainDetailStalenessDeps {
  * and a cron that throws is a cron nobody can read the result of.
  */
 export async function runChainDetailStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: ChainDetailStalenessWatchdogEnv | null | undefined,
   deps: ChainDetailStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/chain-events-cold-tier.ts
+++ b/src/chain-events-cold-tier.ts
@@ -47,6 +47,7 @@ import {
   SUBNET_LEASE_CREATED_KIND,
   SUBNET_LEASE_TERMINATED_KIND,
 } from "./subnet-lease-history.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Kept identical to the deleted handler's SELECT list so both tiers hand the
  * caller the same event shape. */
@@ -146,7 +147,7 @@ export function chainEventsQueryError(query: ChainEventsQuery): string | null {
  * faithfully so the caller keeps its schema-stable empty.
  */
 export async function loadChainEventsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: ChainEventsQuery,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,
@@ -281,7 +282,7 @@ export interface ChainEventsStats {
  * key, so the block bound alone does the work it was always meant to.
  */
 export async function loadChainEventsStatsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   blocks?: unknown,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,
@@ -339,7 +340,7 @@ export async function loadChainEventsStatsColdTier(
  *            visible instead of silently attributing events to netuid 0.
  */
 export async function loadSubnetLeaseHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: number,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,

--- a/src/chain-holders.ts
+++ b/src/chain-holders.ts
@@ -126,9 +126,7 @@ export async function loadChainHolders(
   });
   if (!db?.query) return declined("unavailable");
 
-  const alpha = await latestCompleteHotkeyAlphaPass(
-    db as unknown as Parameters<typeof latestCompleteHotkeyAlphaPass>[0],
-  );
+  const alpha = await latestCompleteHotkeyAlphaPass(db);
   if (!mayPriceHotkeyAlpha(alpha)) {
     return declined(
       alpha.reason === "unavailable" ? "unavailable" : "pool_totals_unproven",

--- a/src/daily-series-coverage-watchdog.ts
+++ b/src/daily-series-coverage-watchdog.ts
@@ -274,7 +274,7 @@ export async function runDailySeriesCoverageWatchdog(
   const holed = verdicts.some((v) => v.missing.length > 0 || v.thin.length > 0);
   const detail = coverageDetail(verdicts);
   if (holed) {
-    await record(env as never, {
+    await record(env, {
       error: new Error(
         `daily series has a hole: ${detail} -- a missing day is invisible to every freshness check, ` +
           `and neuron_daily is only ~26 days deep, so it ages out of any recomputable window`,

--- a/src/daily-series-coverage-watchdog.ts
+++ b/src/daily-series-coverage-watchdog.ts
@@ -40,7 +40,8 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
-import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
+import type { StoreEnv } from "./read-store.ts";
 
 export const DAILY_COVERAGE_LANE = "daily-series-coverage";
 
@@ -234,7 +235,7 @@ export interface DailyCoverageDeps {
  * Returns a summary rather than throwing, matching the rest of the cron family.
  */
 export async function runDailySeriesCoverageWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: (StoreEnv & TelemetryEnv) | null | undefined,
   deps: DailyCoverageDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/degenerate-output-watchdog.ts
+++ b/src/degenerate-output-watchdog.ts
@@ -59,7 +59,7 @@ import {
   readStore,
   type UntypedRowQuerier,
 } from "./read-store.ts";
-import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
 
 export const DEGENERATE_OUTPUT_LANE = "degenerate-output";
 
@@ -207,7 +207,7 @@ export interface DegenerateOutputResult {
 export async function runDegenerateOutputWatchdog(
   // The same loose shape every sibling watchdog takes: callers hand in an
   // `Env`, a bag, or nothing, and a narrower type pushes a cast to the cron.
-  env: Record<string, unknown> | null | undefined,
+  env: TelemetryEnv | null | undefined,
   deps: DegenerateOutputDeps = {},
 ): Promise<DegenerateOutputResult> {
   const db = deps.db ?? readStore(env, ["attribution_sweeps"]);

--- a/src/degenerate-output-watchdog.ts
+++ b/src/degenerate-output-watchdog.ts
@@ -225,7 +225,7 @@ export async function runDegenerateOutputWatchdog(
       // ONE LANE'S FAILURE IS NOT THE TICK'S. A table that does not exist yet
       // -- a migration applied by hand, which is how they land here -- must not
       // stop the lanes after it being checked.
-      await (deps.recordException ?? recordExceptionEvent)(env as never, {
+      await (deps.recordException ?? recordExceptionEvent)(env, {
         error: err instanceof Error ? err : new Error(String(err)),
         route: `watchdog:${DEGENERATE_OUTPUT_LANE}`,
         errorCode: "degenerate_output_query_failed",

--- a/src/emission-pipeline-surface.ts
+++ b/src/emission-pipeline-surface.ts
@@ -71,7 +71,10 @@ export interface EmissionPipelineNarrowing {
  */
 export function parseEmissionPipelineNarrowing(
   params: URLSearchParams,
-  rows: Row[],
+  // Only forwarded to `unknownAgainstRows` for key enumeration, so it takes
+  // what that needs -- which lets the GraphQL resolver pass its typed
+  // `SubnetDecomposition[]` instead of casting it to `Row[]` (#11339).
+  rows: readonly object[],
   { limitMax }: { limitMax: number },
 ):
   | EmissionPipelineNarrowing

--- a/src/emission-pipeline-surface.ts
+++ b/src/emission-pipeline-surface.ts
@@ -22,8 +22,8 @@ import {
   parseFieldsParam,
   projectRows,
   unknownAgainstRows,
-  type Row,
 } from "./field-projection.ts";
+import { recordOrNull } from "./read-store.ts";
 
 /**
  * The per-subnet columns this surface can rank by (#9720).
@@ -271,8 +271,10 @@ export function narrowEmissionPipeline(
     // measures point in opposite directions and need per-key defaults.
     const factor = narrowing.order === "asc" ? 1 : -1;
     subnets = [...subnets].sort((a, b) => {
-      const left = (a as unknown as Row)[key];
-      const right = (b as unknown as Row)[key];
+      // `recordOrNull`, not a cast: reading a key off a typed interface needs
+      // an index signature, which TypeScript never gives an interface (#11339).
+      const left = recordOrNull(a)?.[key];
+      const right = recordOrNull(b)?.[key];
       // A row missing the sort column sinks in EITHER direction rather than
       // riding a null to the top of an ascending list.
       const leftMissing = left == null || !Number.isFinite(Number(left));
@@ -291,10 +293,7 @@ export function narrowEmissionPipeline(
 
   return {
     ...surface,
-    subnets: projectRows(
-      limited as unknown as Row[],
-      narrowing.fields,
-    ) as unknown as typeof surface.subnets,
+    subnets: projectRows(limited, narrowing.fields),
     // Published only when the list was actually narrowed, so today's body is
     // byte-for-byte unchanged for every caller who does not narrow it -- and
     // when they do, a 20-row page and a network that really has 20 subnets stop

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -52,6 +52,7 @@ import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { windowedRowRead } from "./account-events-window.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -85,7 +86,7 @@ export interface AccountEventsQuery {
  * existing fallback.
  */
 export async function loadAccountEventsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   query: AccountEventsQuery,
   /** Which chain's lakehouse namespace to read (#8700). */
@@ -183,7 +184,7 @@ export interface SubnetEventsQuery {
  * seek continues correctly past its cursor.
  */
 export async function loadSubnetEventsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: number,
   query: SubnetEventsQuery,
   /** Which chain's lakehouse namespace to read (#8700). */
@@ -249,7 +250,7 @@ export async function loadSubnetEventsColdTier(
  * top-to-bottom). `ref` is a height or a block hash.
  */
 export async function loadBlockEventsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   page: { limit: number; offset?: number | null },
   /** Which chain's lakehouse namespace to read (#8700). */
@@ -281,7 +282,7 @@ export async function loadBlockEventsColdTier(
 
 /** A block hash resolved to its height, or the height itself. */
 async function resolveBlockHeight(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,
@@ -332,7 +333,7 @@ export interface BlockChainEventsColdResult {
  * schema-stable empty rather than inventing one here.
  */
 export async function loadBlockChainEventsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -63,6 +63,7 @@ import {
   BlocksRowSchema,
   ExtrinsicsRowSchema,
 } from "../schemas-src/lakehouse.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -158,7 +159,7 @@ function feedPredicates(query: ExtrinsicFeedQuery): string[] | null {
 
 /** Rows for a feed-shaped query, offset emulated by over-fetch + slice. */
 async function feedRows(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: ExtrinsicFeedQuery,
   extraWhere: string[] = [],
   /** Which chain's lakehouse namespace to read (#8700). */
@@ -213,7 +214,7 @@ async function feedRows(
 
 /** The recent-extrinsic feed, and the filtered variants built on it. */
 export async function loadExtrinsicFeedColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: ExtrinsicFeedQuery,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,
@@ -229,7 +230,7 @@ export async function loadExtrinsicFeedColdTier(
 
 /** Every extrinsic in one block. `ref` is a height or a block hash. */
 export async function loadBlockExtrinsicsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   page: { limit: number; offset?: number | null },
   /** Which chain's lakehouse namespace to read (#8700). */
@@ -258,7 +259,7 @@ export async function loadBlockExtrinsicsColdTier(
 
 /** One account's extrinsics, newest first. */
 export async function loadAccountExtrinsicsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
   page: {
     limit: number;
@@ -295,7 +296,7 @@ export async function loadAccountExtrinsicsColdTier(
 
 /** A block hash resolved to its height, or the height itself. */
 async function resolveBlockHeight(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,
@@ -320,7 +321,7 @@ async function resolveBlockHeight(
  * account_events it emitted embedded exactly as the Postgres tier embeds them.
  */
 export async function loadExtrinsicColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,

--- a/src/field-projection.ts
+++ b/src/field-projection.ts
@@ -22,6 +22,8 @@
 //
 // Both feed the same parse, the same error idiom, and the same projector.
 
+import { recordOrNull } from "./read-store.ts";
+
 export type Row = Record<string, unknown>;
 
 /**
@@ -209,7 +211,7 @@ export function projectRow<T>(row: T, fields: string[] | null | undefined): T {
   if (!fields || !row || typeof row !== "object" || Array.isArray(row)) {
     return row;
   }
-  const source = row as Row;
+  const source = recordOrNull(row) ?? {};
   return Object.fromEntries(
     fields
       .filter((field) => Object.hasOwn(source, field))
@@ -217,12 +219,21 @@ export function projectRow<T>(row: T, fields: string[] | null | undefined): T {
   ) as T;
 }
 
-/** {@link projectRow} across a collection. */
-export function projectRows(
-  rows: Row[],
+/**
+ * {@link projectRow} across a collection.
+ *
+ * GENERIC, like `projectRow` beside it always was. Pinning this one to `Row[]`
+ * meant a caller holding typed rows had to cast IN and back OUT again --
+ * `projectRows(limited as unknown as Row[], f) as unknown as typeof subnets`
+ * -- which discarded the row type across the projection for no gain (#11339).
+ */
+export function projectRows<T>(
+  rows: T[],
   fields: string[] | null | undefined,
-): Row[] {
+): T[] {
   if (!fields) {
+    // The SAME array, not a copy -- the suite pins this identity, and the
+    // no-projection path is the one every unnarrowed request takes.
     return rows;
   }
   return rows.map((row) => projectRow(row, fields));

--- a/src/field-projection.ts
+++ b/src/field-projection.ts
@@ -95,7 +95,16 @@ export function unknownAgainstSchema(schema: {
  * row. Behaviour is identical to a full-union check, and identical to what
  * workers/list-query.ts did before this module existed.
  */
-export function unknownAgainstRows(rows: Row[]): UnknownFieldResolver {
+// `readonly object[]`, not `Row[]`: this function only ever calls
+// `Object.keys(row)` -- it never indexes a row by a computed key, so requiring
+// an index signature overstated what it needs. The cost of that overstatement
+// was real: a caller holding a well-typed INTERFACE (`SubnetDecomposition`)
+// could not pass it, because TypeScript gives implicit index signatures to type
+// aliases and object literals but never to interfaces -- so the call site
+// reached for a cast, and lost the row type entirely (#11339).
+export function unknownAgainstRows(
+  rows: readonly object[],
+): UnknownFieldResolver {
   const resolve: UnknownFieldResolver = (requested) => {
     const unresolved = new Set(requested);
     for (const row of rows) {

--- a/src/global-operational-health.ts
+++ b/src/global-operational-health.ts
@@ -50,10 +50,9 @@ export async function loadGlobalOperationalHealth(
     readHealthKv,
   }: {
     env: Env;
-    readHealthKv?: (
-      env: Env,
-      key: string,
-    ) => Promise<Record<string, unknown> | null>;
+    // Forwarded verbatim to resolveLiveHealth; declared as its producer
+    // actually returns rather than as its consumer wished (#11339).
+    readHealthKv?: (env: Env, key: string) => Promise<unknown>;
   },
   {
     contractVersion,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -957,16 +957,6 @@ type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFn = (...args: any[]) => any;
 
-// The MCP loaders' ctx parameter requires a readArtifact field, but every
-// call site in this file supplies readArtifact through the loaders' own deps
-// override (`read = deps.readArtifact ?? ctx.readArtifact`), so ctx.readArtifact
-// is never dereferenced here. This cast bridges that gap without weakening the
-// loaders' own signatures.
-const mcpCtx = (context: GqlContext) =>
-  context as GqlContext & {
-    readArtifact: (env: Env, path: string) => ReturnType<typeof readArtifact>;
-  };
-
 // The contextValue handleGraphQLRequest passes to execute() (env + a
 // per-request memo Map + the raw Request), plus the extra fields the
 // graphql-ws subscription path stamps on (clientIp/graphqlWsConnection).
@@ -977,6 +967,18 @@ const mcpCtx = (context: GqlContext) =>
 export interface GqlContext {
   env: Env;
   cache: Map<string, unknown>;
+  /**
+   * The artifact reader every MCP loader reached for.
+   *
+   * DECLARED, not asserted (#11339). This used to be absent from the context
+   * and bolted on at each of 33 call sites by an `mcpCtx()` cast, on the
+   * reasoning that the loaders never dereference it because graphql.ts always
+   * passes its own through their `deps` override. That held right up until it
+   * didn't: the two rpc resolvers spread `{ ...context, readHealthKv }`
+   * instead, and the cast was the only thing hiding that they were handing the
+   * loaders a ctx with no reader at all.
+   */
+  readArtifact: (env: Env, path: string) => ReturnType<typeof readArtifact>;
   request?: Request;
   /** The request's ExecutionContext, threaded so resolvers can select a store
    * (#10086). createPgSql returns its connection via waitUntil, so a resolver
@@ -1890,7 +1892,7 @@ function providerNode(provider: Row) {
 async function loadProviderEndpoints(context: GqlContext, slug: string) {
   try {
     const result = await loadProviderEndpointsList(
-      mcpCtx(context),
+      context,
       { slug },
       { readArtifact },
     );
@@ -2463,7 +2465,7 @@ const rootValue = {
     // cache. Its only throw is an invalid netuid, which becomes BAD_USER_INPUT
     // (mirroring REST's invalid_params 400); an un-baked profile is null.
     try {
-      return await loadSubnetProfile(mcpCtx(context), netuid, {
+      return await loadSubnetProfile(context, netuid, {
         readArtifact: loadArtifact as AnyFn,
       });
     } catch (rawErr) {
@@ -2486,7 +2488,7 @@ const rootValue = {
   // cold/absent artifact throws, becoming a GraphQL error (matching the sibling
   // gaps / subnet_candidates convention), rather than a silent default.
   candidates(args: QueryCandidatesArgs, context: GqlContext) {
-    return loadCandidatesList(mcpCtx(context), args, { readArtifact });
+    return loadCandidatesList(context, args, { readArtifact });
   },
 
   async fixtures(args: Row, context: GqlContext) {
@@ -2504,7 +2506,7 @@ const rootValue = {
   // null, matching adapter's cold/absent convention.
   async fixture(args: QueryFixtureArgs, context: GqlContext) {
     try {
-      return await loadFixture(mcpCtx(context), args, { readArtifact });
+      return await loadFixture(context, args, { readArtifact });
     } catch (rawErr) {
       const err = rowOf(rawErr);
       if (err?.toolError && err.code === "invalid_params") {
@@ -2649,9 +2651,7 @@ const rootValue = {
       // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
       // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
-        context.env as unknown as Parameters<
-          typeof loadSubnetEventCardColdTier
-        >[0],
+        context.env,
         CHAIN_REGISTRATIONS_ROLLUP,
         netuid,
         buildSubnetRegistrations,
@@ -2740,9 +2740,7 @@ const rootValue = {
       // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
       // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
-        context.env as unknown as Parameters<
-          typeof loadSubnetEventCardColdTier
-        >[0],
+        context.env,
         CHAIN_SERVING_ROLLUP,
         netuid,
         buildSubnetServing,
@@ -2921,9 +2919,7 @@ const rootValue = {
       });
     }
     const rows = await loadTaoUsdSeries(
-      readStore(context.env, TAO_USD_TABLES) as never as unknown as Parameters<
-        typeof loadTaoUsdSeries
-      >[0],
+      readStore(context.env, TAO_USD_TABLES),
       { windowHours: TAO_USD_WINDOWS[label] },
     );
     // #10065: the same opt-out REST and MCP take. REST defaults to sending the
@@ -2956,10 +2952,7 @@ const rootValue = {
     }
     const safeLimit = limit ?? SURFACE_HISTORY_LIMIT_DEFAULT;
     const rows = await loadSurfaceHistory(
-      readStore(
-        context.env,
-        SURFACE_HISTORY_TABLES,
-      ) as never as unknown as Parameters<typeof loadSurfaceHistory>[0],
+      readStore(context.env, SURFACE_HISTORY_TABLES),
       netuid,
       { limit: safeLimit },
     );
@@ -2985,10 +2978,7 @@ const rootValue = {
     const safeLimit = limit ?? EMISSION_CHANGES_LIMIT_DEFAULT;
     const safeKind = kind ?? undefined;
     const rows = await loadEmissionChanges(
-      readStore(
-        context.env,
-        EMISSION_CHANGES_TABLES,
-      ) as never as unknown as Parameters<typeof loadEmissionChanges>[0],
+      readStore(context.env, EMISSION_CHANGES_TABLES),
       { limit: safeLimit, kind: safeKind },
     );
     return buildEmissionChanges(rows, { limit: safeLimit, kind: safeKind });
@@ -3011,10 +3001,7 @@ const rootValue = {
       );
     }
     const read = await loadChainHolders(
-      readStore(
-        context.env,
-        ALPHA_PRICING_TABLES,
-      ) as never as unknown as Parameters<typeof loadChainHolders>[0],
+      readStore(context.env, ALPHA_PRICING_TABLES),
     );
     return buildChainHolders(read, {
       sort: sort ?? DEFAULT_CHAIN_HOLDERS_SORT,
@@ -3045,10 +3032,7 @@ const rootValue = {
       kind: kind ?? undefined,
     };
     const rows = await loadFailureReasons(
-      readStore(
-        context.env,
-        FAILURE_REASONS_TABLES,
-      ) as never as unknown as Parameters<typeof loadFailureReasons>[0],
+      readStore(context.env, FAILURE_REASONS_TABLES),
       args,
     );
     return rows === null
@@ -3059,10 +3043,7 @@ const rootValue = {
   async indexer_lag(_args: Record<string, never>, context: GqlContext) {
     // #9620. Shares the REST/MCP loader for #9540's reason.
     const row = await loadIndexerLag(
-      readStore(
-        context.env,
-        INDEXER_LAG_TABLES,
-      ) as never as unknown as Parameters<typeof loadIndexerLag>[0],
+      readStore(context.env, INDEXER_LAG_TABLES),
     );
     return buildIndexerLag(row, Date.now());
   },
@@ -3076,12 +3057,7 @@ const rootValue = {
       window: window ?? DEFAULT_CHAIN_CONCENTRATION_HISTORY_WINDOW,
     };
     const rows = await loadChainConcentrationHistory(
-      readStore(
-        context.env,
-        CHAIN_CONCENTRATION_HISTORY_TABLES,
-      ) as never as unknown as Parameters<
-        typeof loadChainConcentrationHistory
-      >[0],
+      readStore(context.env, CHAIN_CONCENTRATION_HISTORY_TABLES),
       args,
     );
     return rows === null
@@ -3096,10 +3072,7 @@ const rootValue = {
     // #9625. Shares the REST/MCP loader for #9540's reason.
     const args = { window: window ?? DEFAULT_PIPELINE_HISTORY_WINDOW };
     const rows = await loadPipelineHistory(
-      readStore(
-        context.env,
-        SUBNET_SNAPSHOT_TABLES,
-      ) as never as unknown as Parameters<typeof loadPipelineHistory>[0],
+      readStore(context.env, SUBNET_SNAPSHOT_TABLES),
       netuid,
       args,
     );
@@ -3133,10 +3106,7 @@ const rootValue = {
     }
     const safeLimit = limit ?? SUBNET_HOLDERS_LIMIT_DEFAULT;
     const read = await loadSubnetHolders(
-      readStore(
-        context.env,
-        ALPHA_PRICING_TABLES,
-      ) as never as unknown as Parameters<typeof loadSubnetHolders>[0],
+      readStore(context.env, ALPHA_PRICING_TABLES),
       netuid,
       { limit: safeLimit },
     );
@@ -3638,16 +3608,10 @@ const rootValue = {
       // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
       // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
       // resolved to null before it could touch DATA_API.
-      (await loadSubnetWeightsColdTier(
-        context.env as unknown as Parameters<
-          typeof loadSubnetWeightsColdTier
-        >[0],
-        netuid,
-        {
-          windowLabel: windowParam,
-          windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
-        },
-      )) ?? buildSubnetWeights(null, netuid, { window: windowParam });
+      (await loadSubnetWeightsColdTier(context.env, netuid, {
+        windowLabel: windowParam,
+        windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
+      })) ?? buildSubnetWeights(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -3683,9 +3647,7 @@ const rootValue = {
       // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
       // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
-        context.env as unknown as Parameters<
-          typeof loadSubnetEventCardColdTier
-        >[0],
+        context.env,
         CHAIN_STAKE_MOVES_ROLLUP,
         netuid,
         buildSubnetStakeMoves,
@@ -3729,9 +3691,7 @@ const rootValue = {
       // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
       // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
-        context.env as unknown as Parameters<
-          typeof loadSubnetEventCardColdTier
-        >[0],
+        context.env,
         CHAIN_STAKE_TRANSFERS_ROLLUP,
         netuid,
         buildSubnetStakeTransfers,
@@ -3974,9 +3934,7 @@ const rootValue = {
       // Without it this resolver bottomed out in the zeroed builder while
       // `chain_prometheus` answered from the same PrometheusServed stream.
       ((await loadSubnetEventCardColdTier(
-        context.env as unknown as Parameters<
-          typeof loadSubnetEventCardColdTier
-        >[0],
+        context.env,
         CHAIN_PROMETHEUS_ROLLUP,
         netuid,
         buildSubnetPrometheus,
@@ -4023,17 +3981,11 @@ const rootValue = {
       // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
       // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
       // resolved to null before it could touch DATA_API.
-      ((await loadSubnetWeightSettersColdTier(
-        context.env as unknown as Parameters<
-          typeof loadSubnetWeightSettersColdTier
-        >[0],
-        netuid,
-        {
-          windowLabel: windowParam,
-          windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam] ?? 7,
-          limit: SUBNET_WEIGHT_SETTERS_LIMIT,
-        },
-      )) as Row | null) ??
+      ((await loadSubnetWeightSettersColdTier(context.env, netuid, {
+        windowLabel: windowParam,
+        windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam] ?? 7,
+        limit: SUBNET_WEIGHT_SETTERS_LIMIT,
+      })) as Row | null) ??
       buildSubnetWeightSetters([], null, netuid, { window: windowParam });
     return {
       tempo: data.tempo ?? null,
@@ -4076,7 +4028,7 @@ const rootValue = {
       // typed return); the spread into `Row` had kept the dead read compiling,
       // which is exactly what #10864 was filed about.
       const data = await loadProvidersList(
-        mcpCtx(context),
+        context,
         { ...filters },
         {
           readArtifact,
@@ -4119,7 +4071,7 @@ const rootValue = {
   // GraphQL error for an unregistered slug.
   async adapter({ slug }: QueryAdapterArgs, context: GqlContext) {
     try {
-      return await loadAdapter(mcpCtx(context), { slug }, { readArtifact });
+      return await loadAdapter(context, { slug }, { readArtifact });
     } catch (rawErr) {
       const err = rowOf(rawErr);
       if (err?.toolError && err.code === "invalid_params") {
@@ -4186,7 +4138,7 @@ const rootValue = {
   // its own args and throws on an invalid filter/sort (or a cold/absent artifact);
   // that throw becomes a GraphQL error, matching provider_endpoints' convention.
   async surfaces(args: QuerySurfacesArgs, context: GqlContext) {
-    const list = await loadSurfacesList(mcpCtx(context), args, {
+    const list = await loadSurfacesList(context, args, {
       readArtifact,
     });
     // loadSurfacesList's envelope names the rows `surfaces`; the GraphQL
@@ -4207,7 +4159,7 @@ const rootValue = {
   // unsupported filter/sort is a GraphQL error, not a silently substituted
   // default" convention.
   provider_endpoints(args: QueryProvider_EndpointsArgs, context: GqlContext) {
-    return loadProviderEndpointsList(mcpCtx(context), args, { readArtifact });
+    return loadProviderEndpointsList(context, args, { readArtifact });
   },
 
   // #6985: reuse list_endpoint_pools's/list_rpc_pools's/list_endpoint_incidents's
@@ -4219,7 +4171,7 @@ const rootValue = {
   // "an unsupported filter/sort is a GraphQL error, not a silently substituted
   // default" convention.
   endpoint_pools(args: QueryEndpoint_PoolsArgs, context: GqlContext) {
-    return loadEndpointPoolsList(mcpCtx(context), args, { readArtifact });
+    return loadEndpointPoolsList(context, args, { readArtifact });
   },
 
   rpc_pools(args: QueryRpc_PoolsArgs, context: GqlContext) {
@@ -4227,17 +4179,13 @@ const rootValue = {
     // 15-minute cron eligibility overlay (rpc-pools-mcp.ts) -- graphql.ts's
     // own context has no such property, so it's supplied here from the same
     // module-level import loadLiveHealth/loadEconomics already use.
-    return loadRpcPoolsList(
-      { ...context, readHealthKv } as unknown as Parameters<
-        typeof loadRpcPoolsList
-      >[0],
-      args,
-      { readArtifact },
-    );
+    return loadRpcPoolsList({ ...context, readHealthKv }, args, {
+      readArtifact,
+    });
   },
 
   endpoint_incidents(args: QueryEndpoint_IncidentsArgs, context: GqlContext) {
-    return loadEndpointIncidentsList(mcpCtx(context), args, { readArtifact });
+    return loadEndpointIncidentsList(context, args, { readArtifact });
   },
 
   // #6986: reuse list_source_snapshots' own loader unchanged. It validates its
@@ -4247,7 +4195,7 @@ const rootValue = {
   // filter/sort is a GraphQL error, not a silently substituted default"
   // convention.
   source_snapshots(args: QuerySource_SnapshotsArgs, context: GqlContext) {
-    return loadSourceSnapshotsList(mcpCtx(context), args, { readArtifact });
+    return loadSourceSnapshotsList(context, args, { readArtifact });
   },
 
   // #7171: reuse list_gaps / list_evidence loaders unchanged. Each validates
@@ -4256,11 +4204,11 @@ const rootValue = {
   // error, not a silently substituted default" convention. A cold/absent
   // artifact is likewise a GraphQL error (matching REST/MCP not_found).
   gaps(args: QueryGapsArgs, context: GqlContext) {
-    return loadGapsList(mcpCtx(context), args, { readArtifact });
+    return loadGapsList(context, args, { readArtifact });
   },
 
   evidence(args: QueryEvidenceArgs, context: GqlContext) {
-    return loadEvidenceList(mcpCtx(context), args, { readArtifact });
+    return loadEvidenceList(context, args, { readArtifact });
   },
 
   // #6992: reuse list_profiles' own loader unchanged. Its readOptionalArtifact
@@ -4269,7 +4217,7 @@ const rootValue = {
   // exactly that shape (readArtifact(context.env, path), null if not ok), so
   // it's reused directly rather than adding a redundant wrapper.
   profiles(args: QueryProfilesArgs, context: GqlContext) {
-    return loadProfilesList(mcpCtx(context), args, {
+    return loadProfilesList(context, args, {
       readOptionalArtifact: loadArtifact as AnyFn,
     });
   },
@@ -4324,13 +4272,9 @@ const rootValue = {
     // artifact; that throw becomes a GraphQL error, matching endpoint_pools /
     // rpc_pools' "an unsupported filter/sort is a GraphQL error, not a
     // silently substituted default" convention.
-    return loadRpcEndpointsList(
-      { ...context, readHealthKv } as unknown as Parameters<
-        typeof loadRpcEndpointsList
-      >[0],
-      args,
-      { readArtifact },
-    );
+    return loadRpcEndpointsList({ ...context, readHealthKv }, args, {
+      readArtifact,
+    });
   },
 
   // #7170: reuse get_changelog's/get_contracts's own loaders unchanged (the same
@@ -4349,7 +4293,7 @@ const rootValue = {
   // Query resolver is the only hook there is, and the same one subnet_trajectory
   // already uses for its window-keyed deltas.
   async changelog(_args: unknown, context: GqlContext) {
-    const data = (await loadChangelog(mcpCtx(context), {
+    const data = (await loadChangelog(context, {
       readArtifact,
     })) as Row;
     // loadChangelog throws on a cold/absent artifact (the test below pins that
@@ -4364,7 +4308,7 @@ const rootValue = {
 
   async contracts(args: Row, context: GqlContext) {
     return pageDocumentCollection(
-      await loadContracts(mcpCtx(context), { readArtifact }),
+      await loadContracts(context, { readArtifact }),
       "contracts",
       args,
     );
@@ -4374,7 +4318,7 @@ const rootValue = {
   // REST and MCP already use). A cold/absent artifact makes the loader throw,
   // which the graphql executor surfaces as a normal GraphQL error.
   build(_args: unknown, context: GqlContext) {
-    return loadBuildSummary(mcpCtx(context), { readArtifact });
+    return loadBuildSummary(context, { readArtifact });
   },
 
   // #8422: reuse get_self_health's own loader unchanged (the same baked
@@ -4382,7 +4326,7 @@ const rootValue = {
   // artifact makes the loader throw, surfaced as a normal GraphQL error --
   // matching build/changelog/contracts.
   self_health(_args: unknown, context: GqlContext) {
-    return loadSelfHealth(mcpCtx(context), { readArtifact });
+    return loadSelfHealth(context, { readArtifact });
   },
 
   // #7170: reuse get_health_history's own loader unchanged. It takes deps as
@@ -4409,41 +4353,41 @@ const rootValue = {
     args: QueryReview_Adapter_CandidatesArgs,
     context: GqlContext,
   ) {
-    return loadAdapterCandidatesList(mcpCtx(context), args, { readArtifact });
+    return loadAdapterCandidatesList(context, args, { readArtifact });
   },
 
   review_enrichment_evidence(
     args: QueryReview_Enrichment_EvidenceArgs,
     context: GqlContext,
   ) {
-    return loadEnrichmentEvidenceList(mcpCtx(context), args, { readArtifact });
+    return loadEnrichmentEvidenceList(context, args, { readArtifact });
   },
 
   review_enrichment_queue(
     args: QueryReview_Enrichment_QueueArgs,
     context: GqlContext,
   ) {
-    return loadEnrichmentQueueList(mcpCtx(context), args, { readArtifact });
+    return loadEnrichmentQueueList(context, args, { readArtifact });
   },
 
   review_enrichment_targets(
     args: QueryReview_Enrichment_TargetsArgs,
     context: GqlContext,
   ) {
-    return loadReviewEnrichmentTargetsList(mcpCtx(context), args, {
+    return loadReviewEnrichmentTargetsList(context, args, {
       readArtifact,
     });
   },
 
   review_gaps(args: QueryReview_GapsArgs, context: GqlContext) {
-    return loadReviewGapsList(mcpCtx(context), args, { readArtifact });
+    return loadReviewGapsList(context, args, { readArtifact });
   },
 
   review_profile_completeness(
     args: QueryReview_Profile_CompletenessArgs,
     context: GqlContext,
   ) {
-    return loadProfileCompletenessList(mcpCtx(context), args, { readArtifact });
+    return loadProfileCompletenessList(context, args, { readArtifact });
   },
 
   async health(_args: unknown, context: GqlContext) {
@@ -4624,7 +4568,7 @@ const rootValue = {
   // field cannot drift from them. An unsupported filter/sort or a cold artifact
   // is a GraphQL error, matching source_snapshots/evidence/profiles.
   search(args: QuerySearchArgs, context: GqlContext) {
-    return loadSearchList(mcpCtx(context), args, { readArtifact });
+    return loadSearchList(context, args, { readArtifact });
   },
 
   // #7877: reuse loadSearchIndexList (the same loader MCP list_search_index +
@@ -4633,7 +4577,7 @@ const rootValue = {
   // an invalid arg throws and becomes a GraphQL error, matching every other
   // filtered field's convention (search/source_snapshots/evidence/profiles).
   search_index(args: QuerySearch_IndexArgs, context: GqlContext) {
-    return loadSearchIndexList(mcpCtx(context), args, { readArtifact });
+    return loadSearchIndexList(context, args, { readArtifact });
   },
 
   async domains(_args: unknown, context: GqlContext) {
@@ -4714,7 +4658,7 @@ const rootValue = {
   // its own args and throws on an invalid filter/sort (or a cold/absent artifact);
   // that throw becomes a GraphQL error, matching provider_endpoints/evidence.
   curation(args: QueryCurationArgs, context: GqlContext) {
-    return loadCurationList(mcpCtx(context), args, { readArtifact });
+    return loadCurationList(context, args, { readArtifact });
   },
 
   async coverage({ network }: QueryCoverageArgs, context: GqlContext) {
@@ -5189,7 +5133,7 @@ const rootValue = {
     // per-subnet artifact and validates every sort/limit/cursor value against
     // the REST allowlists, throwing on an unsupported one.
     try {
-      return await loadSubnetEvidenceList(mcpCtx(context), args, {
+      return await loadSubnetEvidenceList(context, args, {
         readArtifact,
       });
     } catch (rawErr) {
@@ -5225,7 +5169,7 @@ const rootValue = {
     // allowlists, throwing on an unsupported one; that throw surfaces as a
     // normal GraphQL error, matching the review_* family's convention.
     try {
-      return await loadSubnetCandidatesList(mcpCtx(context), args, {
+      return await loadSubnetCandidatesList(context, args, {
         readArtifact,
       });
     } catch (rawErr) {
@@ -5258,7 +5202,7 @@ const rootValue = {
   // never a silently substituted empty list.
   async subnet_endpoints(args: QuerySubnet_EndpointsArgs, context: GqlContext) {
     try {
-      return await loadSubnetEndpointsList(mcpCtx(context), args, {
+      return await loadSubnetEndpointsList(context, args, {
         readArtifact,
       });
     } catch (rawErr) {
@@ -5430,7 +5374,7 @@ const rootValue = {
   ) {
     try {
       const data = await loadChainEventsFeed(
-        mcpCtx(context),
+        context,
         {
           pallet,
           method,
@@ -5505,7 +5449,7 @@ const rootValue = {
     }
     try {
       return await loadChainActivity(
-        mcpCtx(context),
+        context,
         window,
         chainNetworkFromChainName(network),
       );
@@ -5828,11 +5772,8 @@ const rootValue = {
       // #9265: `chain.blocks` carries the same spec_version column, so the
       // non-null contract below is now satisfied with the real timeline
       // rather than only with the empty shape.
-      ((await loadRuntimeVersionHistoryColdTier(
-        context.env as unknown as Parameters<
-          typeof loadRuntimeVersionHistoryColdTier
-        >[0],
-      )) as Row | null) ?? buildRuntimeVersionHistory([]);
+      ((await loadRuntimeVersionHistoryColdTier(context.env)) as Row | null) ??
+      buildRuntimeVersionHistory([]);
     return {
       // THE PRODUCER (#10786). `coverage_complete` is `gaps.length === 0` and
       // `coverage_gaps` is the array it counted -- buildRuntimeVersionHistory
@@ -6029,7 +5970,7 @@ const rootValue = {
     context: GqlContext,
   ) {
     return loadBlockChainEvents(
-      mcpCtx(context),
+      context,
       blockNumber,
       chainNetworkFromChainName(network),
     );
@@ -6127,10 +6068,7 @@ const rootValue = {
       // the alpha-pricing tables had already left -- and a frozen table answers
       // with a schema-stable wrong number rather than an error.
       const positions = await loadNominatorPositions(
-        readStore(
-          context.env,
-          ALPHA_PRICING_TABLES,
-        ) as never as unknown as Parameters<typeof loadNominatorPositions>[0],
+        readStore(context.env, ALPHA_PRICING_TABLES),
         hotkey,
       );
       return buildNominatorPositions(positions, hotkey, {
@@ -7665,9 +7603,7 @@ const rootValue = {
     }
     const narrowing = parseEmissionPipelineNarrowing(
       narrowingParams,
-      data.subnets as unknown as Parameters<
-        typeof parseEmissionPipelineNarrowing
-      >[1],
+      data.subnets,
       { limitMax: EMISSION_PIPELINE_LIMIT_MAX },
     );
     if ("error" in narrowing) {
@@ -8031,12 +7967,10 @@ const rootValue = {
       // resolved to null before it could touch DATA_API.
       // Same shared loader REST and MCP use; GraphQL keeps its own
       // schema-stable card below because that contract is this surface's own.
-      ((await loadChainWeightsColdTier(
-        context.env as unknown as Parameters<
-          typeof loadChainWeightsColdTier
-        >[0],
-        { window: requestedWindow, limit: safeLimit },
-      )) as Row | null) ??
+      ((await loadChainWeightsColdTier(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainWeights([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -8087,12 +8021,10 @@ const rootValue = {
       // Same shared loader REST and MCP use. GraphQL keeps its own fallback
       // below because answering with the schema-stable card rather than an
       // error is this surface's deliberate contract, not the loader's call.
-      ((await loadChainServingColdTier(
-        context.env as unknown as Parameters<
-          typeof loadChainServingColdTier
-        >[0],
-        { window: requestedWindow, limit: safeLimit },
-      )) as Row | null) ??
+      ((await loadChainServingColdTier(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainServing([], { window: requestedWindow, limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8307,12 +8239,10 @@ const rootValue = {
       // The same lakehouse rung REST and MCP now use (#10248). Wiring one
       // surface and not the others is exactly the drift chain-serving-loader.ts
       // was extracted to stop.
-      ((await loadChainPrometheusColdTier(
-        context.env as unknown as Parameters<
-          typeof loadChainPrometheusColdTier
-        >[0],
-        { window: requestedWindow, limit: safeLimit },
-      )) as Row | null) ??
+      ((await loadChainPrometheusColdTier(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainPrometheus([], { window: requestedWindow, limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8440,12 +8370,10 @@ const rootValue = {
       // Same lakehouse reader REST and MCP use; the zeroed card below stays the
       // fallback because this resolver's contract is a schema-stable card
       // rather than an error, which is why the loader declines with null.
-      ((await loadChainWeightSettersColdTier(
-        context.env as unknown as Parameters<
-          typeof loadChainWeightSettersColdTier
-        >[0],
-        { window: requestedWindow, limit: safeLimit },
-      )) as Row | null) ??
+      ((await loadChainWeightSettersColdTier(context.env, {
+        window: requestedWindow,
+        limit: safeLimit,
+      })) as Row | null) ??
       buildChainWeightSetters([], null, {
         window: requestedWindow,
         limit: safeLimit,
@@ -9297,10 +9225,7 @@ const rootValue = {
     // been recording this subnet" is a real state, and the same convention the
     // sibling history fields already follow.
     const rows = await loadSubnetBurnHistory(
-      readStore(
-        context.env,
-        SUBNET_BURN_HISTORY_TABLES,
-      ) as never as unknown as Parameters<typeof loadSubnetBurnHistory>[0],
+      readStore(context.env, SUBNET_BURN_HISTORY_TABLES),
       netuid,
       { windowDays },
     );
@@ -9963,7 +9888,7 @@ export async function handleGraphQLRequest(
     schema,
     document,
     rootValue: parsedRootValue,
-    contextValue: { env, cache: new Map(), request, ctx },
+    contextValue: { env, cache: new Map(), request, ctx, readArtifact },
     variableValues: variables ?? undefined,
     operationName: operationName ?? undefined,
   });

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2598,10 +2598,7 @@ const rootValue = {
     // every deployed config and is absent from FORWARDABLE_TIER_FLAGS, so that
     // arm resolved to null on every request.
     const data = await loadSubnetTrajectory(netuid, {
-      db: observationsReadDb(
-        context.env as unknown as Record<string, unknown>,
-        context.ctx,
-      ),
+      db: observationsReadDb(context.env, context.ctx),
     });
     return {
       schema_version: data.schema_version ?? 1,
@@ -4470,10 +4467,7 @@ const rootValue = {
       netuids: parsedNetuids,
       dimensions: parsedDimensions!,
       observedAt: await loadObservedAt(context),
-      db: observationsReadDb(
-        context.env as unknown as Record<string, unknown>,
-        context.ctx,
-      ),
+      db: observationsReadDb(context.env, context.ctx),
     });
   },
 
@@ -4983,10 +4977,7 @@ const rootValue = {
       await loadSubnetPercentiles(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
-        db: observationsReadDb(
-          context.env as unknown as Record<string, unknown>,
-          context.ctx,
-        ),
+        db: observationsReadDb(context.env, context.ctx),
       });
     return {
       schema_version: data.schema_version ?? 1,
@@ -5247,10 +5238,7 @@ const rootValue = {
       await loadSubnetIncidents(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
-        db: observationsReadDb(
-          context.env as unknown as Record<string, unknown>,
-          context.ctx,
-        ),
+        db: observationsReadDb(context.env, context.ctx),
       });
     return {
       // THE PRODUCER (#10786). MIN_INCIDENT_SAMPLES is the threshold this
@@ -7481,10 +7469,7 @@ const rootValue = {
       await loadEconomicsTrends({
         windowLabel: label,
         windowDays: days,
-        db: observationsReadDb(
-          context.env as unknown as Record<string, unknown>,
-          context.ctx,
-        ),
+        db: observationsReadDb(context.env, context.ctx),
       })
     ).data;
     // Normalized the same way blocks/validators/accounts are (schema-stable,
@@ -8784,10 +8769,7 @@ const rootValue = {
       (
         await loadBulkHealthTrends({
           observedAt: await loadObservedAt(context),
-          db: observationsReadDb(
-            context.env as unknown as Record<string, unknown>,
-            context.ctx,
-          ),
+          db: observationsReadDb(context.env, context.ctx),
           window: window ?? null,
           limit: limit ?? null,
           offset: offset ?? 0,
@@ -8818,10 +8800,7 @@ const rootValue = {
       // resolved to null before it could touch DATA_API.
       await loadSubnetHealthTrends(netuid, {
         observedAt: await loadObservedAt(context),
-        db: observationsReadDb(
-          context.env as unknown as Record<string, unknown>,
-          context.ctx,
-        ),
+        db: observationsReadDb(context.env, context.ctx),
       });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8963,10 +8942,7 @@ const rootValue = {
       (await loadSubnetUptime(netuid, {
         window: windowParam,
         observedAt: await loadObservedAt(context),
-        db: observationsReadDb(
-          context.env as unknown as Record<string, unknown>,
-          context.ctx,
-        ),
+        db: observationsReadDb(context.env, context.ctx),
       })) as Row;
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -33,7 +33,6 @@ import {
 import { ipv6EmbeddedIpv4 } from "./ip-safety.ts";
 import { OPERATIONAL_SURFACES_R2_KEY } from "./operational-surfaces-sync.ts";
 import {
-  neonOwnsObservations,
   persistProbesToNeon,
   pruneChecksNeon,
   rollupFailureReasonsToNeon,
@@ -42,7 +41,7 @@ import {
   type ObservationsSql,
 } from "./observations-neon.ts";
 import { observationsReadDb } from "./observations-read-runner.ts";
-import { createPgSql, type HyperdriveLike } from "./pg-sql.ts";
+import { createPgSql } from "./pg-sql.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { recordSubnetIdentityChanges } from "./subnet-identity-history.ts";
@@ -66,6 +65,7 @@ import {
 import { emptyStatusCounts } from "./endpoint-score.ts";
 import { readLiveSurfaceStatus } from "./health-status-live.ts";
 import { LIVE_CRON_PROBER } from "./field-provenance.ts";
+import { hyperdriveConnectionString, recordsOrEmpty } from "./read-store.ts";
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 
 type Row = Record<string, unknown>;
@@ -526,9 +526,14 @@ function observationsRunner(
   ctx?: ExecutionContext,
 ): ObservationsSql | null {
   if (!ctx) return null;
-  const bag = env;
-  if (!neonOwnsObservations(bag)) return null;
-  return createPgSql(env.HYPERDRIVE as unknown as HyperdriveLike, ctx);
+  // ONE check, not two. `neonOwnsObservations` is now literally
+  // `hyperdriveConnectionString(env) !== null`, so asking both left the
+  // compiler unable to see that the string was already proven -- which is what
+  // the `env.HYPERDRIVE as unknown as HyperdriveLike` cast here was covering
+  // for (#11339).
+  const connectionString = hyperdriveConnectionString(env);
+  if (!connectionString) return null;
+  return createPgSql({ connectionString }, ctx);
 }
 
 // Run one full probe sweep and persist results. Returns a small summary object.
@@ -725,7 +730,9 @@ export async function runHealthProber(
   if (probeSql) {
     await persistProbesToNeon(
       probeSql,
-      probed as unknown as Record<string, unknown>[],
+      // A real conversion, not an assertion: these are plain objects at
+      // runtime, and `recordsOrEmpty` is what says so (#11339).
+      recordsOrEmpty(probed),
       runAt,
     );
   }
@@ -1137,7 +1144,7 @@ export async function writeSubnetSnapshotRows(
   if (!snapshotSql) return { synced: false, reason: "unavailable" };
   const write = upsertSubnetSnapshotsToNeon(
     snapshotSql,
-    rows as unknown as Record<string, unknown>[],
+    recordsOrEmpty(rows),
   ).then((r) => ({ ok: r.ok, reason: r.reason }));
   return write.then((result) =>
     // The write's own verdict is the lane's verdict, rather than being

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -526,7 +526,7 @@ function observationsRunner(
   ctx?: ExecutionContext,
 ): ObservationsSql | null {
   if (!ctx) return null;
-  const bag = env as unknown as Record<string, unknown>;
+  const bag = env;
   if (!neonOwnsObservations(bag)) return null;
   return createPgSql(env.HYPERDRIVE as unknown as HyperdriveLike, ctx);
 }
@@ -711,7 +711,7 @@ export async function runHealthProber(
   // written by the same sweep, so reading it from the other store would rank on
   // whatever that store last happened to hold.
   const reliability = await loadEndpointReliability(
-    observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+    observationsReadDb(env, ctx),
     runAt,
   );
   const nextCurrent = await persistToKv(kv, probed, runAt, reliability);

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -7,7 +7,10 @@
 // serving zero-downtime and regression-proof. No I/O here: callers pass parsed
 // objects + store rows in.
 
-import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
+import type {
+  SubnetEconomics as SubnetEconomicsRow,
+  SubnetEconomicsRead,
+} from "../schemas-src/shared.ts";
 import {
   computeReliability,
   scoreFromStats,
@@ -2145,7 +2148,7 @@ export async function resolveLiveEconomics({
 // four sites -- which is the signature being ignored rather than used. Both
 // functions are shape-preserving, so the honest spelling is the row/artifact
 // in and the same out.
-export function withSpotPrice<T extends SubnetEconomicsRow | null | undefined>(
+export function withSpotPrice<T extends SubnetEconomicsRead | null | undefined>(
   row: T,
 ): T {
   if (!row || typeof row !== "object") return row;

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -31,6 +31,7 @@ import {
 } from "./endpoint-score.ts";
 import { readLiveSurfaceStatus } from "./health-status-live.ts";
 import { LIVE_CRON_PROBER } from "./field-provenance.ts";
+import { recordOrNull } from "./read-store.ts";
 
 type Row = Record<string, unknown>;
 
@@ -2004,13 +2005,16 @@ export async function resolveLiveHealth({
   env,
   now,
 }: {
-  readHealthKv?: (env: Env, key: string) => Promise<Row | null>;
+  // `unknown`, matching workers/storage.ts: KV holds whatever the cron last
+  // wrote as JSON. Declaring `Row` here was a claim about untrusted bytes that
+  // nothing checked, and the callers cast to satisfy it (#11339).
+  readHealthKv?: (env: Env, key: string) => Promise<unknown>;
   env?: Env;
   now?: () => number;
 } = {}): Promise<Row | null> {
   if (typeof readHealthKv === "function" && env) {
     try {
-      const current = await readHealthKv(env, KV_HEALTH_CURRENT);
+      const current = recordOrNull(await readHealthKv(env, KV_HEALTH_CURRENT));
       // The prober writes surfaces + subnets + summary; accept any live snapshot
       // that carries the per-surface or per-subnet rows the overlays consume —
       // but freshness-gate it exactly like the Postgres fallback below. KV
@@ -2025,7 +2029,12 @@ export async function resolveLiveHealth({
         (Array.isArray(current.surfaces) || Array.isArray(current.subnets))
       ) {
         const currentTime = typeof now === "function" ? now() : Date.now();
-        const lastRun = Date.parse(current.last_run_at as string);
+        // A non-string parses to NaN, which the guard below already treats
+        // as "fresh" -- the same outcome the cast produced, said honestly.
+        const lastRun =
+          typeof current.last_run_at === "string"
+            ? Date.parse(current.last_run_at)
+            : Number.NaN;
         if (
           !Number.isFinite(lastRun) ||
           lastRun >= currentTime - HEALTH_FALLBACK_MAX_AGE_MS

--- a/src/hotkey-alpha-completeness.ts
+++ b/src/hotkey-alpha-completeness.ts
@@ -1,4 +1,4 @@
-import type { RowReader } from "./read-store.ts";
+import type { OptionalRowReader } from "./read-store.ts";
 // "Is the hotkey_alpha pool ledger safe to price positions from?" (#9502)
 //
 // The twin of src/account-balances-completeness.ts, and needed for a strictly
@@ -54,7 +54,19 @@ const NONE: HotkeyAlphaCompleteness = {
  * leaderboard that cannot prove its inputs should fall back, not 500.
  */
 export async function latestCompleteHotkeyAlphaPass(
-  db: RowReader | null | undefined,
+  /**
+   * OPTIONAL `first`, matching what the body actually does.
+   *
+   * This declared `RowReader` -- `first` REQUIRED -- while the line below
+   * guards `if (!db?.first)` and declines. The two disagreed, so every caller
+   * holding a store whose `first` is optional had to cast, and four of them
+   * did: `db as unknown as Parameters<typeof …>[0]`. That cast asserted the
+   * method was there, past a guard whose whole purpose is that it might not be.
+   *
+   * Widening the parameter is the honest direction. The guard is the contract;
+   * the signature now says so, and the casts are gone rather than justified.
+   */
+  db: OptionalRowReader | null | undefined,
 ): Promise<HotkeyAlphaCompleteness> {
   if (!db?.first) return { ...NONE, reason: "unavailable" };
   try {

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -71,6 +71,24 @@ import {
   type ReadStoreDb,
 } from "./read-store.ts";
 import type { HotkeyAlpha } from "../generated/db/types.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type HotkeyAlphaStalenessWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO?: unknown;
+    HOTKEY_ALPHA_PASS_WINDOW_MS?: unknown;
+    HOTKEY_ALPHA_STALENESS_THRESHOLD_MS?: unknown;
+  };
 
 /**
  * How old the pool ledger may get before this is a stall.
@@ -266,7 +284,7 @@ export interface HotkeyAlphaStalenessDeps {
  * and a cron that throws is a cron nobody can read the result of.
  */
 export async function runHotkeyAlphaStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: HotkeyAlphaStalenessWatchdogEnv | null | undefined,
   deps: HotkeyAlphaStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -319,7 +319,7 @@ export async function runHotkeyAlphaStalenessWatchdog(
         verdict.reason === "partial"
           ? `hotkey-alpha lane truncated: the newest pass wrote only ${verdict.covered_rows} pool totals against a floor of ${verdict.coverage_floor_rows} derived from the ${verdict.referenced_pairs} (hotkey, netuid) pairs nominator_positions references (${verdict.total_rows} rows in the table, newest stamp ${age}) -- the capture is RECENT and PARTIAL, so every position naming a pool the pass never reached prices against nothing and its holder is UNDERSTATED rather than missing`
           : `hotkey-alpha lane ${verdict.reason === "no_rows" ? "has never landed a pass" : "stalled"}: ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/top-holders is answering delegated_tao/total_tao from the frozen 2026-08-02 materialization and /subnets/{netuid}/holders is declining every request with pool_totals_unproven`;
-      await record(env as never, {
+      await record(env, {
         error: new Error(message),
         route: "watchdog:hotkey-alpha-staleness",
         errorCode: "stale_lane",

--- a/src/hyperparams-identity-neon-write.ts
+++ b/src/hyperparams-identity-neon-write.ts
@@ -38,6 +38,7 @@ import {
   writeRowsToNeon,
   type NeonWriteResult,
 } from "./neon-write.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 // ---------------------------------------------------------------------------
 // Moved here when D1 was deleted (#10179). These describe the TABLE -- its
@@ -296,7 +297,7 @@ export interface FamilyMirrorOutcome {
  * this function has one behaviour rather than two.
  */
 export async function mirrorFamilyToNeon(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   lane: string,
   input: FamilyMirrorInput,

--- a/src/identity-history-answer.ts
+++ b/src/identity-history-answer.ts
@@ -41,6 +41,12 @@ import {
 import { SUBNET_IDENTITY_HISTORY_TABLES } from "./read-store-tables.ts";
 import { readStore } from "./read-store.ts";
 import { storeAll } from "./analytics-live.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { ArtifactEnv } from "../workers/storage.ts";
+
+/** One env, forwarded to both legs: the Neon store and the lakehouse. */
+type ComposerEnv = R2SqlEnv & StoreEnv & ArtifactEnv;
 
 type Row = Record<string, unknown>;
 
@@ -71,8 +77,10 @@ type Row = Record<string, unknown>;
  * And a live-store MISS still falls through, so the frozen history stays
  * readable for the range that predates the writer.
  */
-async function liveStore(env: unknown): Promise<SqlRunner | null> {
-  const db = readStore(env as never, SUBNET_IDENTITY_HISTORY_TABLES);
+async function liveStore(
+  env: ComposerEnv | null | undefined,
+): Promise<SqlRunner | null> {
+  const db = readStore(env, SUBNET_IDENTITY_HISTORY_TABLES);
   return db ? (sql, params) => storeAll(db as never, sql, params) : null;
 }
 
@@ -107,17 +115,17 @@ function nonEmpty(result: Row | null, key: "entries" | "changes"): Row | null {
 export interface AnswerSubnetIdentityHistoryOptions {
   coldTier?: typeof loadSubnetIdentityHistoryColdTier;
   /** Injectable so a test can drive the live leg without a store. */
-  live?: (env: unknown) => Promise<SqlRunner | null>;
+  live?: (env: ComposerEnv | null | undefined) => Promise<SqlRunner | null>;
 }
 
 export interface AnswerChainIdentityHistoryOptions {
   coldTier?: typeof loadChainIdentityHistoryColdTier;
-  live?: (env: unknown) => Promise<SqlRunner | null>;
+  live?: (env: ComposerEnv | null | undefined) => Promise<SqlRunner | null>;
 }
 
 /** One subnet's identity timeline from whichever store can answer. */
 export async function answerSubnetIdentityHistory(
-  env: unknown,
+  env: ComposerEnv | null | undefined,
   netuid: number,
   tierResult: Row | null | undefined,
   query: { limit: number; offset?: number | null; cursor?: unknown },
@@ -143,7 +151,7 @@ export async function answerSubnetIdentityHistory(
   return (
     tierResult ??
     fresh ??
-    ((await coldTier(env as never, netuid, {
+    ((await coldTier(env, netuid, {
       limit: query.limit,
       offset: query.offset ?? null,
       cursor: query.cursor ?? null,
@@ -158,7 +166,7 @@ export async function answerSubnetIdentityHistory(
 
 /** The network-wide identity feed from whichever store can answer. */
 export async function answerChainIdentityHistory(
-  env: unknown,
+  env: ComposerEnv | null | undefined,
   tierResult: Row | null | undefined,
   query: { limit?: unknown } = {},
   {
@@ -181,7 +189,7 @@ export async function answerChainIdentityHistory(
   return (
     tierResult ??
     fresh ??
-    ((await coldTier(env as never, { limit: query.limit })) as Row | null) ??
+    ((await coldTier(env, { limit: query.limit })) as Row | null) ??
     (buildChainIdentityHistory([], {
       limit: query.limit,
     }) as unknown as Row)

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -335,7 +335,7 @@ export async function runLakehouseSeamWatchdog(
   // this one was simply never wired to either.
   if (reasons.length > 0) {
     const record = deps.recordExceptionEvent ?? recordExceptionEvent;
-    await record(env as never, {
+    await record(env, {
       error: new Error(`lakehouse decode seam drifted: ${reasons.join(", ")}`),
       route: "watchdog:lakehouse-seam",
       errorCode: "stale_lane",

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -276,10 +276,7 @@ export async function runLakehouseSeamWatchdog(
   const query = deps.query ?? r2SqlQuery;
   // The only watchdog in the family that still named the binding here; every
   // other one goes through laneHealthStore (#10154).
-  const laneHealthDb = laneHealthStore(
-    env as unknown as Record<string, unknown>,
-    deps.laneHealthDb,
-  );
+  const laneHealthDb = laneHealthStore(env, deps.laneHealthDb);
   const recordVerdict = (verdict: LaneVerdictInput) =>
     recordLaneVerdict(laneHealthDb, {
       lane: LAKEHOUSE_SEAM_LANE,

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -1247,7 +1247,7 @@ export async function runLaneAlarm(
     // Measured on production before the fix: exactly one event per tick for six
     // consecutive hours, while this watchdog's own verdict read "4 alarming".
     // The lane set is declared and small, so per-lane windows are bounded.
-    await record(env as never, {
+    await record(env, {
       error: new Error(laneAlarmSummary(alarm, nowMs)),
       route: "watchdog:lane-alarm",
       fingerprintDetail: alarm.lane,
@@ -1279,7 +1279,7 @@ export async function runLaneAlarm(
     // Its own code, because the two are different problems with different
     // fixes: this one is "we could not ask GitHub what is already open", and
     // the one below is "we asked, and it refused everything we sent".
-    await record(env as never, {
+    await record(env, {
       error: new Error(
         `lane-alarm could not read its issue list: ${plan.open.length} alarming lane(s) ` +
           "recorded but none filed, because opening without the list would " +
@@ -1291,7 +1291,7 @@ export async function runLaneAlarm(
     }).catch(() => false);
   }
   if (github && !listUnavailable && plan.open.length > 0 && opened === 0) {
-    await record(env as never, {
+    await record(env, {
       error: new Error(
         `lane-alarm delivered nothing: ${plan.open.length} alarming lane(s) planned, ` +
           "GitHub accepted none. The alarm's only push channel is not working. " +
@@ -1319,7 +1319,7 @@ export async function runLaneAlarm(
       // GitHub write is one channel, and a loss nobody can see is the thing
       // this whole list exists to end. Its own code, because "more was lost on
       // a queue already alarming" is a different event from the first loss.
-      await record(env as never, {
+      await record(env, {
         error: new Error(
           `lane ${entry.lane} lost more while already alarming` +
             (entry.record.detail ? ` -- ${entry.record.detail}` : ""),

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -67,6 +67,25 @@ import {
 } from "../schemas-src/foreign-wire.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { countOrZero } from "./read-store.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type LaneAlarmEnv = StoreEnv &
+  TelemetryEnv & {
+    GITHUB_TOKEN?: unknown;
+    LANE_ALARM_GITHUB_TOKEN?: unknown;
+    LANE_ALARM_MIN_STALE_MS?: unknown;
+    LANE_ALARM_REPO?: unknown;
+  };
 
 /**
  * How long a lane must stay stale before it earns an issue.
@@ -1140,7 +1159,7 @@ export interface LaneAlarmDeps {
  * reads: a tick that cannot run is one missed report, not an outage.
  */
 export async function runLaneAlarm(
-  env: Record<string, unknown> | null | undefined,
+  env: LaneAlarmEnv | null | undefined,
   deps: LaneAlarmDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/lane-health-store.ts
+++ b/src/lane-health-store.ts
@@ -32,8 +32,9 @@
 // This preserves that -- a failed verdict write is a dropped verdict, exactly as
 // it is on the store today.
 import { Client } from "pg";
-import { toPositionalPlaceholders, type HyperdriveLike } from "./pg-sql.ts";
+import { toPositionalPlaceholders } from "./pg-sql.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
+import { hyperdriveConnectionString } from "./read-store.ts";
 
 /** The minimal pg client this needs, so a test can hand it a fake. */
 export interface LaneHealthPgClient {
@@ -94,17 +95,15 @@ export function pgLaneHealthDb(
  * store" rather than as an error.
  */
 export function laneHealthStore(
-  // Deliberately loose: the callers hand in an `Env`, a bag, or nothing, and a
-  // narrower type would push a cast to 27 call sites.
-  env: Record<string, unknown> | Record<never, never> | null | undefined,
+  // `unknown`, not `Record<string, unknown>`: the intent above was always to be
+  // loose enough for an `Env`, a bag or nothing, and a Record is not -- an
+  // interface has no implicit index signature, so seven call sites holding a
+  // real `Env` wrote `env` (#11339).
+  env: unknown,
   injected?: LaneHealthDb | null,
   deps: LaneHealthStoreDeps = {},
 ): LaneHealthDb | undefined {
   if (injected) return injected;
-  const hyperdrive = (env as Record<string, unknown> | null | undefined)
-    ?.HYPERDRIVE as HyperdriveLike | undefined;
-  if (hyperdrive?.connectionString) {
-    return pgLaneHealthDb(hyperdrive.connectionString, deps);
-  }
-  return undefined;
+  const connectionString = hyperdriveConnectionString(env);
+  return connectionString ? pgLaneHealthDb(connectionString, deps) : undefined;
 }

--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -44,6 +44,7 @@ import {
   neonWriteRunner,
 } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 // ---------------------------------------------------------------------------
 // Moved here when D1 was deleted (#10179). These describe the TABLE -- its
@@ -193,7 +194,7 @@ export interface LedgerMirrorDeps {
  * what the name "mirror" no longer implies.
  */
 export async function mirrorLedgerToNeon(
-  env: Record<string, unknown> | null | undefined,
+  env: (NeonWriteEnv & { METAGRAPH_HEALTH_DB?: unknown }) | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   lane: string,
   rows: Record<string, unknown>[],

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18527,7 +18527,7 @@ async function serveMcpThroughSdk(
 // a request that never reached a handler.
 export async function handleMcpRequest(
   request: Request,
-  env: Env = {} as unknown as Env,
+  env: Env,
   deps: McpDeps = {},
 ) {
   const response = await dispatchMcpRequest(request, env, deps);
@@ -18537,7 +18537,7 @@ export async function handleMcpRequest(
 
 async function dispatchMcpRequest(
   request: Request,
-  env: Env = {} as unknown as Env,
+  env: Env,
   deps: McpDeps = {},
 ) {
   const { rejection, authTier, accountId, quotaPending } =

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1798,7 +1798,7 @@ import {
   buildNominatorPositions,
   loadNominatorPositions,
 } from "./validator-nominator-positions.ts";
-import { readStore } from "./read-store.ts";
+import { numberOrNull, readStore, recordOrNull } from "./read-store.ts";
 import {
   ALPHA_PRICING_TABLES,
   CHAIN_CONCENTRATION_HISTORY_TABLES,
@@ -3340,20 +3340,13 @@ async function mcpSubnetSurfaces(
  */
 async function mcpRevenueObservations(ctx: McpCtx, netuid: number | null) {
   return loadRevenueObservations(
-    readStore(
-      ctx.env,
-      REVENUE_OBSERVATION_TABLES,
-    ) as never as unknown as Parameters<typeof loadRevenueObservations>[0],
+    readStore(ctx.env, REVENUE_OBSERVATION_TABLES),
     netuid,
   );
 }
 
 async function mcpUsdPerTao(ctx: McpCtx): Promise<number | null> {
-  return usdPerTaoOrNull(
-    readStore(ctx.env, TAO_USD_TABLES) as never as unknown as Parameters<
-      typeof usdPerTaoOrNull
-    >[0],
-  );
+  return usdPerTaoOrNull(readStore(ctx.env, TAO_USD_TABLES));
 }
 
 // One subnet's economics: live KV tier (KV-primary), else the committed R2
@@ -7255,10 +7248,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
         // Same shared loader REST and GraphQL use (#9229's parity lesson).
-        (await loadChainWeightsColdTier(
-          ctx.env as unknown as Parameters<typeof loadChainWeightsColdTier>[0],
-          { window, limit },
-        )) ??
+        (await loadChainWeightsColdTier(ctx.env, { window, limit })) ??
         buildChainWeights([], {
           window,
           limit,
@@ -7301,12 +7291,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
-        (await loadChainWeightSettersColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadChainWeightSettersColdTier
-          >[0],
-          { window, limit },
-        )) ?? buildChainWeightSetters([], null, { window, limit })
+        (await loadChainWeightSettersColdTier(ctx.env, { window, limit })) ??
+        buildChainWeightSetters([], null, { window, limit })
       );
     },
   },
@@ -7481,10 +7467,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // surfaces answer from one implementation. Without this the tool kept
         // returning the zeroed card while /api/v1/chain/serving returned real
         // numbers for the identical question (#9216 wired REST only).
-        (await loadChainServingColdTier(
-          ctx.env as unknown as Parameters<typeof loadChainServingColdTier>[0],
-          { window, limit },
-        )) ?? buildChainServing([], { window, limit })
+        (await loadChainServingColdTier(ctx.env, { window, limit })) ??
+        buildChainServing([], { window, limit })
       );
     },
   },
@@ -7526,12 +7510,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
         // The lakehouse rung, same as REST and GraphQL (#10248).
-        (await loadChainPrometheusColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadChainPrometheusColdTier
-          >[0],
-          { window, limit },
-        )) ?? buildChainPrometheus([], { window, limit })
+        (await loadChainPrometheusColdTier(ctx.env, { window, limit })) ??
+        buildChainPrometheus([], { window, limit })
       );
     },
   },
@@ -8054,14 +8034,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
-        (await loadSubnetWeightsColdTier(
-          ctx.env as unknown as Parameters<typeof loadSubnetWeightsColdTier>[0],
-          netuid,
-          {
-            windowLabel: window,
-            windowDays: SUBNET_WEIGHTS_WINDOWS[window] ?? 7,
-          },
-        )) ?? buildSubnetWeights(null, netuid, { window })
+        (await loadSubnetWeightsColdTier(ctx.env, netuid, {
+          windowLabel: window,
+          windowDays: SUBNET_WEIGHTS_WINDOWS[window] ?? 7,
+        })) ?? buildSubnetWeights(null, netuid, { window })
       );
     },
   },
@@ -8091,17 +8067,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
-        (await loadSubnetWeightSettersColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadSubnetWeightSettersColdTier
-          >[0],
-          netuid,
-          {
-            windowLabel: window,
-            windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[window] ?? 7,
-            limit: SUBNET_WEIGHT_SETTERS_LIMIT,
-          },
-        )) ?? buildSubnetWeightSetters([], null, netuid, { window })
+        (await loadSubnetWeightSettersColdTier(ctx.env, netuid, {
+          windowLabel: window,
+          windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[window] ?? 7,
+          limit: SUBNET_WEIGHT_SETTERS_LIMIT,
+        })) ?? buildSubnetWeightSetters([], null, netuid, { window })
       );
     },
   },
@@ -8131,9 +8101,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadSubnetEventCardColdTier
-          >[0],
+          ctx.env,
           CHAIN_REGISTRATIONS_ROLLUP,
           netuid,
           buildSubnetRegistrations,
@@ -8171,9 +8139,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadSubnetEventCardColdTier
-          >[0],
+          ctx.env,
           CHAIN_STAKE_MOVES_ROLLUP,
           netuid,
           buildSubnetStakeMoves,
@@ -8212,9 +8178,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadSubnetEventCardColdTier
-          >[0],
+          ctx.env,
           CHAIN_STAKE_TRANSFERS_ROLLUP,
           netuid,
           buildSubnetStakeTransfers,
@@ -8284,9 +8248,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
         // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadSubnetEventCardColdTier
-          >[0],
+          ctx.env,
           CHAIN_SERVING_ROLLUP,
           netuid,
           buildSubnetServing,
@@ -8327,9 +8289,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // resolved to null before it could touch DATA_API.
         // #10322: same cold-tier rung as its REST and GraphQL twins.
         (await loadSubnetEventCardColdTier(
-          ctx.env as unknown as Parameters<
-            typeof loadSubnetEventCardColdTier
-          >[0],
+          ctx.env,
           CHAIN_PROMETHEUS_ROLLUP,
           netuid,
           buildSubnetPrometheus,
@@ -8508,7 +8468,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           observedAt: await mcpObservedAt(ctx),
           minSamples: minSamples ?? null,
           db: readStore(ctx.env, UPTIME_DAILY_TABLES) as never,
-        } as unknown as Parameters<typeof loadSubnetUptime>[1])) as Row
+        })) as Row
       );
     },
   },
@@ -9090,12 +9050,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         }
         return buildNominatorPositions(
           await loadNominatorPositions(
-            readStore(
-              ctx.env,
-              ALPHA_PRICING_TABLES,
-            ) as never as unknown as Parameters<
-              typeof loadNominatorPositions
-            >[0],
+            readStore(ctx.env, ALPHA_PRICING_TABLES),
             hotkey,
           ),
           hotkey,
@@ -10015,10 +9970,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         optionalEnum(args, "window", Object.keys(BURN_HISTORY_WINDOWS)) ??
         DEFAULT_BURN_HISTORY_WINDOW;
       const rows = await loadSubnetBurnHistory(
-        readStore(
-          ctx.env,
-          SUBNET_BURN_HISTORY_TABLES,
-        ) as never as unknown as Parameters<typeof loadSubnetBurnHistory>[0],
+        readStore(ctx.env, SUBNET_BURN_HISTORY_TABLES),
         netuid,
         { windowDays: BURN_HISTORY_WINDOWS[label] },
       );
@@ -10054,12 +10006,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const label =
         optionalEnum(args, "window", Object.keys(TAO_USD_WINDOWS)) ??
         DEFAULT_TAO_USD_WINDOW;
-      const rows = await loadTaoUsdSeries(
-        readStore(ctx.env, TAO_USD_TABLES) as never as unknown as Parameters<
-          typeof loadTaoUsdSeries
-        >[0],
-        { windowHours: TAO_USD_WINDOWS[label] },
-      );
+      const rows = await loadTaoUsdSeries(readStore(ctx.env, TAO_USD_TABLES), {
+        windowHours: TAO_USD_WINDOWS[label],
+      });
       // Defaults to FALSE here and to true on REST -- see the schema. The
       // summary is computed over the whole window either way, so this narrows
       // the response without narrowing the measurement.
@@ -10108,10 +10057,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         SURFACE_HISTORY_LIMIT_MAX,
       );
       const rows = await loadSurfaceHistory(
-        readStore(
-          ctx.env,
-          SURFACE_HISTORY_TABLES,
-        ) as never as unknown as Parameters<typeof loadSurfaceHistory>[0],
+        readStore(ctx.env, SURFACE_HISTORY_TABLES),
         netuid,
         { limit },
       );
@@ -10156,10 +10102,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         EMISSION_CHANGES_LIMIT_MAX,
       );
       const rows = await loadEmissionChanges(
-        readStore(
-          ctx.env,
-          EMISSION_CHANGES_TABLES,
-        ) as never as unknown as Parameters<typeof loadEmissionChanges>[0],
+        readStore(ctx.env, EMISSION_CHANGES_TABLES),
         { limit, kind },
       );
       return buildEmissionChanges(rows, { limit, kind });
@@ -10203,10 +10146,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_HOLDERS_LIMIT_MAX,
       );
       const read = await loadChainHolders(
-        readStore(
-          ctx.env,
-          ALPHA_PRICING_TABLES,
-        ) as never as unknown as Parameters<typeof loadChainHolders>[0],
+        readStore(ctx.env, ALPHA_PRICING_TABLES),
       );
       return buildChainHolders(read, { sort, limit });
     },
@@ -10246,10 +10186,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const netuid = typeof args?.netuid === "number" ? args.netuid : undefined;
       const kind = typeof args?.kind === "string" ? args.kind : undefined;
       const rows = await loadFailureReasons(
-        readStore(
-          ctx.env,
-          FAILURE_REASONS_TABLES,
-        ) as never as unknown as Parameters<typeof loadFailureReasons>[0],
+        readStore(ctx.env, FAILURE_REASONS_TABLES),
         { window, netuid, kind },
       );
       return rows === null
@@ -10283,12 +10220,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       _args: z.infer<typeof GetIndexerLagInputSchema>,
       ctx: McpCtx,
     ) {
-      const row = await loadIndexerLag(
-        readStore(
-          ctx.env,
-          INDEXER_LAG_TABLES,
-        ) as never as unknown as Parameters<typeof loadIndexerLag>[0],
-      );
+      const row = await loadIndexerLag(readStore(ctx.env, INDEXER_LAG_TABLES));
       return buildIndexerLag(row, Date.now());
     },
   },
@@ -10327,12 +10259,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           ...CHAIN_CONCENTRATION_HISTORY_WINDOWS,
         ]) ?? DEFAULT_CHAIN_CONCENTRATION_HISTORY_WINDOW;
       const rows = await loadChainConcentrationHistory(
-        readStore(
-          ctx.env,
-          CHAIN_CONCENTRATION_HISTORY_TABLES,
-        ) as never as unknown as Parameters<
-          typeof loadChainConcentrationHistory
-        >[0],
+        readStore(ctx.env, CHAIN_CONCENTRATION_HISTORY_TABLES),
         { window },
       );
       return rows === null
@@ -10375,10 +10302,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         optionalEnum(args, "window", [...PIPELINE_HISTORY_WINDOWS]) ??
         DEFAULT_PIPELINE_HISTORY_WINDOW;
       const rows = await loadPipelineHistory(
-        readStore(
-          ctx.env,
-          SUBNET_SNAPSHOT_TABLES,
-        ) as never as unknown as Parameters<typeof loadPipelineHistory>[0],
+        readStore(ctx.env, SUBNET_SNAPSHOT_TABLES),
         netuid,
         { window },
       );
@@ -10427,12 +10351,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // NOT filtered to `netuid`: rank is relative, so each day is loaded whole
       // and narrowed in the builder -- see the loader's own header.
       const rows = await loadDeregistrationHistory(
-        readStore(
-          ctx.env,
-          SUBNET_DEREGISTRATION_DAILY_TABLES,
-        ) as never as unknown as Parameters<
-          typeof loadDeregistrationHistory
-        >[0],
+        readStore(ctx.env, SUBNET_DEREGISTRATION_DAILY_TABLES),
         { window },
       );
       return rows === null
@@ -10538,10 +10457,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         SUBNET_HOLDERS_LIMIT_MAX,
       );
       const read = await loadSubnetHolders(
-        readStore(
-          ctx.env,
-          ALPHA_PRICING_TABLES,
-        ) as never as unknown as Parameters<typeof loadSubnetHolders>[0],
+        readStore(ctx.env, ALPHA_PRICING_TABLES),
         netuid,
         { limit },
       );
@@ -14984,8 +14900,36 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       if (credentialPlacement?.location === "body" && !requestContentType) {
         requestContentType = "application/json";
       }
+      // The url `callSubnetSurface` will hand to `new URL()` two frames down,
+      // checked HERE rather than assumed. The catalog is a baked artifact, so
+      // by the time a row reaches this line it is untrusted bytes; a row with
+      // no usable url declines the way every other uncallable surface does
+      // instead of throwing a TypeError inside the fetch path (#11339).
+      const surfaceUrl = stringOf(surface.url);
+      if (!surfaceUrl) {
+        throw await uncallableSurfaceError(ctx, args.surface_id);
+      }
+      const surfaceProbe = recordOrNull(surface.probe);
       const result = await callSubnetSurface(
-        surface as unknown as Parameters<typeof callSubnetSurface>[0],
+        {
+          url: surfaceUrl,
+          ...(surfaceProbe
+            ? {
+                probe: {
+                  ...(stringOf(surfaceProbe.method)
+                    ? { method: stringOf(surfaceProbe.method) as string }
+                    : {}),
+                  ...(numberOrNull(surfaceProbe.timeout_ms) !== null
+                    ? {
+                        timeout_ms: numberOrNull(
+                          surfaceProbe.timeout_ms,
+                        ) as number,
+                      }
+                    : {}),
+                },
+              }
+            : {}),
+        },
         {
           query:
             args.query && typeof args.query === "object"

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9709,7 +9709,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const loadParams =
         (ctx as { loadNetworkParameters?: typeof loadNetworkParameters })
           .loadNetworkParameters ?? loadNetworkParameters;
-      const parameters = await loadParams(ctx.env as never);
+      const parameters = await loadParams(ctx.env);
       const ownerCut = parameters?.subnet_owner_cut_effective;
       // #10930: the same flow read REST does, from the same cold-tier
       // function over the same window. Wiring this on one surface only would
@@ -9728,7 +9728,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         (ctx as { loadStakeFlow?: typeof loadAccountStakeFlowColdTier })
           .loadStakeFlow ?? loadAccountStakeFlowColdTier;
       const flows = ownerColdkey
-        ? await loadFlows(ctx.env as never, ownerColdkey, {
+        ? await loadFlows(ctx.env, ownerColdkey, {
             window: OWNER_CUT_FLOW_WINDOW,
           })
         : null;

--- a/src/neon-prune.ts
+++ b/src/neon-prune.ts
@@ -43,6 +43,7 @@ import {
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { HISTORY_RETENTION_MS } from "./health-prober.ts";
 import { BURN_HISTORY_RETENTION_MS } from "./subnet-burn-history.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 export const NEON_PRUNE_LANE = "neon-prune";
 
@@ -204,7 +205,7 @@ export interface PruneOutcome {
 }
 
 export async function runNeonPrune(
-  env: Record<string, unknown> | null | undefined,
+  env: (NeonWriteEnv & { NEON_BACKFILL_LANES?: unknown }) | null | undefined,
   ctx: WaitUntilLike,
   deps: PruneDeps = {},
 ): Promise<PruneOutcome> {

--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -57,6 +57,37 @@ import {
   type HyperdriveLike,
   type WaitUntilLike,
 } from "./pg-sql.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+/**
+ * What a Neon WRITE lane needs from its environment.
+ *
+ * Exported, because the lanes that route through this buffer need the same
+ * three vars and were each declaring `Record<string, unknown>` -- which is not
+ * loose enough for an `Env` and so put `env as unknown as Record<…>` on every
+ * one of their call sites (#11339).
+ *
+ * `unknown` per var rather than `string`: every read here goes through a
+ * coercion that takes unknown, and nothing in this module assumes otherwise.
+ */
+export type NeonWriteEnv = StoreEnv &
+  TelemetryEnv & {
+    NEON_WRITE_BUFFER?: unknown;
+    NEON_WRITE_BUFFER_LANES?: unknown;
+    NEON_DUAL_WRITE_LANES?: unknown;
+  };
+
+type NeonWriteBufferEnv = NeonWriteEnv;
 
 /**
  * One buffered statement, exactly as the lane would have executed it.
@@ -266,7 +297,7 @@ export function shouldFlushEarly(
  * here: an unbuffered lane still writes, it just writes directly.
  */
 export function neonWriteBufferLanes(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteBufferEnv | null | undefined,
 ): Set<string> {
   const raw = env?.NEON_WRITE_BUFFER_LANES;
   if (typeof raw !== "string" || raw.trim() === "") return new Set();
@@ -316,7 +347,7 @@ export const NEVER_BUFFER_LANES: ReadonlySet<string> = new Set([
 
 /** Whether one lane's writes go through the buffer. */
 export function neonWriteBufferEnabled(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteBufferEnv | null | undefined,
   lane: string,
 ): boolean {
   if (NEVER_BUFFER_LANES.has(lane)) return false;
@@ -474,7 +505,7 @@ export function createBufferedPgSql(
  * binding, which is the wrong direction to fail.
  */
 export function neonWriteRunner(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteBufferEnv | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   lane: string,
   hyperdrive: HyperdriveLike | undefined,

--- a/src/network-economics.ts
+++ b/src/network-economics.ts
@@ -118,10 +118,9 @@ export function economicsQueryUrl(
 interface NetworkEconomicsCtx {
   env: Env;
   readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
-  readHealthKv?: (
-    env: Env,
-    key: string,
-  ) => Promise<Record<string, unknown> | null>;
+  // Forwarded verbatim to resolveLiveHealth; declared as its producer
+  // actually returns rather than as its consumer wished (#11339).
+  readHealthKv?: (env: Env, key: string) => Promise<unknown>;
 }
 
 interface NetworkEconomicsDeps {

--- a/src/neuron-daily-cold-tier.ts
+++ b/src/neuron-daily-cold-tier.ts
@@ -63,6 +63,7 @@ import {
 } from "./neuron-history.ts";
 import { buildAccountPositionHistory } from "./account-position-history.ts";
 import { buildValidatorHistory } from "./validator-history.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** The lakehouse namespace holding the decoded/copied chain tables. */
 const NAMESPACE = "chain";
@@ -183,7 +184,7 @@ function datePredicate(range: {
  * could not look".
  */
 export async function loadSubnetHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: unknown,
   start: string | null,
   seam: string | null,
@@ -241,7 +242,7 @@ export async function loadSubnetHistoryColdTier(
  * something this reader should smooth over.
  */
 export async function loadNeuronHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: unknown,
   uid: unknown,
   start: string | null,
@@ -380,7 +381,7 @@ export function mergeHistoryDays<T extends { snapshot_date?: unknown }>(
  * "we could not look" from turning into "there is nothing older".
  */
 export async function overlaySubnetHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   data: ReturnType<typeof buildSubnetHistory>,
   netuid: number,
   window: { label: string; days: number | null },
@@ -416,7 +417,7 @@ export async function overlaySubnetHistoryColdTier(
 /** The neuron twin of `overlaySubnetHistoryColdTier`; same reasoning
  * throughout, keyed by (netuid, uid). */
 export async function overlayNeuronHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   data: ReturnType<typeof buildNeuronHistory>,
   netuid: number,
   uid: number,
@@ -484,7 +485,7 @@ export type ColdAccountPositionRow = Pick<
  * inferred from the name.
  */
 export async function loadAccountPositionHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: unknown,
   netuid: unknown,
   start: string | null,
@@ -511,7 +512,7 @@ export async function loadAccountPositionHistoryColdTier(
 
 /** The account-position twin of the history overlays; same seam, same rules. */
 export async function overlayAccountPositionHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   data: ReturnType<typeof buildAccountPositionHistory>,
   ss58: string,
   netuid: number,
@@ -611,7 +612,7 @@ export interface ColdValidatorHistoryRow {
  * request, exactly as the hot tier reads it.
  */
 export async function loadValidatorHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   hotkey: unknown,
   netuid: number | null,
   start: string | null,
@@ -655,7 +656,7 @@ export async function loadValidatorHistoryColdTier(
 
 /** The validator twin of the history overlays. */
 export async function overlayValidatorHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   data: ReturnType<typeof buildValidatorHistory>,
   hotkey: string,
   netuid: number | null,

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -43,6 +43,7 @@ import {
   writePassTallyToNeon,
   type PassTallyInput,
 } from "./pass-completeness.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 // ---------------------------------------------------------------------------
 // Moved here when D1 was deleted (#10179). These describe the TABLE -- its
@@ -385,7 +386,7 @@ export interface NeuronMirrorDeps {
  * current.
  */
 export async function mirrorNeuronSnapshotToNeon(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   input: NeuronMirrorInput,
   deps: NeuronMirrorDeps = {},

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -335,7 +335,7 @@ export async function runNeuronsStalenessWatchdog(
         verdict.reason === "partial"
           ? `neurons lane truncated: the newest pass covered only ${verdict.covered_netuids} of ${verdict.total_netuids} subnets against a floor of ${verdict.coverage_floor_netuids} (newest stamp ${age}) -- the capture is RECENT and PARTIAL, so every route over a subnet the scan never reached is serving a pass-old metagraph behind a MAX(captured_at) that just advanced`
           : `neurons lane stalled: the newest READABLE snapshot is ${age} (threshold ${thresholdMs / 60_000} min) -- ${suspects}`;
-      await record(env as never, {
+      await record(env, {
         error: new Error(message),
         route: "watchdog:neurons-staleness",
         errorCode: "stale_lane",

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -57,6 +57,22 @@ import {
   type ReadStoreDb,
 } from "./read-store.ts";
 import type { Neurons } from "../generated/db/types.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type NeuronsStalenessWatchdogEnv = NeonWriteEnv & {
+  NEURONS_COVERAGE_FLOOR_NETUIDS?: unknown;
+  NEURONS_PASS_WINDOW_MS?: unknown;
+  NEURONS_STALENESS_THRESHOLD_MS?: unknown;
+};
 
 /** The buffer lane these rows are written on, when buffering is on. */
 export const NEURONS_BUFFER_LANE = "neurons";
@@ -98,7 +114,7 @@ export const NEURONS_STALENESS_THRESHOLD_MS = missedTicksMs("metagraph", 3);
  * slack behind a flag nobody re-reads.
  */
 export function neuronsStalenessThresholdMs(
-  env: Record<string, unknown> | null | undefined,
+  env: NeuronsStalenessWatchdogEnv | null | undefined,
 ): number {
   const declared =
     Number(env?.NEURONS_STALENESS_THRESHOLD_MS) ||
@@ -281,7 +297,7 @@ export interface NeuronsStalenessDeps {
  * outage, and a cron that throws is a cron nobody can read the result of.
  */
 export async function runNeuronsStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: NeuronsStalenessWatchdogEnv | null | undefined,
   deps: NeuronsStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -61,6 +61,7 @@ import { STAKE_ADDED_KIND, STAKE_REMOVED_KIND } from "./account-stake-flow.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { r2SqlQuery, safeSs58Literal } from "./r2-sql.ts";
 import { readStore, type OptionalRowQuerier } from "./read-store.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Kept identical to the retired Postgres tier's SELECT list (minus `coldkey`,
  * which the predicate already fixes) so both tiers hand the formatter the
@@ -97,7 +98,7 @@ export const BIND_PARAM_CHUNK = 100;
  * not a decline.
  */
 export async function neuronStakeByHotkeys(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   hotkeys: string[],
 ): Promise<Map<string, number> | null> {
   if (hotkeys.length === 0) return new Map();
@@ -170,7 +171,7 @@ registerModuleStateReset(
  * null for five minutes.
  */
 export async function ledgerCapturedAt(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   nowMs: number = Date.now(),
 ): Promise<number | null> {
   if (ledgerStampMemo && ledgerStampMemo.expiresAtMs > nowMs) {
@@ -205,7 +206,7 @@ export async function ledgerCapturedAt(
  * is idempotent on an already-safe literal and costs one regex.
  */
 export async function latestStakeEventAt(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
 ): Promise<number | null> {
   const coldkey = safeSs58Literal(ss58);
@@ -224,7 +225,7 @@ export async function latestStakeEventAt(
  * caller keep its existing empty payload.
  */
 export async function loadAccountPositionsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ss58: string,
 ): Promise<ReturnType<typeof buildAccountPositions> | null> {
   // An unusable address is a decline, not an unfiltered scan of the ledger.

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -43,6 +43,7 @@ import {
   neonWriteRunner,
 } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 /** The lane name this writer files its `lane_health` verdict under (`neon:<lane>`). */
 export const NOMINATOR_POSITIONS_NEON_LANE = "nominator-positions";
@@ -103,7 +104,7 @@ export interface NominatorPositionsMirrorDeps {
  * raised, and both callers turn it into the request's failure.
  */
 export async function mirrorNominatorPositionsToNeon(
-  env: Record<string, unknown> | null | undefined,
+  env: (NeonWriteEnv & { METAGRAPH_HEALTH_DB?: unknown }) | null | undefined,
   ctx: WaitUntilLike | null | undefined,
   input: {
     rows: Row[];

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -64,6 +64,24 @@ import {
 } from "./read-store.ts";
 import type { NominatorPositions } from "../generated/db/types.ts";
 import { requireFullScanValue } from "./lane-table-topology.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type NominatorPositionsStalenessWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS?: unknown;
+    NOMINATOR_POSITIONS_PASS_WINDOW_MS?: unknown;
+    NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS?: unknown;
+  };
 
 /**
  * How old the ledger may get before this is a stall.
@@ -351,7 +369,7 @@ export interface NominatorPositionsStalenessDeps {
  * and a cron that throws is a cron nobody can read the result of.
  */
 export async function runNominatorPositionsStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: NominatorPositionsStalenessWatchdogEnv | null | undefined,
   deps: NominatorPositionsStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -407,7 +407,7 @@ export async function runNominatorPositionsStalenessWatchdog(
         verdict.reason === "partial"
           ? `nominator-positions lane truncated: the newest pass covered only ${verdict.covered_coldkeys} of ${verdict.total_coldkeys} coldkeys against a floor of ${verdict.coverage_floor_coldkeys} (newest stamp ${age}) -- the capture is RECENT and PARTIAL, so /accounts/{ss58}/positions answers for every coldkey the scan never reached with a confident position set that is silently a pass old`
           : `nominator-positions lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /accounts/{ss58}/positions is answering from a ledger nothing is refreshing`;
-      await record(env as never, {
+      await record(env, {
         error: new Error(message),
         route: "watchdog:nominator-positions-staleness",
         errorCode: "stale_lane",

--- a/src/observations-neon.ts
+++ b/src/observations-neon.ts
@@ -38,6 +38,7 @@
 // anything failing: each spelling was correct for the store its own file
 // targeted, and neither could run against the other.
 import { OK_LATENCY } from "./health-sql.ts";
+import { hyperdriveConnectionString } from "./read-store.ts";
 
 /** The runner shape createPgSql hands out. Declared here rather than imported
  * so this module depends on the SHAPE and not on another lane's file. */
@@ -433,12 +434,8 @@ export const OBSERVATION_TABLES = [
 /** True when Neon solely owns every observation table AND Hyperdrive is bound.
  * Skipping the D1 write with nowhere to put the rows would drop a probe sweep
  * silently, and a probe not stored is gone. */
-export function neonOwnsObservations(
-  env: Record<string, unknown> | null | undefined,
-): boolean {
+export function neonOwnsObservations(env: unknown): boolean {
   // The injected ownership predicate left with the flag (#10051): Neon is the
   // only store, so durability is the binding question alone.
-  const hyperdrive = env?.HYPERDRIVE as
-    { connectionString?: string } | undefined;
-  return Boolean(hyperdrive?.connectionString);
+  return hyperdriveConnectionString(env) !== null;
 }

--- a/src/observations-read-runner.ts
+++ b/src/observations-read-runner.ts
@@ -38,6 +38,7 @@ import {
   type HyperdriveLike,
   type WaitUntilLike,
 } from "./pg-sql.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 /** The minimal Postgres runner this needs, so a test can hand it a fake. */
 export interface ReadRunnerSql {
@@ -79,7 +80,7 @@ export interface ObservationsReadDeps {
  * the read helpers already treat as zero rows.
  */
 export function observationsReadDb(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   // Optional-`waitUntil` on purpose: the serving handlers pass an EdgeCacheCtx,
   // whose waitUntil is itself optional, and a ctx that cannot defer work is not
   // a ctx for this purpose -- see the guard below.

--- a/src/pass-completeness.ts
+++ b/src/pass-completeness.ts
@@ -1,4 +1,4 @@
-import type { RowReader } from "./read-store.ts";
+import type { OptionalRowReader } from "./read-store.ts";
 // "Did this lane's whole scan arrive?" — one implementation (metagraphed-infra#346).
 //
 // THE QUESTION A ROW COUNT CANNOT ANSWER. `ORDER BY … LIMIT n` over a partial
@@ -85,7 +85,19 @@ export const PASS_TABLES: Readonly<Record<string, string>> = {
  * rank", not as a 500.
  */
 export async function latestCompletePass(
-  db: RowReader | null | undefined,
+  /**
+   * OPTIONAL `first`, matching what the body actually does.
+   *
+   * This declared `RowReader` -- `first` REQUIRED -- while the line below
+   * guards `if (!db?.first)` and declines. The two disagreed, so every caller
+   * holding a store whose `first` is optional had to cast, and four of them
+   * did: `db as unknown as Parameters<typeof …>[0]`. That cast asserted the
+   * method was there, past a guard whose whole purpose is that it might not be.
+   *
+   * Widening the parameter is the honest direction. The guard is the contract;
+   * the signature now says so, and the casts are gone rather than justified.
+   */
+  db: OptionalRowReader | null | undefined,
   lane: string,
 ): Promise<PassCompleteness> {
   const table = PASS_TABLES[lane];

--- a/src/projection-staleness-watchdog.ts
+++ b/src/projection-staleness-watchdog.ts
@@ -253,7 +253,7 @@ export async function runProjectionStalenessWatchdog(
           })`,
       )
       .join(", ");
-    await record(env as never, {
+    await record(env, {
       error: new Error(
         `projection lanes stalled: ${detail} (threshold ${(
           thresholdMs / 3_600_000

--- a/src/projection-staleness-watchdog.ts
+++ b/src/projection-staleness-watchdog.ts
@@ -23,6 +23,22 @@ import { PROJECTION_LANES, PROJECTION_NETWORKS } from "./projection-lanes.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { PROJECTION_LANES_CRON } from "../workers/config.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type ProjectionStalenessWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    PROJECTION_STALENESS_THRESHOLD_MS?: unknown;
+  };
 
 /**
  * The shortest gap between two ticks of a `minute-list * * * *` cron.
@@ -203,7 +219,7 @@ function watchedLanes(): { lane: string; key: string }[] {
  * and a cron that throws is a cron nobody can read the result of.
  */
 export async function runProjectionStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: ProjectionStalenessWatchdogEnv | null | undefined,
   deps: ProjectionStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -34,6 +34,7 @@ import {
   safeHexLiteral,
   safeSs58Literal,
 } from "./r2-sql.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Columns the formatters need — kept identical to the Postgres tier's SELECT
  * list so both tiers hand the formatter the same shape. */
@@ -167,7 +168,7 @@ export function safeAuthorLiteral(value: unknown): string | null {
  * cannot serve faithfully) so the caller keeps its existing fallback.
  */
 export async function loadBlockFeedFromR2Sql(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: BlockFeedQuery,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,
@@ -191,7 +192,7 @@ export async function loadBlockFeedFromR2Sql(
  * over rows from every source.
  */
 export async function fetchBlockRowsFromR2Sql(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: BlockFeedQuery,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,
@@ -271,7 +272,7 @@ export async function fetchBlockRowsFromR2Sql(
  * validated here rather than trusted, because it reaches a string-built query.
  */
 export async function loadBlockFromR2Sql(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   ref: string,
   /** Which chain's lakehouse namespace to read (#8700). */
   network?: ChainNetworkId,

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -36,13 +36,35 @@
 // empty it replaced.
 
 import { z } from "zod";
-import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { LAKEHOUSE_ROW_SCHEMAS } from "../schemas-src/lakehouse.ts";
 import { LAKEHOUSE_NAMESPACES } from "./chain-network.ts";
 import { R2SqlBodySchema } from "../schemas-src/r2-sql-envelope.ts";
 
 /** Personal/API token with R2 SQL read access (wrangler secret). */
+/**
+ * What the R2 SQL client needs from its environment, and nothing else.
+ *
+ * FIVE STRINGS. Taking the whole ambient `Env` instead is what put
+ * `as never` on 33 call sites across the cold-tier readers (#11339): every
+ * composer that holds a loose bag -- and they all do, because `readStore`
+ * deliberately takes `unknown` -- had to assert past this signature to reach
+ * a lakehouse read. `as never` is the worst spelling of that, because it also
+ * makes the SQL and deps arguments unverifiable at the same call.
+ *
+ * Optional and string-typed because that is what a Worker var is: unset reads
+ * as `undefined`, and every read below type-guards what it finds rather than
+ * trusting the declaration.
+ */
+export interface R2SqlEnv extends TelemetryEnv {
+  R2_SQL_TOKEN?: string;
+  R2_SQL_ACCOUNT_ID?: string;
+  R2_SQL_WAREHOUSE?: string;
+  R2_SQL_RATE_LIMIT_COOLDOWN_MS?: string;
+  R2_SQL_MAX_BODY_BYTES?: string;
+}
+
 export const R2_SQL_TOKEN_ENV = "R2_SQL_TOKEN";
 /** Cloudflare account that owns the warehouse. */
 export const R2_SQL_ACCOUNT_ENV = "R2_SQL_ACCOUNT_ID";
@@ -256,8 +278,8 @@ const RateLimitCooldownSchema = z.coerce
   .nonnegative()
   .catch(R2_SQL_RATE_LIMIT_COOLDOWN_DEFAULT_MS);
 
-function rateLimitCooldownMs(env: Env | null | undefined): number {
-  const raw = env?.[R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV as keyof Env];
+function rateLimitCooldownMs(env: R2SqlEnv | null | undefined): number {
+  const raw = env?.[R2_SQL_RATE_LIMIT_COOLDOWN_MS_ENV];
   // Absent coerces to NaN and an empty string to 0, which mean opposite things
   // here -- unset must take the default, while a deliberate "" is as much an
   // unset as `undefined` is. Both route to the default; only a real "0" disables.
@@ -343,7 +365,7 @@ export interface R2SqlDeps {
 type R2SqlBody = z.infer<typeof R2SqlBodySchema>;
 
 /** True when this deployment can talk to R2 SQL at all. */
-export function isR2SqlConfigured(env: Env | null | undefined): boolean {
+export function isR2SqlConfigured(env: R2SqlEnv | null | undefined): boolean {
   const token = env?.[R2_SQL_TOKEN_ENV];
   return typeof token === "string" && token.trim().length > 0;
 }
@@ -386,7 +408,7 @@ const MaxBodyBytesSchema = z.coerce
   .catch(R2_SQL_MAX_BODY_BYTES_DEFAULT);
 
 /** The body-size ceiling for this deployment, or 0 when disabled. */
-export function maxBodyBytes(env: Env | null | undefined): number {
+export function maxBodyBytes(env: R2SqlEnv | null | undefined): number {
   const raw = env?.R2_SQL_MAX_BODY_BYTES;
   if (raw === undefined || raw === null || String(raw).trim() === "") {
     return R2_SQL_MAX_BODY_BYTES_DEFAULT;
@@ -649,13 +671,13 @@ export function isExpectedR2SqlFailure(errorCode: string): boolean {
  * assignable here, because its type parameter defaults.
  */
 export type R2SqlReader = (
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   sql: string,
   deps?: R2SqlDeps,
 ) => Promise<Record<string, unknown>[] | null>;
 
 export async function r2SqlQuery<Row = Record<string, unknown>>(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   sql: string,
   deps: R2SqlDeps = {},
 ): Promise<Row[] | null> {

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -32,6 +32,7 @@ import {
   type ChainNetworkId,
   DEFAULT_CHAIN_NETWORK,
 } from "./chain-network.ts";
+import type { StoreEnv } from "./read-store.ts";
 
 /** Kill switch, matching CHAIN_HEAD_POLL_ENABLED's convention on the head
  * poller: absent or anything but "true" means this lane does not run. */
@@ -226,7 +227,7 @@ export const RAW_CAPTURE_LANES: readonly RawCaptureLane[] = [
   },
 ];
 
-interface RawCaptureEnv extends TelemetryEnv {
+interface RawCaptureEnv extends TelemetryEnv, StoreEnv {
   METAGRAPH_ARCHIVE?: { put(key: string, value: string): Promise<unknown> };
   RAW_CAPTURE_ENABLED?: string;
   CHAIN_HEAD_RPC_URL?: string;
@@ -257,7 +258,7 @@ export interface WatermarkReadDb {
  * read must never be mistaken for a genesis restart.
  */
 function neonWatermarkRead(
-  env: Record<string, unknown> | null | undefined,
+  env: StoreEnv | null | undefined,
   waitUntil: WaitUntilLike | undefined,
   network: string,
 ): (() => Promise<number | null>) | null {
@@ -293,7 +294,7 @@ function neonWatermarkRead(
  * be mistaken for a genesis restart.
  */
 export function neonWatermark(
-  env: Record<string, unknown> | null | undefined,
+  env: StoreEnv | null | undefined,
   waitUntil: WaitUntilLike | undefined,
   network: string,
   now: () => number,
@@ -468,12 +469,7 @@ async function runLane(
       rpcUrl: (env[lane.rpcUrlEnv] as string | undefined) || lane.defaultRpcUrl,
       store,
       // THE TABLE IS THE WATERMARK, so this store is the whole write path.
-      watermark: neonWatermark(
-        ctx.env as unknown as Record<string, unknown>,
-        ctx.waitUntil,
-        lane.network,
-        now,
-      ),
+      watermark: neonWatermark(ctx.env, ctx.waitUntil, lane.network, now),
       genesisFloor: lane.genesisFloor,
       maxPerTick: lane.maxPerTick,
       network: lane.network,

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -23,7 +23,7 @@ import {
   type WatermarkStore,
 } from "./raw-chain-capture.ts";
 import { RAW_CAPTURE_CRON } from "../workers/config.ts";
-import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
 import { mirrorRawCaptureStateToNeon } from "./capture-state-neon-write.ts";
 import { createPgSql, type HyperdriveLike } from "./pg-sql.ts";
 import type { WaitUntilLike } from "./pg-sql.ts";
@@ -226,7 +226,7 @@ export const RAW_CAPTURE_LANES: readonly RawCaptureLane[] = [
   },
 ];
 
-interface RawCaptureEnv {
+interface RawCaptureEnv extends TelemetryEnv {
   METAGRAPH_ARCHIVE?: { put(key: string, value: string): Promise<unknown> };
   RAW_CAPTURE_ENABLED?: string;
   CHAIN_HEAD_RPC_URL?: string;
@@ -361,7 +361,7 @@ export async function runRawCaptureSync(
   const capture = deps.recordException ?? recordExceptionEvent;
   const loud = async (reason: string, message: string) => {
     console.error(`[raw-capture-sync] ${message}`);
-    await capture(env as never, {
+    await capture(env, {
       error: new Error(message),
       route: "raw-capture-sync",
     });
@@ -497,7 +497,7 @@ async function runLane(
   } catch (error) {
     const message = String((error as Error)?.message ?? error);
     console.error(`[raw-capture-sync] ${lane.network}`, message);
-    await capture(env as never, {
+    await capture(env, {
       error,
       route: `raw-capture-sync:${lane.network}`,
     });

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -345,6 +345,18 @@ export function pgReadStore(
  * comes back when no store is available -- which every caller already handles,
  * because an unbound store has always been possible.
  */
+/**
+ * The one binding `readStore` looks for.
+ *
+ * `readStore` itself keeps taking `unknown` -- see its own note -- because its
+ * callers hand in an `Env`, a bag, or nothing. This names the same shape for
+ * COMPOSERS, which forward one env to both legs (the Neon store and the
+ * lakehouse) and therefore need a type that admits either (#11339).
+ */
+export interface StoreEnv {
+  HYPERDRIVE?: { connectionString?: string };
+}
+
 export function readStore(
   // Deliberately loose: callers hand in an `Env`, a bag, or `unknown`, and a
   // narrower type would push a cast to every one of them.

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -35,7 +35,7 @@
 // answer, which is the failure mode this whole migration keeps having to
 // design against.
 import { Client } from "pg";
-import { toPositionalPlaceholders, type HyperdriveLike } from "./pg-sql.ts";
+import { toPositionalPlaceholders } from "./pg-sql.ts";
 
 /** The minimal pg client this needs, so a test can hand it a fake. */
 export interface ReadStoreClient {
@@ -357,6 +357,31 @@ export interface StoreEnv {
   HYPERDRIVE?: { connectionString?: string };
 }
 
+/**
+ * The Hyperdrive connection string an env carries, or null.
+ *
+ * ONE NARROWING, SHARED. `readStore`, `laneHealthStore` and
+ * `neonOwnsObservations` each did this by hand with two casts apiece
+ * (`env as Record<string, unknown>`, then `?.HYPERDRIVE as HyperdriveLike`),
+ * which is the whole binding-detection rule copy-pasted three times -- and it
+ * is the rule that decides whether a lane writes to Neon or silently declines.
+ *
+ * Takes `unknown` for the reason `readStore` documents: callers hand in an
+ * `Env`, a bag, or nothing. `Record<string, unknown>` READS as loose but is
+ * not -- `Env` is an interface, and TypeScript never gives interfaces implicit
+ * index signatures, so every caller holding a real `Env` had to write
+ * `env` to get past it. That is 65 casts
+ * across this repo whose only cause was a parameter type trying to be lenient
+ * and landing one step too strict (#11339).
+ */
+export function hyperdriveConnectionString(env: unknown): string | null {
+  const hyperdrive = recordOrNull(recordOrNull(env)?.HYPERDRIVE);
+  const connectionString = hyperdrive?.connectionString;
+  return typeof connectionString === "string" && connectionString
+    ? connectionString
+    : null;
+}
+
 export function readStore(
   // Deliberately loose: callers hand in an `Env`, a bag, or `unknown`, and a
   // narrower type would push a cast to every one of them.
@@ -366,12 +391,11 @@ export function readStore(
   deps: ReadStoreDeps = {},
 ): ReadStoreDb | undefined {
   if (injected) return injected;
-  const bag = env as Record<string, unknown> | null | undefined;
-  const hyperdrive = bag?.HYPERDRIVE as HyperdriveLike | undefined;
-  if (!hyperdrive?.connectionString) return undefined;
+  const connectionString = hyperdriveConnectionString(env);
+  if (!connectionString) return undefined;
   // Empty `tables` must never read as "Neon owns them all" -- that would send a
   // caller who forgot to declare its tables to Postgres unconditionally.
   if (tables.length === 0) return undefined;
   // the ownership check collapsed with the flag (#10051): Neon is the only store, so the question answered itself.
-  return pgReadStore(hyperdrive.connectionString, deps);
+  return pgReadStore(connectionString, deps);
 }

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -252,6 +252,51 @@ export function integerOrNull(value: unknown): number | null {
   return Number.isInteger(n) ? n : null;
 }
 
+/**
+ * Narrow an untrusted value to a JSON object, or null.
+ *
+ * THE COMPANION TO THE COERCIONS ABOVE, for the shape rather than the scalar.
+ * `readHealthKv` returns `Promise<unknown>` because `KV.get(key, {type:"json"})`
+ * genuinely is arbitrary JSON, and `readArtifact` returns `StorageReadResult`
+ * whose `.data` is `unknown` for the same reason -- an R2 object is whatever
+ * was last written to it. Both are honest. What was NOT honest is that several
+ * consumers DECLARED those producers as returning
+ * `Promise<Record<string, unknown> | null>` and then read fields off the
+ * result: a claim about untrusted bytes that nothing verified, and that
+ * survived only because a cast sat between the two (metagraphed#11339).
+ *
+ * `null` and arrays are excluded deliberately. `typeof null === "object"` is
+ * the classic hole, and an array reaching a site that then reads named fields
+ * is a producer mismatch worth failing on rather than silently indexing.
+ */
+export function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Narrow an untrusted value to an array of JSON objects, or an empty array.
+ *
+ * EMPTY, NOT NULL, because every caller is building a list response and an
+ * absent collection and an empty one render identically there. A non-array
+ * yields empty for the same reason: it is a producer defect, and returning
+ * `[]` keeps the "absence is 404 or ok+null entity, never 200-with-zeros"
+ * contract in the ROUTE's hands rather than fabricating rows here.
+ *
+ * Non-object members are dropped rather than passed through, so a caller that
+ * reads a field off every element cannot meet a string.
+ */
+export function recordsOrEmpty(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  const rows: Record<string, unknown>[] = [];
+  for (const entry of value) {
+    const row = recordOrNull(entry);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
 export interface ReadStoreDeps {
   clientFactory?: (connectionString: string) => ReadStoreClient;
 }

--- a/src/registry-resync-lane.ts
+++ b/src/registry-resync-lane.ts
@@ -56,6 +56,12 @@ import {
   type RegistryResyncPassState,
 } from "../schemas-src/internal-wire.ts";
 
+/** The two vars the registry sync lanes read (#11339). */
+type RegistrySyncEnvVars = {
+  GITHUB_TOKEN?: unknown;
+  REGISTRY_SYNC_SECRET?: unknown;
+};
+
 export const REGISTRY_RESYNC_LANE = "registry-resync";
 const STATE_KEY = "registry-resync:state";
 const COMPLETED_KEY = "registry-resync:last-complete";
@@ -120,7 +126,7 @@ export interface RegistryResyncDeps {
 
 /** Every registry file at `ref`, both directories, sorted for a stable pass. */
 async function listRegistryPaths(
-  env: Record<string, unknown>,
+  env: RegistrySyncEnvVars | null | undefined,
   ref: string,
 ): Promise<string[] | null> {
   const paths: string[] = [];
@@ -151,7 +157,7 @@ async function listRegistryPaths(
  * family: a tick that cannot run is one missed report, not an outage.
  */
 export async function runRegistryResyncLane(
-  env: unknown,
+  env: RegistrySyncEnvVars | null | undefined,
   deps: RegistryResyncDeps = {},
 ): Promise<RegistryResyncResult> {
   const result = await runResyncTick(env, deps);
@@ -187,7 +193,7 @@ export function resyncDetail(result: RegistryResyncResult): string {
 }
 
 async function runResyncTick(
-  env: unknown,
+  env: RegistrySyncEnvVars | null | undefined,
   deps: RegistryResyncDeps,
 ): Promise<RegistryResyncResult> {
   const bag = (env ?? {}) as Record<string, unknown>;

--- a/src/registry-sync-lane.ts
+++ b/src/registry-sync-lane.ts
@@ -32,6 +32,12 @@ import {
 } from "./registry-sync-payload.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 
+/** The two vars the registry sync lanes read (#11339). */
+type RegistrySyncEnvVars = {
+  GITHUB_TOKEN?: unknown;
+  REGISTRY_SYNC_SECRET?: unknown;
+};
+
 /** Where the registry lives. Not configurable: this lane exists to mirror THIS
  * repo's registry, and a wrong value would silently sync someone else's. */
 export const REPO = "JSONbored/metagraphed";
@@ -62,14 +68,16 @@ interface ServiceLike {
   fetch(request: Request): Promise<Response>;
 }
 
-function githubHeaders(env: Record<string, unknown>): Record<string, string> {
+function githubHeaders(
+  env: RegistrySyncEnvVars | null | undefined,
+): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/vnd.github+json",
     // GitHub rejects API requests with no user-agent.
     "user-agent": "metagraphed-registry-sync",
     "x-github-api-version": "2022-11-28",
   };
-  const token = env.GITHUB_TOKEN;
+  const token = env?.GITHUB_TOKEN;
   if (typeof token === "string" && token.trim() !== "") {
     headers.authorization = `Bearer ${token.trim()}`;
   }
@@ -77,7 +85,7 @@ function githubHeaders(env: Record<string, unknown>): Record<string, string> {
 }
 
 export async function ghJson(
-  env: Record<string, unknown>,
+  env: RegistrySyncEnvVars | null | undefined,
   path: string,
 ): Promise<unknown | null> {
   try {
@@ -94,7 +102,7 @@ export async function ghJson(
 
 /** One file's parsed overlay at a commit, or null when it is not there. */
 export async function fileAt(
-  env: Record<string, unknown>,
+  env: RegistrySyncEnvVars | null | undefined,
   path: string,
   ref: string,
 ): Promise<Row | null> {
@@ -127,7 +135,7 @@ export async function fileAt(
  * in surface_history -- which is the exact failure this lane exists to end.
  */
 export async function runRegistrySyncLane(
-  env: unknown,
+  env: RegistrySyncEnvVars | null | undefined,
   deps: {
     kv?: KvLike | null;
     registrySyncApi?: ServiceLike | null;
@@ -172,7 +180,7 @@ function laneDetail(result: RegistrySyncLaneResult): string {
 }
 
 async function runRegistrySyncTick(
-  env: unknown,
+  env: RegistrySyncEnvVars | null | undefined,
   deps: {
     kv?: KvLike | null;
     registrySyncApi?: ServiceLike | null;

--- a/src/reliability-badge.ts
+++ b/src/reliability-badge.ts
@@ -84,7 +84,7 @@ export async function loadReliabilityAggregate(
       const data = (await loadSubnetUptime(netuid, {
         window: RELIABILITY_BADGE_WINDOW,
         db: readStore(env, UPTIME_DAILY_TABLES) as never,
-      } as unknown as Parameters<typeof loadSubnetUptime>[1])) as {
+      })) as {
         reliability?: Record<string, unknown> | null;
       } | null;
       return data?.reliability ?? null;

--- a/src/rpc-endpoints-mcp.ts
+++ b/src/rpc-endpoints-mcp.ts
@@ -18,6 +18,7 @@ import {
   ListRpcEndpointsOutputSchema,
 } from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import { recordOrNull } from "./read-store.ts";
 
 export const RPC_ENDPOINTS_ARTIFACT = "/metagraph/rpc-endpoints.json";
 
@@ -235,10 +236,11 @@ export interface RpcEndpointsListResult {
 type RpcEndpointsCtx = {
   env: Env;
   readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
-  readHealthKv?: (
-    env: Env,
-    key: string,
-  ) => Promise<Record<string, unknown> | null>;
+  // `unknown`, matching workers/storage.ts's actual return: KV holds whatever
+  // the 15-minute cron last wrote as JSON. Declaring an object here was a claim
+  // about untrusted bytes that nothing checked (#11339) -- `recordOrNull` at
+  // the point of use is what checks it now.
+  readHealthKv?: (env: Env, key: string) => Promise<unknown>;
 };
 
 export async function loadRpcEndpointsList(
@@ -280,7 +282,7 @@ export async function loadRpcEndpointsList(
   // stale build-time health/latency before filters run.
   let overlaid = blob as Record<string, unknown>;
   const livePool = ctx.readHealthKv
-    ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+    ? recordOrNull(await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL))
     : null;
   if (livePool) {
     const merged = mergeRpcEndpoints(overlaid, livePool);

--- a/src/rpc-pools-mcp.ts
+++ b/src/rpc-pools-mcp.ts
@@ -19,6 +19,7 @@ import {
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
 import { LIVE_CRON_PROBER } from "./field-provenance.ts";
 import { RPC_POOL_KIND_VALUES } from "../schemas-src/query-params.ts";
+import { recordOrNull } from "./read-store.ts";
 
 export const RPC_POOLS_ARTIFACT = "/metagraph/rpc/pools.json";
 
@@ -150,10 +151,11 @@ export function rpcPoolsQueryUrl(
 interface RpcPoolsMcpCtx {
   env: Env;
   readArtifact: (env: Env, path: string) => Promise<StorageReadResult>;
-  readHealthKv?: (
-    env: Env,
-    key: string,
-  ) => Promise<Record<string, unknown> | null>;
+  // `unknown`, matching workers/storage.ts's actual return: KV holds whatever
+  // the 15-minute cron last wrote as JSON. Declaring an object here was a claim
+  // about untrusted bytes that nothing checked (#11339) -- `recordOrNull` at
+  // the point of use is what checks it now.
+  readHealthKv?: (env: Env, key: string) => Promise<unknown>;
 }
 
 export interface RpcPoolsListResult {
@@ -204,7 +206,7 @@ export async function loadRpcPoolsList(
   // like eligible_count reflects the current snapshot, not the baked one.
   let overlaid = blob as Record<string, unknown>;
   const livePool = ctx.readHealthKv
-    ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+    ? recordOrNull(await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL))
     : null;
   if (
     livePool &&

--- a/src/rpc-usage-answer.ts
+++ b/src/rpc-usage-answer.ts
@@ -305,10 +305,7 @@ export async function answerRpcUsage(
   // not already hold, and only while such a part exists at all.
   const cold = hotTierCoversWindow(hot, label, now)
     ? null
-    : await coldTier(
-        env as unknown as Parameters<typeof loadRpcUsageColdTier>[0],
-        { window: label, now, until: coverageStart(hot) },
-      );
+    : await coldTier(env, { window: label, now, until: coverageStart(hot) });
 
   if (hot && cold) return mergeRpcUsage(cold, hot);
   if (hot) return hot;

--- a/src/safe-mode-watchdog.ts
+++ b/src/safe-mode-watchdog.ts
@@ -198,7 +198,7 @@ export type SafeModeExtrinsicReader = (
  * the decoded range holds no SafeMode call.
  */
 export const readSafeModeExtrinsics: SafeModeExtrinsicReader = async (env) => {
-  const feed = await loadExtrinsicFeedColdTier(env as never, {
+  const feed = await loadExtrinsicFeedColdTier(env, {
     limit: SAFE_MODE_EXTRINSIC_LIMIT,
     module: "SafeMode",
   });
@@ -264,7 +264,7 @@ export async function runSafeModeWatchdog(
     // CHAIN condition, not a staleness of ours -- filing it as a stale lane
     // would publish a false statement about our own freshness.
     if (reasons.length > 0) {
-      await record(env as never, {
+      await record(env, {
         error: new Error(`SafeMode watchdog: ${reasons.join(", ")}`),
         route: "watchdog:safe-mode",
         // fingerprintDetail (#10813). This route reports TWO independent
@@ -286,7 +286,7 @@ export async function runSafeModeWatchdog(
     // reported at all because "the history read has been failing for a week"
     // is exactly the fact that went unnoticed while the 522 ran.
     if (extrinsics === null) {
-      await record(env as never, {
+      await record(env, {
         error:
           historyError ??
           new Error("SafeMode history: the extrinsics tier declined the read"),
@@ -310,7 +310,7 @@ export async function runSafeModeWatchdog(
     // SafeMode monitor is itself worth reporting, because its silence is
     // indistinguishable from "the chain is fine". That equivalence is the
     // whole reason this monitor exists.
-    await record(env as never, {
+    await record(env, {
       error: err,
       route: "watchdog:safe-mode",
       // See above: the two subjects must not share a throttle window.

--- a/src/safe-mode-watchdog.ts
+++ b/src/safe-mode-watchdog.ts
@@ -64,6 +64,22 @@ import { chainRpc } from "./chain-rpc.ts";
 import { bytesToHex, storageMapPrefix } from "../src/twox-storage-key.ts";
 import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type SafeModeWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    SAFE_MODE_RPC_URL?: unknown;
+  };
 
 /** Public archive RPC. A var, not a secret: the endpoint is public. */
 export const SAFE_MODE_RPC_URL_DEFAULT = "https://archive.chain.opentensor.ai";
@@ -178,7 +194,7 @@ async function rpc(
 
 /** Reads the SafeMode extrinsic history, or null when the tier declined. */
 export type SafeModeExtrinsicReader = (
-  env: Record<string, unknown> | null | undefined,
+  env: SafeModeWatchdogEnv | null | undefined,
 ) => Promise<Extrinsic[] | null>;
 
 /**
@@ -215,7 +231,7 @@ export const readSafeModeExtrinsics: SafeModeExtrinsicReader = async (env) => {
  * measured and the failed path are testable without a chain.
  */
 export async function runSafeModeWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: SafeModeWatchdogEnv | null | undefined,
   deps: {
     fetchImpl?: Fetcher;
     readExtrinsics?: SafeModeExtrinsicReader;

--- a/src/self-health-cold-tier.ts
+++ b/src/self-health-cold-tier.ts
@@ -24,6 +24,7 @@
 import { r2SqlQuery } from "./r2-sql.ts";
 import { utcWindowCutoffDay } from "./health-serving.ts";
 import { buildSelfHealth, type SelfHealthDailyRow } from "./self-health.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** The exact day::text shape the Postgres route selects. A cell that does
  * not serialize to this cannot be windowed or served faithfully. */
@@ -56,7 +57,7 @@ function restoreDailyRow(
  * so the caller keeps its schema-stable empty card.
  */
 export async function loadSelfHealthColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   nowMs: number = Date.now(),
 ): Promise<ReturnType<typeof buildSelfHealth> | null> {
   const rows = await r2SqlQuery(

--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -209,16 +209,12 @@ export async function loadSelfHealth(
     // reader already goes through it; this one still named D1, so self-health
     // would have reported an empty lane floor -- which renders as "no alarms"
     // -- the moment D1 went away.
-    laneHealthStore(
-      ctx.env as unknown as Record<string, unknown>,
-    ) as unknown as Parameters<typeof loadLatestLaneHealth>[0],
+    laneHealthStore(ctx.env as unknown as Record<string, unknown>),
   );
   // Same sample the REST twin takes (#10232/#10333), so both surfaces judge a
   // silent lane identically rather than one of them serving a dead verdict.
   const cadences = await loadLaneMaxGap(
-    laneHealthStore(
-      ctx.env as unknown as Record<string, unknown>,
-    ) as unknown as Parameters<typeof loadLaneMaxGap>[0],
+    laneHealthStore(ctx.env as unknown as Record<string, unknown>),
     Date.now() - LANE_ALARM_CADENCE_WINDOW_MS,
   );
   return withLaneHealth(card as SelfHealth, lanes, { cadences });

--- a/src/self-health-mcp.ts
+++ b/src/self-health-mcp.ts
@@ -209,12 +209,12 @@ export async function loadSelfHealth(
     // reader already goes through it; this one still named D1, so self-health
     // would have reported an empty lane floor -- which renders as "no alarms"
     // -- the moment D1 went away.
-    laneHealthStore(ctx.env as unknown as Record<string, unknown>),
+    laneHealthStore(ctx.env),
   );
   // Same sample the REST twin takes (#10232/#10333), so both surfaces judge a
   // silent lane identically rather than one of them serving a dead verdict.
   const cadences = await loadLaneMaxGap(
-    laneHealthStore(ctx.env as unknown as Record<string, unknown>),
+    laneHealthStore(ctx.env),
     Date.now() - LANE_ALARM_CADENCE_WINDOW_MS,
   );
   return withLaneHealth(card as SelfHealth, lanes, { cadences });

--- a/src/self-health-prober.ts
+++ b/src/self-health-prober.ts
@@ -42,6 +42,7 @@ import {
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { SELF_HEALTH_COMPONENTS } from "./self-health.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 export const SELF_HEALTH_PROBE_LANE = "self-health-probe";
 
@@ -144,7 +145,7 @@ export interface SelfHealthProbeOutcome {
  * evidence.
  */
 export async function runSelfHealthProbe(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   ctx?: WaitUntilLike | null,
   deps: SelfHealthProberDeps = {},
 ): Promise<SelfHealthProbeOutcome> {

--- a/src/subnet-deregistration-daily.ts
+++ b/src/subnet-deregistration-daily.ts
@@ -34,6 +34,7 @@ import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { createPgSql } from "./pg-sql.ts";
 import { projectDeregistrationRanking } from "./subnet-deregistration-ranking.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 interface WaitUntilLike {
   waitUntil: (promise: Promise<unknown>) => void;
@@ -208,7 +209,7 @@ export function snapshotDateFor(nowMs: number): string {
  * than a gap in the series.
  */
 export async function runSubnetDeregistrationDailyLane(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   deps: DeregistrationDailyDeps,
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/subnet-event-summary-cold-tier.ts
+++ b/src/subnet-event-summary-cold-tier.ts
@@ -39,6 +39,7 @@ import { SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT } from "./route-limits.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -119,7 +120,7 @@ function byKind(rows: Row[]): Map<string, unknown> {
  * broken tier -- the inverse of the bug this fixes.
  */
 export async function loadSubnetEventSummaryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: number,
   {
     window,

--- a/src/subnet-events-answer.ts
+++ b/src/subnet-events-answer.ts
@@ -26,6 +26,12 @@
 
 import { loadSubnetEventsColdTier } from "./events-cold-tier.ts";
 import { buildSubnetEvents } from "./account-events.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { ArtifactEnv } from "../workers/storage.ts";
+
+/** One env, forwarded to both legs: the Neon store and the lakehouse. */
+type ComposerEnv = R2SqlEnv & StoreEnv & ArtifactEnv;
 
 type Row = Record<string, unknown>;
 
@@ -53,7 +59,7 @@ export interface AnswerSubnetEventsOptions {
  * the same route rather than each inventing it.
  */
 export async function answerSubnetEvents(
-  env: unknown,
+  env: ComposerEnv | null | undefined,
   netuid: number,
   tierResult: Row | null | undefined,
   query: AnswerSubnetEventsQuery,
@@ -61,7 +67,7 @@ export async function answerSubnetEvents(
 ): Promise<Row> {
   return (
     tierResult ??
-    ((await coldTier(env as never, netuid, {
+    ((await coldTier(env, netuid, {
       limit: query.limit,
       offset: query.offset,
       cursor: query.cursor ?? null,

--- a/src/subnet-holders.ts
+++ b/src/subnet-holders.ts
@@ -177,9 +177,7 @@ export async function loadSubnetHolders(
   if (netuid === ROOT_NETUID) return declined("root_not_in_alpha_map");
   if (!db?.query) return declined("unavailable");
 
-  const alpha = await latestCompleteHotkeyAlphaPass(
-    db as unknown as Parameters<typeof latestCompleteHotkeyAlphaPass>[0],
-  );
+  const alpha = await latestCompleteHotkeyAlphaPass(db);
   if (!mayPriceHotkeyAlpha(alpha)) {
     // "The table is missing" and "no pass has completed" are the same fact to a
     // caller -- the pool totals are not proven -- so `unavailable` is reported

--- a/src/subnet-hyperparams-cold-tier.ts
+++ b/src/subnet-hyperparams-cold-tier.ts
@@ -18,6 +18,7 @@ import {
   SUBNET_HYPERPARAMS_INSERT_COLUMNS,
 } from "./subnet-hyperparams.ts";
 import { buildSubnetHyperparamsHistory } from "./subnet-hyperparams-history.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 // Both SELECT lists are DERIVED from the same exported column set the write
 // path and data-api's reads are built on, rather than restated: 35 columns is
@@ -42,7 +43,7 @@ const CURSOR_ARITY = 2;
  * answer, so the caller keeps its existing schema-stable fallback.
  */
 export async function loadSubnetHyperparamsColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: unknown,
 ): Promise<ReturnType<typeof buildSubnetHyperparams> | null> {
   // netuid reaches a string-built query (R2 SQL has no bound parameters), so
@@ -64,7 +65,7 @@ export async function loadSubnetHyperparamsColdTier(
  * exact order, columns, cursor token, and OFFSET-only-without-cursor rule.
  */
 export async function loadSubnetHyperparamsHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: unknown,
   query: { limit: number; offset?: number | null; cursor?: unknown },
 ): Promise<ReturnType<typeof buildSubnetHyperparamsHistory> | null> {

--- a/src/subnet-identity-cold-tier.ts
+++ b/src/subnet-identity-cold-tier.ts
@@ -19,6 +19,7 @@ import {
   CHAIN_IDENTITY_HISTORY_LIMIT_MAX,
 } from "./chain-identity-history.ts";
 import type { SubnetIdentityHistoryRow } from "../generated/lakehouse/types.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. The network feed adds netuid up front, exactly as
@@ -35,7 +36,7 @@ const CURSOR_ARITY = 2;
  * lakehouse cannot answer, so the caller keeps its schema-stable empty.
  */
 export async function loadSubnetIdentityHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: unknown,
   query: { limit: number; offset?: number | null; cursor?: unknown },
 ): Promise<ReturnType<typeof buildSubnetIdentityHistory> | null> {
@@ -90,7 +91,7 @@ export async function loadSubnetIdentityHistoryColdTier(
  * data-api's own single-shot LIMIT query.
  */
 export async function loadChainIdentityHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   query: { limit?: unknown } = {},
 ): Promise<ReturnType<typeof buildChainIdentityHistory> | null> {
   // An absent limit takes the route default, exactly as data-api resolves it.

--- a/src/subnet-lifecycle.ts
+++ b/src/subnet-lifecycle.ts
@@ -43,6 +43,7 @@ import {
   NEURONS_COVERAGE_FLOOR_NETUIDS,
   NEURONS_PASS_WINDOW_MS,
 } from "./neurons-staleness-watchdog.ts";
+import type { NeonWriteEnv } from "./neon-write-buffer.ts";
 
 export const SUBNET_LIFECYCLE_LANE = "subnet-lifecycle";
 
@@ -144,7 +145,7 @@ export interface SubnetLifecycleDeps {
  * One tick. Returns a summary rather than throwing, like the rest of the family.
  */
 export async function runSubnetLifecycleLane(
-  env: Record<string, unknown> | null | undefined,
+  env: NeonWriteEnv | null | undefined,
   deps: SubnetLifecycleDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/subnet-ohlc-cold-tier.ts
+++ b/src/subnet-ohlc-cold-tier.ts
@@ -59,6 +59,7 @@ import {
   STAKE_REMOVED_KIND,
 } from "./subnet-ohlc.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Same day length the REST/MCP callers and data-api use, so every tier
  * resolves the same ?days= to the same request-time cutoff. */
@@ -94,7 +95,7 @@ export interface SubnetOhlcQuery {
  * already carries the correct root_excluded shape.
  */
 export async function loadSubnetOhlcColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: unknown,
   query: SubnetOhlcQuery = {},
 ): Promise<{

--- a/src/subnet-ownership-cold-tier.ts
+++ b/src/subnet-ownership-cold-tier.ts
@@ -28,6 +28,7 @@ import {
   OWNERSHIP_CHANGE_EVENT_METHOD,
 } from "./subnet-ownership-history.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+import type { R2SqlEnv } from "./r2-sql.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -51,7 +52,7 @@ const OWNERSHIP_EVENT_COLUMNS =
  * ownership transfers are rare chain-wide events, not a feed.
  */
 async function loadOwnershipChangeRows(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
 ): Promise<Record<string, unknown>[] | null> {
   const rows = await r2SqlQuery(
     env,
@@ -92,7 +93,7 @@ async function loadOwnershipChangeRows(
  * schema-stable empty-ties fallback.
  */
 export async function loadAccountEntitiesColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   coldkey: string,
 ): Promise<ReturnType<typeof buildAccountEntities> | null> {
   const rows = await loadOwnershipChangeRows(env);
@@ -117,7 +118,7 @@ export async function loadAccountEntitiesColdTier(
  * echoing a nonsense value back into the payload.
  */
 export async function loadSubnetOwnershipHistoryColdTier(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: unknown,
 ): Promise<ReturnType<typeof buildSubnetOwnershipHistory> | null> {
   const subnet = safeBlockNumber(netuid);
@@ -163,7 +164,7 @@ const OWNER_OBSERVATION_COLUMNS = "owner_coldkey, captured_at";
  * watched since".
  */
 export async function loadSubnetOwnerObservations(
-  env: Env | null | undefined,
+  env: R2SqlEnv | null | undefined,
   netuid: number,
 ): Promise<Record<string, unknown>[] | null> {
   return await r2SqlQuery(

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -957,7 +957,7 @@ export interface FreshnessDeps {
  */
 export async function confirmRedirectedStale(
   stale: readonly StaleTable[],
-  env: Record<string, unknown> | null | undefined,
+  env: unknown,
   deps: FreshnessDeps = {},
   now: () => number = Date.now,
   spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
@@ -1000,7 +1000,7 @@ export async function confirmRedirectedStale(
 }
 
 export async function crossCheckStamps(
-  env: Record<string, unknown> | null | undefined,
+  env: unknown,
   deps: FreshnessDeps = {},
   spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
 ): Promise<{ divergences: StampDivergence[]; failed: boolean }> {
@@ -1040,7 +1040,7 @@ export interface FreshnessOutcome {
  * because "nothing was measured" and "nothing is stale" must not look alike.
  */
 export async function runTableFreshnessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: unknown,
   deps: FreshnessDeps = {},
 ): Promise<FreshnessOutcome> {
   const laneDb = laneHealthStore(env, deps.laneHealthDb);

--- a/src/tao-usd-index-watchdog.ts
+++ b/src/tao-usd-index-watchdog.ts
@@ -323,7 +323,7 @@ export function evaluateTaoUsdIndex({
  * failure this issue is about.
  */
 export async function runTaoUsdIndexWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: unknown,
   deps: {
     db?: TaoUsdWatchdogDb | null;
     laneHealthDb?: Parameters<typeof recordLaneVerdict>[0];

--- a/src/tao-usd-index-watchdog.ts
+++ b/src/tao-usd-index-watchdog.ts
@@ -333,8 +333,7 @@ export async function runTaoUsdIndexWatchdog(
   const now = deps.now ?? Date.now;
   const nowMs = now();
   const db =
-    deps.db ??
-    (readStore(env as never, TAO_USD_TABLES) as unknown as TaoUsdWatchdogDb);
+    deps.db ?? (readStore(env, TAO_USD_TABLES) as unknown as TaoUsdWatchdogDb);
 
   let rows: Row[] | null;
   try {

--- a/src/top-holders-holdings.ts
+++ b/src/top-holders-holdings.ts
@@ -276,14 +276,10 @@ export async function topHoldersHoldings(
   // this module's OptionalRowStore names bind()/all(), the completeness readers name
   // first() -- so the casts go through unknown rather than widening either
   // interface to satisfy the other.
-  const asFirst = db as unknown as Parameters<
-    typeof latestCompleteAccountBalancesPass
-  >[0];
+  const asFirst = db;
   const [balances, alpha] = await Promise.all([
     latestCompleteAccountBalancesPass(asFirst),
-    latestCompleteHotkeyAlphaPass(
-      db as unknown as Parameters<typeof latestCompleteHotkeyAlphaPass>[0],
-    ),
+    latestCompleteHotkeyAlphaPass(db),
   ]);
   const free = mayRankAccountBalances(balances);
   const delegated = mayPriceHotkeyAlpha(alpha);

--- a/src/top-holders-staleness-watchdog.ts
+++ b/src/top-holders-staleness-watchdog.ts
@@ -56,6 +56,25 @@ import {
 } from "./top-holders-flow-tier.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type TopHoldersStalenessWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    /** Partial: the guard below handles a binding with no `get`. */
+    METAGRAPH_ARCHIVE?: Partial<ArtifactBucket>;
+    TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS?: unknown;
+    TOP_HOLDERS_HOLDINGS_STALENESS_THRESHOLD_MS?: unknown;
+  };
 
 /**
  * The same bound for the LIVE half of this leaderboard (#9469).
@@ -200,6 +219,22 @@ export function evaluateTopHoldersStaleness(input: {
   };
 }
 
+/**
+ * Does this binding actually answer `get`?
+ *
+ * A TYPE PREDICATE, not `if (!bucket?.get)` followed by a cast. The binding is
+ * whatever the platform injected -- a deployment can bind nothing, and the
+ * suite exercises exactly that (`{ METAGRAPH_ARCHIVE: {} }` must degrade, not
+ * throw) -- so the declared type is `Partial` and this is what narrows it
+ * (#11339). The old spelling checked the same thing but left the compiler
+ * believing the value could still be partial one line later.
+ */
+function usableBucket(
+  bucket: Partial<ArtifactBucket> | null | undefined,
+): bucket is ArtifactBucket {
+  return typeof bucket?.get === "function";
+}
+
 interface ArtifactBucket {
   get(key: string): Promise<{ json(): Promise<unknown> } | null>;
 }
@@ -264,14 +299,15 @@ export async function readTopHoldersArtifactState(
  * and a cron that throws is a cron nobody can read the result of.
  */
 export async function runTopHoldersStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: TopHoldersStalenessWatchdogEnv | null | undefined,
   deps: TopHoldersStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;
   const record = deps.recordException ?? recordExceptionEvent;
-  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
-    ?.METAGRAPH_ARCHIVE;
-  if (!bucket?.get) return { ok: false, reason: "r2 binding unavailable" };
+  const bucket = env?.METAGRAPH_ARCHIVE;
+  if (!usableBucket(bucket)) {
+    return { ok: false, reason: "r2 binding unavailable" };
+  }
 
   const flowThresholdMs =
     Number(env?.TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS) ||

--- a/src/top-holders-staleness-watchdog.ts
+++ b/src/top-holders-staleness-watchdog.ts
@@ -301,7 +301,7 @@ export async function runTopHoldersStalenessWatchdog(
       flow.age_ms === null
         ? "age unknown"
         : `${(flow.age_ms / 3_600_000).toFixed(1)} h old`;
-    await record(env as never, {
+    await record(env, {
       error: new Error(
         `top-holders flow lane ${flow.reason}: the net_flow_* ranking is ` +
           `${age} (threshold ${(flowThresholdMs / 3_600_000).toFixed(1)} h) ` +
@@ -326,7 +326,7 @@ export async function runTopHoldersStalenessWatchdog(
       holdings.age_ms === null
         ? "age unknown"
         : `${(holdings.age_ms / 3_600_000).toFixed(1)} h old`;
-    await record(env as never, {
+    await record(env, {
       error: new Error(
         `top-holders holdings refresh ${holdings.reason}: free_tao, ` +
           `delegated_tao and total_tao are ${age} (threshold ` +

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -245,7 +245,7 @@ function parseRate(value: unknown): number | undefined {
 }
 
 function usageSampleRatesByRoute(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
 ): Record<string, number> {
   const raw = env?.[POSTHOG_USAGE_SAMPLE_RATES_ENV];
   if (typeof raw !== "string" || !raw.trim()) return {};
@@ -311,7 +311,7 @@ export const MCP_PING_ROUTE = `${MCP_PROTOCOL_ROUTE_PREFIX}ping`;
  * sampled (failures, every MCP surface), otherwise the route override,
  * otherwise the deployment default. */
 export function resolveUsageSampleRate(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: UsageEvent,
 ): number {
   if (event.ok === false) return 1;
@@ -419,12 +419,11 @@ export type DeploymentEnvironment = "production" | "development";
  * exists on a real deployment, and the case this function exists to detect is
  * precisely the one where it does not.
  */
-export function resolveDeployment(env: Env | null | undefined): {
+export function resolveDeployment(env: TelemetryEnv | null | undefined): {
   environment: DeploymentEnvironment;
   release?: string;
 } {
-  const metadata = (env as Record<string, unknown> | null | undefined)
-    ?.CF_VERSION_METADATA as Partial<WorkerVersionMetadata> | undefined;
+  const metadata = env?.CF_VERSION_METADATA;
   const id = sanitizeLabel(metadata?.id);
   if (id === undefined) return { environment: "development" };
   // Prefer the human-meaningful tag when the deployment set one; the id is a
@@ -438,7 +437,7 @@ export function resolveDeployment(env: Env | null | undefined): {
  * from -- the same discipline assignMcpAttribution already applies. */
 function assignDeployment(
   properties: Record<string, unknown>,
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
 ): void {
   const { environment, release } = resolveDeployment(env);
   properties.environment = environment;
@@ -554,8 +553,41 @@ export function parseUserAgentClient(userAgent: unknown): {
 }
 
 /** True when this deployment has a non-empty PostHog project token configured. */
+/**
+ * What the telemetry path needs from its environment, and nothing else.
+ *
+ * NAMED MINIMAL CONTRACT, following `SurfaceCredentialEnv`'s precedent rather
+ * than taking the whole ambient `Env` (metagraphed#11339). The difference is
+ * not stylistic: `Env` is an INTERFACE, so it has no implicit index signature
+ * and cannot be satisfied by a caller holding a structural bag -- which is why
+ * `neon-write-buffer-hub.ts` was passing `BufferEnv` through five
+ * `as unknown as Parameters<…>` casts to reach this function. A cast at a
+ * boundary that is only about five optional strings.
+ *
+ * Every field is optional and every read below type-guards what it finds
+ * (`typeof token === "string"`), because an unset runtime var reads as
+ * `undefined` rather than absent. So this describes the KEYS this module looks
+ * up, and the guards remain the thing that decides whether a value is usable.
+ *
+ * NOT A ZOD SCHEMA, deliberately: these are platform-injected bindings read
+ * once per invocation, not a payload crossing a wire. The repo's parsed
+ * boundaries are the wire ones -- `schemas-src/lakehouse.ts` for rows,
+ * `foreign-wire.ts` for third-party bodies -- and this is neither.
+ */
+export interface TelemetryEnv {
+  POSTHOG_PROJECT_TOKEN?: string;
+  POSTHOG_HOST?: string;
+  POSTHOG_USAGE_SAMPLE_RATE?: string;
+  POSTHOG_USAGE_SAMPLE_RATES?: string;
+  POSTHOG_EXCEPTION_STORM_WINDOW_MS?: string;
+  /** Stamped onto every event by `assignDeployment`. */
+  CF_VERSION_METADATA?: Partial<WorkerVersionMetadata>;
+  /** The shared storm gate's window store -- see `admitExceptionCaptureShared`. */
+  METAGRAPH_CONTROL?: ExceptionStormKv;
+}
+
 export function isUsageTelemetryConfigured(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
 ): boolean {
   const token = env?.[POSTHOG_PROJECT_TOKEN_ENV];
   return typeof token === "string" && token.trim().length > 0;
@@ -678,7 +710,7 @@ function isUsagePerson(distinctId?: string): boolean {
  * being remembered, which is the only version of this that holds.
  */
 async function capturePostHogEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   eventName: string,
   properties: Record<string, unknown>,
   deps: RecordUsageEventDeps,
@@ -749,7 +781,7 @@ export function assignUsagePersonProcessing(
  * should schedule the returned promise via `ctx.waitUntil(...)`.
  */
 export async function recordUsageEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: UsageEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -783,7 +815,9 @@ export async function recordUsageEvent(
   }
 }
 
-export function resolvePostHogHost(env: Env | null | undefined): string {
+export function resolvePostHogHost(
+  env: TelemetryEnv | null | undefined,
+): string {
   return typeof env?.[POSTHOG_HOST_ENV] === "string" &&
     env[POSTHOG_HOST_ENV].trim()
     ? env[POSTHOG_HOST_ENV].trim()
@@ -1320,7 +1354,7 @@ export interface McpToolsListEvent extends McpServerIdentity {
  * Same no-throw contract as recordUsageEvent.
  */
 export async function recordMcpToolCallEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpToolCallEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1450,7 +1484,7 @@ export async function recordMcpToolCallEvent(
  * Same no-throw contract as recordUsageEvent.
  */
 export async function recordMcpInitializeEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpInitializeEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1490,7 +1524,7 @@ export async function recordMcpInitializeEvent(
  * Same no-throw contract as recordUsageEvent.
  */
 export async function recordMcpToolsListEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpToolsListEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1584,7 +1618,7 @@ export interface McpResourceEvent extends McpServerIdentity {
  * how the deployment stamp ends up on three of them.
  */
 async function postMcpResourceEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   eventName: string,
   event: McpResourceEvent,
   deps: RecordUsageEventDeps,
@@ -1623,7 +1657,7 @@ async function postMcpResourceEvent(
 
 /** Emit `$mcp_resources_list`. Same no-throw contract as recordUsageEvent. */
 export async function recordMcpResourcesListEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpResourceEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1632,7 +1666,7 @@ export async function recordMcpResourcesListEvent(
 
 /** Emit `$mcp_resource_read`. Same no-throw contract as recordUsageEvent. */
 export async function recordMcpResourceReadEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpResourceEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1641,7 +1675,7 @@ export async function recordMcpResourceReadEvent(
 
 /** Emit `$mcp_prompts_list`. Same no-throw contract as recordUsageEvent. */
 export async function recordMcpPromptsListEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpResourceEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1650,7 +1684,7 @@ export async function recordMcpPromptsListEvent(
 
 /** Emit `$mcp_prompt_get`. Same no-throw contract as recordUsageEvent. */
 export async function recordMcpPromptGetEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpResourceEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1686,7 +1720,7 @@ export interface McpMissingCapabilityEvent extends McpServerIdentity {
  * the SDK defined the schema, but the words are the caller's.
  */
 export async function recordMcpMissingCapabilityEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: McpMissingCapabilityEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -1892,8 +1926,8 @@ const ExceptionStormWindowSchema = z.coerce
   .positive()
   .catch(0);
 
-function exceptionStormWindowMs(env: Env | null | undefined): number {
-  const raw = env?.[POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV as keyof Env];
+function exceptionStormWindowMs(env: TelemetryEnv | null | undefined): number {
+  const raw = env?.[POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV];
   // z.coerce.number() maps "" and null to 0, which .positive() then rejects
   // into the same disabled sentinel -- but undefined coerces to NaN, so the
   // schema covers every case without a pre-check.
@@ -1921,7 +1955,7 @@ const exceptionThrottle = new Map<string, ExceptionThrottleState>();
  * Same reasoning as captureDataApiError's boolean return.
  */
 export function admitExceptionCapture(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   fingerprint: string,
   nowMs: number = Date.now(),
 ): number | null {
@@ -1982,15 +2016,14 @@ const KV_MIN_EXPIRATION_TTL_SECONDS = 60;
  * trade a billing problem for an availability one.
  */
 export async function admitExceptionCaptureShared(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   fingerprint: string,
   deps: { now?: () => number } = {},
 ): Promise<number | null> {
   const windowMs = exceptionStormWindowMs(env);
   if (windowMs === 0) return 0;
 
-  const kv = (env as { METAGRAPH_CONTROL?: ExceptionStormKv } | null)
-    ?.METAGRAPH_CONTROL;
+  const kv = env?.METAGRAPH_CONTROL;
   if (!kv?.get || !kv?.put) return 0;
 
   const key = `${EXCEPTION_STORM_KV_PREFIX}${fingerprint}`;
@@ -2042,7 +2075,7 @@ const mcpRefusalThrottle = new Map<string, ExceptionThrottleState>();
  * storm.
  */
 export function admitMcpRefusalCapture(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   reason: string,
   nowMs: number = Date.now(),
 ): number | null {
@@ -2168,7 +2201,7 @@ export function isBenignPlatformMessage(message: string): boolean {
  * into this function, only the general caution free text always deserves.
  */
 export async function recordExceptionEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: ExceptionEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -2352,7 +2385,7 @@ export interface AiDegradedEvent {
  * no-op-when-unconfigured contract as every recorder here.
  */
 export async function recordAiDegradedEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: AiDegradedEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -2407,7 +2440,7 @@ export interface AiEmbeddingEvent {
  * reported and the cost column is left genuinely empty.
  */
 export async function recordAiEmbeddingEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: AiEmbeddingEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
@@ -2475,7 +2508,7 @@ export async function recordAiEmbeddingEvent(
  * no-op-when-unconfigured contract as recordUsageEvent/recordExceptionEvent.
  */
 export async function recordAiGenerationEvent(
-  env: Env | null | undefined,
+  env: TelemetryEnv | null | undefined,
   event: AiGenerationEvent,
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -340,7 +340,7 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
         verdict.reason === "partial"
           ? `validator-nominator-counts lane truncated: the newest pass reached only ${verdict.covered_rows} hotkeys against a floor of ${verdict.coverage_floor_rows} (${verdict.total_rows} rows in the table, newest stamp ${age}) -- the capture is RECENT and PARTIAL, so /validators serves a nominator_count that is silently a pass old for every hotkey the scan never got to`
           : `validator-nominator-counts lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 3_600_000} h) -- /validators is serving nominator_count from a table nothing is refreshing`;
-      await record(env as never, {
+      await record(env, {
         error: new Error(message),
         route: "watchdog:validator-nominator-counts-staleness",
         errorCode: "stale_lane",

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -54,6 +54,24 @@ import {
 import type { ValidatorNominatorCounts } from "../generated/db/types.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+/**
+ * What this module reads from its environment, and nothing else.
+ *
+ * Named rather than left as `Record<string, unknown>` (#11339): a Record
+ * READS as loose but is not, because `Env` is an interface and TypeScript
+ * never gives interfaces implicit index signatures -- so every caller
+ * holding a real `Env` wrote `env as unknown as Record<string, unknown>`
+ * to get past it. Listing the keys costs nothing and states the contract.
+ */
+type ValidatorNominatorCountsStalenessWatchdogEnv = StoreEnv &
+  TelemetryEnv & {
+    VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS?: unknown;
+    VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS?: unknown;
+    VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS?: unknown;
+  };
 
 /**
  * How old the counts table may get before this is a stall.
@@ -282,7 +300,7 @@ export interface ValidatorNominatorCountsStalenessDeps {
  * and a cron that throws is a cron nobody can read the result of.
  */
 export async function runValidatorNominatorCountsStalenessWatchdog(
-  env: Record<string, unknown> | null | undefined,
+  env: ValidatorNominatorCountsStalenessWatchdogEnv | null | undefined,
   deps: ValidatorNominatorCountsStalenessDeps = {},
 ): Promise<Record<string, unknown>> {
   const now = deps.now ?? Date.now;

--- a/src/validator-nominator-positions.ts
+++ b/src/validator-nominator-positions.ts
@@ -90,9 +90,7 @@ export async function loadNominatorPositions(
   ): NominatorPositionsRead => ({ rows: [], capturedAt: null, decline });
   if (!db?.query) return declined("unavailable");
 
-  const alpha = await latestCompleteHotkeyAlphaPass(
-    db as unknown as Parameters<typeof latestCompleteHotkeyAlphaPass>[0],
-  );
+  const alpha = await latestCompleteHotkeyAlphaPass(db);
   if (!mayPriceHotkeyAlpha(alpha)) {
     return declined(
       alpha.reason === "unavailable" ? "unavailable" : "pool_totals_unproven",

--- a/src/web-push.ts
+++ b/src/web-push.ts
@@ -198,11 +198,10 @@ export async function encryptPushPayload(
   );
   const sharedSecret = new Uint8Array(
     await crypto.subtle.deriveBits(
-      // Cast: Cloudflare's typings name this member `$public`, while the
-      // runtime (and the WebCrypto spec) use `public`.
-      { name: "ECDH", public: uaKey } as unknown as Parameters<
-        SubtleCrypto["deriveBits"]
-      >[0],
+      // `public`, not `$public`: the generated types misname this member, and
+      // workers/env-extra.d.ts corrects it by declaration merge rather than
+      // this call site asserting past the whole parameter (#11339).
+      { name: "ECDH", public: uaKey },
       serverKeys.privateKey,
       256,
     ),

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -671,6 +671,10 @@ describe("handleScheduled dispatch", () => {
     const probeResult = (await handleScheduled(
       { cron: HEALTH_PROBER_CRON } as unknown as ScheduledController,
       {} as unknown as Env,
+      // Supplied rather than defaulted: the runtime always passes one, and the
+      // default that used to stand in here was `{} as unknown as ExecutionContext`
+      // on the production signature (#11339).
+      { waitUntil: () => {} } as unknown as ExecutionContext,
     )) as Row;
     assert.equal(probeResult.ok, false);
     assert.equal(probeResult.reason, "no-operational-surfaces");
@@ -814,6 +818,7 @@ describe("handleScheduled dispatch", () => {
         const result = (await handleScheduled(
           { cron: HEALTH_PROBER_CRON } as unknown as ScheduledController,
           { POSTHOG_PROJECT_TOKEN: "phc_test_token" } as unknown as Env,
+          { waitUntil: () => {} } as unknown as ExecutionContext,
         )) as Row;
         assert.equal(result.ok, false);
         assert.equal(result.reason, "no-operational-surfaces");

--- a/tests/read-store-narrowing.test.ts
+++ b/tests/read-store-narrowing.test.ts
@@ -15,7 +15,11 @@
 // So most of these pin the cases a cast silently accepted and a parse must not.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { recordOrNull, recordsOrEmpty } from "../src/read-store.ts";
+import {
+  hyperdriveConnectionString,
+  recordOrNull,
+  recordsOrEmpty,
+} from "../src/read-store.ts";
 
 describe("recordOrNull", () => {
   test("NULL IS NOT AN OBJECT, whatever typeof says", () => {
@@ -85,5 +89,54 @@ describe("recordsOrEmpty", () => {
 
   test("EMPTY ARRAY IN, EMPTY ARRAY OUT -- not an error", () => {
     assert.deepEqual(recordsOrEmpty([]), []);
+  });
+});
+
+describe("hyperdriveConnectionString", () => {
+  // The rule that decides whether a lane writes to Neon or silently declines.
+  // It lived in three copies (readStore, laneHealthStore, neonOwnsObservations),
+  // each with two casts, so a divergence between them was one edit away.
+  test("it reads the string off a real binding", () => {
+    assert.equal(
+      hyperdriveConnectionString({
+        HYPERDRIVE: { connectionString: "postgres://x" },
+      }),
+      "postgres://x",
+    );
+  });
+
+  test("AN EMPTY STRING IS NOT A CONNECTION", () => {
+    // A bound-but-blank var used to pass the `?.connectionString` truthiness
+    // check in one copy and not another. Blank means unconfigured.
+    assert.equal(
+      hyperdriveConnectionString({ HYPERDRIVE: { connectionString: "" } }),
+      null,
+    );
+  });
+
+  test("a non-string connectionString declines rather than being stringified", () => {
+    // `String(42)` would hand pg a connection string of "42" and fail deep in
+    // the driver instead of declining here.
+    assert.equal(
+      hyperdriveConnectionString({ HYPERDRIVE: { connectionString: 42 } }),
+      null,
+    );
+  });
+
+  test("a bound-but-empty HYPERDRIVE declines", () => {
+    assert.equal(hyperdriveConnectionString({ HYPERDRIVE: {} }), null);
+  });
+
+  test("HYPERDRIVE that is not an object declines", () => {
+    for (const v of [null, "postgres://x", 7, []]) {
+      assert.equal(hyperdriveConnectionString({ HYPERDRIVE: v }), null);
+    }
+  });
+
+  test("no env at all declines rather than throwing", () => {
+    assert.equal(hyperdriveConnectionString(null), null);
+    assert.equal(hyperdriveConnectionString(undefined), null);
+    assert.equal(hyperdriveConnectionString({}), null);
+    assert.equal(hyperdriveConnectionString("not an env"), null);
   });
 });

--- a/tests/read-store-narrowing.test.ts
+++ b/tests/read-store-narrowing.test.ts
@@ -1,0 +1,89 @@
+// `recordOrNull` / `recordsOrEmpty` -- the shape half of the read boundary
+// (#11339).
+//
+// The scalar coercions beside them (read-store-coercions.test.ts) answer "is
+// this number usable". These answer the question that was previously answered
+// by a cast: "is this untrusted thing an object I can read fields off".
+//
+// The producers are honest -- `readHealthKv` returns `unknown` because
+// `KV.get(key, {type:"json"})` genuinely is arbitrary JSON, and
+// `StorageReadResult.data` is `unknown` because an R2 object is whatever was
+// last written to it. Several consumers DECLARED those as
+// `Record<string, unknown> | null` and then read fields off the result, which
+// is a claim about untrusted bytes that nothing verified.
+//
+// So most of these pin the cases a cast silently accepted and a parse must not.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { recordOrNull, recordsOrEmpty } from "../src/read-store.ts";
+
+describe("recordOrNull", () => {
+  test("NULL IS NOT AN OBJECT, whatever typeof says", () => {
+    // `typeof null === "object"` is the hole every hand-rolled version of this
+    // check has fallen through, and the one a cast cannot catch at all: the
+    // field read that follows throws rather than declining.
+    assert.equal(recordOrNull(null), null);
+    assert.equal(recordOrNull(undefined), null);
+  });
+
+  test("AN ARRAY IS NOT A RECORD", () => {
+    // An array reaching a site that then reads named fields is a producer
+    // mismatch. Passing it through would read `undefined` off every field and
+    // report that as data -- the failure mode is a silently empty answer, not
+    // an error, which is the worst kind here.
+    assert.equal(recordOrNull([]), null);
+    assert.equal(recordOrNull([{ endpoints: [] }]), null);
+  });
+
+  test("scalars decline rather than being wrapped", () => {
+    for (const v of ["", "text", 0, 42, true, false]) {
+      assert.equal(recordOrNull(v), null, JSON.stringify(v));
+    }
+  });
+
+  test("a plain object passes through UNCHANGED, same reference", () => {
+    // Identity matters: callers overlay onto the result, and a copy would
+    // silently drop a later mutation by the producer's own code path.
+    const kv = { endpoints: [1], last_run_at: "2026-08-15T00:00:00Z" };
+    assert.equal(recordOrNull(kv), kv);
+  });
+
+  test("an empty object is a RECORD, not an absence", () => {
+    // `{}` from KV means "the cron wrote a snapshot with nothing in it", which
+    // is different from "no snapshot". Collapsing them would make a live-tier
+    // degradation read as a cold tier.
+    assert.deepEqual(recordOrNull({}), {});
+  });
+});
+
+describe("recordsOrEmpty", () => {
+  test("a non-array yields EMPTY, not a one-element list", () => {
+    // The tempting alternative -- wrap a lone object -- would invent a row
+    // that the producer never published.
+    assert.deepEqual(recordsOrEmpty({ netuid: 1 }), []);
+    assert.deepEqual(recordsOrEmpty(null), []);
+    assert.deepEqual(recordsOrEmpty(undefined), []);
+    assert.deepEqual(recordsOrEmpty("[]"), []);
+  });
+
+  test("non-object members are DROPPED, not passed through", () => {
+    // So a caller that reads a field off every element cannot meet a string.
+    assert.deepEqual(recordsOrEmpty([{ a: 1 }, "x", null, 7, { b: 2 }, []]), [
+      { a: 1 },
+      { b: 2 },
+    ]);
+  });
+
+  test("an all-invalid array yields empty rather than throwing", () => {
+    assert.deepEqual(recordsOrEmpty([null, 1, "x"]), []);
+  });
+
+  test("an already-clean array survives intact, in order", () => {
+    const rows = [{ netuid: 64 }, { netuid: 51 }, { netuid: 107 }];
+    assert.deepEqual(recordsOrEmpty(rows), rows);
+  });
+
+  test("EMPTY ARRAY IN, EMPTY ARRAY OUT -- not an error", () => {
+    assert.deepEqual(recordsOrEmpty([]), []);
+  });
+});

--- a/tests/safe-mode-extrinsics-reader.test.ts
+++ b/tests/safe-mode-extrinsics-reader.test.ts
@@ -30,7 +30,9 @@ const { SAFE_MODE_EXTRINSIC_LIMIT, readSafeModeExtrinsics } =
 test("it asks the extrinsics cold tier for the SafeMode module, within the route's own ceiling", async () => {
   coldTier.calls.length = 0;
   coldTier.result = { extrinsics: [] };
-  const env = { MARKER: 1 };
+  // A real key rather than an invented one, so the fixture is a valid env;
+  // the assertion below is identity, so any value proves the threading.
+  const env = { SAFE_MODE_RPC_URL: "sentinel" };
   await readSafeModeExtrinsics(env);
   assert.equal(coldTier.calls.length, 1, "one tier read, no HTTP hop");
   const [passedEnv, query] = coldTier.calls[0] as [

--- a/tests/subnet-economics-read-schema.test.ts
+++ b/tests/subnet-economics-read-schema.test.ts
@@ -1,0 +1,91 @@
+// The read-tolerant economics contract (#11339, closing #10789).
+//
+// `subnetEconomicsRow` and `withSpotPrice` used to reach their typed row via
+// `rows as SubnetEconomicsRow[]` and `withSpotPrice(row as never)`. `as never`
+// is the worst of the two: it makes ANY value satisfy the parameter, so a
+// producer that renamed `alpha_in_pool` would have gone on computing spot price
+// from `undefined` and publishing the result.
+//
+// Replacing an assertion with a parse is only safe if the parse is the RIGHT
+// one. The strict schema is the PRODUCER's contract, where an undeclared key is
+// genuine drift. Reading through it would make every read fail the day a
+// producer adds a field -- turning a schema into an availability risk. So the
+// read path gets partial+catchall, the same contract every lakehouse row schema
+// is declared with, and these pin that the tolerance goes exactly one way.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  SubnetEconomicsReadSchema,
+  SubnetEconomicsSchema,
+} from "../schemas-src/shared.ts";
+
+/** One subnet exactly as api.metagraphed.com served it, 2026-08-15T12:27Z. */
+const SERVED = {
+  netuid: 64,
+  slug: "sn-64",
+  name: "Chutes",
+  alpha_in_pool: 2582597.356934225,
+  alpha_out_pool: 3362984.870231824,
+  alpha_price_tao: 0.085211829,
+  tao_in_pool_tao: 219140.449957903,
+  registration_allowed: true,
+  emission_enabled: true,
+};
+
+describe("SubnetEconomicsReadSchema", () => {
+  test("A NEW PRODUCER FIELD DOES NOT EMPTY THE ROUTE", () => {
+    // The failure this schema exists to prevent. Under the strict schema every
+    // row would fail together, and a leaderboard that answers nothing is
+    // indistinguishable from one whose data is gone.
+    const row = { ...SERVED, A_FIELD_SHIPPED_BEFORE_THIS_FILE_KNEW: "x" };
+    assert.equal(SubnetEconomicsSchema.safeParse(row).success, false);
+    assert.equal(SubnetEconomicsReadSchema.safeParse(row).success, true);
+  });
+
+  test("and the new field SURVIVES the parse", () => {
+    // Dropping it would be a quieter version of the same bug: the route keeps
+    // answering, minus a column its own producer publishes.
+    const parsed = SubnetEconomicsReadSchema.parse({
+      ...SERVED,
+      brand_new: 1,
+    });
+    assert.equal((parsed as Record<string, unknown>).brand_new, 1);
+  });
+
+  test("a PROJECTION carrying a subset of columns still parses", () => {
+    // `fields=netuid,name` is a supported query, and its rows are missing
+    // almost everything the schema declares as required.
+    assert.equal(
+      SubnetEconomicsReadSchema.safeParse({ netuid: 64, name: "Chutes" })
+        .success,
+      true,
+    );
+  });
+
+  test("THE TYPE STAYS PINNED -- this is the half that catches a defect", () => {
+    // The whole point of parsing rather than asserting. A renamed or retyped
+    // column is exactly what `as never` let through.
+    const wrong = { ...SERVED, alpha_in_pool: "not-a-number" };
+    const result = SubnetEconomicsReadSchema.safeParse(wrong);
+    assert.equal(result.success, false);
+    assert.equal(result.error?.issues[0]?.path.join("."), "alpha_in_pool");
+  });
+
+  test("a live served row parses clean under BOTH schemas", () => {
+    // Verified against production before the assertion was replaced: the
+    // served row carries zero fields the strict schema does not declare, so
+    // the read schema is loosening a contract that already held rather than
+    // papering over a drift that already existed.
+    assert.equal(SubnetEconomicsReadSchema.safeParse(SERVED).success, true);
+  });
+
+  test("a non-object is rejected by the read schema too", () => {
+    for (const v of [null, [], "x", 7]) {
+      assert.equal(
+        SubnetEconomicsReadSchema.safeParse(v).success,
+        false,
+        JSON.stringify(v),
+      );
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3699,9 +3699,7 @@ async function dispatchScheduled(
     // stopped, losing ground to the raw capture, or publishing a height the
     // lakehouse does not back. All three look like a healthy block list with
     // empty block detail, which is why nothing noticed for a day.
-    return runLakehouseSeamWatchdog(
-      env as unknown as Parameters<typeof runLakehouseSeamWatchdog>[0],
-    );
+    return runLakehouseSeamWatchdog(env);
   }
   if (cron === PROJECTION_LANES_CRON) {
     // #9146: recompute the windowed-aggregate artifacts (every lane in

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3332,8 +3332,8 @@ export const LANE_PRODUCERS: ReadonlyArray<{
 
 export async function handleScheduled(
   controller: ScheduledController,
-  env: Env = {} as unknown as Env,
-  ctx: ExecutionContext = {} as unknown as ExecutionContext,
+  env: Env,
+  ctx: ExecutionContext,
 ) {
   const startedAt = Date.now();
   const label = cronLabel(controller?.cron || "");
@@ -3449,8 +3449,8 @@ export const API_HANDLED_CRONS: readonly string[] = [
 
 async function dispatchScheduled(
   controller: ScheduledController,
-  env: Env = {} as unknown as Env,
-  ctx: ExecutionContext = {} as unknown as ExecutionContext,
+  env: Env,
+  ctx: ExecutionContext,
 ) {
   const cron = controller?.cron || "";
   // The former fast-load cron (#1346 Option A, EVENTS_LOAD_CRON, "*/3 * * * *")
@@ -5921,22 +5921,14 @@ async function handleChainFirehoseIngest(request: Request, env: Env) {
  * early returns, and wrapping it from outside is what makes the label
  * unforgettable rather than 40 more places to remember.
  */
-export async function handleRequest(
-  request: Request,
-  env: Env = {} as unknown as Env,
-  ctx: Ctx = {},
-) {
+export async function handleRequest(request: Request, env: Env, ctx: Ctx = {}) {
   const before = degradedSnapshot();
   const response = await dispatchRequest(request, env, ctx);
   labelDegradedResponse(response, before);
   return response;
 }
 
-async function dispatchRequest(
-  request: Request,
-  env: Env = {} as unknown as Env,
-  ctx: Ctx = {},
-) {
+async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {
   let url = new URL(request.url);
 
   if (request.method === "OPTIONS") {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1159,10 +1159,7 @@ export async function runFreshnessWatchdog(
     (readArtifact as unknown as ArtifactReader)) as ArtifactReader;
   // laneHealthStore, not the binding (#10158) -- one of the last three callers
   // still reaching past it.
-  const laneHealthDb = laneHealthStore(
-    env as unknown as Record<string, unknown>,
-    deps.laneHealthDb,
-  ) as never;
+  const laneHealthDb = laneHealthStore(env, deps.laneHealthDb) as never;
   try {
     const artifact = (await readArtifactFn(
       env,
@@ -2327,10 +2324,7 @@ export default {
       // The dead-letter record is a lane verdict, so it goes where the other
       // 27 do (#10158). recordLaneVerdict swallows failures, so a dead letter
       // written to a store nobody reads is a message lost twice over.
-      await handleDeadLetterBatch(
-        batch,
-        laneHealthStore(env as unknown as Record<string, unknown>) as never,
-      );
+      await handleDeadLetterBatch(batch, laneHealthStore(env) as never);
       return;
     }
     if (batch.queue === PROBE_JOBS_QUEUE) {
@@ -3593,18 +3587,15 @@ async function dispatchScheduled(
         // while the series sat frozen. Now it lands where every other lane's
         // does, and lane-alarm can see it.
         ctx.waitUntil(
-          recordLaneVerdict(
-            laneHealthStore(env as unknown as Record<string, unknown>),
-            {
-              lane: "subnet-burn",
-              verdict: result.ok ? "ok" : "stale",
-              age_ms: null,
-              detail: result.ok
-                ? `captured ${result.captured}${result.pruned ? ", pruned" : ""}`
-                : (result.reason ?? "capture failed"),
-              checked_at: Date.now(),
-            },
-          ).then(() => undefined),
+          recordLaneVerdict(laneHealthStore(env), {
+            lane: "subnet-burn",
+            verdict: result.ok ? "ok" : "stale",
+            age_ms: null,
+            detail: result.ok
+              ? `captured ${result.captured}${result.pruned ? ", pruned" : ""}`
+              : (result.reason ?? "capture failed"),
+            checked_at: Date.now(),
+          }).then(() => undefined),
         );
         // COVERAGE, on the same tick that wrote it (#10308).
         //
@@ -3691,7 +3682,7 @@ async function dispatchScheduled(
   if (cron === SAFE_MODE_WATCHDOG_CRON) {
     // SafeMode is the emergency chain pause. Zero alerts is the correct steady
     // state -- it means nothing has gone wrong, not that the watchdog is idle.
-    return runSafeModeWatchdog(env as unknown as Record<string, unknown>);
+    return runSafeModeWatchdog(env);
   }
   if (cron === LAKEHOUSE_SEAM_CRON) {
     // The seam that routes every cold block read now follows the decode
@@ -3763,7 +3754,7 @@ async function dispatchScheduled(
     // in this dispatcher produces a verdict; this is the only one that CONSUMES
     // them, which is why a 28-hour outage could sit in lane_health with a
     // correct verdict on every tick and reach nobody (#9330/#9340).
-    return runLaneAlarm(env as unknown as Record<string, unknown>);
+    return runLaneAlarm(env);
   }
   if (cron === NEURONS_STALENESS_WATCHDOG_CRON) {
     // The neurons live lane's alarm. Zero alerts is the correct steady state;
@@ -3779,13 +3770,10 @@ async function dispatchScheduled(
     // bearing half. A lifecycle write that throws must not cost the estate its
     // neurons staleness verdict, so its failure is swallowed here and recorded
     // in its own lane_health row.
-    const staleness = await runNeuronsStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
+    const staleness = await runNeuronsStalenessWatchdog(env);
+    const lifecycle = runSubnetLifecycleLane(env, { ctx }).catch(
+      () => undefined,
     );
-    const lifecycle = runSubnetLifecycleLane(
-      env as unknown as Record<string, unknown>,
-      { ctx },
-    ).catch(() => undefined);
     // waitUntil where there is one, AWAIT where there is not. A bare `{}` ctx
     // reaches here from callers that have none to give, and calling
     // `ctx.waitUntil` on it throws -- which would take the staleness alarm down
@@ -3802,9 +3790,7 @@ async function dispatchScheduled(
     // under watchdog:projection-staleness. An ABSENT artifact alerts too --
     // every registered lane is meant to have written on the last tick, and a
     // route over a missing card serves its zeroed floor as though measured.
-    return runProjectionStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    return runProjectionStalenessWatchdog(env);
   }
   if (cron === NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON) {
     // The nominator-positions lane's alarm (#9273). Zero alerts is the correct
@@ -3812,9 +3798,7 @@ async function dispatchScheduled(
     // watchdog:nominator-positions-staleness, the project's alert channel. An
     // EMPTY table alerts too -- until the revived lane posts, every positions
     // read is still answering from the frozen lakehouse export.
-    return runNominatorPositionsStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    return runNominatorPositionsStalenessWatchdog(env);
   }
   if (cron === VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON) {
     // The validator-nominator-counts lane's alarm (#9301) -- the sibling of
@@ -3824,9 +3808,7 @@ async function dispatchScheduled(
     // project's alert channel. An EMPTY table alerts too -- until the
     // re-enabled lane posts, every nominator_count is still coming from the
     // frozen lakehouse mirror or serving null outright.
-    return runValidatorNominatorCountsStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    return runValidatorNominatorCountsStalenessWatchdog(env);
   }
   if (cron === REGISTRY_SYNC_CRON) {
     // #9779: the registry had NO writer. Its only sync path was a pair of
@@ -3859,7 +3841,7 @@ async function dispatchScheduled(
     // either, so the value is noticing at all, not noticing fast. They record
     // separate lane verdicts, so sharing a minute does not merge their
     // reporting.
-    const bag = env as unknown as Record<string, unknown>;
+    const bag = env;
     const [series] = await Promise.all([
       runDailySeriesCoverageWatchdog(bag),
       runDegenerateOutputWatchdog(bag),
@@ -3901,9 +3883,7 @@ async function dispatchScheduled(
     // The chain-detail live lane's alarm. Zero alerts is the correct steady
     // state; a stale verdict records one exception under
     // watchdog:chain-detail-staleness, the project's alert channel.
-    return runChainDetailStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    return runChainDetailStalenessWatchdog(env);
   }
   if (cron === SUBNET_DEREGISTRATION_DAILY_CRON) {
     // #10296: one row per subnet per day of what the deregistration ranking is
@@ -3914,37 +3894,34 @@ async function dispatchScheduled(
     // Reads the same economics blob the live route does, so there is no
     // producer change and no new chain read. Never throws: a capture lane that
     // could take down the cron it shares would be worse than a gap.
-    return runSubnetDeregistrationDailyLane(
-      env as unknown as Record<string, unknown>,
-      {
-        ctx,
-        readEconomics: () =>
-          resolveEmissionPipelineEconomics({
-            env,
-            // Wrapped rather than passed by reference: readEconomicsCurrentKv's
-            // second parameter is `now`, not the `key` this seam declares, and
-            // handing it over directly would bind a cache key into a clock.
-            readHealthKv: (e: Env) => readEconomicsCurrentKv(e),
-            contractVersion: contractVersion(env),
-            // NO ARTIFACT FALLBACK, deliberately. The published
-            // /metagraph/economics.json cannot produce a ranking -- measured
-            // 2026-08-10, it carries `moving_price_pinned` and NOTHING ELSE
-            // this needs:
-            //
-            //   chain_state.network_immunity_period   absent
-            //   subnets[].registered_at_block         null
-            //   subnets[].subnet_mechanism            null
-            //
-            // Only the live KV blob (meta.source: live-cron-prober) has them,
-            // which is why /api/v1/chain/deregistration-ranking answers from
-            // it. Passing a fallback that provably cannot succeed would mean an
-            // `economics_unavailable` verdict has two possible causes and the
-            // operator has to rule one out; with KV as the only source it has
-            // exactly one.
-            readArtifact: async () => null,
-          }),
-      },
-    );
+    return runSubnetDeregistrationDailyLane(env, {
+      ctx,
+      readEconomics: () =>
+        resolveEmissionPipelineEconomics({
+          env,
+          // Wrapped rather than passed by reference: readEconomicsCurrentKv's
+          // second parameter is `now`, not the `key` this seam declares, and
+          // handing it over directly would bind a cache key into a clock.
+          readHealthKv: (e: Env) => readEconomicsCurrentKv(e),
+          contractVersion: contractVersion(env),
+          // NO ARTIFACT FALLBACK, deliberately. The published
+          // /metagraph/economics.json cannot produce a ranking -- measured
+          // 2026-08-10, it carries `moving_price_pinned` and NOTHING ELSE
+          // this needs:
+          //
+          //   chain_state.network_immunity_period   absent
+          //   subnets[].registered_at_block         null
+          //   subnets[].subnet_mechanism            null
+          //
+          // Only the live KV blob (meta.source: live-cron-prober) has them,
+          // which is why /api/v1/chain/deregistration-ranking answers from
+          // it. Passing a fallback that provably cannot succeed would mean an
+          // `economics_unavailable` verdict has two possible causes and the
+          // operator has to rule one out; with KV as the only source it has
+          // exactly one.
+          readArtifact: async () => null,
+        }),
+    });
   }
   if (cron === TOP_HOLDERS_FLOW_CRON) {
     // #9469: recompute the top-holders net_flow_7d/30d/90d ranking from
@@ -3973,9 +3950,7 @@ async function dispatchScheduled(
     // (#9475 removed the special case that kept this quiet). An ABSENT,
     // UNREADABLE or EMPTY artifact alerts too -- that is the condition where
     // the route silently answers 200 with an empty leaderboard.
-    return runTopHoldersStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    return runTopHoldersStalenessWatchdog(env);
   }
   if (cron === HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON) {
     // The pool ledger's alarm (#9576) -- the twin of the watchdog above, for
@@ -3986,9 +3961,7 @@ async function dispatchScheduled(
     // pool_totals_unproven, both of which are correct and both of which look
     // identical to a producer that died. An EMPTY table alerts, because that is
     // the state the lane has been in since the sink landed.
-    return runHotkeyAlphaStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    return runHotkeyAlphaStalenessWatchdog(env);
   }
   if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON) {
     // The account-balances lane's alarm (#9478) -- the SOURCE side of the
@@ -4001,9 +3974,7 @@ async function dispatchScheduled(
     // project's alert channel. An
     // EMPTY table alerts too -- until the revived lane posts, every top-holders
     // read is still answering from the frozen 2026-08-02 materialization.
-    return runAccountBalancesStalenessWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    return runAccountBalancesStalenessWatchdog(env);
   }
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) {
     // The live-economics refresh, formerly the 3-hourly Actions schedule and
@@ -9366,9 +9337,7 @@ export async function readChainEventsDb(
     // THROUGH THE WATCHDOG'S OWN READER, not a second copy of its SQL: this
     // endpoint publishes the number and the watchdog alerts on it, and two
     // queries would drift apart silently, each looking correct alone.
-    const head = await readChainDetailHead(
-      env as unknown as Record<string, unknown>,
-    );
+    const head = await readChainDetailHead(env);
     // A blank or zero timestamp is ABSENT, not the epoch: Number(null) is 0,
     // which would publish an age of 56 years instead of "no heartbeat".
     if (head.latestObservedAtMs && head.latestObservedAtMs > 0) {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -9003,10 +9003,7 @@ async function handleRawArtifactRequest(
     data.endpoints.some((endpoint: Row) => endpoint?.surface_id)
   ) {
     const liveSnapshot = await resolveLiveHealth({
-      readHealthKv: readHealthKv as unknown as (
-        env: Env,
-        key: string,
-      ) => Promise<Row | null>,
+      readHealthKv: readHealthKv,
       env,
     });
     data = overlayArtifactEndpoints(data, liveSnapshot) ?? data;
@@ -9607,10 +9604,7 @@ async function handleApiRequest(
       data: await loadGlobalOperationalHealth(
         {
           env,
-          readHealthKv: readHealthKv as unknown as (
-            env: Env,
-            key: string,
-          ) => Promise<Record<string, unknown> | null>,
+          readHealthKv,
         },
         { contractVersion: (e: Env) => contractVersion(e) },
       ),
@@ -10778,10 +10772,7 @@ async function handleAskRequest(request: Request, env: Env, ctx?: Ctx) {
     // current operational status of each subnet's surfaces, not the build-time
     // "unknown" stub baked into the agent-catalog artifact.
     const liveHealth = await resolveLiveHealth({
-      readHealthKv: readHealthKv as unknown as (
-        env: Env,
-        key: string,
-      ) => Promise<Row | null>,
+      readHealthKv: readHealthKv,
       env,
     });
     const data = await askQuestion(
@@ -10857,10 +10848,7 @@ async function liveHealthOverlay(
     if (resolved === undefined) {
       resolved =
         (await resolveLiveHealth({
-          readHealthKv: readHealthKv as unknown as (
-            env: Env,
-            key: string,
-          ) => Promise<Row | null>,
+          readHealthKv: readHealthKv,
           env,
         })) || null;
     }

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -1270,11 +1270,7 @@ export class ChainFirehoseHub implements DurableObject {
         // handle here -- a Durable Object has no ExecutionContext, and
         // createPgSql needs one to hand the pooled connection back to
         // Hyperdrive.
-        await mirrorBlocksHeadToNeon(
-          this.env as unknown as Record<string, unknown>,
-          this.state,
-          block,
-        );
+        await mirrorBlocksHeadToNeon(this.env, this.state, block);
         await this.state.storage.put("head:last_seen", block.block_number);
       }
     } catch (error) {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -1055,7 +1055,7 @@ async function handleChainDetailSync(
     neon = await mirrorChainDetailToNeon(
       env as unknown as Record<string, unknown>,
       ctx,
-      batch.rows as unknown as Parameters<typeof mirrorChainDetailToNeon>[2],
+      batch.rows,
     );
   } catch (err) {
     console.error("data-api chain-detail-sync write failed:", err);

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -871,21 +871,17 @@ async function handleNeuronsSync(
   // store every route reads, so a pass that did not reach it did not happen,
   // and the check below returns 502 rather than recording a mirror verdict.
   // It still reports its own outcome and cannot throw.
-  const neon = await mirrorNeuronSnapshotToNeon(
-    env as unknown as Record<string, unknown>,
-    ctx,
-    {
-      rows,
-      dailyRows,
-      positionRows,
-      // The tally follows the rows into the store that holds them (#10056).
-      pass,
-      // The deregistration prune's cutoffs (#10184). Derived by the SAME
-      // function that produced dailyRows/positionRows above, so the writer and
-      // the prune cannot disagree about where the floor is.
-      netuidMaxCapturedAt,
-    },
-  );
+  const neon = await mirrorNeuronSnapshotToNeon(env, ctx, {
+    rows,
+    dailyRows,
+    positionRows,
+    // The tally follows the rows into the store that holds them (#10056).
+    pass,
+    // The deregistration prune's cutoffs (#10184). Derived by the SAME
+    // function that produced dailyRows/positionRows above, so the writer and
+    // the prune cannot disagree about where the floor is.
+    netuidMaxCapturedAt,
+  });
 
   // AUTHORITATIVE ONCE NEON OWNS THE TABLES. During dual-write a Neon failure
   // cost a mirror and a lane verdict, never the pass, because D1 was still the
@@ -1052,11 +1048,7 @@ async function handleChainDetailSync(
     // ONE OF THIS LANE'S TWO WRITERS. The sync-batches queue consumer is the
     // other and mirrors too -- #9728 is the precedent for why covering one of
     // two is worse than covering neither: the row count looks nearly right.
-    neon = await mirrorChainDetailToNeon(
-      env as unknown as Record<string, unknown>,
-      ctx,
-      batch.rows,
-    );
+    neon = await mirrorChainDetailToNeon(env, ctx, batch.rows);
   } catch (err) {
     console.error("data-api chain-detail-sync write failed:", err);
     await captureDataApiError(err, "chain-detail-sync-d1", env);
@@ -1267,11 +1259,11 @@ async function handleNeuronDailyBackfill(
   // `rows: []` because this route carries no `neurons` rows: the mirror treats
   // an empty table as a clean no-op and still records its verdict, so the
   // absence is visible rather than assumed.
-  const neon = await mirrorNeuronSnapshotToNeon(
-    env as unknown as Record<string, unknown>,
-    ctx,
-    { rows: [], dailyRows, positionRows },
-  );
+  const neon = await mirrorNeuronSnapshotToNeon(env, ctx, {
+    rows: [],
+    dailyRows,
+    positionRows,
+  });
 
   // Once Neon owns the tables, a backfill that did not reach Neon did not
   // happen -- and the operator replaying a year of history is precisely the
@@ -1570,7 +1562,7 @@ async function handleSubnetHyperparamsSync(
   }
 
   const neon = await mirrorFamilyToNeon(
-    env as unknown as Record<string, unknown>,
+    env,
     ctx,
     SUBNET_HYPERPARAMS_NEON_LANE,
     { rows, historyRows: neonHistoryRows },
@@ -1904,12 +1896,10 @@ async function handleAccountIdentitySync(
     return writeJson({ error: "history read failed" }, 502);
   }
 
-  const neon = await mirrorFamilyToNeon(
-    env as unknown as Record<string, unknown>,
-    ctx,
-    ACCOUNT_IDENTITY_NEON_LANE,
-    { rows, historyRows: neonHistoryRows },
-  );
+  const neon = await mirrorFamilyToNeon(env, ctx, ACCOUNT_IDENTITY_NEON_LANE, {
+    rows,
+    historyRows: neonHistoryRows,
+  });
 
   // AUTHORITATIVE -- see the hyperparams sync for the reasoning.
   const failed = failedTables(neon);
@@ -2065,12 +2055,10 @@ async function handleSubnetIdentitySync(
     historyRows.push({ ...base, observed_at: observedAt });
   }
 
-  const neon = await mirrorFamilyToNeon(
-    env as unknown as Record<string, unknown>,
-    ctx,
-    SUBNET_IDENTITY_NEON_LANE,
-    { rows, historyRows },
-  );
+  const neon = await mirrorFamilyToNeon(env, ctx, SUBNET_IDENTITY_NEON_LANE, {
+    rows,
+    historyRows,
+  });
 
   // AUTHORITATIVE: Neon is the only store, so its failure is the request's.
   const failed = failedTables(neon);
@@ -2219,7 +2207,7 @@ async function handleSubnetOwnershipSync(
   }
 
   const neon = await mirrorFamilyToNeon(
-    env as unknown as Record<string, unknown>,
+    env,
     ctx,
     SUBNET_OWNERSHIP_NEON_LANE,
     // The card and the history take the SAME columns (0024 names the
@@ -2441,7 +2429,7 @@ async function handleValidatorNominatorCountsSync(
   // other and mirrors too -- #9728 was a single unmirrored writer leaving a
   // table short while the row count looked nearly right.
   const neon = await mirrorLedgerToNeon(
-    env as unknown as Record<string, unknown>,
+    env,
     ctx,
     "validator-nominator-counts",
     rows,
@@ -2673,11 +2661,11 @@ async function handleNominatorPositionsSync(
   // NO D1 WRITE, and no store binding requirement: nominator_positions and its
   // pass ledger are Neon's outright (#10111). The queue consumer below is this
   // lane's other entry point and it does not write D1 either.
-  const neon = await mirrorNominatorPositionsToNeon(
-    env as unknown as Record<string, unknown>,
-    ctx,
-    { rows, coldkeyMaxCapturedAt: cutoffs, pass },
-  );
+  const neon = await mirrorNominatorPositionsToNeon(env, ctx, {
+    rows,
+    coldkeyMaxCapturedAt: cutoffs,
+    pass,
+  });
 
   // Once Neon is the store, a pass that did not reach it did not happen.
   {
@@ -2824,16 +2812,12 @@ async function handleSelfStakeSync(
   const rows = incoming.map(coerceNominatorPositionSyncRow);
   const cutoffs = coldkeyMaxCapturedAt(rows);
 
-  const neon = await mirrorNominatorPositionsToNeon(
-    env as unknown as Record<string, unknown>,
-    ctx,
-    {
-      rows,
-      coldkeyMaxCapturedAt: cutoffs,
-      source: POSITION_SOURCE_SELF_STAKE,
-      lane: SELF_STAKE_NEON_LANE,
-    },
-  );
+  const neon = await mirrorNominatorPositionsToNeon(env, ctx, {
+    rows,
+    coldkeyMaxCapturedAt: cutoffs,
+    source: POSITION_SOURCE_SELF_STAKE,
+    lane: SELF_STAKE_NEON_LANE,
+  });
 
   // AUTHORITATIVE, and the prune counts as much as the write: rows landing
   // while this lane's own superseded rows survive is a ledger that
@@ -3396,7 +3380,7 @@ async function handleHotkeyAlphaSync(
   // the row count looked nearly right. THE PASS RIDES ALONG: it did not, so
   // the store's tally filled while hotkey_alpha_passes stayed empty in Neon.
   const neon = await mirrorLedgerToNeon(
-    env as unknown as Record<string, unknown>,
+    env,
     ctx,
     "hotkey-alpha",
     rows,
@@ -3495,7 +3479,7 @@ async function handlePollerLaneHealthSync(request: Request, env: Env) {
   // poller's job outcomes were the only verdicts that would have stopped
   // landing when D1 went away -- and recordLaneVerdict swallows failures, so
   // they would have stopped silently.
-  const laneDb = laneHealthStore(env as unknown as Record<string, unknown>);
+  const laneDb = laneHealthStore(env);
   if (!laneDb) {
     return writeJson({ error: "no lane_health store bound" }, 503);
   }
@@ -8925,7 +8909,7 @@ export async function writeTaoUsdIndexRow(
   // through waitUntil; without one this would leak a connection per tick, so
   // it declines rather than writing.
   const sql = neonWriteRunner(
-    env as unknown as Record<string, unknown>,
+    env,
     ctx ?? null,
     TAO_USD_INDEX_NEON_LANE,
     env.HYPERDRIVE,
@@ -9092,7 +9076,7 @@ export default {
       // through Hyperdrive. This line read "D1 only" until #10223 -- which is
       // exactly the kind of stale marker that sends an investigation looking
       // for a dead store instead of at the verdict (#10635).
-      const bag = env as unknown as Record<string, unknown>;
+      const bag = env;
       // The TAO/USD index rides this cron rather than its own (#8603). Its
       // staleness bound already lives in TABLE_FRESHNESS, the store is already
       // reachable here, and a NEW cron expression would need
@@ -9112,7 +9096,7 @@ export default {
       // prune. Kept separate from the lane that produces the rows it trims for
       // the original reason -- a prune that waits on its producer stops pruning
       // the moment the producer breaks.
-      return runNeonPrune(env as unknown as Record<string, unknown>, ctx);
+      return runNeonPrune(env, ctx);
     }
     // Unreachable for anything DECLARED and branched, and deliberately kept:
     // it is the net under `DATA_API_CRON_LANES` gaining an entry whose branch
@@ -9229,10 +9213,7 @@ export default {
       // The dead-letter record is a lane verdict, so it goes where the other
       // 27 do (#10158). recordLaneVerdict swallows failures, so a dead letter
       // written to a store nobody reads is a message lost twice over.
-      await handleDeadLetterBatch(
-        batch,
-        laneHealthStore(env as unknown as Record<string, unknown>) as never,
-      );
+      await handleDeadLetterBatch(batch, laneHealthStore(env) as never);
       return;
     }
     // DECOMPRESS BEFORE ANYTHING READS THE BODY (metagraphed#9759). A
@@ -9284,11 +9265,7 @@ export default {
         const result = { statements: 0 };
         // THE LANE'S OTHER WRITER, mirrored here as well as on the HTTP
         // path.
-        await mirrorChainDetailToNeon(
-          env as unknown as Record<string, unknown>,
-          ctx,
-          rows,
-        );
+        await mirrorChainDetailToNeon(env, ctx, rows);
         return result;
       },
     };
@@ -9296,7 +9273,7 @@ export default {
       "hotkey-alpha": async (rows, pass) => {
         const result = { statements: 0 };
         const neon = await mirrorLedgerToNeon(
-          env as unknown as Record<string, unknown>,
+          env,
           ctx,
           "hotkey-alpha",
           rows,
@@ -9342,11 +9319,11 @@ export default {
         // queue knows a message was DELIVERED, not whether the producer's
         // whole scan arrived, and only the second fact catches a load that
         // stopped halfway.
-        const neon = await mirrorNominatorPositionsToNeon(
-          env as unknown as Record<string, unknown>,
-          ctx,
-          { rows, coldkeyMaxCapturedAt: cutoffs, pass },
-        );
+        const neon = await mirrorNominatorPositionsToNeon(env, ctx, {
+          rows,
+          coldkeyMaxCapturedAt: cutoffs,
+          pass,
+        });
         const failed = [neon.write, neon.prune, neon.pass].filter(
           (r) => r && !r.ok,
         );
@@ -9371,7 +9348,7 @@ export default {
         // account_balances_passes was empty there, and this lane was about to
         // become the only writer of it.
         const neon = await mirrorLedgerToNeon(
-          env as unknown as Record<string, unknown>,
+          env,
           ctx,
           "account-balances",
           rows,
@@ -9405,11 +9382,10 @@ export default {
         // reads.
         const write = neuronSnapshotWrite(rows, Date.now());
         const result = { statements: 0 };
-        const neon = await mirrorNeuronSnapshotToNeon(
-          env as unknown as Record<string, unknown>,
-          ctx,
-          { ...write, pass },
-        );
+        const neon = await mirrorNeuronSnapshotToNeon(env, ctx, {
+          ...write,
+          pass,
+        });
         // THROW, never return, on a failed write: a normal return acks the
         // queue message and the rows are gone. writeSyncBatch turns a throw
         // into a retry.
@@ -9439,7 +9415,7 @@ export default {
         // throw rather than return: a normal return acks the message and
         // the rows are gone. writeSyncBatch turns a throw into a retry.
         const neon = await mirrorLedgerToNeon(
-          env as unknown as Record<string, unknown>,
+          env,
           ctx,
           "validator-nominator-counts",
           rows,
@@ -9477,16 +9453,13 @@ export default {
     }
     if (invalid > 0) {
       ctx.waitUntil(
-        recordLaneVerdict(
-          laneHealthStore(env as unknown as Record<string, unknown>),
-          {
-            lane: "sync-batches",
-            verdict: "stale",
-            age_ms: null,
-            detail: `${invalid} unparseable message(s) in a batch of ${batch.messages.length}`,
-            checked_at: Date.now(),
-          },
-        ).then(() => undefined),
+        recordLaneVerdict(laneHealthStore(env), {
+          lane: "sync-batches",
+          verdict: "stale",
+          age_ms: null,
+          detail: `${invalid} unparseable message(s) in a batch of ${batch.messages.length}`,
+          checked_at: Date.now(),
+        }).then(() => undefined),
       );
     }
   },

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -286,3 +286,25 @@ interface Env {
    * the measured RPC_USAGE_STALENESS_THRESHOLD_MS default. */
   RPC_USAGE_STALENESS_THRESHOLD_MS?: string;
 }
+
+/**
+ * The WebCrypto ECDH member Cloudflare's generated types misname.
+ *
+ * `wrangler types` emits `$public?: CryptoKey` on
+ * `SubtleCryptoDeriveKeyAlgorithm`, but both the WebCrypto spec and the
+ * workerd runtime read `public` -- so src/web-push.ts (RFC 8291 §3.3, the
+ * shared secret behind every push notification) had to spell its call
+ * `{ name: "ECDH", public: uaKey } as unknown as Parameters<…>[0]`.
+ *
+ * DECLARATION MERGE RATHER THAN A CAST (#11339). The cast asserted the whole
+ * parameter, so it also suppressed any error in `name` or in the key itself;
+ * this corrects exactly the one member the vendor types get wrong and leaves
+ * the rest of the signature checked. The emitted object is byte-identical --
+ * this changes what TypeScript believes, not what the runtime receives.
+ *
+ * Remove once the generated types spell it `public`; the call site then still
+ * compiles, which is the property that makes this safe to leave in place.
+ */
+interface SubtleCryptoDeriveKeyAlgorithm {
+  public?: CryptoKey;
+}

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -53,7 +53,10 @@ import { createPgSql, type HyperdriveLike } from "../src/pg-sql.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "../src/lane-health.ts";
 import { neonLaneKey } from "../src/neon-write.ts";
-import { recordExceptionEvent } from "../src/usage-telemetry.ts";
+import {
+  recordExceptionEvent,
+  type TelemetryEnv,
+} from "../src/usage-telemetry.ts";
 
 /** The lane the drain itself reports under. */
 export const BUFFER_FLUSH_LANE = "neon:buffer-flush";
@@ -148,7 +151,7 @@ export interface BufferStorage {
 }
 
 /** What the hub needs from its environment, so the flush can be driven alone. */
-export interface BufferEnv {
+export interface BufferEnv extends TelemetryEnv {
   HYPERDRIVE?: HyperdriveLike;
   [key: string]: unknown;
 }
@@ -236,7 +239,6 @@ export async function flushBuffer(
   const now = deps.now ?? Date.now;
   const laneDb = deps.laneHealthDb ?? laneHealthStore(env);
   const capture = deps.captureException ?? recordExceptionEvent;
-  const asEnv = env as unknown as Parameters<typeof recordExceptionEvent>[0];
   const stored = await storage.list<Uint8Array>({
     prefix: STATEMENT_PREFIX,
     limit: FLUSH_LIST_LIMIT,
@@ -278,7 +280,7 @@ export async function flushBuffer(
     });
     // The backlog is safe but growing, and nothing else will say so until a
     // freshness watchdog trips two hours later.
-    await capture(asEnv, {
+    await capture(env, {
       error: new Error(
         `neon write buffer cannot flush: hyperdrive unbound, ${groups.length} statement(s) held`,
       ),
@@ -309,7 +311,7 @@ export async function flushBuffer(
       // DISCARDING A STATEMENT IS DATA LOSS, and the only kind this design can
       // produce. It must page rather than show up as a number in a detail
       // string nobody reads.
-      await capture(asEnv, {
+      await capture(env, {
         error: new Error(
           `neon write buffer discarded an unreadable statement at seq ${group.seq}`,
         ),
@@ -343,7 +345,7 @@ export async function flushBuffer(
       });
       await recordFlushVerdicts(laneDb, perLane, now());
       const reason = error instanceof Error ? error.message : String(error);
-      await capture(asEnv, {
+      await capture(env, {
         error,
         route: BUFFER_ROUTE,
         errorCode: "flush_failed",
@@ -470,16 +472,13 @@ export class NeonWriteBufferHub implements DurableObject {
       // drains, which means the flush is failing or Neon is refusing -- and
       // from here on, capture rows are being turned away. The lane verdict
       // says so too, but this is the path that pages.
-      await recordExceptionEvent(
-        this.env as unknown as Parameters<typeof recordExceptionEvent>[0],
-        {
-          error: new Error(
-            `neon write buffer refused a statement: ${result.reason}`,
-          ),
-          route: BUFFER_ROUTE,
-          errorCode: "buffer_full",
-        },
-      );
+      await recordExceptionEvent(this.env, {
+        error: new Error(
+          `neon write buffer refused a statement: ${result.reason}`,
+        ),
+        route: BUFFER_ROUTE,
+        errorCode: "buffer_full",
+      });
     }
     // 503, not 500: the buffer being full is backpressure the producer should
     // retry against, not a bug in the request it just made.
@@ -502,10 +501,11 @@ export class NeonWriteBufferHub implements DurableObject {
       // WITHOUT THIS THE ALARM DIES SILENTLY: an uncaught throw in alarm()
       // leaves no verdict, no capture, and no rescheduled alarm, so the buffer
       // stops draining and nothing says why until a freshness watchdog trips.
-      await recordExceptionEvent(
-        this.env as unknown as Parameters<typeof recordExceptionEvent>[0],
-        { error, route: BUFFER_ROUTE, errorCode: "flush_alarm_threw" },
-      );
+      await recordExceptionEvent(this.env, {
+        error,
+        route: BUFFER_ROUTE,
+        errorCode: "flush_alarm_threw",
+      });
       outcome = {
         drained: 0,
         undecodable: 0,

--- a/workers/registry-sync-api.ts
+++ b/workers/registry-sync-api.ts
@@ -321,7 +321,7 @@ export default {
     if (controller?.cron !== SELF_HEALTH_PROBE_CRON) {
       return { ok: false, skipped: true, reason: "unknown cron" };
     }
-    return runSelfHealthProbe(env as unknown as Record<string, unknown>, ctx);
+    return runSelfHealthProbe(env, ctx);
   },
   async fetch(request: Request, env: Env): Promise<Response> {
     // metagraphed#7768: PostHog distributed tracing (alpha), one root span

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -290,7 +290,7 @@ export async function handleTrajectory(
   // analytics.ts.
   const readFailureGeneration = currentStoreReadFailureGeneration();
   const data = (await loadSubnetTrajectory(netuid, {
-    db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+    db: observationsReadDb(env, ctx),
   })) as ReturnType<typeof formatTrajectory>;
   const isFallback =
     !env.HYPERDRIVE?.connectionString ||
@@ -341,7 +341,7 @@ export async function handleEconomicsTrends(
   const loaded = await loadEconomicsTrends({
     windowLabel: label,
     windowDays: days,
-    db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+    db: observationsReadDb(env, ctx),
   });
   // `let`, not `const`: the USD overlay below reassigns it (#10382).
   let data = loaded.data;
@@ -423,7 +423,7 @@ export async function handleUptime(
     window: windowParam,
     observedAt: healthMeta?.last_run_at || null,
     minSamples: (minSamples as number | undefined) ?? null,
-    db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+    db: observationsReadDb(env, ctx),
   })) as ReturnType<typeof formatUptime>;
   const isFallback =
     !env.HYPERDRIVE?.connectionString ||

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -90,6 +90,11 @@ import {
   withAlphaUsdTrendDays,
 } from "../../src/alpha-usd-history.ts";
 import { DAY_MS } from "../config.ts";
+import { recordOrNull, recordsOrEmpty } from "../../src/read-store.ts";
+import {
+  SubnetEconomicsReadSchema,
+  type SubnetEconomicsRead,
+} from "../../schemas-src/shared.ts";
 
 type HealthMetaKvReader = (
   env: Env,
@@ -355,12 +360,10 @@ export async function handleEconomicsTrends(
     // the floor of the window the index has to cover.
     const oldest = trendDays[trendDays.length - 1]?.snapshot_date;
     const sinceMs = Date.parse(`${String(oldest)}T00:00:00.000Z`);
-    const usdRows = await loadTaoUsdBuckets(
-      readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
-        typeof loadTaoUsdBuckets
-      >[0],
-      { sinceMs: Number.isFinite(sinceMs) ? sinceMs : 0, bucketMs: DAY_MS },
-    );
+    const usdRows = await loadTaoUsdBuckets(readStore(env, TAO_USD_TABLES), {
+      sinceMs: Number.isFinite(sinceMs) ? sinceMs : 0,
+      bucketMs: DAY_MS,
+    });
     data = withAlphaUsdTrendDays(
       data as unknown as Record<string, unknown>,
       usdRows === null ? null : taoUsdBucketMap(usdRows),
@@ -421,9 +424,7 @@ export async function handleUptime(
     observedAt: healthMeta?.last_run_at || null,
     minSamples: (minSamples as number | undefined) ?? null,
     db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-  } as unknown as Parameters<typeof loadSubnetUptime>[1])) as ReturnType<
-    typeof formatUptime
-  >;
+  })) as ReturnType<typeof formatUptime>;
   const isFallback =
     !env.HYPERDRIVE?.connectionString ||
     currentStoreReadFailureGeneration() !== storeGeneration;
@@ -553,24 +554,48 @@ async function leaderboardProfilesProjection(
   return projection;
 }
 
-async function resolveEconomicsRows(env: Env): Promise<unknown[]> {
-  const live = (await resolveLiveEconomics({
+/**
+ * Parse a tier's `subnets` into economics rows.
+ *
+ * PARSED, not asserted (#10789). Both tiers arrive as untrusted bytes -- KV
+ * JSON on the live path, an R2 object on the artifact path -- and the four
+ * casts this replaces (`as {data?:{subnets?:unknown[]}}`, `as {subnets?:…}`,
+ * and `row as never` twice) were the only thing typing them. `as never` in
+ * particular defeats the check entirely: it makes ANY row satisfy
+ * `withSpotPrice`, so a producer that renamed `alpha_in_pool` would have gone
+ * on computing spot from `undefined` silently.
+ *
+ * Read-tolerant by construction (SubnetEconomicsReadSchema): a row missing
+ * fields or carrying new ones still ranks, a row whose declared field has the
+ * WRONG TYPE is dropped rather than fed to the arithmetic.
+ */
+function economicsRowsFrom(subnets: unknown): SubnetEconomicsRead[] {
+  const rows: SubnetEconomicsRead[] = [];
+  for (const entry of recordsOrEmpty(subnets)) {
+    const parsed = SubnetEconomicsReadSchema.safeParse(entry);
+    // #9408: spot is derived here, at the ONE point both tiers pass through,
+    // rather than written by either producer -- the inputs are on every row
+    // already, so a stored field would be two writers to keep in step for a
+    // division.
+    if (parsed.success) rows.push(withSpotPrice(parsed.data));
+  }
+  return rows;
+}
+
+async function resolveEconomicsRows(env: Env): Promise<SubnetEconomicsRead[]> {
+  // Already typed `{ data: Row; source: "live-kv" } | null` by its own
+  // signature -- the cast that used to sit here restated it, wrongly.
+  const live = await resolveLiveEconomics({
     readHealthKv: (e: Env) => readEconomicsCurrentKv(e),
     env,
     contractVersion: contractVersion(env),
-  })) as { data?: { subnets?: unknown[] } } | null;
-  // #9408: spot is derived here, at the ONE point both tiers pass through, rather
-  // than written by either producer -- the inputs are on every row already, so a
-  // stored field would be two writers to keep in step for a division.
+  });
   if (Array.isArray(live?.data?.subnets)) {
-    return live.data.subnets.map((row) => withSpotPrice(row as never));
+    return economicsRowsFrom(live.data.subnets);
   }
   const artifact = await readArtifact(env, "/metagraph/economics.json");
-  const artifactSubnets = artifact.ok
-    ? (artifact.data as { subnets?: unknown[] })?.subnets
-    : undefined;
-  return Array.isArray(artifactSubnets)
-    ? artifactSubnets.map((row) => withSpotPrice(row as never))
+  return artifact.ok
+    ? economicsRowsFrom(recordOrNull(artifact.data)?.subnets)
     : [];
 }
 
@@ -621,7 +646,7 @@ export async function composeLeaderboardsData(
     reliabilityRows,
     economicsRows,
     subnetMeta,
-  } as unknown as Parameters<typeof formatLeaderboards>[0]);
+  });
   return {
     data,
     // Only a payload whose boards are genuinely empty is barred from the edge
@@ -1103,7 +1128,7 @@ export async function handleCompareValidators(
 
   const data = composeValidatorComparison(details, {
     netuid: requestedNetuid,
-  } as unknown as Parameters<typeof composeValidatorComparison>[1]);
+  });
   return envelopeResponse(
     request,
     {

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -776,7 +776,7 @@ export async function handleHealthTrends(
     const data = await loadSubnetHealthTrends(netuid, {
       observedAt: meta?.last_run_at || null,
       db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-    } as unknown as Parameters<typeof loadSubnetHealthTrends>[1]);
+    });
     const usedFallback =
       !env.HYPERDRIVE?.connectionString ||
       currentStoreReadFailureGeneration() !== storeGeneration;
@@ -832,7 +832,7 @@ export async function handleHealthPercentiles(
         window: label,
         observedAt: meta?.last_run_at || null,
         db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-      } as unknown as Parameters<typeof loadSubnetPercentiles>[1]);
+      });
       const usedFallback =
         !env.HYPERDRIVE?.connectionString ||
         currentStoreReadFailureGeneration() !== storeGeneration;
@@ -886,7 +886,7 @@ export async function handleHealthIncidents(
         window: label,
         observedAt: meta?.last_run_at || null,
         db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-      } as unknown as Parameters<typeof loadSubnetIncidents>[1]);
+      });
       const usedFallback =
         !env.HYPERDRIVE?.connectionString ||
         currentStoreReadFailureGeneration() !== storeGeneration;
@@ -1307,7 +1307,7 @@ export async function handleChainActivity(
             buildChainActivity({
               window: label,
               observedAt: meta?.last_run_at || null,
-            } as unknown as Parameters<typeof buildChainActivity>[0]),
+            }),
           ),
         windowDays,
       );
@@ -1392,7 +1392,7 @@ export async function handleChainCalls(
           observedAt: meta?.last_run_at || null,
           total: 0,
           rows: [],
-        } as unknown as Parameters<typeof buildChainCalls>[0]);
+        });
       }
       if (csv) {
         const csvRes = await csvResponse(
@@ -1478,7 +1478,7 @@ export async function handleChainSigners(
             sort,
             observedAt: meta?.last_run_at || null,
             rows: [],
-          } as unknown as Parameters<typeof buildChainSigners>[0]),
+          }),
         );
       if (csv) {
         return csvResponse(
@@ -1664,7 +1664,7 @@ export async function handleChainTransferPairs(
             window: label,
             sort,
             observedAt: meta?.last_run_at || null,
-          } as unknown as Parameters<typeof buildChainTransferPairs>[0]),
+          }),
         );
       // CSV exports the row-shaped top corridors; the totals + top_pair_share
       // rollup stay JSON-only (mirrors chain-stake-flow / chain-weights).
@@ -1753,7 +1753,7 @@ export async function handleChainStakeFlow(
           buildChainStakeFlow([], {
             window: label,
             limit,
-          } as unknown as Parameters<typeof buildChainStakeFlow>[1]),
+          }),
         );
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // net_flow_distribution stay JSON-only (mirrors chain-fees' top_fee_payers).
@@ -1855,7 +1855,7 @@ export async function handleChainAlphaVolume(
         unmeasured(
           buildChainAlphaVolume([], {
             limit,
-          } as unknown as Parameters<typeof buildChainAlphaVolume>[1]),
+          }),
         );
       // USD on the network rollup, the spread and every per-subnet row
       // (#10383). Overlaid before the CSV branch so both formats carry the
@@ -1933,15 +1933,12 @@ export async function handleChainWeights(
         // Same shared loader MCP and GraphQL call, so all three surfaces
         // answer from one implementation. Declines (null) rather than
         // half-answering, leaving the empty payload below as the fallback.
-        (await loadChainWeightsColdTier(
-          env as unknown as Parameters<typeof loadChainWeightsColdTier>[0],
-          { window: label, limit },
-        )) ??
+        (await loadChainWeightsColdTier(env, { window: label, limit })) ??
         unmeasured(
           buildChainWeights([], {
             window: label,
             limit,
-          } as unknown as Parameters<typeof buildChainWeights>[1]),
+          }),
         );
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-stake-flow).
@@ -2011,12 +2008,7 @@ export async function handleChainWeightSetters(
         // The same WeightsSet stream /chain/weights already reads, grouped one
         // level finer (#9249). Through the shared loader so MCP and GraphQL get
         // it too rather than being wired one surface at a time.
-        (await loadChainWeightSettersColdTier(
-          env as unknown as Parameters<
-            typeof loadChainWeightSettersColdTier
-          >[0],
-          { window: label, limit },
-        )) ??
+        (await loadChainWeightSettersColdTier(env, { window: label, limit })) ??
         unmeasured(buildChainWeightSetters([], null, { window: label, limit }));
       if (csv) {
         return csvResponse(
@@ -2085,15 +2077,12 @@ export async function handleChainServing(
         // surfaces answer from a single implementation rather than three
         // copies that can drift. It declines (null) rather than
         // half-answering, leaving the empty payload below as the fallback.
-        (await loadChainServingColdTier(
-          env as unknown as Parameters<typeof loadChainServingColdTier>[0],
-          { window: label, limit },
-        )) ??
+        (await loadChainServingColdTier(env, { window: label, limit })) ??
         unmeasured(
           buildChainServing([], {
             window: label,
             limit,
-          } as unknown as Parameters<typeof buildChainServing>[1]),
+          }),
         );
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-weights).
@@ -2163,14 +2152,11 @@ export async function handleChainPrometheus(
         // lakehouse rollup here since #9216; prometheus fell straight from a
         // tier that always misses to the empty stub, so it published a
         // confident zero no amount of curation could have fixed.
-        (await loadChainPrometheusColdTier(
-          env as unknown as Parameters<typeof loadChainPrometheusColdTier>[0],
-          { window: label, limit },
-        )) ??
+        (await loadChainPrometheusColdTier(env, { window: label, limit })) ??
         buildChainPrometheus([], {
           window: label,
           limit,
-        } as unknown as Parameters<typeof buildChainPrometheus>[1]);
+        });
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-serving).
       if (csv) {
@@ -2239,7 +2225,7 @@ export async function handleChainAxonRemovals(
         buildChainAxonRemovals([], {
           window: label,
           limit,
-        } as unknown as Parameters<typeof buildChainAxonRemovals>[1]);
+        });
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-serving).
       if (csv) {
@@ -2326,7 +2312,7 @@ export async function handleChainRegistrations(
           buildChainRegistrations([], {
             window: label,
             limit,
-          } as unknown as Parameters<typeof buildChainRegistrations>[1]),
+          }),
         );
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-serving).
@@ -2493,7 +2479,7 @@ export async function handleChainDeregistrations(
             buildChainDeregistrations([], {
               window: label,
               limit,
-            } as unknown as Parameters<typeof buildChainDeregistrations>[1]),
+            }),
           ),
         );
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
@@ -2578,7 +2564,7 @@ export async function handleChainStakeMoves(
           buildChainStakeMoves([], {
             window: label,
             limit,
-          } as unknown as Parameters<typeof buildChainStakeMoves>[1]),
+          }),
         );
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-registrations).
@@ -2662,7 +2648,7 @@ export async function handleChainStakeTransfers(
           buildChainStakeTransfers([], {
             window: label,
             limit,
-          } as unknown as Parameters<typeof buildChainStakeTransfers>[1]),
+          }),
         );
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-stake-moves).
@@ -2754,7 +2740,7 @@ export async function handleChainFees(
         buildChainFees({
           window: label,
           observedAt: meta?.last_run_at || null,
-        } as unknown as Parameters<typeof buildChainFees>[0]),
+        }),
       );
       // #8242: see handleChainActivity — trim the UTC-day buckets down to the
       // requested window so "7d" never reports 8 days.

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -709,7 +709,7 @@ export async function handleBulkHealthTrends(
       const storeGeneration = currentStoreReadFailureGeneration();
       const result = await loadBulkHealthTrends({
         observedAt: meta?.last_run_at || null,
-        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+        db: observationsReadDb(env, ctx),
         window: trendsWindow ?? null,
         limit: trendsLimit ?? null,
         offset: trendsOffset ?? 0,
@@ -775,7 +775,7 @@ export async function handleHealthTrends(
     const meta = await readHealthMetaKv(env);
     const data = await loadSubnetHealthTrends(netuid, {
       observedAt: meta?.last_run_at || null,
-      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+      db: observationsReadDb(env, ctx),
     });
     const usedFallback =
       !env.HYPERDRIVE?.connectionString ||
@@ -831,7 +831,7 @@ export async function handleHealthPercentiles(
       const data = await loadSubnetPercentiles(netuid, {
         window: label,
         observedAt: meta?.last_run_at || null,
-        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+        db: observationsReadDb(env, ctx),
       });
       const usedFallback =
         !env.HYPERDRIVE?.connectionString ||
@@ -885,7 +885,7 @@ export async function handleHealthIncidents(
       const data = await loadSubnetIncidents(netuid, {
         window: label,
         observedAt: meta?.last_run_at || null,
-        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+        db: observationsReadDb(env, ctx),
       });
       const usedFallback =
         !env.HYPERDRIVE?.connectionString ||

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -511,7 +511,11 @@ import {
   DEFAULT_CHAIN_TURNOVER_WINDOW,
 } from "../../src/chain-turnover.ts";
 import { buildSubnetIdentityHistory } from "../../src/subnet-identity-history.ts";
-import { readStore, type ReadStoreDb } from "../../src/read-store.ts";
+import {
+  readStore,
+  recordsOrEmpty,
+  type ReadStoreDb,
+} from "../../src/read-store.ts";
 import { laneHealthStore } from "../../src/lane-health-store.ts";
 import {
   ALPHA_PRICING_TABLES,
@@ -1167,8 +1171,7 @@ export async function handleSubnetHyperparamsHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/hyperparameters/history.json`,
-        (data.entries as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.entries)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -1218,8 +1221,7 @@ export async function handleSubnetLifecycle(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/lifecycle.json`,
-        (data.entries as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.entries)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -1757,8 +1759,7 @@ export async function handleNeuronHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/neurons/${uid}/history.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.captured_at ?? null,
+        recordsOrEmpty(data.points)[0]?.captured_at ?? null,
       ),
     },
     "short",
@@ -1848,8 +1849,7 @@ export async function handleSubnetIdentityHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/identity-history.json`,
-        (data.entries as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.entries)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -2115,8 +2115,7 @@ export async function handleChainIdentityHistory(
         "/metagraph/chain/identity-history.json",
         // Freshness = the newest change's observed_at (feed is newest-first), else
         // null when the store is cold.
-        (data.changes as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.changes)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -2533,9 +2532,7 @@ export async function handleSubnetConcentrationHistory(
       capped: false,
     });
   if (csvRequested(url, request)) {
-    const points = [
-      ...(data.points as unknown as Array<Record<string, unknown>>),
-    ].sort((a, b) =>
+    const points = [...recordsOrEmpty(data.points)].sort((a, b) =>
       String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
     );
     return csvResponse(
@@ -2553,8 +2550,7 @@ export async function handleSubnetConcentrationHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/concentration/history.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.snapshot_date ?? null,
+        recordsOrEmpty(data.points)[0]?.snapshot_date ?? null,
       ),
     },
     "short",
@@ -2594,9 +2590,7 @@ export async function handleSubnetPerformanceHistory(
       capped: false,
     });
   if (csvRequested(url, request)) {
-    const points = [
-      ...(data.points as unknown as Array<Record<string, unknown>>),
-    ].sort((a, b) =>
+    const points = [...recordsOrEmpty(data.points)].sort((a, b) =>
       String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
     );
     return csvResponse(
@@ -2614,8 +2608,7 @@ export async function handleSubnetPerformanceHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/performance/history.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.snapshot_date ?? null,
+        recordsOrEmpty(data.points)[0]?.snapshot_date ?? null,
       ),
     },
     "short",
@@ -2655,9 +2648,7 @@ export async function handleSubnetYieldHistory(
       capped: false,
     });
   if (csvRequested(url, request)) {
-    const points = [
-      ...(data.points as unknown as Array<Record<string, unknown>>),
-    ].sort((a, b) =>
+    const points = [...recordsOrEmpty(data.points)].sort((a, b) =>
       String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
     );
     return csvResponse(
@@ -2675,8 +2666,7 @@ export async function handleSubnetYieldHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/yield/history.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.snapshot_date ?? null,
+        recordsOrEmpty(data.points)[0]?.snapshot_date ?? null,
       ),
     },
     "short",
@@ -2715,9 +2705,7 @@ export async function handleSubnetEmissionSplitHistory(
       capped: false,
     });
   if (csvRequested(url, request)) {
-    const points = [
-      ...(data.points as unknown as Array<Record<string, unknown>>),
-    ].sort((a, b) =>
+    const points = [...recordsOrEmpty(data.points)].sort((a, b) =>
       String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
     );
     return csvResponse(
@@ -2735,8 +2723,7 @@ export async function handleSubnetEmissionSplitHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/emission-split/history.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.snapshot_date ?? null,
+        recordsOrEmpty(data.points)[0]?.snapshot_date ?? null,
       ),
     },
     "short",
@@ -2776,8 +2763,7 @@ export async function handleSubnetMinerFairness(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/miner-fairness.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.snapshot_date ?? null,
+        recordsOrEmpty(data.points)[0]?.snapshot_date ?? null,
       ),
     },
     "short",
@@ -2897,8 +2883,7 @@ export async function handleSubnetOwnerCapture(
       meta: await metagraphMeta(
         env,
         `/metagraph/subnets/${netuid}/owner-capture.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.snapshot_date ?? null,
+        recordsOrEmpty(data.points)[0]?.snapshot_date ?? null,
       ),
     },
     "short",
@@ -4973,8 +4958,7 @@ export async function handleAccountEvents(
       meta: await accountMeta(
         env,
         `/metagraph/accounts/${ss58}/events.json`,
-        (priced.events as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(priced.events)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -5147,8 +5131,7 @@ export async function handleAccountExtrinsics(
       meta: await accountMeta(
         env,
         `/metagraph/accounts/${ss58}/extrinsics.json`,
-        (data.extrinsics as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.extrinsics)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -5222,8 +5205,7 @@ export async function handleAccountTransfers(
       meta: await accountMeta(
         env,
         `/metagraph/accounts/${ss58}/transfers.json`,
-        (data.transfers as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.transfers)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -5510,8 +5492,7 @@ export async function handleAccountPositionHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/accounts/${ss58}/subnets/${netuid}/history.json`,
-        (data.points as unknown as Array<Record<string, unknown>>)[0]
-          ?.captured_at ?? null,
+        recordsOrEmpty(data.points)[0]?.captured_at ?? null,
       ),
     },
     "short",
@@ -5610,8 +5591,7 @@ export async function handleAccountIdentityHistory(
       meta: await metagraphMeta(
         env,
         `/metagraph/accounts/${ss58}/identity-history.json`,
-        (data.entries as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.entries)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -5693,8 +5673,7 @@ export async function handleSubnetEvents(
       meta: await accountMeta(
         env,
         `/metagraph/subnets/${netuid}/events.json`,
-        (data.events as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.events)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -6731,8 +6710,7 @@ export async function handleBlocks(
       meta: await accountMeta(
         env,
         "/metagraph/blocks.json",
-        (data.blocks as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.blocks)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -6910,9 +6888,7 @@ export async function handleBlockExtrinsics(
   // the same formatExtrinsic row shape (#5746). Cold block → empty → header-only.
   if (csvRequested(url, request)) {
     return csvResponse(
-      extrinsicsToCsvRows(
-        data.extrinsics as unknown as Array<Record<string, unknown>>,
-      ),
+      extrinsicsToCsvRows(recordsOrEmpty(data.extrinsics)),
       `block-${ref}-extrinsics`,
       "short",
       request,
@@ -6926,8 +6902,7 @@ export async function handleBlockExtrinsics(
       meta: await accountMeta(
         env,
         `/metagraph/blocks/${ref}/extrinsics.json`,
-        (data.extrinsics as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.extrinsics)[0]?.observed_at ?? null,
       ),
     },
     cacheProfile,
@@ -6999,8 +6974,7 @@ export async function handleBlockEvents(
       meta: await accountMeta(
         env,
         `/metagraph/blocks/${ref}/events.json`,
-        (data.events as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.events)[0]?.observed_at ?? null,
       ),
     },
     cacheProfile,
@@ -7110,9 +7084,7 @@ export async function handleExtrinsics(
     unmeasured(buildExtrinsicFeed([], { limit, offset, nextCursor: null }));
   if (csvRequested(url, request)) {
     return csvResponse(
-      extrinsicsToCsvRows(
-        data.extrinsics as unknown as Array<Record<string, unknown>>,
-      ),
+      extrinsicsToCsvRows(recordsOrEmpty(data.extrinsics)),
       "extrinsics",
       "short",
       request,
@@ -7126,8 +7098,7 @@ export async function handleExtrinsics(
       meta: await accountMeta(
         env,
         "/metagraph/extrinsics.json",
-        (data.extrinsics as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.extrinsics)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -7173,9 +7144,7 @@ export async function handleSudo(request: Request, env: Env, url: URL) {
     unmeasured(buildExtrinsicFeed([], { limit, offset, nextCursor: null }));
   if (csvRequested(url, request)) {
     return csvResponse(
-      extrinsicsToCsvRows(
-        data.extrinsics as unknown as Array<Record<string, unknown>>,
-      ),
+      extrinsicsToCsvRows(recordsOrEmpty(data.extrinsics)),
       "sudo-calls",
       "short",
       request,
@@ -7189,8 +7158,7 @@ export async function handleSudo(request: Request, env: Env, url: URL) {
       meta: await accountMeta(
         env,
         "/metagraph/sudo.json",
-        (data.extrinsics as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.extrinsics)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -7239,9 +7207,7 @@ export async function handleGovernanceConfigChanges(
     unmeasured(buildExtrinsicFeed([], { limit, offset, nextCursor: null }));
   if (csvRequested(url, request)) {
     return csvResponse(
-      extrinsicsToCsvRows(
-        data.extrinsics as unknown as Array<Record<string, unknown>>,
-      ),
+      extrinsicsToCsvRows(recordsOrEmpty(data.extrinsics)),
       "governance-config-changes",
       "short",
       request,
@@ -7255,8 +7221,7 @@ export async function handleGovernanceConfigChanges(
       meta: await accountMeta(
         env,
         "/metagraph/governance/config-changes.json",
-        (data.extrinsics as unknown as Array<Record<string, unknown>>)[0]
-          ?.observed_at ?? null,
+        recordsOrEmpty(data.extrinsics)[0]?.observed_at ?? null,
       ),
     },
     "short",
@@ -7326,9 +7291,8 @@ export async function handleRuntime(request: Request, env: Env, url: URL) {
       meta: await accountMeta(
         env,
         "/metagraph/runtime.json",
-        (data.transitions as unknown as Array<Record<string, unknown>>)[
-          (data.transitions as unknown as Array<Record<string, unknown>>)
-            .length - 1
+        recordsOrEmpty(data.transitions)[
+          recordsOrEmpty(data.transitions).length - 1
         ]?.observed_at ?? null,
       ),
     },

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -2170,9 +2170,7 @@ export async function handleSelfHealth(
     // this is /health's own lane floor. Reading it from the store would render an
     // empty result as "no alarms", which is the one answer a health endpoint
     // must never invent.
-    laneHealthStore(env as unknown as Record<string, unknown>) as Parameters<
-      typeof loadLatestLaneHealth
-    >[0],
+    laneHealthStore(env) as Parameters<typeof loadLatestLaneHealth>[0],
   );
   // The sample the silence bound needs (#10232), as the LONGEST observed gap
   // rather than the mean (#10333). One extra GROUP BY over the table the read
@@ -2180,9 +2178,7 @@ export async function handleSelfHealth(
   // withLaneHealth then leaves every verdict alone -- so a failed read costs
   // today's behaviour, never a false alarm.
   const cadences = await loadLaneMaxGap(
-    laneHealthStore(env as unknown as Record<string, unknown>) as Parameters<
-      typeof loadLaneMaxGap
-    >[0],
+    laneHealthStore(env) as Parameters<typeof loadLaneMaxGap>[0],
     Date.now() - LANE_ALARM_CADENCE_WINDOW_MS,
   );
   const withLanes = withLaneHealth(data, lanes, { cadences });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -1587,9 +1587,7 @@ export async function handleValidatorNominators(
     const positionsLimit = pageLimit(url);
     const positionsOffset = routeInt(url, "offset") ?? 0;
     const read = await loadNominatorPositions(
-      readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
-        typeof loadNominatorPositions
-      >[0],
+      readStore(env, ALPHA_PRICING_TABLES),
       hotkey,
     );
     const positionsData = buildNominatorPositions(read, hotkey, {
@@ -2988,14 +2986,10 @@ export async function handleSubnetWeights(
     // it this card answered a confident 0 for every subnet once the Postgres box
     // went away, while the leaderboard it summarises read 14 setters / 2,750 sets
     // from the same stream.
-    (await loadSubnetWeightsColdTier(
-      env as unknown as Parameters<typeof loadSubnetWeightsColdTier>[0],
-      netuid,
-      {
-        windowLabel: windowParam,
-        windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
-      },
-    )) ?? buildSubnetWeights(null, netuid, { window: windowParam });
+    (await loadSubnetWeightsColdTier(env, netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
+    })) ?? buildSubnetWeights(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -3041,15 +3035,11 @@ export async function handleSubnetWeightSetters(
     // resolved to null before it could touch DATA_API.
     // #9267: the same WeightsSet stream the chain-wide leaderboard reads
     // (#9251), narrowed to this subnet.
-    (await loadSubnetWeightSettersColdTier(
-      env as unknown as Parameters<typeof loadSubnetWeightSettersColdTier>[0],
-      netuid,
-      {
-        windowLabel: windowParam,
-        windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam] ?? 7,
-        limit: SUBNET_WEIGHT_SETTERS_LIMIT,
-      },
-    )) ?? buildSubnetWeightSetters([], null, netuid, { window: windowParam });
+    (await loadSubnetWeightSettersColdTier(env, netuid, {
+      windowLabel: windowParam,
+      windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam] ?? 7,
+      limit: SUBNET_WEIGHT_SETTERS_LIMIT,
+    })) ?? buildSubnetWeightSetters([], null, netuid, { window: windowParam });
   // account_events-derived: the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling /weights route.
   return envelopeResponse(
@@ -3097,7 +3087,7 @@ export async function handleSubnetServing(
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
     (await loadSubnetEventCardColdTier(
-      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      env,
       CHAIN_SERVING_ROLLUP,
       netuid,
       buildSubnetServing,
@@ -3159,7 +3149,7 @@ export async function handleSubnetPrometheus(
     // 30d while this route answered 0 for that same subnet, so the two
     // contradicted each other on one event stream.
     (await loadSubnetEventCardColdTier(
-      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      env,
       CHAIN_PROMETHEUS_ROLLUP,
       netuid,
       buildSubnetPrometheus,
@@ -3216,7 +3206,7 @@ export async function handleSubnetStakeMoves(
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
     (await loadSubnetEventCardColdTier(
-      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      env,
       CHAIN_STAKE_MOVES_ROLLUP,
       netuid,
       buildSubnetStakeMoves,
@@ -3273,7 +3263,7 @@ export async function handleSubnetStakeTransfers(
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
     (await loadSubnetEventCardColdTier(
-      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      env,
       CHAIN_STAKE_TRANSFERS_ROLLUP,
       netuid,
       buildSubnetStakeTransfers,
@@ -3329,7 +3319,7 @@ export async function handleSubnetRegistrations(
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
     (await loadSubnetEventCardColdTier(
-      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      env,
       CHAIN_REGISTRATIONS_ROLLUP,
       netuid,
       buildSubnetRegistrations,
@@ -4470,12 +4460,10 @@ export async function handleSubnetOhlc(
   const usdRows =
     sinceMs === null
       ? []
-      : await loadTaoUsdBuckets(
-          readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
-            typeof loadTaoUsdBuckets
-          >[0],
-          { sinceMs, bucketMs },
-        );
+      : await loadTaoUsdBuckets(readStore(env, TAO_USD_TABLES), {
+          sinceMs,
+          bucketMs,
+        });
   return envelopeResponse(
     request,
     {
@@ -4966,9 +4954,7 @@ export async function handleAccountEvents(
     : [];
   const usdByInstant = eventRows.length
     ? await loadTaoUsdAtInstants(
-        readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
-          typeof loadTaoUsdAtInstants
-        >[0],
+        readStore(env, TAO_USD_TABLES),
         eventRows
           .map((e) => Date.parse(String(e?.observed_at)))
           .filter((n) => Number.isFinite(n)),
@@ -6077,10 +6063,7 @@ export async function handleSubnetBurnHistory(
     });
   }
   const rows = await loadSubnetBurnHistory(
-    readStore(
-      env,
-      SUBNET_BURN_HISTORY_TABLES,
-    ) as never as unknown as Parameters<typeof loadSubnetBurnHistory>[0],
+    readStore(env, SUBNET_BURN_HISTORY_TABLES),
     netuid,
     { windowDays },
   );
@@ -6125,9 +6108,7 @@ export async function handleSubnetHolders(
   const limit = pageLimit(url);
 
   const read = await loadSubnetHolders(
-    readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
-      typeof loadSubnetHolders
-    >[0],
+    readStore(env, ALPHA_PRICING_TABLES),
     netuid,
     { limit: limit },
   );
@@ -6162,12 +6143,9 @@ export async function handleTaoUsd(request: Request, env: Env, url: URL) {
       message: `window must be one of ${Object.keys(TAO_USD_WINDOWS).join(", ")}.`,
     });
   }
-  const rows = await loadTaoUsdSeries(
-    readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
-      typeof loadTaoUsdSeries
-    >[0],
-    { windowHours },
-  );
+  const rows = await loadTaoUsdSeries(readStore(env, TAO_USD_TABLES), {
+    windowHours,
+  });
   // A cold or unwritten table yields an EMPTY series with a null `latest`, not
   // a 404: "we have not priced this window" is a real state.
   const data = buildTaoUsdSeries(rows, {
@@ -6202,9 +6180,7 @@ export async function handleSubnetSurfaceHistory(
   const limit = pageLimit(url);
 
   const rows = await loadSurfaceHistory(
-    readStore(env, SURFACE_HISTORY_TABLES) as never as unknown as Parameters<
-      typeof loadSurfaceHistory
-    >[0],
+    readStore(env, SURFACE_HISTORY_TABLES),
     netuid,
     { limit: limit },
   );
@@ -6245,9 +6221,7 @@ export async function handleEmissionChanges(
   const limit = pageLimit(url);
 
   const rows = await loadEmissionChanges(
-    readStore(env, EMISSION_CHANGES_TABLES) as never as unknown as Parameters<
-      typeof loadEmissionChanges
-    >[0],
+    readStore(env, EMISSION_CHANGES_TABLES),
     { limit: limit, kind: kindParam ?? undefined },
   );
   // These tables gain a row only when a value MOVED, so an empty feed is the
@@ -6287,11 +6261,7 @@ export async function handleChainHolders(request: Request, env: Env, url: URL) {
   }
   const limit = pageLimit(url);
 
-  const read = await loadChainHolders(
-    readStore(env, ALPHA_PRICING_TABLES) as never as unknown as Parameters<
-      typeof loadChainHolders
-    >[0],
-  );
+  const read = await loadChainHolders(readStore(env, ALPHA_PRICING_TABLES));
   const data = buildChainHolders(read, { sort, limit: limit });
   return envelopeResponse(
     request,
@@ -6374,9 +6344,7 @@ export async function handleFailureReasons(
   const kind = routeText(url, "kind") ?? undefined;
 
   const rows = await loadFailureReasons(
-    readStore(env, FAILURE_REASONS_TABLES) as never as unknown as Parameters<
-      typeof loadFailureReasons
-    >[0],
+    readStore(env, FAILURE_REASONS_TABLES),
     { window, netuid, kind },
   );
   // An empty window is a MEASUREMENT and reaches buildFailureReasons; only a
@@ -6401,11 +6369,7 @@ export async function handleIndexerLag(request: Request, env: Env, url: URL) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
 
-  const row = await loadIndexerLag(
-    readStore(env, INDEXER_LAG_TABLES) as never as unknown as Parameters<
-      typeof loadIndexerLag
-    >[0],
-  );
+  const row = await loadIndexerLag(readStore(env, INDEXER_LAG_TABLES));
   // The handler owns the clock, so the module whose subject is two clocks does
   // not quietly introduce a third of its own.
   const data = buildIndexerLag(row, Date.now());
@@ -6430,12 +6394,7 @@ export async function handleChainConcentrationHistory(
 
   const window = routeValue<string>(url, "window");
   const rows = await loadChainConcentrationHistory(
-    readStore(
-      env,
-      CHAIN_CONCENTRATION_HISTORY_TABLES,
-    ) as never as unknown as Parameters<
-      typeof loadChainConcentrationHistory
-    >[0],
+    readStore(env, CHAIN_CONCENTRATION_HISTORY_TABLES),
     { window },
   );
   // An empty window is a MEASUREMENT -- a window narrower than the rollup's
@@ -6465,9 +6424,7 @@ export async function handleSubnetPipelineHistory(
 
   const window = routeValue<string>(url, "window");
   const rows = await loadPipelineHistory(
-    readStore(env, SUBNET_SNAPSHOT_TABLES) as never as unknown as Parameters<
-      typeof loadPipelineHistory
-    >[0],
+    readStore(env, SUBNET_SNAPSHOT_TABLES),
     netuid,
     { window },
   );
@@ -6502,10 +6459,7 @@ export async function handleSubnetDeregistrationHistory(
   // NOT filtered to `netuid`: rank is relative and does not exist in one
   // subnet's row, so each day is loaded whole and narrowed in the builder.
   const rows = await loadDeregistrationHistory(
-    readStore(
-      env,
-      SUBNET_DEREGISTRATION_DAILY_TABLES,
-    ) as never as unknown as Parameters<typeof loadDeregistrationHistory>[0],
+    readStore(env, SUBNET_DEREGISTRATION_DAILY_TABLES),
     { window },
   );
   // An empty series is a MEASUREMENT -- a subnet registered after the lane
@@ -7343,9 +7297,8 @@ export async function handleRuntime(request: Request, env: Env, url: URL) {
     // The same spec_version column, from the tier that actually has it
     // (#9265). Through the shared reader so MCP and GraphQL get the timeline
     // too rather than being wired one surface at a time.
-    (await loadRuntimeVersionHistoryColdTier(
-      env as unknown as Parameters<typeof loadRuntimeVersionHistoryColdTier>[0],
-    )) ?? buildRuntimeVersionHistory([]);
+    (await loadRuntimeVersionHistoryColdTier(env)) ??
+    buildRuntimeVersionHistory([]);
   // #8702: the forward-looking half of the same question. `transitions` is
   // where the runtime has BEEN (first-party block observations); `current` is
   // where it IS and what is queued behind it (live chain reads + the captured
@@ -7879,9 +7832,5 @@ async function subnetSurfacesFor(
  * correctly converge on "no rate" -- and none of them is a rate of zero.
  */
 async function usdPerTaoOrNull(env: Env): Promise<number | null> {
-  return sharedUsdPerTaoOrNull(
-    readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
-      typeof sharedUsdPerTaoOrNull
-    >[0],
-  );
+  return sharedUsdPerTaoOrNull(readStore(env, TAO_USD_TABLES));
 }

--- a/workers/request-handlers/fullnode-rpc-proxy.ts
+++ b/workers/request-handlers/fullnode-rpc-proxy.ts
@@ -46,6 +46,7 @@ import {
 } from "../config.ts";
 import { recordUsageEvent } from "../../src/usage-telemetry.ts";
 import { recordRpcUsageEvent } from "../../src/rpc-usage-capture.ts";
+import { rateLimiterBinding } from "../tiered-rate-limit.ts";
 
 // PostHog usage telemetry for this gate (metagraphed#7153): excluded from the
 // generic withUsageTelemetry chokepoint (workers/api.ts's usageRouteLabel
@@ -317,9 +318,7 @@ async function runAuthenticatedFullnodeRpc(
   // `|| FULLNODE_RPC_TIER_RATE_LIMITS.free` fallback already handles a
   // missing/unmapped tier, so this is a safe cast, not a new assumption.
   const rateLimitPolicy = rateLimitPolicyForTier(auth.tier as string);
-  const rateLimiter = (env as unknown as Record<string, RateLimit | undefined>)[
-    rateLimitPolicy.envVar
-  ];
+  const rateLimiter = rateLimiterBinding(env, rateLimitPolicy.envVar);
   if (rateLimiter?.limit) {
     const { success } = await rateLimiter.limit({
       key: `fullnode-rpc:${auth.accountId}`,

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -75,6 +75,7 @@ import {
   type TieredRateLimitConfig,
 } from "../tiered-rate-limit.ts";
 import { buildTierPolicies } from "../../src/api-tiers.ts";
+import { recordOrNull } from "../../src/read-store.ts";
 
 export interface RpcEndpoint {
   id: string;
@@ -317,7 +318,9 @@ export async function handleSurfaceVerify(
       surface = findSurface(
         catalogSurfaces,
         surfaceId,
-        aliases.data as unknown as Parameters<typeof findSurface>[2],
+        // `.data` is `unknown` -- an R2 object is whatever was last written to
+        // it -- so the alias map is narrowed rather than asserted (#11339).
+        recordOrNull(aliases.data),
       );
     }
   }
@@ -340,7 +343,7 @@ export async function handleSurfaceVerify(
     },
     {
       waitUntil: (promise: Promise<unknown>) => ctx?.waitUntil?.(promise),
-    } as unknown as Parameters<typeof verifySurfaceWithCache>[2],
+    },
   );
   return envelopeResponse(
     request,

--- a/workers/storage.ts
+++ b/workers/storage.ts
@@ -86,7 +86,7 @@ interface RunManifestEntry {
 const runManifestMemo = new Map<string, Map<string, string> | null>();
 
 async function runManifestIndex(
-  env: Env,
+  env: ArtifactEnv,
   manifestKey: string,
 ): Promise<Map<string, string> | null> {
   const cached = runManifestMemo.get(manifestKey);
@@ -94,10 +94,10 @@ async function runManifestIndex(
 
   let index: Map<string, string> | null = null;
   try {
-    const object = await withTimeout(
-      env.METAGRAPH_ARCHIVE.get(manifestKey),
-      r2TimeoutMs(env),
-    );
+    const archive = env.METAGRAPH_ARCHIVE;
+    const object = archive
+      ? await withTimeout(archive.get(manifestKey), r2TimeoutMs(env))
+      : null;
     const body = object
       ? ((await object.json()) as { artifacts?: unknown })
       : null;
@@ -124,7 +124,7 @@ async function runManifestIndex(
 // Structured request logging on non-happy paths (R2 timeout, static fallback) so
 // it does not spam logs. Disabled with METAGRAPH_DISABLE_REQUEST_LOGS=true.
 export function logEvent(
-  env: Env,
+  env: ArtifactEnv,
   level: string,
   event: string,
   fields: Record<string, unknown> = {},
@@ -139,7 +139,7 @@ export function logEvent(
   }
 }
 
-export function r2TimeoutMs(env: Env): number {
+export function r2TimeoutMs(env: ArtifactEnv): number {
   const raw = Number(env.METAGRAPH_R2_TIMEOUT_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_R2_TIMEOUT_MS;
 }
@@ -162,10 +162,36 @@ export async function withTimeout<T>(
   }
 }
 
+/**
+ * What the artifact readers need from their environment, and nothing else.
+ *
+ * Named for the same reason `R2SqlEnv` and `TelemetryEnv` are (#11339): a
+ * composer holding a loose bag had to assert past `Env` to read an artifact,
+ * and `env as never` was the spelling -- which also made the PATH argument
+ * unverifiable at the same call.
+ */
+export interface ArtifactEnv {
+  ASSETS?: { fetch(request: Request): Promise<Response> };
+  METAGRAPH_ARCHIVE?: R2Bucket;
+  METAGRAPH_CONTROL?: KVNamespace;
+  METAGRAPH_ALLOW_R2_STATIC_FALLBACK?: string;
+  METAGRAPH_R2_LATEST_PREFIX?: string;
+  METAGRAPH_R2_TIMEOUT_MS?: string;
+  METAGRAPH_DISABLE_REQUEST_LOGS?: string;
+}
+
 export async function readArtifact(
-  env: Env,
+  // NULLABLE, because callers legitimately hold one: this function is
+  // documented to THROW when the binding is absent, and every caller wraps it
+  // for exactly that. Declaring it non-null pushed a cast onto the composers
+  // instead of stating the contract (#11339).
+  env: ArtifactEnv | null | undefined,
   artifactPath: string,
 ): Promise<StorageReadResult> {
+  // The throw the doc comment promises, said out loud. Previously this was an
+  // implicit TypeError one frame down; callers catch both identically, and an
+  // explicit one names the cause in the log.
+  if (!env) throw new Error("readArtifact: no environment bound");
   const storageTier = artifactStorageTierForPath(artifactPath);
 
   if (storageTier === ARTIFACT_STORAGE_TIERS.r2) {
@@ -210,7 +236,7 @@ export async function readArtifact(
 }
 
 export async function readAsset(
-  env: Env,
+  env: ArtifactEnv,
   artifactPath: string,
   storageTier: string,
 ): Promise<StorageReadResult> {
@@ -245,7 +271,7 @@ export async function readAsset(
 }
 
 export async function readR2(
-  env: Env,
+  env: ArtifactEnv,
   artifactPath: string,
   storageTier: string,
 ): Promise<StorageReadResult> {
@@ -267,7 +293,7 @@ export async function readR2(
 // artifacts (the og-image.png card, see src/og-image.ts) that readR2's
 // .json() would throw on. readR2 above is implemented in terms of this.
 export async function readR2Object(
-  env: Env,
+  env: ArtifactEnv,
   artifactPath: string,
   storageTier: string,
 ): Promise<R2ObjectReadResult> {
@@ -283,10 +309,10 @@ export async function readR2Object(
   const { key, resolution } = await resolveArtifactKey(artifactPath, env);
   let object;
   try {
-    object = await withTimeout(
-      env.METAGRAPH_ARCHIVE.get(key),
-      r2TimeoutMs(env),
-    );
+    const archive = env.METAGRAPH_ARCHIVE;
+    object = archive
+      ? await withTimeout(archive.get(key), r2TimeoutMs(env))
+      : null;
   } catch {
     logEvent(env, "warn", "r2_read_timeout", {
       key,
@@ -411,7 +437,7 @@ const STABLE_LATEST_ARTIFACT_PATTERNS = [
  */
 export async function resolveArtifactKey(
   artifactPath: string,
-  env: Env,
+  env: ArtifactEnv,
 ): Promise<{ key: string; resolution: ArtifactResolution }> {
   const relativePath = artifactPath.replace(/^\/metagraph\//, "");
   if (
@@ -440,7 +466,7 @@ export async function resolveArtifactKey(
 
 export async function latestR2Key(
   artifactPath: string,
-  env: Env,
+  env: ArtifactEnv,
 ): Promise<string> {
   return (await resolveArtifactKey(artifactPath, env)).key;
 }
@@ -455,7 +481,7 @@ export async function latestR2Key(
 // on the env object so tests (and any multi-binding caller) never cross-read.
 const POINTER_MEMO_TTL_MS = 60_000;
 let pointerMemo: {
-  env: Env | null;
+  env: ArtifactEnv | null;
   value: LatestPointer | null;
   expiresAt: number;
 } = { env: null, value: null, expiresAt: 0 };
@@ -464,7 +490,9 @@ registerModuleStateReset("workers/storage.ts", () => {
   pointerMemo = { env: null, value: null, expiresAt: 0 };
 });
 
-export async function latestPointer(env: Env): Promise<LatestPointer | null> {
+export async function latestPointer(
+  env: ArtifactEnv,
+): Promise<LatestPointer | null> {
   if (!env.METAGRAPH_CONTROL?.get) {
     return null;
   }
@@ -487,7 +515,10 @@ export async function latestPointer(env: Env): Promise<LatestPointer | null> {
 // Read a live health snapshot written by the cron prober (KV health:* keys).
 // Returns null when KV is unbound or the key is cold so callers fall back to the
 // static artifact.
-export async function readHealthKv(env: Env, key: string): Promise<unknown> {
+export async function readHealthKv(
+  env: ArtifactEnv,
+  key: string,
+): Promise<unknown> {
   if (!env.METAGRAPH_CONTROL?.get) {
     return null;
   }

--- a/workers/tiered-rate-limit.ts
+++ b/workers/tiered-rate-limit.ts
@@ -22,6 +22,32 @@ import {
 } from "../src/api-key-validation.ts";
 import { routeCost } from "../src/route-cost-weights.ts";
 import { evaluateBlock, type BlockVerdict } from "../src/api-key-abuse.ts";
+import { recordOrNull } from "../src/read-store.ts";
+
+/**
+ * The rate-limiter binding a policy NAMES, or undefined.
+ *
+ * A real lookup, not a property access: the policy config carries its binding
+ * as a string (`policy.envVar`), and `Env` is an interface, which TypeScript
+ * never gives an implicit index signature -- so all three call sites wrote
+ * `env as unknown as Record<string, RateLimit | undefined>` to index it
+ * (#11339).
+ *
+ * Narrows on `.limit` rather than on mere presence, which the cast could not
+ * do at all: an unbound name reads as `undefined`, but a WRONG name reads as
+ * whatever else is bound under it. A KV namespace passes `!== undefined` and
+ * then throws inside `.limit()` -- on the request path, mid-flight, as a 500
+ * rather than as the open-fail the callers below intend.
+ */
+export function rateLimiterBinding(
+  env: unknown,
+  name: string,
+): RateLimit | undefined {
+  const binding = recordOrNull(env)?.[name];
+  return typeof (binding as RateLimit | undefined)?.limit === "function"
+    ? (binding as RateLimit)
+    : undefined;
+}
 
 export interface RateLimitTierPolicy {
   /** Env binding name for this tier's Cloudflare Rate Limiting binding. */
@@ -265,9 +291,7 @@ export async function applyTieredRateLimit(
       tier && Object.hasOwn(config.tiers ?? {}, tier)
         ? (config.tiers as Record<string, RateLimitTierPolicy>)[tier]
         : config.keyed;
-    const limiter = (env as unknown as Record<string, RateLimit | undefined>)[
-      policy.envVar
-    ];
+    const limiter = rateLimiterBinding(env, policy.envVar);
     // `String()` unconditionally turned a null account id into the LITERAL
     // "null" -- a single fabricated tenant that every identity-less key shared.
     // verifyUnkeyKey returns `accountId: identity?.externalId ?? null` while
@@ -353,9 +377,7 @@ export async function applyTieredRateLimit(
   }
 
   const policy = config.anonymous;
-  const limiter = (env as unknown as Record<string, RateLimit | undefined>)[
-    policy.envVar
-  ];
+  const limiter = rateLimiterBinding(env, policy.envVar);
   if (!limiter?.limit) {
     return { allowed: true, policy, tier: "anonymous", accountId: null };
   }

--- a/workers/wss-lb.ts
+++ b/workers/wss-lb.ts
@@ -49,6 +49,7 @@ import {
   recordUsageEvent,
 } from "../src/usage-telemetry.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import type { TelemetryEnv } from "../src/usage-telemetry.ts";
 
 /**
  * This Worker's OWN bindings, kept hand-written on purpose (#10861).
@@ -68,7 +69,7 @@ import { registerModuleStateReset } from "../src/module-state-registry.ts";
  * `POSTHOG_EXCEPTION_STORM_WINDOW_MS` bound in the config and absent below,
  * which is why they now appear.
  */
-export interface WssLbEnv {
+export interface WssLbEnv extends TelemetryEnv {
   // Where the pools artifact is read from. Not hardcoded so a staging
   // deployment can point at a staging API without a code change.
   METAGRAPHED_API?: string;
@@ -76,18 +77,13 @@ export interface WssLbEnv {
   NETWORKS?: string;
   MAX_BLOCK_LAG?: string;
   HANDSHAKE_TIMEOUT_MS?: string;
-  // PostHog wiring, matching every other Worker (secret + optional host
-  // override). Absent => capture is a no-op, the same
-  // isUsageTelemetryConfigured contract src/usage-telemetry.ts gives the
-  // main Workers.
-  POSTHOG_PROJECT_TOKEN?: string;
-  POSTHOG_HOST?: string;
-  // Read by src/usage-telemetry.ts through the `env as unknown as Env` casts
-  // below, never by this file directly -- which is exactly how it stayed
-  // undeclared here while being bound in the config all along.
-  POSTHOG_EXCEPTION_STORM_WINDOW_MS?: string;
-  // Same: bound in the config, consumed by shared helpers rather than here.
-  CF_VERSION_METADATA?: { id: string; tag?: string };
+  // The PostHog wiring is inherited from `TelemetryEnv` rather than restated
+  // here (#11339). It was restated because `recordExceptionEvent` used to
+  // demand the whole ambient `Env`, so this file listed the keys AND cast to
+  // `Env` at each call -- and that cast is what made the header's own warning
+  // toothless: it asserted exactly the bindings this Worker does not have.
+  // The shared helper now takes the five keys it reads, so the calls below
+  // pass `env` unchanged and the compiler checks them.
   // Optional. Absent => no per-IP limiting (fail open, see header).
   WSS_CONNECT_RATE_LIMITER?: {
     limit(o: { key: string }): Promise<{ success: boolean }>;
@@ -182,7 +178,7 @@ function captureCondition(
 ): void {
   if (!shouldEmitCondition(route)) return;
   const pending = recordUsageEvent(
-    env as unknown as Env,
+    env,
     {
       route,
       ok: false,
@@ -652,7 +648,7 @@ export default {
         // Two statements, not `waitUntil?.(record...())`: an optional call
         // short-circuits its ARGUMENT too, so the one-liner would silently
         // skip the capture whenever ctx is absent.
-        const pending = recordExceptionEvent(env as unknown as Env, {
+        const pending = recordExceptionEvent(env, {
           error,
           route: "wss-lb-unhandled-exception",
         });


### PR DESCRIPTION
188 casts removed across 98 files. Every one was load-bearing for a claim
nobody was checking, and four of them were hiding a live defect.

## The defects the casts were hiding

- **Two GraphQL resolvers were handing their loaders a context with no
  artifact reader at all.** `mcpCtx()` bolted `readArtifact` onto the
  context at 33 call sites on the reasoning that loaders never dereference
  it. That held until the rpc resolvers spread `{ ...context, readHealthKv }`
  instead. The cast was the only thing hiding it.
- **`withSpotPrice(row as never)`.** `as never` makes *any* value satisfy a
  parameter, so a producer that renamed `alpha_in_pool` would have gone on
  computing spot price from `undefined` and publishing the result.
- **`top-holders-staleness-watchdog` declared `METAGRAPH_ARCHIVE` as a bucket
  with a required `get`, while its own code reads `if (!bucket?.get)` and its
  suite proves `{}` must degrade.** The guard outranked the type.
- **A rate-limiter lookup that could not tell an unbound name from a wrong
  one.** `env as unknown as Record<string, RateLimit>` returns whatever is
  bound under that name; a KV namespace passes `!== undefined` and then throws
  inside `.limit()` — on the request path, as a 500 rather than the open-fail
  the callers intend.

## Why they existed

Almost all of them trace to one fact: **`Env` is an interface, and TypeScript
never gives interfaces implicit index signatures.** So a parameter trying to be
lenient by taking `Record<string, unknown>` lands one step too strict, and every
caller holding a real `Env` casts past it. `laneHealthStore` predicted this in
its own signature — "a narrower type would push a cast to 27 call sites" — and
undercounted: there were 67.

`readStore` had the answer three lines away: `env: unknown`, narrowing inside,
zero call-site casts.

## What replaced them

Five named contracts, each listing what its module actually reads:

| contract | what it is |
|---|---|
| `TelemetryEnv` | 5 PostHog strings + `CF_VERSION_METADATA` + `METAGRAPH_CONTROL` |
| `R2SqlEnv` | 5 `R2_SQL_*` strings — cascaded to 59 signatures across 15 cold-tier files |
| `ArtifactEnv` | 7 R2/KV/ASSETS bindings |
| `StoreEnv` | `HYPERDRIVE` |
| `NeonWriteEnv` | the write buffer's 3 lane-routing vars |

Plus four narrowing helpers where an untrusted `unknown` meets a typed
parameter — `recordOrNull`, `recordsOrEmpty`, `hyperdriveConnectionString`,
`rateLimiterBinding`. The third of those replaced the same
"does this env have a Neon binding" rule copy-pasted into three modules with
two casts apiece — the rule deciding whether a lane *writes* or silently
declines — and states it more strictly than any of the three did.

## Closes #10789

`subnetEconomicsRow`'s own comment asked for it: *"#10789 replaces the assertion
with a parse; until then there is exactly one to replace."*

Read paths get `SubnetEconomicsReadSchema` — partial + catchall, the same
contract every lakehouse row schema carries. The strict schema stays the
*producer's*, where an undeclared key is real drift. Reading through the strict
one would empty the leaderboards the day a producer adds a field, which turns a
schema into an availability risk.

**Verified against production before the swap:** a live served economics row
carries zero fields the strict schema does not declare, so this loosens a
contract that already held.

## Not included

The identity-history composer's 6 casts are left in place. Replacing them needs
the same tolerant-parse treatment as economics — a strict artifact parse there
changes tier fall-through semantics, so one missing field would make a tier's
whole answer vanish and the route serve empty. That is a design change, not a
cast swap, and it deserves its own diff.

79 `as unknown as` remain, concentrated in `workers/api.ts` (9) and the
request handlers.

## Verification

- `tsc` clean, `eslint` clean (uncached), `prettier` clean
- 8 CI validators green, including `validate:boundary-casts` and
  `validate:worker-types-parity`
- **5,152 tests across 81 suites** — every suite matching a touched module
- New helpers are mutation-tested: dropping the string guard in
  `hyperdriveConnectionString` fails 1 test; allowing arrays through
  `recordOrNull` fails 2

Two regressions were caught by existing tests during the work and fixed:
a guard that short-circuited before a stubbed reader, and a hoisted
`await coldTier(...)` that made every request pay for an R2 SQL scan the
`??` chain was supposed to skip.