### PR TITLE
feat(cron): lanes run on a declared cadence, not on whichever minute was free

### DIFF
--- a/src/lane-scheduler.ts
+++ b/src/lane-scheduler.ts
@@ -1,0 +1,154 @@
+// Which lanes are due to run on this tick (#10709).
+//
+// ## The failure class this removes
+//
+// `dispatchScheduled` keys on the LITERAL cron string -- `if (cron === X_CRON)`
+// against 38 registered expressions. Two lanes sharing an expression means the
+// first branch wins and the second silently never runs, which is the shape
+// #10566, #10680 and #10548 all turned out to be. A lane therefore needed its
+// own minute, and the hourly grid was 97% full: accounting for the `*/5` and
+// `*/15` expressions, exactly THREE every-hour minutes were free (17, 24, 56).
+//
+// #10715 took the first half of the fix -- one heartbeat expression, and a lane
+// registry (`LANE_PRODUCERS`) that a new lane joins instead of the grid. This
+// module is the second half: a lane declares HOW OFTEN it wants to run, and the
+// dispatcher runs whichever lanes are due. "How often" stops being a function of
+// "which minute is free".
+//
+// ## The tick grid quantises every cadence, and that is not a bug to hide
+//
+// A lane cannot run more often than the dispatcher ticks. Declaring
+// `everyMinutes: 5` against an hourly grid does not produce a 5-minute lane; it
+// produces a lane that runs on every tick. The registry is a request for a
+// cadence FLOOR, never a promise of one, and `everyMinutes` below the tick
+// interval is the caller asking for "every tick".
+//
+// This matters because the free minutes are unevenly spaced. A widened grid of
+// {17, 26, 56} has gaps of 9, 30 and 21 minutes, so a lane declaring 15 minutes
+// would run at :17 and :56 -- twice an hour, unevenly -- not four times. Sizing
+// a cadence against the grid is the caller's job; this module only answers
+// "has enough time passed".
+//
+// ## Extra ticks are RETRIES, not extra runs
+//
+// This is the reason widening the grid is worth anything while every registered
+// lane is hourly. Without a cadence gate, three ticks an hour would run every
+// lane three times an hour. With one, a lane that ran at :26 is simply not due
+// at :56, and the extra ticks cost a single last-run read.
+//
+// What they buy is recovery. If the :26 tick fails -- a Worker error, a deploy
+// window, a cold start that timed out -- the lane used to wait a full hour for
+// its one clock to come round again. Now :56 sees an elapsed of 90 minutes and
+// runs it. The gate converts spare capacity on the grid into a shorter worst
+// case, without changing the steady-state rate.
+
+/** A lane that declares its own cadence instead of taking a cron minute. */
+export interface ScheduledLane {
+  /** Matches the `lane` column in `lane_health`, which is where last-run comes
+   * from. A name that does not match means the lane reads as never-run and
+   * therefore runs every tick -- loud, not silent, which is the intended way
+   * round for a typo. */
+  name: string;
+  /** Requested cadence FLOOR in minutes. Quantised up to the tick grid (see the
+   * header): this is "not more often than", never "exactly every". */
+  everyMinutes: number;
+}
+
+/**
+ * How early a lane may run before its cadence has strictly elapsed.
+ *
+ * WITHOUT this, the gate halves the rate of any lane whose cadence equals the
+ * tick interval. Cron delivery is not to-the-millisecond: an hourly lane that
+ * ran at 12:26:04 and is re-checked at 13:26:01 has an elapsed of 59m57s, which
+ * is less than 60 minutes, so it would be skipped -- and the next tick is a full
+ * interval away. An hourly lane silently becomes two-hourly, and the symptom is
+ * a staleness watchdog firing at roughly double the declared cadence.
+ *
+ * Four minutes, sized against the GRID rather than against the jitter: it has to
+ * be comfortably larger than any plausible delivery skew, and strictly smaller
+ * than the smallest gap between two ticks (9 minutes, :17 to :26) or a lane
+ * could satisfy its cadence on two consecutive ticks and run twice.
+ */
+export const LANE_DUE_TOLERANCE_MS = 4 * 60 * 1000;
+
+/**
+ * Reduce a `lane_health` snapshot to the last-run map `lanesDue` wants.
+ *
+ * Pure, and here rather than inline in the dispatcher, because `workers/api.ts`
+ * is where an untested branch hides best: a loop over a store result inside a
+ * cron branch is reachable only with a live Postgres handle. As a function it is
+ * exercised directly.
+ *
+ * `checked_at` is only a LAST-RUN stamp for lanes that write it at the moment
+ * they run. Several lanes stamp their producer's pass time instead, which
+ * freezes while the producer is down -- feeding those to `lanesDue` would read a
+ * dead lane as permanently overdue. Callers must know which they have.
+ */
+export function lastRunFromLaneHealth(
+  health: Readonly<
+    Record<string, { checked_at?: number | null } | null | undefined>
+  >,
+): Record<string, number> {
+  const lastRun: Record<string, number> = {};
+  for (const [lane, record] of Object.entries(health ?? {})) {
+    const stamp = record?.checked_at;
+    // Anything unusable is OMITTED rather than defaulted, so the lane reads as
+    // never-run and `lanesDue` returns it. Writing a 0 here would say the same
+    // thing by accident; leaving it out says it on purpose.
+    if (typeof stamp === "number" && Number.isFinite(stamp) && stamp > 0) {
+      lastRun[lane] = stamp;
+    }
+  }
+  return lastRun;
+}
+
+/**
+ * The lanes that should run on this tick.
+ *
+ * `lastRunMs` maps lane name to the wall-clock time that lane last RAN. It must
+ * come from a source the caller knows is a run stamp -- see the note in
+ * `workers/api.ts` about `lane_health.checked_at`, which is a true run stamp for
+ * the heartbeat's own lanes and is NOT one for lanes stamped with a producer's
+ * pass time.
+ *
+ * ## Every uncertain case resolves to RUNNING
+ *
+ * A missing, zero, non-finite or FUTURE stamp all return the lane as due. That
+ * is deliberate and it is the whole safety argument for putting a gate in front
+ * of 39 producers:
+ *
+ *   - Missing: a newly registered lane, or one whose 90-day history was pruned.
+ *     Waiting a full period to start is a slow silent stop.
+ *   - Future: a clock skew or a bad row. Subtracting gives a negative elapsed,
+ *     which under a strict comparison would stall the lane until real time
+ *     caught up -- potentially forever, with no error anywhere.
+ *
+ * Running a lane sooner than asked costs one extra enqueue. Not running it is
+ * the failure this issue exists to remove, so the gate fails toward running.
+ */
+export function lanesDue<T extends ScheduledLane>(
+  lanes: readonly T[],
+  lastRunMs: Readonly<Record<string, number | null | undefined>>,
+  nowMs: number,
+): T[] {
+  if (!Number.isFinite(nowMs)) return [...lanes];
+  return lanes.filter((lane) => {
+    const last = lastRunMs?.[lane.name];
+    // `<= 0` and not just `== null`: `lane_health.checked_at` reads through
+    // `safeIntOrNull(...) ?? 0`, so a row with an unparseable stamp arrives as a
+    // real 0 rather than as absent, and 0 would otherwise read as "ran at the
+    // epoch" -- which is due anyway, but only by accident of arithmetic.
+    if (typeof last !== "number" || !Number.isFinite(last) || last <= 0) {
+      return true;
+    }
+    const elapsed = nowMs - last;
+    // A future stamp is a broken clock, not a lane that just ran.
+    if (elapsed < 0) return true;
+    const every = lane.everyMinutes;
+    // An absent or nonsensical cadence runs every tick rather than never. Same
+    // polarity as the rest of this function: a registry entry someone forgot to
+    // give a cadence is a lane that runs too often, which is visible.
+    if (!Number.isFinite(every) || every <= 0) return true;
+    return elapsed >= every * 60 * 1000 - LANE_DUE_TOLERANCE_MS;
+  });
+}

--- a/tests/attribution-sweep.test.ts
+++ b/tests/attribution-sweep.test.ts
@@ -359,7 +359,9 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       path.join(repoRoot, "workers/api.ts"),
       "utf8",
     );
-    assert.match(api, /if \(cron === LANE_HEARTBEAT_CRON\) \{/);
+    // Membership since #10709 -- the heartbeat runs on more than one
+    // expression, so equality against a single constant would be the bug.
+    assert.match(api, /if \(LANE_HEARTBEAT_CRONS\.includes\(cron\)\) \{/);
     assert.match(api, /return "lane-heartbeat"/);
   });
 

--- a/tests/lane-scheduler.test.ts
+++ b/tests/lane-scheduler.test.ts
@@ -1,0 +1,336 @@
+// #10709: lanes run on a declared cadence, not on whichever minute was free.
+//
+// The thing under test gates 39 producers. Every assertion here is written from
+// the same premise: the expensive failure is a lane that silently STOPS, so the
+// tests care much more about "does an uncertain input still run" than about
+// "does a due lane run on the exact millisecond".
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import {
+  LANE_DUE_TOLERANCE_MS,
+  lanesDue,
+  lastRunFromLaneHealth,
+  type ScheduledLane,
+} from "../src/lane-scheduler.ts";
+import {
+  LANE_HEARTBEAT_CRON,
+  LANE_HEARTBEAT_CRONS,
+  LANE_HEARTBEAT_EXTRA_CRON,
+} from "../workers/config.ts";
+import { LANE_PRODUCERS } from "../workers/api.ts";
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = 1_760_000_000_000;
+
+const hourly: ScheduledLane[] = [{ name: "a", everyMinutes: 60 }];
+const names = (lanes: readonly ScheduledLane[]) => lanes.map((l) => l.name);
+
+describe("lanesDue — the steady state", () => {
+  test("a lane that just ran is not due again", () => {
+    assert.deepEqual(names(lanesDue(hourly, { a: NOW - 60_000 }, NOW)), []);
+  });
+
+  test("a lane whose cadence has elapsed is due", () => {
+    assert.deepEqual(names(lanesDue(hourly, { a: NOW - HOUR_MS }, NOW)), ["a"]);
+  });
+
+  test("lanes are filtered independently, not all-or-nothing", () => {
+    // The point of a registry is that one lane being due says nothing about
+    // another. A gate that ran all-or-none would reintroduce the coupling the
+    // shared heartbeat had before cadences existed.
+    const lanes: ScheduledLane[] = [
+      { name: "hourly", everyMinutes: 60 },
+      { name: "daily", everyMinutes: 1440 },
+    ];
+    const lastRun = { hourly: NOW - HOUR_MS, daily: NOW - HOUR_MS };
+    assert.deepEqual(names(lanesDue(lanes, lastRun, NOW)), ["hourly"]);
+  });
+
+  test("an empty registry yields nothing rather than throwing", () => {
+    assert.deepEqual(lanesDue([], {}, NOW), []);
+  });
+});
+
+describe("lanesDue — tolerance, and why it is not zero", () => {
+  // WITHOUT tolerance an hourly lane silently becomes two-hourly: cron delivery
+  // is not to-the-millisecond, so an elapsed of 59m57s fails a strict >= 60min
+  // and the next tick is a full interval away. This is the regression test for
+  // that, and it is the reason LANE_DUE_TOLERANCE_MS exists at all.
+  test("a lane arriving a few seconds early still runs", () => {
+    const lastRun = { a: NOW - (HOUR_MS - 3_000) };
+    assert.deepEqual(names(lanesDue(hourly, lastRun, NOW)), ["a"]);
+  });
+
+  test("exactly at the tolerance boundary is due", () => {
+    const lastRun = { a: NOW - (HOUR_MS - LANE_DUE_TOLERANCE_MS) };
+    assert.deepEqual(names(lanesDue(hourly, lastRun, NOW)), ["a"]);
+  });
+
+  test("one millisecond inside the boundary is NOT due", () => {
+    // The other side of the same boundary. Without this, a tolerance of
+    // `everyMinutes` would pass every test above and gate nothing.
+    const lastRun = { a: NOW - (HOUR_MS - LANE_DUE_TOLERANCE_MS - 1) };
+    assert.deepEqual(names(lanesDue(hourly, lastRun, NOW)), []);
+  });
+
+  test("tolerance is smaller than the smallest gap between two ticks", () => {
+    // A tolerance wider than the gap between two ticks lets a lane come due on
+    // both of them and run twice. Derived from the registered expressions
+    // rather than restated, so widening the grid cannot quietly invalidate it.
+    const minutes = LANE_HEARTBEAT_CRONS.flatMap((cron) =>
+      cron.split(/\s+/)[0].split(",").map(Number),
+    ).sort((a, b) => a - b);
+    assert.ok(minutes.length >= 2, "expected a multi-tick grid");
+    let smallestGap = 60 - minutes[minutes.length - 1] + minutes[0];
+    for (let i = 1; i < minutes.length; i += 1) {
+      smallestGap = Math.min(smallestGap, minutes[i] - minutes[i - 1]);
+    }
+    assert.ok(
+      LANE_DUE_TOLERANCE_MS < smallestGap * 60 * 1000,
+      `tolerance ${LANE_DUE_TOLERANCE_MS}ms is not below the ${smallestGap}min gap`,
+    );
+  });
+});
+
+describe("lanesDue — every uncertain input resolves to RUNNING", () => {
+  // This block is the safety argument. A gate in front of 39 producers must
+  // fail toward running: an extra enqueue costs one queue message, a missed one
+  // is the silent stop #10566, #10680 and #10548 all turned out to be.
+  test("a lane with no last-run entry runs", () => {
+    assert.deepEqual(names(lanesDue(hourly, {}, NOW)), ["a"]);
+  });
+
+  test("an explicit null or undefined last-run runs", () => {
+    assert.deepEqual(names(lanesDue(hourly, { a: null }, NOW)), ["a"]);
+    assert.deepEqual(names(lanesDue(hourly, { a: undefined }, NOW)), ["a"]);
+  });
+
+  test("a zero last-run runs rather than reading as the epoch", () => {
+    // lane_health reads checked_at through `safeIntOrNull(...) ?? 0`, so an
+    // unparseable stamp arrives as a real 0, not as absent.
+    assert.deepEqual(names(lanesDue(hourly, { a: 0 }, NOW)), ["a"]);
+  });
+
+  test("a NaN last-run runs", () => {
+    assert.deepEqual(names(lanesDue(hourly, { a: NaN }, NOW)), ["a"]);
+  });
+
+  test("a FUTURE last-run runs instead of stalling until time catches up", () => {
+    // Clock skew or a bad row. Under a strict comparison a stamp an hour in the
+    // future would park the lane for an hour with no error anywhere.
+    assert.deepEqual(names(lanesDue(hourly, { a: NOW + HOUR_MS }, NOW)), ["a"]);
+  });
+
+  test("a lane with a missing or nonsensical cadence runs every tick", () => {
+    const broken = [
+      { name: "a", everyMinutes: 0 },
+      { name: "b", everyMinutes: -5 },
+      { name: "c" } as ScheduledLane,
+    ];
+    const lastRun = { a: NOW - 1, b: NOW - 1, c: NOW - 1 };
+    assert.deepEqual(names(lanesDue(broken, lastRun, NOW)), ["a", "b", "c"]);
+  });
+
+  test("a non-finite now runs everything", () => {
+    // Nothing can be decided without a clock, so the answer is "run", and the
+    // returned array is a copy rather than the caller's own registry.
+    const out = lanesDue(hourly, { a: NOW }, Number.NaN);
+    assert.deepEqual(names(out), ["a"]);
+    assert.notEqual(out, hourly);
+  });
+
+  test("a lane name that matches no health row runs", () => {
+    // A renamed lane reads as never-run, so it runs too often rather than never
+    // — the loud direction for a typo.
+    assert.deepEqual(names(lanesDue(hourly, { different: NOW }, NOW)), ["a"]);
+  });
+});
+
+describe("lastRunFromLaneHealth — omit rather than default", () => {
+  test("a usable stamp is carried through", () => {
+    const out = lastRunFromLaneHealth({ a: { checked_at: NOW } });
+    assert.deepEqual(out, { a: NOW });
+  });
+
+  test("every unusable stamp is OMITTED, so the lane reads as never-run", () => {
+    // Omitted rather than zeroed. Both make `lanesDue` return the lane, but a 0
+    // says it by accident of arithmetic and would survive a later change to the
+    // comparison; an absent key says it on purpose.
+    const out = lastRunFromLaneHealth({
+      zero: { checked_at: 0 },
+      negative: { checked_at: -1 },
+      nan: { checked_at: Number.NaN },
+      nullish: { checked_at: null },
+      missing: {},
+      nullRecord: null,
+      undefinedRecord: undefined,
+    });
+    assert.deepEqual(out, {});
+  });
+
+  test("an empty or nullish snapshot yields an empty map", () => {
+    // loadLatestLaneHealth returns {} on ANY store failure, so this is the
+    // degraded path: no stamps, every lane due, pre-#10709 behaviour.
+    assert.deepEqual(lastRunFromLaneHealth({}), {});
+    assert.deepEqual(
+      lastRunFromLaneHealth(
+        undefined as unknown as Record<string, { checked_at?: number }>,
+      ),
+      {},
+    );
+  });
+
+  test("a failed lane-health read runs every lane, never none", () => {
+    // The composed property, and the one that matters: a broken store must
+    // degrade to running everything. The opposite polarity would let one failed
+    // query silently stop all four producers.
+    const lastRun = lastRunFromLaneHealth({});
+    assert.deepEqual(names(lanesDue(LANE_PRODUCERS, lastRun, NOW)), [
+      ...LANE_PRODUCERS.map((l) => l.name),
+    ]);
+  });
+});
+
+describe("the registry — every lane keeps a path to run", () => {
+  // #10709's own acceptance criterion: a gate proving every registered lane is
+  // still reachable, and that the set has not shrunk.
+  test("every registered producer declares a usable cadence", () => {
+    for (const lane of LANE_PRODUCERS) {
+      assert.ok(lane.name, "a producer has no name");
+      assert.equal(
+        typeof lane.everyMinutes,
+        "number",
+        `${lane.name} has no everyMinutes`,
+      );
+      assert.ok(
+        Number.isFinite(lane.everyMinutes) && lane.everyMinutes > 0,
+        `${lane.name} has a nonsensical cadence`,
+      );
+      assert.equal(typeof lane.enqueue, "function");
+    }
+  });
+
+  test("the registry has not shrunk", () => {
+    // Named rather than counted: a count passes when one lane is swapped for
+    // another, which is the migration mistake worth catching.
+    assert.deepEqual(
+      [...LANE_PRODUCERS.map((l) => l.name)].sort(),
+      [
+        "attribution-sweep",
+        "compute-declarations",
+        "origin-reachability",
+        "revenue-probe",
+      ],
+      "a lane left LANE_PRODUCERS — it now has no clock at all",
+    );
+  });
+
+  test("no lane declares a cadence finer than the grid can deliver", () => {
+    // Declaring 5 minutes against a grid whose tightest gap is 9 does not make
+    // a 5-minute lane; it makes a lane that runs every tick while reading as
+    // though it were faster. Caught here rather than discovered in a dashboard.
+    const minutes = LANE_HEARTBEAT_CRONS.flatMap((cron) =>
+      cron.split(/\s+/)[0].split(",").map(Number),
+    ).sort((a, b) => a - b);
+    let smallestGap = 60 - minutes[minutes.length - 1] + minutes[0];
+    for (let i = 1; i < minutes.length; i += 1) {
+      smallestGap = Math.min(smallestGap, minutes[i] - minutes[i - 1]);
+    }
+    for (const lane of LANE_PRODUCERS) {
+      assert.ok(
+        lane.everyMinutes >= smallestGap,
+        `${lane.name} wants ${lane.everyMinutes}min, finer than the ${smallestGap}min grid`,
+      );
+    }
+  });
+
+  test("every lane is reachable from a tick within its own cadence", () => {
+    // The end-to-end property, replayed against the real grid: step a whole day
+    // of ticks and assert each lane actually comes up. A cadence nothing can
+    // satisfy is a lane that never runs, which is the failure being removed.
+    const ticks: number[] = [];
+    const minutes = LANE_HEARTBEAT_CRONS.flatMap((cron) =>
+      cron.split(/\s+/)[0].split(",").map(Number),
+    ).sort((a, b) => a - b);
+    for (let hour = 0; hour < 24; hour += 1) {
+      for (const minute of minutes) {
+        ticks.push(NOW + hour * HOUR_MS + minute * 60_000);
+      }
+    }
+    const lastRun: Record<string, number> = {};
+    const runs: Record<string, number> = {};
+    for (const tick of ticks) {
+      for (const lane of lanesDue(LANE_PRODUCERS, lastRun, tick)) {
+        lastRun[lane.name] = tick;
+        runs[lane.name] = (runs[lane.name] ?? 0) + 1;
+      }
+    }
+    for (const lane of LANE_PRODUCERS) {
+      // Hourly lanes over 24h of ticks: at least 20 runs, and never once per
+      // tick (which would mean the gate is not gating).
+      assert.ok(
+        (runs[lane.name] ?? 0) >= 20,
+        `${lane.name} ran only ${runs[lane.name] ?? 0} times in a day`,
+      );
+      assert.ok(
+        (runs[lane.name] ?? 0) < ticks.length,
+        `${lane.name} ran on every tick — the cadence gate is not gating`,
+      );
+    }
+  });
+});
+
+describe("the wiring — the grid is registered and dispatch matches all of it", () => {
+  test("every heartbeat expression is a registered trigger", async () => {
+    const wrangler = await fs.readFile(
+      path.join(repoRoot, "wrangler.jsonc"),
+      "utf8",
+    );
+    for (const cron of LANE_HEARTBEAT_CRONS) {
+      assert.ok(
+        wrangler.includes(`"${cron}"`),
+        `${cron} is not in wrangler.jsonc triggers.crons — it will never fire`,
+      );
+    }
+  });
+
+  test("the original expression is still in the set", () => {
+    // The migration's whole safety property: minute 26 is the expression the
+    // account already has registered, so code deployed before a triggers deploy
+    // still runs the heartbeat. Removing it from this set is what would create
+    // the silent window.
+    assert.ok(LANE_HEARTBEAT_CRONS.includes(LANE_HEARTBEAT_CRON));
+    assert.equal(LANE_HEARTBEAT_CRON, "26 * * * *");
+    assert.ok(LANE_HEARTBEAT_CRONS.includes(LANE_HEARTBEAT_EXTRA_CRON));
+  });
+
+  test("the expressions are distinct and share no minute", () => {
+    // Two heartbeat expressions firing in the same minute would run the lanes
+    // twice concurrently. Distinctness is also what the literal-string dispatch
+    // requires of every registered cron.
+    assert.equal(
+      new Set(LANE_HEARTBEAT_CRONS).size,
+      LANE_HEARTBEAT_CRONS.length,
+    );
+    const minutes = LANE_HEARTBEAT_CRONS.flatMap((cron) =>
+      cron.split(/\s+/)[0].split(","),
+    );
+    assert.equal(new Set(minutes).size, minutes.length);
+  });
+
+  test("dispatch tests membership rather than equality", async () => {
+    const api = await fs.readFile(
+      path.join(repoRoot, "workers/api.ts"),
+      "utf8",
+    );
+    assert.match(api, /if \(LANE_HEARTBEAT_CRONS\.includes\(cron\)\) \{/);
+    // The old shape, explicitly. An equality check against one constant would
+    // silently ignore every other expression on the grid.
+    assert.doesNotMatch(api, /if \(cron === LANE_HEARTBEAT_CRON\) \{/);
+  });
+});

--- a/tests/origin-reachability.test.ts
+++ b/tests/origin-reachability.test.ts
@@ -425,7 +425,9 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       path.join(repoRoot, "workers/api.ts"),
       "utf8",
     );
-    assert.match(api, /if \(cron === LANE_HEARTBEAT_CRON\) \{/);
+    // Membership since #10709 -- the heartbeat runs on more than one
+    // expression, so equality against a single constant would be the bug.
+    assert.match(api, /if \(LANE_HEARTBEAT_CRONS\.includes\(cron\)\) \{/);
     assert.match(api, /return "lane-heartbeat"/);
   });
 

--- a/tests/revenue-observations.test.ts
+++ b/tests/revenue-observations.test.ts
@@ -777,7 +777,9 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       path.join(repoRoot, "workers/api.ts"),
       "utf8",
     );
-    assert.match(api, /if \(cron === LANE_HEARTBEAT_CRON\) \{/);
+    // Membership since #10709 -- the heartbeat runs on more than one
+    // expression, so equality against a single constant would be the bug.
+    assert.match(api, /if \(LANE_HEARTBEAT_CRONS\.includes\(cron\)\) \{/);
     assert.match(api, /return "lane-heartbeat"/);
   });
 

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -167,10 +167,16 @@ import {
   shouldRecordTraceSpan,
 } from "../src/tracing.ts";
 import {
+  loadLatestLaneHealth,
   recordLaneVerdict,
   type LaneHealthDb,
   type LaneVerdict,
 } from "../src/lane-health.ts";
+import {
+  lanesDue,
+  lastRunFromLaneHealth,
+  type ScheduledLane,
+} from "../src/lane-scheduler.ts";
 import {
   handleDeadLetterBatch,
   isDeadLetterQueue,
@@ -722,7 +728,7 @@ import {
   GOVERNANCE_CONFIG_CHANGES_PATH_PATTERN,
   HEALTH_PROBER_CRON,
   HEALTH_PRUNE_CRON,
-  LANE_HEARTBEAT_CRON,
+  LANE_HEARTBEAT_CRONS,
   INCIDENTS_PATH_PATTERN,
   JSON_CONTENT_TYPE,
   MAX_ASK_BODY_BYTES,
@@ -2844,7 +2850,11 @@ export { composeCompareData } from "./request-handlers/analytics-routes.ts";
 // is the shape #9001 removed elsewhere, and a name survives a schedule change
 // where "0 * * * *" does not.
 function cronLabel(cron: string): string {
-  if (cron === LANE_HEARTBEAT_CRON) return "lane-heartbeat";
+  // Membership, not equality: the heartbeat runs on more than one expression
+  // (see LANE_HEARTBEAT_CRONS), and every one of them is the same lane for
+  // reporting purposes -- a per-expression label would split one lane's cron
+  // outcomes across three series.
+  if (LANE_HEARTBEAT_CRONS.includes(cron)) return "lane-heartbeat";
   if (cron === HEALTH_PRUNE_CRON) return "health-prune";
   if (cron === EMBEDDING_SYNC_CRON) return "embedding-sync";
   if (cron === GITHUB_SIGNALS_SYNC_CRON) return "github-signals-sync";
@@ -3283,12 +3293,29 @@ export function laneHeartbeatVerdict(result: {
   };
 }
 
-export const LANE_PRODUCERS: ReadonlyArray<{
-  name: string;
-  enqueue: (env: Env) => Promise<EnqueueResult>;
-}> = [
+/**
+ * Every queue-backed lane, with the cadence it wants (#10709).
+ *
+ * Typed as the scheduler's own `ScheduledLane` rather than restating `name` and
+ * `everyMinutes` here, so a lane cannot be registered in a shape `lanesDue`
+ * would not understand.
+ *
+ * `everyMinutes` is a FLOOR quantised up to the tick grid, never an exact
+ * period -- see src/lane-scheduler.ts. All four are hourly today, matching the
+ * dedicated crons they replaced, so the widened grid changes nothing about how
+ * often any of them runs; it only shortens the wait when a tick fails.
+ */
+export const LANE_PRODUCERS: ReadonlyArray<
+  ScheduledLane & {
+    enqueue: (env: Env) => Promise<EnqueueResult>;
+  }
+> = [
   {
     name: "attribution-sweep",
+    // Hourly with a SLICE of the eight least-recently-swept subnets: a full
+    // pass over 129 subnets x up to 8 sources is ~1000 outbound requests, so
+    // the cadence is what keeps a pass inside a day without ever bursting.
+    everyMinutes: 60,
     enqueue: async (env) =>
       enqueueSweeps(
         env.PROBE_JOBS,
@@ -3297,6 +3324,8 @@ export const LANE_PRODUCERS: ReadonlyArray<{
   },
   {
     name: "origin-reachability",
+    // Hourly, also a slice: 277 origins x up to 3 samples is ~800 requests.
+    everyMinutes: 60,
     enqueue: async (env) =>
       enqueueOriginChecks(env.PROBE_JOBS, [
         ...surfacesByOrigin(await registeredSurfaces(env)).keys(),
@@ -3307,6 +3336,7 @@ export const LANE_PRODUCERS: ReadonlyArray<{
     // The surface list is the registry's, read the same way the origin lane
     // reads it -- so a declaration surface added by a contributor PR joins the
     // lane on the next tick with nothing else to change.
+    everyMinutes: 60,
     enqueue: async (env) =>
       enqueueComputeDeclarations(
         env.PROBE_JOBS,
@@ -3315,6 +3345,11 @@ export const LANE_PRODUCERS: ReadonlyArray<{
   },
   {
     name: "revenue-probe",
+    // Hourly for CITIZENSHIP rather than freshness -- these are a small team's
+    // billing endpoints. SN64's `daily_revenue_summary` restates the current
+    // day all day, so an hourly pass settles each day's final value where a
+    // daily snapshot would freeze whatever it read mid-afternoon.
+    everyMinutes: 60,
     enqueue: async (env) => {
       const artifact = await readArtifact(
         env,
@@ -3411,7 +3446,7 @@ export const API_HANDLED_CRONS: readonly string[] = [
   WEBHOOK_DISPATCH_CRON,
   HEALTH_PRUNE_CRON,
   EMBEDDING_SYNC_CRON,
-  LANE_HEARTBEAT_CRON,
+  ...LANE_HEARTBEAT_CRONS,
   SUBNET_BURN_CAPTURE_CRON,
   RAW_CAPTURE_CRON,
   GITHUB_SIGNALS_SYNC_CRON,
@@ -3523,15 +3558,43 @@ async function dispatchScheduled(
   if (cron === EMBEDDING_SYNC_CRON) {
     return runEmbeddingSync(env, { readArtifact });
   }
-  if (cron === LANE_HEARTBEAT_CRON) {
+  if (LANE_HEARTBEAT_CRONS.includes(cron)) {
     // ONE clock for every queue-backed lane (#10715). Each producer reads a
     // list and enqueues it -- no fetching, no store handle -- so running them
     // together costs one artifact read each and nothing else.
     //
     // A new lane is added to LANE_PRODUCERS, not to the cron grid. The three
     // this replaced took three of the two minutes that were still free.
+    //
+    // #10709: the grid ticks more often than any lane wants, so the lanes are
+    // filtered to those actually DUE. `lane_health.checked_at` is the last-run
+    // stamp, and for THESE lanes it genuinely is one -- the verdict write below
+    // stamps `Date.now()` at the moment the heartbeat ran. That is not true of
+    // lane_health generally: several lanes are stamped with their producer's
+    // pass time, which freezes while the producer is down, so this read must
+    // never be generalised into "ask lane_health when anything last ran".
+    //
+    // A FAILED READ RUNS EVERYTHING. loadLatestLaneHealth returns `{}` on any
+    // error, every lane then reads as never-run, and `lanesDue` returns them
+    // all -- so a broken store degrades to the pre-#10709 behaviour of running
+    // every lane every tick. The opposite polarity would let one failed query
+    // silently stop all four producers, which is the exact class of failure
+    // this issue exists to remove.
+    const due = lanesDue(
+      LANE_PRODUCERS,
+      lastRunFromLaneHealth(await loadLatestLaneHealth(laneHealthStore(env))),
+      Date.now(),
+    );
+    // NOTHING DUE NEEDS NO SPECIAL CASE, and deliberately does not get one. On a
+    // widened grid most ticks legitimately have no work, and every step below
+    // already does the right thing on an empty list: the verdict writes map over
+    // `results`, so a lane that did not run is not stamped -- which matters,
+    // because a fresh `checked_at` on a lane that never ran would push its next
+    // due time out by a tick and starve it. `[].every()` is `true`, so an idle
+    // tick reports ok. An early return here would only add a branch reachable
+    // solely with a live Postgres handle.
     const results = await Promise.all(
-      LANE_PRODUCERS.map(async (lane) => ({
+      due.map(async (lane) => ({
         lane: lane.name,
         ...(await lane.enqueue(env)),
       })),
@@ -3567,6 +3630,9 @@ async function dispatchScheduled(
     return {
       ok: results.every((r) => r.ok),
       lanes: results,
+      // How many were gated out, so a tick that ran two of four is readable as
+      // "two were not due" rather than as two lanes having gone missing.
+      skipped: LANE_PRODUCERS.length - results.length,
     };
   }
   if (cron === SUBNET_BURN_CAPTURE_CRON) {

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -107,32 +107,6 @@ export const SELF_HEALTH_PROBE_CRON =
  */
 export const SUBNET_BURN_CAPTURE_CRON = "1,16,31,46 * * * *";
 
-/**
- * The revenue probe lane (#10566).
- *
- * src/revenue-probe.ts shipped in #10444 with NO caller -- no worker imported
- * it and no config carried a trigger -- so `revenue_observations` was never
- * written and every revenue route reported null for all 129 subnets. Nothing
- * failed, because the epic's own rule is that absent revenue serialises as null
- * rather than zero, which is exactly what a dead producer looks like.
- *
- * Minute 24 is one of only TWO free on the hourly grid (24 and 56), computed
- * from the full trigger list in wrangler.jsonc rather than guessed.
- *
- * HOURLY, not the 15-minute probe grid. Four surfaces are eligible today --
- * three on SN64, one on SN51 -- and these are a small team's BILLING endpoints,
- * which the lane's own header calls out: a lane that hammers them is a bad
- * citizen. Hourly is chosen for correctness rather than freshness: SN64's
- * `daily_revenue_summary` restates the current day all day, so an hourly pass
- * settles each day's final value, where a single daily snapshot would capture
- * whatever the figure happened to be mid-afternoon and store it as the day. 4
- * surfaces x 24 = 96 requests/day.
- *
- * THE TRIGGER MUST BE DEPLOYED SEPARATELY. Workers Builds ships code but not
- * cron triggers, so this expression needs a `wrangler triggers deploy` or the
- * lane silently never fires -- which is indistinguishable from the state it was
- * added to fix.
- */
 /** #10715: ONE producer heartbeat for every queue-backed lane.
  *
  * Replaces three per-lane crons -- the attribution sweep, the origin
@@ -145,36 +119,58 @@ export const SUBNET_BURN_CAPTURE_CRON = "1,16,31,46 * * * *";
  * A new lane joins LANE_PRODUCERS, not this grid. That is the property worth
  * having: the next lane needs no minute at all.
  *
- * Hourly, matching what the three replaced. Minute 26 was one of only two still
- * free; retiring the others returns 17, 24 and 56 to the pool.
+ * Minute 26 was one of only two still free; retiring the others returned 17, 24
+ * and 56 to the pool. Recomputed from the full trigger list 2026-08-15,
+ * accounting for the `*\/5` and `*\/15` expressions that the earlier count
+ * missed: 17, 24 and 56 are the ONLY free every-hour minutes.
+ *
+ * WHAT EACH RETIRED LANE'S CADENCE WAS FOR, since the comments that carried this
+ * outlived their constants and were describing minutes nobody owns any more:
+ *   - revenue-probe: hourly for CITIZENSHIP, not freshness. These are a small
+ *     team's billing endpoints. SN64's `daily_revenue_summary` restates the
+ *     current day all day, so an hourly pass settles each day's final value
+ *     where a daily snapshot would freeze whatever it read mid-afternoon.
+ *   - attribution-sweep: hourly with a SLICE. 129 subnets x up to 8 sources is
+ *     ~1000 outbound requests, which is not a tick; the lane takes the eight
+ *     least-recently-swept, so a full pass lands inside a day and never bursts.
+ *   - origin-reachability: hourly with a SLICE. 277 origins x up to 3 samples is
+ *     ~800 requests, already down from the ~2700 a per-surface pass would cost.
  */
 export const LANE_HEARTBEAT_CRON = "26 * * * *";
 
-/** #10489-#10509: the attribution sweep.
+/**
+ * The rest of the heartbeat grid (#10709), spending the minutes the retired
+ * per-lane crons gave back.
  *
- * Minute 56 is the other free slot on the hourly grid (24 went to the revenue
- * probe). Hourly with a SLICE rather than daily with a full pass: 129 subnets x
- * up to 8 sources is ~1000 outbound requests, which is not a tick. The lane
- * takes the eight least-recently-swept each hour, so a full pass lands inside a
- * day and never bursts. */
+ * A SECOND EXPRESSION RATHER THAN A WIDER FIRST ONE, deliberately. Dispatch
+ * compares the literal string, and Workers Builds ships code without applying
+ * cron triggers -- so editing LANE_HEARTBEAT_CRON to "17,26,56 * * * *" would
+ * deploy code that matches an expression the account has not registered, and the
+ * heartbeat would stop dead until someone ran `wrangler triggers deploy`. Every
+ * queue-backed lane would go silent, which is precisely the failure #10709
+ * exists to remove. Adding an expression is safe in both orders: until the
+ * trigger is deployed it simply never fires, and minute 26 carries the lanes
+ * exactly as it does today.
+ *
+ * 24 is left FREE on purpose -- the last slot on the grid, kept for a lane that
+ * genuinely cannot be expressed as a cadence. It would also sit two minutes
+ * after 26, and LANE_DUE_TOLERANCE_MS has to stay below the smallest gap between
+ * ticks or a lane could come due on two consecutive ones.
+ *
+ * These extra ticks do NOT make any lane run more often -- `lanesDue` gates on
+ * declared cadence, and every registered lane is hourly. They shorten the worst
+ * case when a tick fails: a lane that missed :26 runs at :56 instead of waiting
+ * a full hour. See src/lane-scheduler.ts.
+ */
+export const LANE_HEARTBEAT_EXTRA_CRON = "17,56 * * * *";
 
-/** #10548: the origin-reachability lane.
- *
- * Minute 17 -- one of only TWO minutes still free on this grid (17 and 26; the
- * other 58 are taken, and dispatch keys on the literal string so a duplicate
- * silently routes one lane into another lane's branch). Hourly rather than the
- * twice-hourly this wanted, because there is no free pair left. A
- * SLICE per tick: 277 distinct origins x up to 3 samples is ~800 requests, and
- * one check per ORIGIN already replaces the ~2700 a per-surface pass would
- * cost. Twice-hourly rather than hourly because a deleted host is not urgent to
- * catch within the hour -- it is urgent to catch AT ALL, which is what
- * probe.enabled:false prevented.
- *
- * THE GRID IS 97% FULL AND THIS IS THE SECOND-TO-LAST SLOT. Keying dispatch on
- * the literal cron string does not scale past 60 lanes, and the next one after
- * 26 has nowhere to go. The fix is a single dispatcher cron running whichever
- * lanes are due from a declared cadence -- which decouples "how often" from
- * "which minute is free" and removes this whole failure class. */
+/** Every expression that dispatches the lane heartbeat. Dispatch tests
+ * membership rather than equality so the grid can be widened by appending, with
+ * no window where the deployed triggers and the deployed code disagree. */
+export const LANE_HEARTBEAT_CRONS: readonly string[] = [
+  LANE_HEARTBEAT_CRON,
+  LANE_HEARTBEAT_EXTRA_CRON,
+];
 
 // The remaining three machine-data lanes (#9096), moved off their retired
 // GitHub Actions sync workflows onto Worker-native crons writing their R2

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1210,6 +1210,18 @@
       // cron triggers; this one needs `wrangler triggers deploy` or nothing
       // fires.
       "26 * * * *",
+      // 17,56 = the rest of the heartbeat grid (#10709). The lanes are gated on
+      // a declared cadence (src/lane-scheduler.ts), so these ticks do NOT make
+      // any lane run more often -- every registered lane is hourly. They exist
+      // so a lane that missed :26 runs at :56 instead of waiting a full hour.
+      // 24 is deliberately left free as the last slot on the grid.
+      //
+      // A SEPARATE expression rather than widening "26 * * * *": dispatch
+      // compares the literal string, so editing that one would deploy code
+      // matching an expression the account has not registered yet, and every
+      // queue-backed lane would go silent until the triggers deploy landed.
+      // Appending is safe in either order.
+      "17,56 * * * *",
       "54 * * * *",
     ],
   },


### PR DESCRIPTION
Closes #10709

## The constraint, recomputed

`dispatchScheduled` keys on the **literal cron string**, so a lane needs its own minute or it silently routes into another lane's branch. The issue put the free count at two. Measured against the full trigger list, accounting for the `*/5` and `*/15` expressions the earlier count missed:

```
every-hour expressions: 25 of 38 triggers
genuinely free minutes: 17, 24, 56
```

#10715 took the first half of the fix — one heartbeat expression, and a registry (`LANE_PRODUCERS`) a lane joins instead of the grid. But it runs **all four lanes on every tick**: there is no cadence, so "how often" is still whatever the grid does.

## What this adds

`src/lane-scheduler.ts` — `lanesDue(lanes, lastRun, now)`, pure. A lane declares `everyMinutes`; the dispatcher runs the ones actually due.

The grid widens to `{17, 26, 56}`. **24 is deliberately left free** as the last slot for a lane that genuinely cannot be expressed as a cadence.

Widening does **not** make any lane run more often — all four are hourly and the gate holds them there. It shortens the worst case when a tick fails: a lane that missed :26 runs at :56 instead of waiting a full hour. **Extra ticks become retries, not extra runs.** That is the whole reason widening buys anything while every lane is hourly.

## The migration is additive, on purpose

Adding a second expression rather than editing `"26 * * * *"`. Dispatch compares the literal string, and Workers Builds ships code without applying cron triggers — so editing that constant deploys code matching an expression the account has not registered, and **every queue-backed lane goes silent** until a triggers deploy lands. That is precisely the failure this issue exists to remove.

Appending is safe in either order: until the trigger is deployed the new expression simply never fires, and minute 26 carries the lanes exactly as today. Dispatch now tests membership, and a test asserts the original expression is still in the set.

⚠️ `"17,56 * * * *"` needs a `wrangler triggers deploy` to start firing. Nothing breaks until it does.

## Every uncertain input resolves to RUNNING

A gate in front of 39 producers has to fail toward running. Missing, zero, non-finite and **future** stamps, a nonsensical cadence, and a failed lane-health read (`loadLatestLaneHealth` returns `{}`, so every lane reads never-run) all degrade to the pre-change behaviour of running everything.

An extra enqueue costs one queue message. A missed one is the silent stop that #10566, #10680 and #10548 all turned out to be.

## Why the tolerance is not zero

A strict comparison halves the rate of any lane whose cadence equals the tick interval. Cron delivery is not to-the-millisecond: an hourly lane that ran at 12:26:04 and is re-checked at 13:26:01 has elapsed 59m57s, fails `>= 60min`, and the next tick is a full interval away — an hourly lane silently becomes two-hourly.

`LANE_DUE_TOLERANCE_MS` is sized against the **grid**, not the jitter: above any plausible skew, and strictly below the 9-minute gap between :17 and :26, or a lane could come due on two consecutive ticks. A test derives that gap from the registered expressions rather than restating it.

## The last-run source is deliberately not generalised

`lane_health.checked_at` is a true last-run stamp for **these** lanes, because the heartbeat stamps `Date.now()` at the moment it runs. It is **not** one generally — several lanes carry their producer's pass time, which freezes while the producer is down, and feeding those to `lanesDue` would read a dead lane as permanently overdue. `lanesDue` therefore takes an explicit map, and the caller supplies it from a source it knows.

## Tests

28 in `tests/lane-scheduler.test.ts`, including the acceptance criterion the issue asks for: every registered lane has a cadence, the lane set has not shrunk (**by name**, since a count passes when one lane is swapped for another), and a replay of a full day of real ticks proving each lane comes up between 20 and 71 times — the upper bound catching a gate that has stopped gating.

Verified the gate can fail: mutating the comparison to always-true fails 4 tests.

`assert.doesNotMatch` pins the old `cron === LANE_HEARTBEAT_CRON` shape out of the source, so a revert to equality is caught rather than silently ignoring the rest of the grid.

## Also

Folds three doc comments describing retired per-lane crons (minutes 24, 56, 17) back into the heartbeat. They outlived their constants and were documenting minutes nobody owns any more; the cadence rationale each carried is preserved on the lane it belongs to.

## Verification

- `tsc --noEmit` clean
- full suite: **931 files, 21,392 passed, 0 failed**
- patch coverage by diff intersection: **24/24 lines, 24/24 branches, 100%**
- `validate:operations`, `validate:lane-topology`, `validate:unreferenced-modules`, `validate:unreferenced-exports`, `validate:no-hand-written-mjs`, `validate:module-state-resets`, `validate:type-duplicates`, `validate:api` all pass
- `prettier --check` and `eslint` (uncached) clean
