### PR TITLE
fix(neon): a deadlock is a retriable row, not a broken connection

### DIFF
--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -13,6 +13,8 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   BUFFER_FLUSH_LANE,
+  FLUSH_RETRY_BUDGET_MS,
+  isRetriableWriteError,
   BUFFER_ROUTE,
   countPending,
   FLUSH_LIST_LIMIT,
@@ -951,5 +953,250 @@ describe("the counter may be absent, and the drain must cope", () => {
     });
     assert.equal(out.ok, false);
     assert.equal(await storage.get("pending"), 0, "clamped, never negative");
+  });
+});
+
+// #11357: a Postgres deadlock is a ROW-level failure -- the server aborts one
+// victim and leaves the connection healthy -- but the drain's stop-on-first-
+// failure rule was built on "a failure here is nearly always the connection".
+// Treating the two the same turned ONE retriable row into a head-of-line block
+// on the whole buffer: measured 2026-08-15, a 93-second deadlock stalled four
+// consecutive flushes, which drained 491, 1, 0 and 93 statements while
+// re-attempting the same poisoned statement first every time.
+describe("a retriable conflict is retried in place, not treated as a stop", () => {
+  /** A pg-shaped error: node-postgres puts the SQLSTATE on `code`. */
+  function pgError(code: string, message = "deadlock detected") {
+    return Object.assign(new Error(message), { code });
+  }
+
+  /** A sql double whose Nth call fails with `error`, then succeeds. */
+  function failingTimes(times: number, error: unknown) {
+    const seen: string[] = [];
+    let failures = 0;
+    return {
+      seen,
+      get attempts() {
+        return seen.length;
+      },
+      sql: {
+        async unsafe(text: string) {
+          seen.push(text);
+          if (failures < times) {
+            failures += 1;
+            throw error;
+          }
+          return [];
+        },
+      },
+    };
+  }
+
+  test("isRetriableWriteError names only what Postgres declares retriable", () => {
+    assert.equal(isRetriableWriteError(pgError("40P01")), true, "deadlock");
+    assert.equal(
+      isRetriableWriteError(pgError("40001")),
+      true,
+      "serialization",
+    );
+    // Everything else is either fatal to the connection or fatal to the row,
+    // and retrying it is a wasted round trip.
+    assert.equal(
+      isRetriableWriteError(pgError("23505")),
+      false,
+      "unique violation",
+    );
+    assert.equal(
+      isRetriableWriteError(pgError("42601")),
+      false,
+      "syntax error",
+    );
+    assert.equal(
+      isRetriableWriteError(pgError("08006")),
+      false,
+      "connection failure",
+    );
+    // The drain catches `unknown`, so a non-error must answer false rather
+    // than crash the handler that exists to keep the buffer draining.
+    for (const junk of [null, undefined, "deadlock", 17, {}, { code: 40001 }]) {
+      assert.equal(isRetriableWriteError(junk), false, JSON.stringify(junk));
+    }
+  });
+
+  test("a deadlock that clears on the retry drains the whole backlog", async () => {
+    const storage = fakeStorage();
+    for (const t of ["A", "B", "C"])
+      await enqueueStatement(storage, stmt("l", t), NOW);
+    const runner = failingTimes(1, pgError("40P01"));
+    const slept: number[] = [];
+    const spy = laneSpy();
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      sql: runner.sql,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    // A retried, not skipped: the failing statement runs again IN PLACE, so
+    // the order the backlog replays in is unchanged.
+    assert.deepEqual(runner.seen, ["A", "A", "B", "C"]);
+    assert.equal(out.drained, 3);
+    assert.equal(out.ok, true);
+    assert.equal(await countPending(storage), 0);
+    assert.deepEqual(slept, [50]);
+  });
+
+  test("the retry is announced, because recovering silently hides the frequency", async () => {
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("l", "A"), NOW);
+    const spy = laneSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      sql: failingTimes(1, pgError("40P01")).sql,
+      sleep: async () => {},
+    });
+    const verdict = spy.rows.find((r) => r.lane === BUFFER_FLUSH_LANE);
+    assert.equal(verdict?.verdict, "ok");
+    assert.match(
+      String(verdict?.detail),
+      /retried 1 after a retriable conflict/,
+    );
+  });
+
+  // The behaviour this change must never remove.
+  test("a NON-retriable failure still stops the drain immediately", async () => {
+    const storage = fakeStorage();
+    for (const t of ["A", "B", "C"])
+      await enqueueStatement(storage, stmt("l", t), NOW);
+    const runner = failingTimes(99, pgError("08006", "connection terminated"));
+    const slept: number[] = [];
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: runner.sql,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    // ONE attempt, no sleep: a broken connection would fail for every
+    // remaining statement, so stopping is what saves the round trips.
+    assert.deepEqual(runner.seen, ["A"]);
+    assert.deepEqual(slept, []);
+    assert.equal(out.ok, false);
+    assert.equal(out.remaining, true);
+    // And the rows are still there -- the invariant that must never regress.
+    assert.equal(await countPending(storage), 3);
+  });
+
+  test("a deadlock that outlasts the retries stops, keeping every row", async () => {
+    const storage = fakeStorage();
+    for (const t of ["A", "B", "C"])
+      await enqueueStatement(storage, stmt("l", t), NOW);
+    const runner = failingTimes(99, pgError("40P01"));
+    const slept: number[] = [];
+    const spy = laneSpy();
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      sql: runner.sql,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    // Both backoffs spent on the one statement, then the existing stop.
+    assert.deepEqual(runner.seen, ["A", "A", "A"]);
+    assert.deepEqual(slept, [50, 250]);
+    assert.equal(out.ok, false);
+    assert.equal(await countPending(storage), 3);
+    const verdict = spy.rows.find((r) => r.lane === BUFFER_FLUSH_LANE);
+    assert.match(String(verdict?.detail), /after 2 retries/);
+  });
+
+  // The failure message has to read correctly at ONE, which is the count a
+  // single transient produces and therefore the one an operator sees most.
+  test("one spent retry then a hard failure reads as `after 1 retry`", async () => {
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("l", "A"), NOW);
+    let calls = 0;
+    const spy = laneSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          calls += 1;
+          // Retriable first, then the connection genuinely goes.
+          throw calls === 1
+            ? pgError("40P01")
+            : pgError("08006", "connection terminated");
+        },
+      },
+      sleep: async () => {},
+    });
+    const verdict = spy.rows.find((r) => r.lane === BUFFER_FLUSH_LANE);
+    assert.match(String(verdict?.detail), /after 1 retry\)/);
+    assert.doesNotMatch(String(verdict?.detail), /retries/);
+    assert.equal(await countPending(storage), 1);
+  });
+
+  // Every other test injects a sleep, so the REAL one is otherwise never run --
+  // and a broken default would only show up in production, as a flush that
+  // either never waits or never returns.
+  test("the default backoff is a real wait, and the flush still completes", async () => {
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("l", "A"), NOW);
+    const runner = failingTimes(1, pgError("40P01"));
+    const started = Date.now();
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: runner.sql,
+      // no `sleep` dep -- the production path
+    });
+    const elapsed = Date.now() - started;
+    assert.equal(out.ok, true);
+    assert.equal(out.drained, 1);
+    assert.deepEqual(runner.seen, ["A", "A"]);
+    // It genuinely waited the first backoff rather than spinning.
+    assert.ok(
+      elapsed >= 40,
+      `elapsed ${elapsed}ms, expected the ~50ms backoff`,
+    );
+    assert.equal(await countPending(storage), 0);
+  });
+
+  // THE BUDGET IS THE WHOLE DESIGN. A per-statement allowance would be
+  // FLUSH_LIST_LIMIT x attempts x delay in the worst case, which spends the
+  // alarm on waiting instead of writing. One shared budget makes the worst
+  // case the budget itself.
+  test("the retry budget is shared across the flush, not per statement", async () => {
+    const storage = fakeStorage();
+    for (const t of ["A", "B", "C", "D", "E", "F"])
+      await enqueueStatement(storage, stmt("l", t), NOW);
+    const slept: number[] = [];
+    // Every statement deadlocks once. Unbudgeted this would sleep 6 x 50ms;
+    // budgeted it stops as soon as the next backoff would exceed the cap.
+    let calls = 0;
+    const failEveryOther = {
+      async unsafe() {
+        calls += 1;
+        if (calls % 2 === 1) throw pgError("40P01");
+        return [];
+      },
+    };
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: failEveryOther,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    const spent = slept.reduce((a, b) => a + b, 0);
+    assert.ok(
+      spent <= FLUSH_RETRY_BUDGET_MS,
+      `spent ${spent}ms against a ${FLUSH_RETRY_BUDGET_MS}ms budget`,
+    );
   });
 });

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -140,6 +140,67 @@ export const FLUSH_LIST_LIMIT = 500;
  */
 export const FLUSH_BACKLOG_RETRY_MS = 10_000;
 
+/**
+ * Postgres SQLSTATEs that mean "retry this exact statement", and nothing else
+ * (#11357).
+ *
+ * These two are the only classes the server itself declares retriable: it
+ * chooses one transaction as the victim, aborts ONLY that one, and leaves the
+ * connection healthy. Every other failure the drain can see -- a broken socket,
+ * a constraint violation, a syntax error -- is either fatal to the connection
+ * or fatal to the row, and retrying it is a wasted round trip.
+ *
+ *   40P01  deadlock_detected
+ *   40001  serialization_failure
+ *
+ * The distinction matters because the drain's stop-on-first-failure rule is
+ * built on "a failure here is nearly always the connection rather than the
+ * row". That is true, except for these -- and treating a deadlock as a
+ * connection fault turns ONE retriable row into a head-of-line block on the
+ * whole buffer. Measured 2026-08-15: a 93-second deadlock stalled four
+ * consecutive flushes, which drained 491, 1, 0 and 93 statements while
+ * re-attempting the same poisoned statement first every time.
+ */
+const RETRIABLE_SQLSTATES = new Set(["40P01", "40001"]);
+
+/**
+ * How long ONE flush may spend retrying, in total.
+ *
+ * A BUDGET FOR THE WHOLE DRAIN, not per statement, and that is the whole
+ * design. This runs inside a Durable Object alarm that drains up to
+ * FLUSH_LIST_LIMIT statements; a per-statement allowance of even two short
+ * retries is 500 x 2 x delay in the worst case, which spends the alarm on
+ * waiting rather than writing. One shared budget makes the worst case the
+ * budget itself.
+ *
+ * 1.5 SECONDS, sized against what a deadlock actually costs: Postgres aborts
+ * the victim as soon as its detector runs (`deadlock_timeout`, 1s by default,
+ * and the loser is already dead when the error arrives), so a retry usually
+ * succeeds immediately. The budget is there for the case where it does not --
+ * and when it runs out the drain stops exactly as it does today, which is a
+ * behaviour this change never removes.
+ */
+export const FLUSH_RETRY_BUDGET_MS = 1_500;
+
+/** Backoffs between retries of one statement, in order. Two attempts, because
+ * a third inside one alarm is worth less than coming back on the next: the
+ * first covers "the victim was already aborted", the second covers "the winner
+ * had not committed yet". */
+const RETRY_BACKOFF_MS = [50, 250];
+
+/**
+ * Whether an error is one Postgres told us to retry.
+ *
+ * Reads `code` off the error, which is where node-postgres puts the SQLSTATE.
+ * A TYPE TEST rather than a cast: the drain catches `unknown`, and a thrown
+ * string or a plain object must answer `false` here rather than crash the
+ * handler that exists to keep the buffer draining.
+ */
+export function isRetriableWriteError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "string" && RETRIABLE_SQLSTATES.has(code);
+}
+
 /** The storage surface this hub uses, narrowed so a test can supply a fake. */
 export interface BufferStorage {
   get<T>(key: string): Promise<T | undefined>;
@@ -234,11 +295,17 @@ export async function flushBuffer(
     sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
     now?: () => number;
     captureException?: typeof recordExceptionEvent;
+    /** The retry backoff, injectable so a test exercises the retry path
+     * without spending its budget in real time. Defaults to a real wait. */
+    sleep?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<FlushOutcome> {
   const now = deps.now ?? Date.now;
   const laneDb = deps.laneHealthDb ?? laneHealthStore(env);
   const capture = deps.captureException ?? recordExceptionEvent;
+  const sleep =
+    deps.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const stored = await storage.list<Uint8Array>({
     prefix: STATEMENT_PREFIX,
     limit: FLUSH_LIST_LIMIT,
@@ -300,6 +367,9 @@ export async function flushBuffer(
   const perLane = new Map<string, { ok: number; failed: number }>();
   let undecodable = 0;
   let drained = 0;
+  // Shared across every statement in this flush -- see FLUSH_RETRY_BUDGET_MS.
+  let retrySpentMs = 0;
+  let retriedStatements = 0;
   for (const group of groups) {
     const parts = group.keys.map((key) => stored.get(key) ?? new Uint8Array(0));
     const statement = decodeStatement(joinPayload(parts));
@@ -322,7 +392,30 @@ export async function flushBuffer(
     }
     const tally = perLane.get(statement.lane) ?? { ok: 0, failed: 0 };
     try {
-      await sql.unsafe(statement.text, statement.values);
+      // RETRIED IN PLACE, never skipped: order is the reason the drain stops on
+      // a failure at all, and replaying a backlog out of order is the one thing
+      // worse than replaying it late. Only the SQLSTATEs Postgres declares
+      // retriable are retried, and only while the flush's shared budget lasts
+      // -- everything else, including a budget that has run out, falls through
+      // to the stop below exactly as before (#11357).
+      for (let attempt = 0; ; attempt += 1) {
+        try {
+          await sql.unsafe(statement.text, statement.values);
+          break;
+        } catch (error) {
+          const backoff = RETRY_BACKOFF_MS[attempt];
+          if (
+            backoff === undefined ||
+            !isRetriableWriteError(error) ||
+            retrySpentMs + backoff > FLUSH_RETRY_BUDGET_MS
+          ) {
+            throw error;
+          }
+          retrySpentMs += backoff;
+          retriedStatements += 1;
+          await sleep(backoff);
+        }
+      }
       tally.ok += 1;
       drained += 1;
       drainedKeys.push(...group.keys);
@@ -354,7 +447,14 @@ export async function flushBuffer(
         lane: BUFFER_FLUSH_LANE,
         verdict: "stale",
         age_ms: null,
-        detail: `drained ${drained}, stopped on ${statement.lane}: ${reason}`,
+        detail:
+          `drained ${drained}, stopped on ${statement.lane}: ${reason}` +
+          // Says whether the budget was spent before giving up, so "stopped on
+          // a deadlock" is distinguishable from "stopped on a deadlock after
+          // trying twice" -- different repairs.
+          (retriedStatements > 0
+            ? ` (after ${retriedStatements} retr${retriedStatements === 1 ? "y" : "ies"})`
+            : ""),
         checked_at: now(),
       });
       // Stopped mid-backlog: everything from here on is still stored.
@@ -392,8 +492,16 @@ export async function flushBuffer(
     lane: BUFFER_FLUSH_LANE,
     verdict: "ok",
     age_ms: null,
+    // A RETRY THAT SUCCEEDED IS STILL NEWS. Recovering silently would make the
+    // deadlock frequency this change exists to survive invisible -- and that
+    // number is what says whether the write pattern needs fixing rather than
+    // retrying (#11357).
     detail: `drained ${drained} statement(s)${
       undecodable > 0 ? `, discarded ${undecodable} unreadable` : ""
+    }${
+      retriedStatements > 0
+        ? `, retried ${retriedStatements} after a retriable conflict`
+        : ""
     }`,
     checked_at: now(),
   });


### PR DESCRIPTION
## The drain's own comment names the reason, and a deadlock is the exception to it

```ts
// STOP AT THE FIRST FAILURE and keep this statement and everything after
// it. Skipping ahead would replay the backlog out of order on the next
// alarm, and a failure here is nearly always the connection rather than
// the row -- so the rest would fail too, one wasted round trip each.
```

Both halves are right. Order **is** why the drain stops, and a broken connection **does** poison the rest. Neither applies to a deadlock: Postgres picks one transaction as the victim, aborts **only** that one, and leaves the connection healthy. Every statement after it would have succeeded.

Measured 2026-08-15, a 93-second deadlock stalled four consecutive flushes:

```
11:48:07  drained 491, stopped on nominator-positions: deadlock detected
11:48:22  drained   1, stopped on nominator-positions: deadlock detected
11:48:34  drained   0, stopped on nominator-positions: deadlock detected
11:49:10  drained  93, stopped on nominator-positions: deadlock detected
```

Each alarm re-attempted the same poisoned statement first, stopped again, drained less. Nothing was lost — the buffer simply made no forward progress for a minute and a half while nothing was actually wrong with it.

`40P01` (deadlock_detected) and `40001` (serialization_failure) are the only classes the server declares retriable, and node-postgres puts the SQLSTATE on `error.code`. Nothing in the drain looked at it.

## Retried in place, never skipped

Order is the reason the drain stops on a failure at all. Replaying a backlog out of order is the one thing worse than replaying it late, so the failing statement runs **again in the same position** — no skip, no reorder.

## The budget is shared across the flush, and that is the design

This runs inside a Durable Object alarm draining up to `FLUSH_LIST_LIMIT` (500) statements. A **per-statement** allowance of even two short retries is `500 × 2 × delay` in the worst case — an alarm spent waiting rather than writing.

One shared **1.5 s** budget makes the worst case the budget itself. Two backoffs, 50 ms then 250 ms: Postgres has already aborted the loser by the time the error arrives, so the first covers the common case, and a third inside one alarm is worth less than coming back on the next.

## What this never removes

Every other failure — and a budget that has run out — falls through to the existing stop, unchanged. Two tests pin exactly that:

- a **non-retriable** error makes exactly **one** attempt with **no** sleep, and all three rows survive;
- a deadlock that **outlasts** the retries stops after both backoffs, and all three rows survive.

## The retry is announced

Recovering silently would hide the deadlock frequency — which is the number that says whether the write **pattern** needs fixing rather than retrying. Both verdicts carry it:

```
drained 3 statement(s), retried 1 after a retriable conflict
drained 0, stopped on l: deadlock detected (after 2 retries)
```

## Proved the tests fail on the pre-fix behaviour

Emptying `RETRIABLE_SQLSTATES` fails four tests and leaves the two invariant tests passing — which is what says they guard the behaviour this must not change, rather than the behaviour it adds.

The `isRetriableWriteError` test also carries the negative cases: a unique violation, a syntax error and a connection failure must all answer `false`, and so must `null`, a bare string, a number and `{ code: 40001 }` as a **number** — the drain catches `unknown`, so a non-error has to answer rather than crash the handler that exists to keep the buffer draining.

## Validation

```
tsc --noEmit                                   clean
eslint + prettier                              clean
validate:unreferenced-exports, boundary-casts,
  contract-drift, lane-topology                pass
vitest neon-write-buffer-hub, neon-write-buffer,
  lane-health                                  128 passed (8 new)
patch coverage (git diff -U0 ∩ lcov)           19/19 lines, 15/15 branches = 100%
```

The default backoff is covered by a test that omits the `sleep` dep entirely and asserts the flush genuinely waited — otherwise the production path is the one path no test runs, and a broken default would surface only as a flush that never waits or never returns.

Closes #11357
