### PR TITLE
feat(watchdog): report a subnet whose miners stop announcing an axon

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -1,0 +1,347 @@
+// When a subnet's miners stop announcing an axon (#11328).
+//
+// ## The event this exists for
+//
+// On 2026-08-11, 94 of SN101's 256 miners stopped publishing an axon and had
+// not resumed four days later. The hotkey set did not change, emission stayed
+// flat at ~295.17 TAO/day, and validator permits held. The miners kept earning
+// while becoming unreachable-by-announcement, and NOTHING in the fleet reported
+// it -- the axon-removals routes that exist to surface exactly this answer a
+// permanent zero (#10805), and no watchdog read `neuron_daily.axon` at all.
+//
+// Sweeping the whole table rather than the one subnet found it is not rare.
+// Measured 2026-08-15 over 37 retained days, six subnets had a sustained
+// collapse; two (25 and 102) were still in one, and SN25's was worse than the
+// filed case: 80 announced axons down to 14 in four days.
+//
+// ## Against a TRAILING BASELINE, not against yesterday
+//
+// This is the measurement that decided the shape. SN25's decline ran
+// 80 -> 59 -> 21 -> 13 -> 14. The first step is a 26% drop, under any sane
+// day-over-day threshold, so a yesterday-comparison does not see the collapse
+// start; it only catches the middle of it. Comparing each day against the
+// median of the previous week catches it on the first day that matters and
+// keeps catching it while it continues.
+//
+// Gradual is also the COMMON case here, not the exotic one: of the six measured
+// incidents, 102, 65 and 25 all bled over days rather than dropping in a step.
+//
+// ## `neurons` travels with `with_axon`, because they answer different questions
+//
+// SN103 looked like the biggest axon event in the window -- 252 to zero on
+// 2026-08-04. It is not an axon event: `neurons` went 256 -> 2 on the same day.
+// The metagraph emptied, which on a recycled netuid is a deregistration and
+// re-registration rather than miners ceasing to announce
+// (a netuid is an unstable join key). Reading `with_axon` alone would have
+// reported a subnet's miners going dark when the subnet itself had turned over,
+// which is a different fact for a different reader -- so both counts are
+// carried and the finding says which happened.
+//
+// ## A day where everything drops is OUR capture, not their behaviour
+//
+// #11328 established this by controlling against the rest of the network:
+// excluding SN101, the network-wide axon series was flat across its boundary,
+// which is what made "they stopped publishing" separable from "we stopped
+// reading". The same control is cheap here and falls out of the same rows: the
+// one day in the window where three subnets dropped together (2026-07-16) is
+// also the only one that did not persist. So a fleet-wide flag count is a guard
+// against reporting our own wobble as somebody else's outage.
+//
+// ## What this does NOT claim
+//
+// The baseline decays toward whatever the subnet settles at, so an incident
+// alarms for a few days and then goes quiet even while the subnet stays down.
+// That is correct for a CHANGE detector and it is the whole contract: this
+// answers "something moved", never "this subnet is currently healthy".
+
+import { readStore, type StoreEnv } from "./read-store.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
+
+/** Lane name, in `lane_health` and in the watchdog's own route label. */
+export const AXON_ANNOUNCEMENT_LANE = "axon-announcement";
+
+/**
+ * Days of history the baseline is taken over, not counting the day under test.
+ *
+ * Seven, so the baseline spans a week of ordinary variation and a single bad
+ * capture day cannot move a median of seven values far.
+ */
+export const AXON_BASELINE_DAYS = 7;
+
+/**
+ * Flag when the day under test holds less than this share of its baseline.
+ *
+ * 0.7 measured against the real distribution over 4,644 subnet-day
+ * transitions: the 5th percentile of the day-over-day ratio is 0.980 and the
+ * 1st is 0.722, so a third of a subnet's announcements disappearing is already
+ * far outside ordinary movement. Every one of the six incidents in the window
+ * clears it comfortably; the tightest is SN101 at 0.578.
+ */
+export const AXON_DROP_RATIO = 0.7;
+
+/**
+ * Baselines below this are not evaluated.
+ *
+ * Without a floor the flag list is dominated by subnets where the whole
+ * announced set is single digits and a 30% move is three miners. With it, the
+ * window's flags are six real incidents rather than dozens of rounding events.
+ */
+export const AXON_BASELINE_FLOOR = 20;
+
+/**
+ * Flags on one day at or above this count are reported as OUR capture rather
+ * than as findings about subnets.
+ *
+ * Four: the window's genuine incidents flag at most three subnets on a day, and
+ * they are independent events that happen to overlap. The one day where several
+ * moved together (2026-07-16, three subnets) is also the only one that did not
+ * persist -- the signature of the poller wobbling. Set above the observed
+ * independent maximum so a real cluster is not silently reclassified, and low
+ * enough that a genuine fleet-wide read failure is never reported as 129
+ * separate subnet outages.
+ */
+export const AXON_FLEET_WIDE_FLAGS = 4;
+
+/** Most subnets named in one detail string, so a fleet event stays readable. */
+export const AXON_MAX_LISTED = 8;
+
+/** One subnet-day, as read from `neuron_daily`. */
+export interface AxonDay {
+  date: string;
+  /** Neurons publishing a non-empty axon. */
+  withAxon: number;
+  /** Neurons present at all. Distinguishes withdrawal from turnover. */
+  neurons: number;
+}
+
+/** What happened to one subnet. */
+export interface AxonFinding {
+  netuid: number;
+  date: string;
+  withAxon: number;
+  baseline: number;
+  ratio: number;
+  neurons: number;
+  neuronBaseline: number;
+  /**
+   * `announcements-withdrawn`: the miners are still there and stopped
+   * announcing -- the #11328 shape. `subnet-turned-over`: the metagraph itself
+   * emptied, so the missing axons are missing NEURONS and the subnet's
+   * membership is the story.
+   */
+  kind: "announcements-withdrawn" | "subnet-turned-over";
+}
+
+/** Median of a list, on a copy — the caller's array is never reordered. */
+export function medianOf(values: readonly number[]): number | null {
+  const sorted = [...values]
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Evaluate ONE subnet's series, oldest first. Null when there is nothing to say.
+ *
+ * Deliberately returns null rather than a "healthy" finding: a subnet with too
+ * little history, or a baseline under the floor, has not been measured, and
+ * reporting it as fine would be the [[a-correct-decline-hides-a-dead-producer]]
+ * shape one level down.
+ */
+export function evaluateSubnetAxons(
+  netuid: number,
+  series: readonly AxonDay[],
+): AxonFinding | null {
+  if (!Array.isArray(series) || series.length < 2) return null;
+  const latest = series[series.length - 1];
+  if (!latest || !Number.isFinite(latest.withAxon)) return null;
+  const window = series.slice(
+    Math.max(0, series.length - 1 - AXON_BASELINE_DAYS),
+    series.length - 1,
+  );
+  const baseline = medianOf(window.map((d) => d.withAxon));
+  if (baseline === null || baseline < AXON_BASELINE_FLOOR) return null;
+  const ratio = latest.withAxon / baseline;
+  if (!(ratio < AXON_DROP_RATIO)) return null;
+  const neuronBaseline = medianOf(window.map((d) => d.neurons)) ?? 0;
+  // Turnover is judged on the SAME ratio as the axons, so the two cannot
+  // disagree about what "collapsed" means. A subnet whose neuron count held
+  // while its axons vanished is the #11328 shape; one where both fell is a
+  // membership change wearing an axon costume.
+  const turnedOver =
+    neuronBaseline >= AXON_BASELINE_FLOOR &&
+    latest.neurons / neuronBaseline < AXON_DROP_RATIO;
+  return {
+    netuid,
+    date: latest.date,
+    withAxon: latest.withAxon,
+    baseline,
+    ratio,
+    neurons: latest.neurons,
+    neuronBaseline,
+    kind: turnedOver ? "subnet-turned-over" : "announcements-withdrawn",
+  };
+}
+
+/** Every subnet's finding, netuid order, from rows grouped per subnet. */
+export function evaluateAxonAnnouncements(
+  bySubnet: ReadonlyMap<number, readonly AxonDay[]>,
+): AxonFinding[] {
+  const out: AxonFinding[] = [];
+  for (const [netuid, series] of bySubnet) {
+    const finding = evaluateSubnetAxons(netuid, series);
+    if (finding) out.push(finding);
+  }
+  return out.sort((a, b) => a.ratio - b.ratio || a.netuid - b.netuid);
+}
+
+/** True when this many subnets flagging at once is more likely to be us. */
+export function isFleetWide(findings: readonly AxonFinding[]): boolean {
+  return findings.length >= AXON_FLEET_WIDE_FLAGS;
+}
+
+/** Human-readable summary, bounded so a fleet event cannot produce a wall. */
+export function axonDetail(findings: readonly AxonFinding[]): string {
+  if (findings.length === 0) return "no subnet below baseline";
+  const listed = findings
+    .slice(0, AXON_MAX_LISTED)
+    .map(
+      (f) =>
+        `SN${f.netuid} ${f.withAxon}/${f.baseline} axons (${Math.round(f.ratio * 100)}%` +
+        (f.kind === "subnet-turned-over"
+          ? `, neurons ${f.neurons}/${f.neuronBaseline} -- the subnet turned over`
+          : "") +
+        ")",
+    )
+    .join("; ");
+  const rest =
+    findings.length > AXON_MAX_LISTED
+      ? ` (+${findings.length - AXON_MAX_LISTED} more)`
+      : "";
+  return `${listed}${rest}`;
+}
+
+export interface AxonWatchdogDeps {
+  laneHealthDb?: LaneHealthDb | null;
+  now?: () => number;
+  recordException?: typeof recordExceptionEvent;
+}
+
+/**
+ * One tick. Returns a summary rather than throwing, matching the cron family.
+ */
+export async function runAxonAnnouncementWatchdog(
+  env: (StoreEnv & TelemetryEnv) | null | undefined,
+  deps: AxonWatchdogDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const db = readStore(env, ["neuron_daily"]);
+  if (!db?.query) return { ok: false, reason: "no store bound" };
+
+  let bySubnet: Map<number, AxonDay[]>;
+  try {
+    // Aggregated in the store: the raw window is ~129 subnets x 256 neurons x 8
+    // days, and the answer is two integers per subnet-day.
+    const rows = await db.query(
+      "SELECT netuid, snapshot_date AS date, " +
+        "COUNT(*) FILTER (WHERE axon IS NOT NULL AND axon <> '') AS with_axon, " +
+        "COUNT(*) AS neurons FROM neuron_daily " +
+        "WHERE snapshot_date >= ? GROUP BY netuid, snapshot_date " +
+        "ORDER BY netuid, snapshot_date",
+      [isoDaysAgo(now(), AXON_BASELINE_DAYS + 1)],
+    );
+    bySubnet = groupAxonDays(rows);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "query_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const findings = evaluateAxonAnnouncements(bySubnet);
+  const fleetWide = isFleetWide(findings);
+  const detail = axonDetail(findings);
+
+  if (findings.length > 0) {
+    // A fleet-wide flag is reported as OUR failure and given its own error
+    // code, because it sends a reader somewhere completely different: to the
+    // poller, not to a subnet's operators. Collapsing the two would make an
+    // outage of ours read as 129 subnets going dark at once.
+    await record(env, {
+      error: new Error(
+        fleetWide
+          ? `${findings.length} subnets dropped below their axon baseline on the same day -- ` +
+              `that is far more than any observed independent cluster (max 3), so read this as the ` +
+              `metagraph capture failing rather than as subnets going dark: ${detail}`
+          : `announced axons collapsed: ${detail} -- these miners are still registered and still ` +
+              `earning, so an axon that stops being published is a reachability change nothing ` +
+              `else in the fleet reports (#11328)`,
+      ),
+      route: `watchdog:${AXON_ANNOUNCEMENT_LANE}`,
+      errorCode: fleetWide
+        ? "axon_capture_suspect"
+        : "axon_announcements_dropped",
+    }).catch(() => false);
+  }
+
+  await recordLaneVerdict(laneHealthStore(env, deps.laneHealthDb), {
+    lane: AXON_ANNOUNCEMENT_LANE,
+    // `stale` is the vocabulary `lane_health` has for "this lane has a finding";
+    // there is no `finding` verdict, and inventing one would drift from the
+    // published enum every other reader shares.
+    verdict: findings.length > 0 ? "stale" : "ok",
+    age_ms: null,
+    detail,
+    checked_at: now(),
+  });
+
+  return {
+    ok: true,
+    alerted: findings.length > 0,
+    fleet_wide: fleetWide,
+    subnets_measured: bySubnet.size,
+    findings,
+  };
+}
+
+/** `YYYY-MM-DD`, `days` before `nowMs`, matching `snapshot_date`'s text form. */
+export function isoDaysAgo(nowMs: number, days: number): string {
+  const t = Number.isFinite(nowMs) ? nowMs : Date.now();
+  return new Date(t - days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/** Group store rows into per-subnet series, oldest first. */
+export function groupAxonDays(
+  rows: readonly Record<string, unknown>[],
+): Map<number, AxonDay[]> {
+  const out = new Map<number, AxonDay[]>();
+  for (const row of rows ?? []) {
+    const netuid = Number(row?.netuid);
+    const date = String(row?.date ?? "");
+    if (!Number.isFinite(netuid) || date === "") continue;
+    const day: AxonDay = {
+      date,
+      withAxon: Number(row?.with_axon ?? 0),
+      neurons: Number(row?.neurons ?? 0),
+    };
+    if (!Number.isFinite(day.withAxon) || !Number.isFinite(day.neurons))
+      continue;
+    const series = out.get(netuid);
+    if (series) series.push(day);
+    else out.set(netuid, [day]);
+  }
+  // Sorted here rather than trusted from the query, so the evaluator is correct
+  // on whatever it is handed -- the same discipline loadLatestLaneHealth applies
+  // to its own reduction.
+  for (const series of out.values())
+    series.sort((a, b) => a.date.localeCompare(b.date));
+  return out;
+}

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -1,0 +1,556 @@
+// #11328: a subnet's miners stopping announcing an axon.
+//
+// The fixtures are the REAL measured series, taken from production Neon on
+// 2026-08-15 over 37 retained days. That matters here more than usual, because
+// the detector's shape was chosen by those numbers: SN25's collapse begins with
+// a 26% step that no day-over-day threshold catches, and SN103 looks like the
+// largest axon event in the window while actually being a subnet turning over.
+// A synthetic fixture would have agreed with whatever was implemented.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import {
+  AXON_BASELINE_FLOOR,
+  AXON_FLEET_WIDE_FLAGS,
+  AXON_MAX_LISTED,
+  axonDetail,
+  evaluateAxonAnnouncements,
+  evaluateSubnetAxons,
+  groupAxonDays,
+  isFleetWide,
+  isoDaysAgo,
+  medianOf,
+  runAxonAnnouncementWatchdog,
+  type AxonDay,
+  type AxonFinding,
+} from "../src/axon-announcement-watchdog.ts";
+
+/** Days at a uniform width, oldest first. */
+const flat = (n: number, withAxon: number, neurons = 256): AxonDay[] =>
+  Array.from({ length: n }, (_, i) => ({
+    date: `2026-08-${String(i + 1).padStart(2, "0")}`,
+    withAxon,
+    neurons,
+  }));
+
+const then = (base: AxonDay[], ...tail: [number, number][]): AxonDay[] => [
+  ...base,
+  ...tail.map(([withAxon, neurons], i) => ({
+    date: `2026-09-${String(i + 1).padStart(2, "0")}`,
+    withAxon,
+    neurons,
+  })),
+];
+
+describe("medianOf", () => {
+  test("odd and even lengths", () => {
+    assert.equal(medianOf([3, 1, 2]), 2);
+    assert.equal(medianOf([4, 1, 3, 2]), 2.5);
+  });
+
+  test("empty is null, not zero", () => {
+    // Zero would read as "the subnet had no axons", which is a measurement.
+    assert.equal(medianOf([]), null);
+    assert.equal(medianOf([Number.NaN]), null);
+  });
+
+  test("non-finite values are dropped, not propagated", () => {
+    assert.equal(medianOf([1, Number.NaN, 3, Number.POSITIVE_INFINITY]), 2);
+  });
+
+  test("the caller's array is not reordered", () => {
+    const input = [3, 1, 2];
+    medianOf(input);
+    assert.deepEqual(input, [3, 1, 2]);
+  });
+});
+
+describe("evaluateSubnetAxons — the real incidents", () => {
+  test("SN101: 223 steady, then 129 and held (the filed case)", () => {
+    const series = then(flat(8, 223), [129, 256]);
+    const f = evaluateSubnetAxons(101, series);
+    assert.ok(f, "SN101's drop is a finding");
+    assert.equal(f.kind, "announcements-withdrawn");
+    assert.equal(f.withAxon, 129);
+    assert.equal(f.baseline, 223);
+    assert.ok(f.ratio < 0.6);
+  });
+
+  test("SN25: the GRADUAL collapse a day-over-day test misses", () => {
+    // 80 -> 59 is a 26% step. Against the trailing baseline the 21 is caught,
+    // which is the whole reason the baseline form was chosen.
+    const series = then(flat(8, 80), [59, 256], [21, 256]);
+    const f = evaluateSubnetAxons(25, series);
+    assert.ok(f, "SN25's decline is caught against baseline");
+    assert.equal(f.withAxon, 21);
+    assert.equal(f.kind, "announcements-withdrawn");
+  });
+
+  test("the first 26% step alone is NOT flagged", () => {
+    // The other side of the same boundary: a detector that fired here would
+    // fire on ordinary movement, whose 5th percentile is a 2% drop.
+    assert.equal(evaluateSubnetAxons(25, then(flat(8, 80), [59, 256])), null);
+  });
+
+  test("SN103: neurons collapsed too, so it is turnover, not withdrawal", () => {
+    // 252 -> 0 axons looks like the largest axon event in the window. It is a
+    // subnet that emptied: 256 -> 2 neurons on the same day.
+    const series = then(flat(8, 252, 256), [0, 2]);
+    const f = evaluateSubnetAxons(103, series);
+    assert.ok(f);
+    assert.equal(f.kind, "subnet-turned-over");
+    assert.equal(f.neurons, 2);
+    assert.equal(f.neuronBaseline, 256);
+  });
+
+  test("a steady subnet is not a finding", () => {
+    assert.equal(evaluateSubnetAxons(1, flat(9, 200)), null);
+  });
+});
+
+describe("evaluateSubnetAxons — what it refuses to measure", () => {
+  test("a baseline under the floor is skipped rather than flagged", () => {
+    // Without this the list is dominated by subnets where a 30% move is three
+    // miners. Floor-1 so the boundary itself is exercised.
+    const series = then(flat(8, AXON_BASELINE_FLOOR - 1), [0, 256]);
+    assert.equal(evaluateSubnetAxons(7, series), null);
+  });
+
+  test("a baseline exactly at the floor IS measured", () => {
+    const series = then(flat(8, AXON_BASELINE_FLOOR), [0, 256]);
+    assert.ok(evaluateSubnetAxons(7, series));
+  });
+
+  test("too little history is null, never a clean verdict", () => {
+    assert.equal(evaluateSubnetAxons(1, []), null);
+    assert.equal(evaluateSubnetAxons(1, flat(1, 200)), null);
+    assert.equal(
+      evaluateSubnetAxons(1, undefined as unknown as AxonDay[]),
+      null,
+    );
+  });
+
+  test("a non-finite latest reading is null", () => {
+    const series = then(flat(8, 200));
+    series.push({ date: "2026-09-09", withAxon: Number.NaN, neurons: 256 });
+    assert.equal(evaluateSubnetAxons(1, series), null);
+  });
+
+  test("a neuron baseline under the floor cannot claim turnover", () => {
+    // Axons collapse while the neuron count is too small to judge: the finding
+    // stands, but it must not assert the subnet turned over.
+    const series = [
+      ...Array.from({ length: 8 }, (_, i) => ({
+        date: `2026-08-0${i + 1}`,
+        withAxon: 40,
+        neurons: 5,
+      })),
+      { date: "2026-09-01", withAxon: 2, neurons: 1 },
+    ];
+    const f = evaluateSubnetAxons(9, series);
+    assert.ok(f);
+    assert.equal(f.kind, "announcements-withdrawn");
+  });
+});
+
+describe("the fleet-wide guard", () => {
+  const finding = (netuid: number): AxonFinding => ({
+    netuid,
+    date: "2026-08-15",
+    withAxon: 1,
+    baseline: 100,
+    ratio: 0.01,
+    neurons: 256,
+    neuronBaseline: 256,
+    kind: "announcements-withdrawn",
+  });
+
+  test("three subnets is the observed independent maximum, so not fleet-wide", () => {
+    assert.equal(isFleetWide([finding(1), finding(2), finding(3)]), false);
+  });
+
+  test("at the threshold it IS fleet-wide", () => {
+    const many = Array.from({ length: AXON_FLEET_WIDE_FLAGS }, (_, i) =>
+      finding(i),
+    );
+    assert.equal(isFleetWide(many), true);
+  });
+
+  test("nothing flagged is not fleet-wide", () => {
+    assert.equal(isFleetWide([]), false);
+  });
+});
+
+describe("evaluateAxonAnnouncements and axonDetail", () => {
+  test("worst ratio first, and only subnets with findings", () => {
+    const bySubnet = new Map<number, AxonDay[]>([
+      [101, then(flat(8, 223), [129, 256])],
+      [1, flat(9, 200)],
+      [103, then(flat(8, 252), [0, 2])],
+    ]);
+    const found = evaluateAxonAnnouncements(bySubnet);
+    assert.deepEqual(
+      found.map((f) => f.netuid),
+      [103, 101],
+      "sorted by severity, and the healthy subnet is absent",
+    );
+  });
+
+  test("equal ratios fall back to netuid so the order is stable", () => {
+    const bySubnet = new Map<number, AxonDay[]>([
+      [9, then(flat(8, 100), [10, 256])],
+      [2, then(flat(8, 100), [10, 256])],
+    ]);
+    assert.deepEqual(
+      evaluateAxonAnnouncements(bySubnet).map((f) => f.netuid),
+      [2, 9],
+    );
+  });
+
+  test("an empty detail says so rather than reading as an empty finding", () => {
+    assert.equal(axonDetail([]), "no subnet below baseline");
+  });
+
+  test("detail names the counts and calls out turnover", () => {
+    const bySubnet = new Map<number, AxonDay[]>([
+      [103, then(flat(8, 252), [0, 2])],
+    ]);
+    const detail = axonDetail(evaluateAxonAnnouncements(bySubnet));
+    assert.match(detail, /SN103 0\/252 axons/);
+    assert.match(detail, /the subnet turned over/);
+  });
+
+  test("a long list is bounded and says how many it withheld", () => {
+    const bySubnet = new Map<number, AxonDay[]>();
+    for (let i = 0; i < AXON_MAX_LISTED + 3; i += 1) {
+      bySubnet.set(i + 1, then(flat(8, 100), [10 + i, 256]));
+    }
+    const detail = axonDetail(evaluateAxonAnnouncements(bySubnet));
+    assert.match(detail, /\(\+3 more\)/);
+  });
+});
+
+describe("groupAxonDays", () => {
+  test("groups by netuid and sorts oldest first regardless of row order", () => {
+    const grouped = groupAxonDays([
+      { netuid: 5, date: "2026-08-02", with_axon: 2, neurons: 10 },
+      { netuid: 5, date: "2026-08-01", with_axon: 1, neurons: 10 },
+      { netuid: 6, date: "2026-08-01", with_axon: 9, neurons: 10 },
+    ]);
+    assert.deepEqual(
+      grouped.get(5)?.map((d) => d.date),
+      ["2026-08-01", "2026-08-02"],
+    );
+    assert.equal(grouped.get(6)?.length, 1);
+  });
+
+  test("unusable rows are dropped rather than defaulted into the series", () => {
+    const grouped = groupAxonDays([
+      { netuid: "nope", date: "2026-08-01", with_axon: 1, neurons: 1 },
+      { netuid: 5, date: "", with_axon: 1, neurons: 1 },
+      { netuid: 5, date: "2026-08-01", with_axon: "x", neurons: 1 },
+      { netuid: 5, date: "2026-08-02", with_axon: 1, neurons: 1 },
+    ]);
+    assert.equal(grouped.size, 1);
+    assert.equal(grouped.get(5)?.length, 1);
+  });
+
+  test("COUNT(*) arrives as a STRING from Postgres and is still counted", () => {
+    // Verified against production Neon 2026-08-15: `COUNT(*)` is int8, and the
+    // driver hands int8 back as a string. A reader that compared these without
+    // coercing would silently measure nothing -- every ratio would be NaN and
+    // `NaN < 0.7` is false, so the watchdog would report a permanently clean
+    // sweep. See tests/pg-int8-shape.test.ts for the same trap elsewhere.
+    const grouped = groupAxonDays([
+      { netuid: 101, date: "2026-08-01", with_axon: "223", neurons: "256" },
+    ]);
+    assert.deepEqual(grouped.get(101), [
+      { date: "2026-08-01", withAxon: 223, neurons: 256 },
+    ]);
+  });
+
+  test("a string-typed series still produces a finding end to end", () => {
+    // The composed version of the above: the failure mode is silence, so the
+    // assertion has to be that something IS found.
+    const rows = [
+      ...Array.from({ length: 8 }, (_, i) => ({
+        netuid: 101,
+        date: `2026-08-0${i + 1}`,
+        with_axon: "223",
+        neurons: "256",
+      })),
+      { netuid: 101, date: "2026-08-09", with_axon: "129", neurons: "256" },
+    ];
+    const found = evaluateAxonAnnouncements(groupAxonDays(rows));
+    assert.equal(found.length, 1);
+    assert.equal(found[0].withAxon, 129);
+    assert.equal(found[0].baseline, 223);
+  });
+
+  test("a null row set is empty, not a throw", () => {
+    assert.equal(
+      groupAxonDays(null as unknown as Record<string, unknown>[]).size,
+      0,
+    );
+  });
+});
+
+describe("the defensive fallbacks, each exercised", () => {
+  // These are the paths that only run when something upstream is already
+  // malformed. Untested, they are where a watchdog quietly starts measuring
+  // nothing — so each one gets its own case rather than being assumed.
+
+  test("absent columns default rather than producing NaN rows", () => {
+    // A row missing with_axon/neurons entirely (a schema change, a partial
+    // projection) reads as zero rather than NaN. NaN would make every ratio
+    // NaN, and `NaN < 0.7` is false — a permanently clean sweep.
+    const grouped = groupAxonDays([{ netuid: 5, date: "2026-08-01" }]);
+    assert.deepEqual(grouped.get(5), [
+      { date: "2026-08-01", withAxon: 0, neurons: 0 },
+    ]);
+  });
+
+  test("an absent date is skipped, not coerced to the string 'undefined'", () => {
+    assert.equal(groupAxonDays([{ netuid: 5 }]).size, 0);
+  });
+
+  test("a neuron baseline that cannot be measured does not claim turnover", () => {
+    // Every neuron reading in the window is unusable, so the median is null and
+    // the fallback is 0 — which must NOT be read as "neurons collapsed to zero".
+    const series: AxonDay[] = [
+      ...Array.from({ length: 8 }, (_, i) => ({
+        date: `2026-08-0${i + 1}`,
+        withAxon: 100,
+        neurons: Number.NaN,
+      })),
+      { date: "2026-09-01", withAxon: 10, neurons: 256 },
+    ];
+    const f = evaluateSubnetAxons(11, series);
+    assert.ok(f);
+    assert.equal(f.neuronBaseline, 0);
+    assert.equal(
+      f.kind,
+      "announcements-withdrawn",
+      "an unmeasurable neuron baseline cannot assert the subnet turned over",
+    );
+  });
+
+  test("a non-Error thrown by the store is still reported", async () => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.failNext = "connection went away" as unknown as Error;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { ok: boolean; detail: string };
+    assert.equal(result.ok, false);
+    assert.match(result.detail, /connection went away/);
+  });
+
+  test("a failing exception recorder does not take the verdict down with it", async () => {
+    // The verdict write is the durable half. A telemetry outage must not stop
+    // it, which is the same contract recordLaneVerdict promises its callers.
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.answers.push({
+      match: /FROM neuron_daily/,
+      rows: [
+        ...Array.from({ length: 8 }, (_, i) => ({
+          netuid: 101,
+          date: `2026-08-0${i + 1}`,
+          with_axon: 223,
+          neurons: 256,
+        })),
+        { netuid: 101, date: "2026-08-09", with_axon: 129, neurons: 256 },
+      ],
+    });
+    pg.control.answers.push({ match: /.*/, rows: [] });
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => {
+        throw new Error("posthog down");
+      }) as never,
+    })) as { ok: boolean; alerted: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+    assert.ok(
+      pg.control.queries.some((q) =>
+        q.text.includes("INSERT INTO lane_health"),
+      ),
+      "the verdict landed even though the exception capture threw",
+    );
+  });
+
+  test("runs with no deps at all, taking its own clock and recorder", async () => {
+    // The production call site passes none of them.
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.answers.push({ match: /.*/, rows: [] });
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv())) as {
+      ok: boolean;
+      alerted: boolean;
+    };
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false);
+  });
+});
+
+describe("isoDaysAgo", () => {
+  test("returns a snapshot_date-shaped string", () => {
+    assert.equal(
+      isoDaysAgo(Date.parse("2026-08-15T12:00:00Z"), 8),
+      "2026-08-07",
+    );
+  });
+
+  test("a broken clock degrades to now rather than producing NaN", () => {
+    assert.match(isoDaysAgo(Number.NaN, 8), /^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("the watchdog tick", () => {
+  beforeEach(() => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.rows = null;
+    pg.control.failNext = null;
+  });
+
+  const answerWith = (rows: Record<string, unknown>[]) => {
+    pg.control.answers.push({ match: /FROM neuron_daily/, rows });
+    pg.control.answers.push({ match: /.*/, rows: [] });
+  };
+
+  const recordedVerdict = () => {
+    const insert = pg.control.queries.find((q) =>
+      q.text.includes("INSERT INTO lane_health"),
+    );
+    assert.ok(insert, "the tick recorded a verdict");
+    return {
+      lane: insert.values[0],
+      verdict: insert.values[1],
+      detail: insert.values[3],
+    };
+  };
+
+  const rowsFor = (netuid: number, series: AxonDay[]) =>
+    series.map((d) => ({
+      netuid,
+      date: d.date,
+      with_axon: d.withAxon,
+      neurons: d.neurons,
+    }));
+
+  test("records `stale` and NAMES the subnet when axons collapse", async () => {
+    answerWith(rowsFor(101, then(flat(8, 223), [129, 256])));
+    let captured: Record<string, unknown> | null = null;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    })) as { ok: boolean; alerted: boolean; fleet_wide: boolean };
+
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, true);
+    assert.equal(result.fleet_wide, false);
+    const v = recordedVerdict();
+    assert.equal(v.lane, "axon-announcement");
+    assert.equal(v.verdict, "stale");
+    assert.match(String(v.detail), /SN101 129\/223 axons/);
+    assert.equal(
+      (captured as unknown as { errorCode: string }).errorCode,
+      "axon_announcements_dropped",
+    );
+    assert.equal(
+      (captured as unknown as { route: string }).route,
+      "watchdog:axon-announcement",
+      "the route is NOT a lane-alarm or -staleness shape, so it still pages",
+    );
+  });
+
+  test("records `ok` when nothing moved", async () => {
+    answerWith(rowsFor(1, flat(9, 200)));
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { alerted: boolean };
+    assert.equal(result.alerted, false);
+    assert.equal(recordedVerdict().verdict, "ok");
+    assert.match(String(recordedVerdict().detail), /no subnet below baseline/);
+  });
+
+  test("many subnets at once is reported as OUR capture, not their outage", async () => {
+    const rows: Record<string, unknown>[] = [];
+    for (let i = 0; i < AXON_FLEET_WIDE_FLAGS; i += 1) {
+      rows.push(...rowsFor(i + 1, then(flat(8, 100), [5, 256])));
+    }
+    answerWith(rows);
+    let captured: Record<string, unknown> | null = null;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    })) as { fleet_wide: boolean };
+
+    assert.equal(result.fleet_wide, true);
+    assert.equal(
+      (captured as unknown as { errorCode: string }).errorCode,
+      "axon_capture_suspect",
+      "a different code, because it sends a reader to the poller not to a subnet",
+    );
+    assert.match(
+      String((captured as unknown as { error: Error }).error.message),
+      /capture failing rather than as subnets going dark/,
+    );
+  });
+
+  test("a failing read is reported, not rendered as a clean sweep", async () => {
+    pg.control.failNext = new Error("connection reset");
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { ok: boolean; reason: string; detail: string };
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "query_failed");
+    assert.match(result.detail, /connection reset/);
+    assert.equal(
+      pg.control.queries.some((q) =>
+        q.text.includes("INSERT INTO lane_health"),
+      ),
+      false,
+      "a failed read records NO verdict -- silence beats a false `ok`",
+    );
+  });
+
+  test("declines rather than reporting a clean sweep with no store", async () => {
+    const result = (await runAxonAnnouncementWatchdog(undefined, {
+      now: () => 1000,
+      recordException: (async () => true) as never,
+    })) as { ok: boolean; reason: string };
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "no store bound");
+  });
+
+  test("the window it asks for covers the baseline plus the day under test", async () => {
+    answerWith(rowsFor(1, flat(9, 200)));
+    await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-15T12:00:00Z"),
+      recordException: (async () => true) as never,
+    });
+    const read = pg.control.queries.find((q) =>
+      q.text.includes("FROM neuron_daily"),
+    );
+    assert.ok(read);
+    assert.equal(read.values[0], "2026-08-07");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -613,6 +613,7 @@ import {
 import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
 import { runRegistryResyncLane } from "../src/registry-resync-lane.ts";
 import { runDailySeriesCoverageWatchdog } from "../src/daily-series-coverage-watchdog.ts";
+import { runAxonAnnouncementWatchdog } from "../src/axon-announcement-watchdog.ts";
 import { runDegenerateOutputWatchdog } from "../src/degenerate-output-watchdog.ts";
 import { runSubnetLifecycleLane } from "../src/subnet-lifecycle.ts";
 import { runSubnetDeregistrationDailyLane } from "../src/subnet-deregistration-daily.ts";
@@ -3902,18 +3903,25 @@ async function dispatchScheduled(
     // in the middle. neuron_daily is the history source and only ~26 days deep,
     // so a missed day ages out of any recomputable window and becomes permanent.
     //
-    // TWO WATCHDOGS, ONE MINUTE (#11226). The degenerate-output check shares
-    // this tick rather than taking a cron of its own: #10709 is open to halve
-    // the 43 crons this Worker already declares, and spending one while that
-    // is in flight works against it. The cadence argument is the same one
-    // written above -- a lane that classifies nothing does not heal on its own
-    // either, so the value is noticing at all, not noticing fast. They record
-    // separate lane verdicts, so sharing a minute does not merge their
-    // reporting.
+    // THREE WATCHDOGS, ONE MINUTE (#11226, #11328). The degenerate-output and
+    // axon-announcement checks share this tick rather than taking crons of
+    // their own: #10709 halved nothing by adding two more, and this Worker
+    // still declares 39. The cadence argument is the same one written above --
+    // neither a lane that classifies nothing nor a subnet whose miners stopped
+    // announcing heals on its own, so the value is noticing at all, not
+    // noticing fast. They record separate lane verdicts, so sharing a minute
+    // does not merge their reporting.
+    //
+    // The axon check belongs on THIS tick specifically rather than any spare
+    // one: it reads `neuron_daily`, which is the table the coverage watchdog
+    // beside it already opens, and 07:35/19:35 is after both daily rollup
+    // windows -- so it compares a day that is complete rather than one being
+    // written underneath it.
     const bag = env;
     const [series] = await Promise.all([
       runDailySeriesCoverageWatchdog(bag),
       runDegenerateOutputWatchdog(bag),
+      runAxonAnnouncementWatchdog(bag),
     ]);
     return series;
   }


### PR DESCRIPTION
Closes #11328

## SN101 is not the only one, and it is not the worst

The issue filed one subnet. Sweeping the whole table found **six** sustained collapses in 37 retained days, **two still ongoing**:

| subnet | when | axons | neurons | state |
| --- | --- | --- | --- | --- |
| **25** | 08-12 → | 80 → **14** | 256 throughout | **ongoing** |
| **102** | 07-24 → | 42 → **8** | 256 throughout | **ongoing** |
| **101** | 08-11 | 223 → 128 | 256 throughout | holding down |
| 65 | 07-29 | 168 → 65 | 256 throughout | recovered baseline |
| 111 | 07-20 | 40 → 19 | 256 throughout | recovered baseline |
| 103 | 08-04 | 252 → 0 | **256 → 2** | different event |

SN25 is a worse version of the filed case and it is happening now: 83% of announcements lost over four days, same 256 hotkeys, emission flat at 295.202.

## Against a trailing median, not against yesterday

This measurement decided the shape. SN25's decline ran `80 → 59 → 21 → 13 → 14`. **The first step is 26%** — under any sane day-over-day threshold, so a yesterday-comparison does not see the collapse start. Gradual is also the *common* case here: three of the six incidents bled over days rather than dropping in a step.

Median rather than mean over the window, because a prolonged decline drags a mean down with it and the alarm goes quiet while the subnet is still falling. On SN25 today the median baseline is 80 where the mean had already decayed to 59.

## `neurons` travels with `with_axon`

SN103 looked like the largest axon event in the window and is not one: `neurons` went 256 → **2** on the same day. The metagraph emptied, which on a recycled netuid is a deregistration rather than miners going quiet. Reading `with_axon` alone would have reported a subnet's miners going dark when the subnet itself turned over — a different fact for a different reader — so both counts are carried and the finding says which happened.

## A day where everything drops is our capture

#11328 established this control by excluding SN101 and showing the rest of the network flat. The same control falls out of these rows: the one day where three subnets moved together (07-16) is also the only one that **did not persist**. Four or more flags on a day is reported under its own error code (`axon_capture_suspect`), because it sends a reader to the poller, not to a subnet's operators.

## Thresholds are measured, not picked

- **0.7** — against 4,644 subnet-day transitions whose 5th-percentile ratio is 0.980 and 1st is 0.722. The tightest real incident is SN101 at 0.578.
- **floor 20** — without it the list is dozens of three-miner roundings instead of six real incidents.
- **fleet-wide at 4** — one above the observed independent maximum, so a genuine cluster is not silently reclassified.

## No new cron

Rides the existing `35 7,19 * * *` tick. That tick already opens `neuron_daily` and runs after both daily rollup windows, so the day under test is complete rather than being written underneath it — and its own comment records that spending a minute while #10709 was in flight worked against it. #10709 has since landed; adding two crons now would undo part of it.

## Verified against production

The exact algorithm, run over the live table today, flags exactly:

```
SN25   14 axons / baseline 80    ratio 0.175  announcements-withdrawn
SN102   8 axons / baseline 23.5  ratio 0.340  announcements-withdrawn
```

Both correctly classified as withdrawal (neurons unchanged at 256), and two is below the fleet-wide threshold, so it reports as a finding rather than as capture-suspect.

The SQL was executed against production Neon rather than only against the mock — which is how the int8 shape surfaced: `COUNT(*)` returns **strings**, and a reader that compared them without coercing would make every ratio `NaN`, and `NaN < 0.7` is false — a permanently clean sweep. Pinned by two tests.

## It reaches a human

`route: watchdog:axon-announcement` contains neither `watchdog:lane-alarm` nor `-staleness:`, so it passes the Discord issue filter rather than being treated as a duplicate lane-staleness report. A test asserts that shape, because the alert being swallowed is the exact failure this issue is about.

## Verification

- `tsc --noEmit`, `prettier --check`, `eslint` clean
- 41 tests; patch coverage by diff intersection **66/66 lines, 71/71 branches, 100%**
- `validate:operations`, `validate:lane-topology`, `validate:unreferenced-modules`, `validate:unreferenced-exports`, `validate:no-hand-written-mjs`, `validate:module-state-resets`, `validate:type-duplicates`, `validate:pg-json-binds` all pass

## Deliberately out of scope

#10805 owns whether the axon-removals route family is derived or retired. This reports the fact; it does not decide the routes.
