### PR TITLE
fix(cron): the coverage gate read its own comments as cron declarations

### DIFF
--- a/src/tao-usd-index-watchdog.ts
+++ b/src/tao-usd-index-watchdog.ts
@@ -316,11 +316,15 @@ export function evaluateTaoUsdIndex({
  * Load the recent window and record a verdict.
  *
  * Runs on the freshness cron rather than on its own: `tao_usd_index`'s
- * staleness is already checked there, the store is already reachable, and a new
- * cron expression would need `wrangler triggers deploy` to take effect (Workers
- * Builds deploys code, not schedules) -- a deployment step that is easy to
- * forget and silently leaves the watchdog never running, which is the exact
- * failure this issue is about.
+ * staleness is already checked there, and the store is already reachable.
+ *
+ * This previously also cited a manual `wrangler triggers deploy` as a reason.
+ * Measured 2026-08-15, that is false for this Worker -- #11362's new schedule
+ * was created two seconds after the merge deployed, with no manual step (see
+ * workers/config.ts's LANE_HEARTBEAT_EXTRA_CRON note). What still argues
+ * against a dedicated cron is the grid: only three every-hour minutes were
+ * free, and a watchdog that shares a tick with the thing it watches costs none
+ * of them.
  */
 export async function runTaoUsdIndexWatchdog(
   env: unknown,

--- a/tests/api-crons-have-handlers.test.ts
+++ b/tests/api-crons-have-handlers.test.ts
@@ -10,21 +10,89 @@
 // writes surface_checks, surface_status, surface_uptime_daily, subnet_snapshots
 // and lane_health, on whatever cadence the stray expression happened to have.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, test } from "vitest";
 import { API_HANDLED_CRONS } from "../workers/api.ts";
 import { HEALTH_PROBER_CRON } from "../workers/config.ts";
+import { stripJsonComments } from "../scripts/lib.ts";
 
 const CONFIG = "wrangler.jsonc";
 
-/** The cron expressions declared in a wrangler config. JSONC, so parsed rather
- * than JSON.parse'd -- see tests/data-api-crons-have-handlers.test.ts. */
+/**
+ * The cron expressions declared in a wrangler config.
+ *
+ * COMMENTS ARE STRIPPED FIRST, and that is not tidiness. This used to match
+ * every quoted string inside the `crons` block, including quoted text inside
+ * `//` comments -- and the block is heavily commented, one paragraph per lane.
+ *
+ * Both directions were wrong. A comment quoting a phrase that is not a cron
+ * ("Workers Builds does not ...") failed the DECLARED direction on text alone.
+ * Worse, the HANDLED direction builds a Set from this list, so a comment merely
+ * MENTIONING a cron in quotes made that expression look declared -- and a
+ * handled lane whose trigger was never actually registered would have passed,
+ * while silently never firing. That is the exact failure this file exists to
+ * catch, so the parser must not be the thing that hides it.
+ */
 function declaredCrons(path: string): string[] {
-  const source = readFileSync(path, "utf8");
+  const source = stripJsonComments(readFileSync(path, "utf8"));
   const block = /"crons"\s*:\s*\[([\s\S]*?)\]/.exec(source);
   assert.ok(block, `no "crons" array found in ${path}`);
   return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
 }
+
+describe("the parser itself — a comment is not a declaration", () => {
+  // Without these, the two directions below are assertions about prose. The
+  // real `crons` block carries one commented paragraph per lane, so quoted text
+  // inside comments is the normal case, not a contrived one.
+  const fixture = (body: string) => {
+    const file = path.join(
+      os.tmpdir(),
+      `crons-${Math.random().toString(36).slice(2)}.jsonc`,
+    );
+    writeFileSync(file, `{ "triggers": { "crons": [\n${body}\n] } }`);
+    return file;
+  };
+
+  test("a cron quoted inside a // comment is NOT read as declared", () => {
+    // The false-PASS direction, and the dangerous one: `every HANDLED cron is
+    // declared` builds a Set from this list, so a lane whose trigger was never
+    // registered would look scheduled because a comment mentioned it.
+    const file = fixture(
+      `      // renamed from "9,39 * * * *" when the lane moved\n      "26 * * * *",`,
+    );
+    const parsed = declaredCrons(file);
+    assert.deepEqual(parsed, ["26 * * * *"]);
+    unlinkSync(file);
+  });
+
+  test("quoted prose in a comment is not read as a cron", () => {
+    // The false-FAILURE direction: this is what actually broke, on a comment
+    // reading `the blanket "Workers Builds does not ..." note`.
+    const file = fixture(
+      `      // the blanket "Workers Builds does not apply cron triggers" claim\n      "26 * * * *",`,
+    );
+    assert.deepEqual(declaredCrons(file), ["26 * * * *"]);
+    unlinkSync(file);
+  });
+
+  test("a /* block */ comment is stripped too", () => {
+    const file = fixture(
+      `      /* was "1,16,31,46 * * * *" */\n      "26 * * * *",`,
+    );
+    assert.deepEqual(declaredCrons(file), ["26 * * * *"]);
+    unlinkSync(file);
+  });
+
+  test("a real cron containing no comment survives unchanged", () => {
+    // The positive control: a stripper that returned nothing would pass every
+    // test above.
+    const file = fixture(`      "26 * * * *",\n      "17,56 * * * *",`);
+    assert.deepEqual(declaredCrons(file), ["26 * * * *", "17,56 * * * *"]);
+    unlinkSync(file);
+  });
+});
 
 describe("wrangler.jsonc crons and their handlers", () => {
   test("the parse finds the full grid, so the assertions below are real", () => {

--- a/tests/data-api-crons-have-handlers.test.ts
+++ b/tests/data-api-crons-have-handlers.test.ts
@@ -16,6 +16,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
+import { stripJsonComments } from "../scripts/lib.ts";
 import { DATA_API_CRON_LANES } from "../workers/data-api.ts";
 import { TABLE_FRESHNESS_CRON, TAO_USD_INDEX_CRON } from "../workers/config.ts";
 import { NEON_PRUNE_CRON } from "../src/neon-prune.ts";
@@ -30,7 +31,11 @@ const CONFIG = "wrangler.data.jsonc";
  * lifting the quoted strings out of it is exact rather than approximate.
  */
 function declaredCrons(path: string): string[] {
-  const source = readFileSync(path, "utf8");
+  // Comments stripped first -- a quoted string inside a `//` comment is not a
+  // declaration. See the long note on the same helper in
+  // tests/api-crons-have-handlers.test.ts: reading comments as declarations
+  // makes the HANDLED direction pass for a cron that was never registered.
+  const source = stripJsonComments(readFileSync(path, "utf8"));
   const block = /"crons"\s*:\s*\[([^\]]*)\]/.exec(source);
   assert.ok(
     block,

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3665,12 +3665,15 @@ async function dispatchScheduled(
         );
         // COVERAGE, on the same tick that wrote it (#10308).
         //
-        // Deliberately not its own cron. Workers Builds deploys code but not
-        // cron triggers, so a new expression would need a separate
-        // `wrangler triggers deploy` and would silently never fire until
-        // someone ran it -- and a watchdog that does not run is worse than
-        // none, because the lane card then reads "no verdict" rather than
-        // "nobody checked".
+        // Deliberately not its own cron -- but NOT for the reason this comment
+        // used to give. It cited Workers Builds deploying code without cron
+        // triggers; measured 2026-08-15 that is false for this Worker (#11362's
+        // new schedule appeared two seconds after its deploy, with no manual
+        // step). See workers/config.ts's LANE_HEARTBEAT_EXTRA_CRON note.
+        //
+        // The reasons that survive are the ones below: a minute on this grid is
+        // scarce (three were free), and riding the capture tick is when the
+        // answer is knowable at all.
         //
         // Riding the capture tick is also when the answer is knowable: the
         // rows have just landed, so "how many netuids does the newest stamp

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -143,14 +143,29 @@ export const LANE_HEARTBEAT_CRON = "26 * * * *";
  * per-lane crons gave back.
  *
  * A SECOND EXPRESSION RATHER THAN A WIDER FIRST ONE, deliberately. Dispatch
- * compares the literal string, and Workers Builds ships code without applying
- * cron triggers -- so editing LANE_HEARTBEAT_CRON to "17,26,56 * * * *" would
- * deploy code that matches an expression the account has not registered, and the
- * heartbeat would stop dead until someone ran `wrangler triggers deploy`. Every
- * queue-backed lane would go silent, which is precisely the failure #10709
- * exists to remove. Adding an expression is safe in both orders: until the
- * trigger is deployed it simply never fires, and minute 26 carries the lanes
- * exactly as it does today.
+ * compares the literal string, so editing LANE_HEARTBEAT_CRON to
+ * "17,26,56 * * * *" replaces the expression the account has registered. If the
+ * code reaches production before the schedule does, it matches nothing, the
+ * heartbeat stops dead, and every queue-backed lane goes silent -- precisely the
+ * failure #10709 exists to remove. Appending needs no ordering assumption at
+ * all: until the new trigger is applied it simply never fires, and minute 26
+ * carries the lanes exactly as it does today.
+ *
+ * ON WHETHER A DEPLOY APPLIES TRIGGERS -- MEASURE, DO NOT ASSUME. This file
+ * previously asserted that Workers Builds ships code without applying cron
+ * triggers. That is NOT true of this Worker: #11362's merge deployed
+ * 7c354652a at 17:40:17Z and Cloudflare's schedules API shows "17,56 * * * *"
+ * with created_on 17:40:19Z, two seconds later, with no `wrangler triggers
+ * deploy` run by hand. The same day, every schedule's modified_on tracked the
+ * preceding deployment by two seconds. The manual step WAS needed on
+ * wrangler.registry.jsonc on 2026-08-08 -- a different Worker, with its own
+ * build command -- which is where the blanket claim came from. Check the Worker
+ * you actually changed:
+ *
+ *   GET /accounts/{account}/workers/scripts/{script}/schedules
+ *
+ * and compare created_on against the deployment. The append-don't-edit rule
+ * above stands either way, which is the point of choosing it.
  *
  * 24 is left FREE on purpose -- the last slot on the grid, kept for a lane that
  * genuinely cannot be expressed as a cadence. It would also sit two minutes

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1206,9 +1206,14 @@
       // Replaces the three per-lane crons that used to sit on 17, 24 and 56 --
       // each of which only read a list and enqueued it. A new lane joins
       // LANE_PRODUCERS in workers/api.ts and needs no minute here at all, which
-      // matters on a grid that was 97% full. NOTE: Workers Builds does not apply
-      // cron triggers; this one needs `wrangler triggers deploy` or nothing
-      // fires.
+      // matters on a grid that was 97% full. NOTE: this Worker's deploy DOES
+      // apply cron triggers -- measured 2026-08-15, #11362's merge deployed at
+      // 17:40:17Z and the new schedule's created_on was 17:40:19Z with no
+      // `wrangler triggers deploy` by hand. The blanket "Workers Builds does not
+      // apply cron triggers" note this replaces came from wrangler.registry.jsonc
+      // on 2026-08-08, a different Worker with its own build command. Verify per
+      // Worker via GET /accounts/{account}/workers/scripts/{script}/schedules
+      // rather than assuming either way.
       "26 * * * *",
       // 17,56 = the rest of the heartbeat grid (#10709). The lanes are gated on
       // a declared cadence (src/lane-scheduler.ts), so these ticks do NOT make


### PR DESCRIPTION
Found while landing #11362: adding a comment to `wrangler.jsonc`'s `crons` block failed `tests/api-crons-have-handlers.test.ts` on the comment's text.

## The gate parsed prose

`declaredCrons` matched every quoted string inside the `crons` block, comments included — and that block carries one commented paragraph per lane, so quoted text inside comments is the normal case, not a contrived one.

```ts
const block = /"crons"\s*:\s*\[([\s\S]*?)\]/.exec(source);
return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
```

Both directions were wrong, and **one of them fails open**:

- **DECLARED → handled**: a comment quoting a phrase that is not a cron fails the gate on prose alone. Noisy, and how this surfaced.
- **HANDLED → declared**: this builds a `Set` from the same list, so a comment merely *mentioning* a cron in quotes made that expression look declared. **A handled lane whose trigger was never registered would have passed the gate while silently never firing** — the exact failure this file exists to catch.

It has been latent: #11362 added a comment containing `"26 * * * *"`, which passed only because that string happens to be a real declared cron.

## The fix

Strip comments first, using the repo's own `stripJsonComments` (`scripts/lib.ts`) rather than a second implementation free to drift. Applied to both this test and its `wrangler.data.jsonc` twin, which had the same helper.

Four tests pin it, including a **positive control** — reverting the strip fails three of them and leaves the control passing, so they are testing the stripper rather than passing on an empty result:

```
× a cron quoted inside a // comment is NOT read as declared
× quoted prose in a comment is not read as a cron
× a /* block */ comment is stripped too
✓ a real cron containing no comment survives unchanged
```

## A claim this repo stated in four places is false

The repo asserted that Workers Builds ships code without applying cron triggers. **That is not true of the main Worker.**

#11362's merge deployed `7c354652a` at `17:40:17Z`. Cloudflare's schedules API shows the new `"17,56 * * * *"` with `created_on` `17:40:19Z` — two seconds later, with **no `wrangler triggers deploy` run by hand**. Every other schedule's `modified_on` tracked the preceding deployment the same way (`16:55:35Z` deploy → `16:55:37Z` schedules).

The blanket claim came from `wrangler.registry.jsonc` on 2026-08-08 — a **different Worker**, with its own build command — and was then repeated as a general rule in `workers/config.ts`, `workers/api.ts`, `wrangler.jsonc` and `src/tao-usd-index-watchdog.ts`, where it justified design decisions.

Those decisions stand on their surviving reasons — a minute on this grid is scarce, and riding an existing tick is when the answer is knowable — but the stated reason was false, and a false premise in a comment is what misleads the next person. Each site now points at the measurement instead:

```
GET /accounts/{account}/workers/scripts/{script}/schedules
```

Scoped deliberately: I only corrected sites about the **main** Worker. `workers/data-api.ts` makes the same claim about a different Worker, where I have not measured, so it is left alone.

## Verification

- `tsc --noEmit` clean, `prettier --check` clean, `eslint` clean
- affected suites pass (82 tests across 5 files)
- mutation-tested: reverting the strip fails 3 of the 4 new tests, control still passes
- comment-only changes to `src/`/`workers/` — no behaviour change, so no patch-coverage surface
