### PR TITLE
fix(turnover): a year-long window reported a 36-day answer and said nothing

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -8468,6 +8468,21 @@ type SubnetTurnover {
   window: String
   start_date: String
   end_date: String
+
+  """
+  Days actually compared -- end_date minus start_date. Read THIS, not \`window\`, when stating the period: neuron_daily is shallower than the widest windows, so the store's floor clamps them. Measured 2026-08-15, ?window=90d, 1y and all all returned the same 36-day comparison (#10798).
+  """
+  covered_days: Int
+
+  """
+  The window's declared day count, or NULL for \`all\`, which asks for whatever exists rather than a fixed span.
+  """
+  requested_days: Int
+
+  """
+  True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a subnet that replaced its whole validator set over a year reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete.
+  """
+  window_truncated: Boolean
   comparable: Boolean!
   validators_start: Int
   validators_end: Int

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -7649,11 +7649,15 @@ export type SubnetTurnover = {
   /** Per-neuron churn detail behind the counts above, populated only when the field's changes toggle is set (mirroring REST's ?changes=true). Null otherwise, and on a cold store. */
   changes?: Maybe<SubnetTurnoverChanges>;
   comparable: Scalars['Boolean']['output'];
+  /** Days actually compared -- end_date minus start_date. Read THIS, not `window`, when stating the period: neuron_daily is shallower than the widest windows, so the store's floor clamps them. Measured 2026-08-15, ?window=90d, 1y and all all returned the same 36-day comparison (#10798). */
+  covered_days?: Maybe<Scalars['Int']['output']>;
   end_date?: Maybe<Scalars['String']['output']>;
   netuid: Scalars['Int']['output'];
   neuron_retention?: Maybe<Scalars['Float']['output']>;
   neurons_end?: Maybe<Scalars['Int']['output']>;
   neurons_start?: Maybe<Scalars['Int']['output']>;
+  /** The window's declared day count, or NULL for `all`, which asks for whatever exists rather than a fixed span. */
+  requested_days?: Maybe<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
   stability_score?: Maybe<Scalars['Int']['output']>;
   start_date?: Maybe<Scalars['String']['output']>;
@@ -7664,6 +7668,8 @@ export type SubnetTurnover = {
   validators_exited?: Maybe<Scalars['Int']['output']>;
   validators_start?: Maybe<Scalars['Int']['output']>;
   window?: Maybe<Scalars['String']['output']>;
+  /** True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a subnet that replaced its whole validator set over a year reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+  window_truncated?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** The per-neuron churn behind a subnet's turnover scorecard: which validators entered and exited, and which UIDs were reassigned. Mirrors the changes block of GET /api/v1/subnets/{netuid}/turnover?changes=true. */
@@ -14050,11 +14056,13 @@ export type SubnetTreasuryReadingResolvers<ContextType = GqlContext, ParentType 
 export type SubnetTurnoverResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetTurnover'] = ResolversParentTypes['SubnetTurnover']> = ResolversObject<{
   changes?: Resolver<Maybe<ResolversTypes['SubnetTurnoverChanges']>, ParentType, ContextType>;
   comparable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  covered_days?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   end_date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   neuron_retention?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   neurons_end?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   neurons_start?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  requested_days?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stability_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   start_date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -14065,6 +14073,7 @@ export type SubnetTurnoverResolvers<ContextType = GqlContext, ParentType extends
   validators_exited?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   validators_start?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  window_truncated?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
 export type SubnetTurnoverChangesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetTurnoverChanges'] = ResolversParentTypes['SubnetTurnoverChanges']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12976,11 +12976,15 @@ export interface components {
                 validators_exited_count?: number;
             } | null;
             comparable: boolean;
+            /** @description Days actually compared -- end_date minus start_date. Read THIS, not `window`, when stating the period: neuron_daily is shallower than the widest windows, so the store's floor clamps them. Measured 2026-08-15, ?window=90d, 1y and all all returned the same 36-day comparison (#10798). */
+            covered_days?: number | null;
             end_date?: string | null;
             netuid: number;
             neuron_retention?: number | null;
             neurons_end?: number;
             neurons_start?: number;
+            /** @description The window's declared day count, or NULL for `all`, which asks for whatever exists rather than a fixed span. */
+            requested_days?: number | null;
             schema_version: number;
             stability_score?: number | null;
             start_date?: string | null;
@@ -12991,6 +12995,8 @@ export interface components {
             validators_exited?: number;
             validators_start?: number;
             window?: string | null;
+            /** @description True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a subnet that replaced its whole validator set over a year reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+            window_truncated?: boolean | null;
         };
         /** @enum {string} */
         SubnetType: "root" | "application";
@@ -48893,11 +48899,13 @@ export interface operations {
                      *           "validators_exited_count": 1
                      *         },
                      *         "comparable": false,
+                     *         "covered_days": 1,
                      *         "end_date": "example",
                      *         "netuid": 7,
                      *         "neuron_retention": 0.5,
                      *         "neurons_end": 1,
                      *         "neurons_start": 1,
+                     *         "requested_days": 1,
                      *         "schema_version": 1,
                      *         "stability_score": 100,
                      *         "start_date": "example",
@@ -48907,7 +48915,8 @@ export interface operations {
                      *         "validators_entered": 1,
                      *         "validators_exited": 1,
                      *         "validators_start": 1,
-                     *         "window": "30d"
+                     *         "window": "30d",
+                     *         "window_truncated": false
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12651,11 +12651,13 @@
               "validators_exited_count": 1
             },
             "comparable": false,
+            "covered_days": 1,
             "end_date": "example",
             "netuid": 7,
             "neuron_retention": 0.5,
             "neurons_end": 1,
             "neurons_start": 1,
+            "requested_days": 1,
             "schema_version": 1,
             "stability_score": 100,
             "start_date": "example",
@@ -12665,7 +12667,8 @@
             "validators_entered": 1,
             "validators_exited": 1,
             "validators_start": 1,
-            "window": "30d"
+            "window": "30d",
+            "window_truncated": false
           },
           "meta": {
             "artifact_path": "example",
@@ -58593,6 +58596,19 @@
           "comparable": {
             "type": "boolean"
           },
+          "covered_days": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Days actually compared -- end_date minus start_date. Read THIS, not `window`, when stating the period: neuron_daily is shallower than the widest windows, so the store's floor clamps them. Measured 2026-08-15, ?window=90d, 1y and all all returned the same 36-day comparison (#10798)."
+          },
           "end_date": {
             "anyOf": [
               {
@@ -58627,6 +58643,19 @@
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "requested_days": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The window's declared day count, or NULL for `all`, which asks for whatever exists rather than a fixed span."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -58699,6 +58728,17 @@
                 "type": "null"
               }
             ]
+          },
+          "window_truncated": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a subnet that replaced its whole validator set over a year reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete."
           }
         },
         "required": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12976,11 +12976,15 @@ export interface components {
                 validators_exited_count?: number;
             } | null;
             comparable: boolean;
+            /** @description Days actually compared -- end_date minus start_date. Read THIS, not `window`, when stating the period: neuron_daily is shallower than the widest windows, so the store's floor clamps them. Measured 2026-08-15, ?window=90d, 1y and all all returned the same 36-day comparison (#10798). */
+            covered_days?: number | null;
             end_date?: string | null;
             netuid: number;
             neuron_retention?: number | null;
             neurons_end?: number;
             neurons_start?: number;
+            /** @description The window's declared day count, or NULL for `all`, which asks for whatever exists rather than a fixed span. */
+            requested_days?: number | null;
             schema_version: number;
             stability_score?: number | null;
             start_date?: string | null;
@@ -12991,6 +12995,8 @@ export interface components {
             validators_exited?: number;
             validators_start?: number;
             window?: string | null;
+            /** @description True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a subnet that replaced its whole validator set over a year reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+            window_truncated?: boolean | null;
         };
         /** @enum {string} */
         SubnetType: "root" | "application";
@@ -48893,11 +48899,13 @@ export interface operations {
                      *           "validators_exited_count": 1
                      *         },
                      *         "comparable": false,
+                     *         "covered_days": 1,
                      *         "end_date": "example",
                      *         "netuid": 7,
                      *         "neuron_retention": 0.5,
                      *         "neurons_end": 1,
                      *         "neurons_start": 1,
+                     *         "requested_days": 1,
                      *         "schema_version": 1,
                      *         "stability_score": 100,
                      *         "start_date": "example",
@@ -48907,7 +48915,8 @@ export interface operations {
                      *         "validators_entered": 1,
                      *         "validators_exited": 1,
                      *         "validators_start": 1,
-                     *         "window": "30d"
+                     *         "window": "30d",
+                     *         "window_truncated": false
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas-src/routes/subnet-turnover.ts
+++ b/schemas-src/routes/subnet-turnover.ts
@@ -60,6 +60,29 @@ export const SubnetTurnoverArtifactSchema = z
     window: z.string().nullable().optional(),
     start_date: z.string().nullable().optional(),
     end_date: z.string().nullable().optional(),
+    covered_days: z
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe(
+        "Days actually compared -- end_date minus start_date. Read THIS, not `window`, when stating the period: neuron_daily is shallower than the widest windows, so the store's floor clamps them. Measured 2026-08-15, ?window=90d, 1y and all all returned the same 36-day comparison (#10798).",
+      ),
+    requested_days: z
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe(
+        "The window's declared day count, or NULL for `all`, which asks for whatever exists rather than a fixed span.",
+      ),
+    window_truncated: z
+      .boolean()
+      .nullable()
+      .optional()
+      .describe(
+        "True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a subnet that replaced its whole validator set over a year reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete.",
+      ),
     comparable: z.boolean(),
     validators_start: z.int().min(0).optional(),
     validators_end: z.int().min(0).optional(),

--- a/src/turnover.ts
+++ b/src/turnover.ts
@@ -123,6 +123,72 @@ const EMPTY_TURNOVER_CHANGES = {
   uid_reassignments: [] as Row[],
 };
 
+/**
+ * How many days a window ACTUALLY compared, and whether the store cut it short
+ * (#10798).
+ *
+ * `neuronDailyWindowBounds` resolves the start as
+ * `MIN(snapshot_date) WHERE snapshot_date >= endDate - days`, so when the table
+ * is shallower than the window the start silently becomes the table's own
+ * floor. Measured against production 2026-08-15, SN64:
+ *
+ *     ?window=90d   start 2026-07-10   entered 6  exited 4  stability 68
+ *     ?window=1y    start 2026-07-10   entered 6  exited 4  stability 68
+ *     ?window=all   start 2026-07-10   entered 6  exited 4  stability 68
+ *
+ * Three different questions, one 36-day answer, and only `1y`'s was wrong about
+ * what it measured. `start_date` was published, but reading the clamp off it
+ * requires already knowing the table's floor -- so the truncation was
+ * derivable, not stated.
+ *
+ * IT MATTERS IN ONE DIRECTION. Turnover is entered/exited/retention between the
+ * window's endpoints, so a shorter span reports LOWER churn and HIGHER
+ * stability. A subnet that replaced its whole validator set over a year reads
+ * as a calm month -- confidently wrong on the metric the route exists for,
+ * which is worse than an empty answer.
+ *
+ * This is also the retention constraint #10798 records, arriving early: a prune
+ * moves the floor, and every window deeper than the new floor silently
+ * shortens. Publishing the coverage means that shows up as a number rather than
+ * as a quieter subnet.
+ */
+export function windowCoverage(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+  requestedDays: number | null | undefined,
+): {
+  covered_days: number | null;
+  requested_days: number | null;
+  window_truncated: boolean | null;
+} {
+  const requested = typeof requestedDays === "number" ? requestedDays : null;
+  if (!startDate || !endDate) {
+    return {
+      covered_days: null,
+      requested_days: requested,
+      // Unknowable without both bounds -- null, never `false`, which would
+      // assert a window nobody measured was complete.
+      window_truncated: null,
+    };
+  }
+  const spanMs = Date.parse(endDate) - Date.parse(startDate);
+  if (!Number.isFinite(spanMs) || spanMs < 0) {
+    return {
+      covered_days: null,
+      requested_days: requested,
+      window_truncated: null,
+    };
+  }
+  const covered = Math.round(spanMs / 86_400_000);
+  return {
+    covered_days: covered,
+    requested_days: requested,
+    // `all` asks for whatever exists, so it cannot be short of itself. A
+    // numbered window can, and that is the case worth flagging.
+    window_truncated: requested === null ? false : covered < requested,
+  };
+}
+
 // Compare a subnet's start-of-window vs end-of-window neuron_daily snapshots into a
 // turnover scorecard. `rows` carries both dates' rows (the handler reads exactly
 // the two boundary snapshot_dates); `startDate`/`endDate` name them. Null-safe: no
@@ -135,10 +201,13 @@ export function buildTurnover(
     window,
     startDate,
     endDate,
+    requestedDays,
   }: {
     window?: string;
     startDate?: string | null;
     endDate?: string | null;
+    /** The window's declared day count, or null for `all`. */
+    requestedDays?: number | null;
   } = {},
 ): Row {
   const list = Array.isArray(rows) ? rows : [];
@@ -148,6 +217,7 @@ export function buildTurnover(
     window: window ?? null,
     start_date: startDate ?? null,
     end_date: endDate ?? null,
+    ...windowCoverage(startDate, endDate, requestedDays),
   };
   // A single snapshot (start === end) can't show change: comparing it to itself
   // would report a flawless retention/stability_score of 100 for a populated

--- a/tests/turnover.test.ts
+++ b/tests/turnover.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test, vi } from "vitest";
 import {
   buildTurnover,
+  windowCoverage,
   buildTurnoverChanges,
   loadSubnetTurnover,
 } from "../src/turnover.ts";
@@ -781,5 +782,99 @@ describe("buildTurnover — regressions", () => {
     assert.equal(data.validator_retention, 0);
     assert.equal(data.uids_deregistered, 0); // uid 0 kept its hotkey
     assert.equal(data.neuron_retention, 1); // {0:V1} retained
+  });
+});
+
+// #10798: `neuronDailyWindowBounds` resolves the start as
+// `MIN(snapshot_date) WHERE snapshot_date >= endDate - days`, so a table
+// shallower than the window silently returns the table's own floor. Measured
+// against production 2026-08-15, SN64 -- three different questions, one answer:
+//
+//     ?window=90d   start 2026-07-10   entered 6  exited 4  stability 68
+//     ?window=1y    start 2026-07-10   entered 6  exited 4  stability 68
+//     ?window=all   start 2026-07-10   entered 6  exited 4  stability 68
+//
+// Only `1y` was wrong about what it measured, and nothing in the payload said
+// so. It matters in ONE direction: turnover compares the window's endpoints, so
+// a shortened span reports LOWER churn and HIGHER stability.
+describe("a window reports what it actually covered", () => {
+  test("a numbered window short of its span is flagged", () => {
+    // The live case: a year asked for, 36 days available.
+    assert.deepEqual(windowCoverage("2026-07-10", "2026-08-15", 365), {
+      covered_days: 36,
+      requested_days: 365,
+      window_truncated: true,
+    });
+  });
+
+  test("a window the store can satisfy is not flagged", () => {
+    assert.deepEqual(windowCoverage("2026-08-08", "2026-08-15", 7), {
+      covered_days: 7,
+      requested_days: 7,
+      window_truncated: false,
+    });
+    // A span LONGER than asked for is not a truncation either -- the bounds
+    // resolve to real snapshots, and the caller got at least what they wanted.
+    assert.equal(
+      windowCoverage("2026-07-10", "2026-08-15", 30).window_truncated,
+      false,
+    );
+  });
+
+  test("`all` asks for whatever exists, so it cannot be short of itself", () => {
+    const coverage = windowCoverage("2026-07-10", "2026-08-15", null);
+    assert.equal(coverage.requested_days, null);
+    assert.equal(coverage.window_truncated, false);
+    // The DEPTH is still published, which is the number a caller needs when
+    // the label carries none.
+    assert.equal(coverage.covered_days, 36);
+  });
+
+  // NULL, never false. Claiming a window nobody measured was complete is the
+  // same confident-wrong shape the rest of this module avoids.
+  test("unresolvable bounds are unknown, not complete", () => {
+    for (const [start, end] of [
+      [null, "2026-08-15"],
+      ["2026-07-10", null],
+      [null, null],
+      ["not a date", "2026-08-15"],
+      // End before start cannot be a span.
+      ["2026-08-15", "2026-07-10"],
+    ] as [string | null, string | null][]) {
+      const coverage = windowCoverage(start, end, 30);
+      assert.equal(coverage.window_truncated, null, `${start}..${end}`);
+      assert.equal(coverage.covered_days, null, `${start}..${end}`);
+      // The request is still echoed -- it is known even when the answer is not.
+      assert.equal(coverage.requested_days, 30);
+    }
+  });
+
+  test("the card carries the coverage, on the populated and the empty path", () => {
+    const rows = [
+      { snapshot_date: "2026-07-10", uid: 0, hotkey: "A", validator_permit: 1 },
+      { snapshot_date: "2026-08-15", uid: 0, hotkey: "B", validator_permit: 1 },
+    ];
+    const populated = buildTurnover(rows, 64, {
+      window: "1y",
+      startDate: "2026-07-10",
+      endDate: "2026-08-15",
+      requestedDays: 365,
+    }) as Row;
+    assert.equal(populated.covered_days, 36);
+    assert.equal(populated.window_truncated, true);
+    assert.equal(populated.comparable, true);
+
+    // The empty card is where a caller most needs to know the window was not
+    // what they asked for -- an unresolvable comparison and a truncated one
+    // look identical without it.
+    const empty = buildTurnover([], 64, {
+      window: "1y",
+      startDate: null,
+      endDate: null,
+      requestedDays: 365,
+    }) as Row;
+    assert.equal(empty.comparable, false);
+    assert.equal(empty.requested_days, 365);
+    assert.equal(empty.window_truncated, null);
   });
 });

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8108,7 +8108,15 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
             FROM neuron_daily
             WHERE netuid = ${netuid} AND snapshot_date IN (${startDate}, ${endDate})
             ORDER BY snapshot_date ASC, uid ASC`;
-      const turnoverOptions = { window: windowLabel, startDate, endDate };
+      const turnoverOptions = {
+        window: windowLabel,
+        startDate,
+        endDate,
+        // What the caller ASKED for, so the payload can say when the store's
+        // floor cut it short -- see windowCoverage. `all` is null by
+        // construction: it asks for whatever exists.
+        requestedDays: windowDays ?? null,
+      };
       const data = buildTurnover(rows, netuid, turnoverOptions);
       return json(
         includeChanges


### PR DESCRIPTION
## Three different questions, one 36-day answer

Production, SN64, just now:

| request | `start_date` | entered | exited | stability |
|---|---|---|---|---|
| `?window=90d` | 2026-07-10 | 6 | 4 | 68 |
| `?window=1y` | 2026-07-10 | 6 | 4 | 68 |
| `?window=all` | 2026-07-10 | 6 | 4 | 68 |

`neuronDailyWindowBounds` resolves the start as `MIN(snapshot_date) WHERE snapshot_date >= endDate - days`, so a table shallower than the window returns the table's own floor. `neuron_daily` holds 36 days, so **a year-long window is answered with 36 days of data, labelled `"1y"`**.

`start_date` was published — but reading the clamp off it requires already knowing the table's floor. The truncation was *derivable*, not *stated*.

## It is wrong in one direction, which is the bad one

Turnover is entered / exited / Jaccard retention **between the window's endpoints**. A shorter span does not add noise — it reports **lower churn and higher stability**. A subnet that replaced its whole validator set over a year reads as a calm month.

That is a confident wrong answer on the metric the route exists for, which is worse than the empty answer a missing table would give.

## What ships

`covered_days`, `requested_days` and `window_truncated`, on the populated **and** the empty path — an unresolvable comparison and a truncated one are indistinguishable without them.

- **`all` is never flagged.** It asks for whatever exists and cannot be short of itself. It still publishes `covered_days`, which is the number a caller needs when the label carries none.
- **Unresolvable bounds report `null`, never `false`.** Asserting that a window nobody measured was complete is the same confident-wrong shape this module avoids everywhere else.
- A span *longer* than requested is not a truncation either — the bounds resolved to real snapshots and the caller got at least what they asked for.

## Relationship to #10798, and a correction to my own note there

That issue records the retention constraint: pruning `neuron_daily` would silently shorten every window deeper than the new floor. **The shallow table already does it, before any prune** — so this is that defect arriving early, and the fix makes a future prune's effect a number rather than a quieter subnet.

My comment on #10798 proposed *"route the turnover family through `neuron-daily-cold-tier`"*. **That is not achievable where the route lives.** `R2_SQL_TOKEN` is bound to the main Worker in `wrangler.jsonc` and is not on `metagraphed-data-api` (`wrangler.data.jsonc`), so the lakehouse is unreachable from this handler — the fix cannot go where I pointed. Publishing the coverage needs no lakehouse at all.

I will correct that on the issue.

## Not in scope

`movers`, `chain-turnover` and the concentration history offer 90d windows over the same 36-day table and have the same clamp. They are a different builder each and a wider change; this PR fixes the family where the mislabelling is largest — a **year** reported as a month — and where `1y`/`all` exist at all.

## Validation

```
tsc --noEmit                                    clean
eslint + prettier                               clean
npm run build                                   openapi + types regenerated
validate:api/openapi/types/contract-drift, docs,
  single-schema-source, unreferenced-exports,
  schema-shape-duplicates, nullable-overpromises   all pass
vitest turnover, chain-turnover, data-api,
  zod-schemas                                   479 passed (5 new)
```

Refs #10798
