### PR TITLE
fix(turnover, movers): a 90-day window reported a 36-day answer and said nothing

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -7241,6 +7241,21 @@ type ChainTurnover {
   end_date: String
 
   """
+  Days actually spanned between start_date and end_date. Null when either bound is unresolvable.
+  """
+  covered_days: Int
+
+  """
+  Days the requested window asked for (7, 30 or 90). Null when the label is not one this route serves.
+  """
+  requested_days: Int
+
+  """
+  True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a network that replaced its whole validator set over a quarter reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete.
+  """
+  window_truncated: Boolean
+
+  """
   False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable.
   """
   comparable: Boolean!

--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -7165,6 +7165,21 @@ type SubnetMovers {
   window: String
   start_date: String
   end_date: String
+
+  """
+  Days actually spanned between start_date and end_date. Null when either bound is unresolvable.
+  """
+  covered_days: Int
+
+  """
+  Days the requested window asked for (7, 30 or 90). Null when no window was resolved.
+  """
+  requested_days: Int
+
+  """
+  True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: every figure here is a DELTA between the window's endpoints, so a shortened span understates each change -- and the leaderboard is ORDERED by that understated delta, so truncation reorders it, not just shrinks it. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete.
+  """
+  window_truncated: Boolean
   sort: String!
   subnet_count: Int!
 

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1802,10 +1802,14 @@ export type ChainTurnover = {
   __typename?: 'ChainTurnover';
   /** False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable. */
   comparable: Scalars['Boolean']['output'];
+  /** Days actually spanned between start_date and end_date. Null when either bound is unresolvable. */
+  covered_days?: Maybe<Scalars['Int']['output']>;
   /** End snapshot date; null on a cold store. */
   end_date?: Maybe<Scalars['String']['output']>;
   /** Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network. */
   network: ChainTurnoverNetwork;
+  /** Days the requested window asked for (7, 30 or 90). Null when the label is not one this route serves. */
+  requested_days?: Maybe<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
   /** Null when no subnet had a stability score in the window (nothing to distribute). */
   stability_distribution?: Maybe<ChainTurnoverStabilityDistribution>;
@@ -1814,6 +1818,8 @@ export type ChainTurnover = {
   subnet_count: Scalars['Int']['output'];
   subnets: Array<ChainTurnoverSubnet>;
   window?: Maybe<Scalars['String']['output']>;
+  /** True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a network that replaced its whole validator set over a quarter reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+  window_truncated?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network. */
@@ -10733,14 +10739,17 @@ export type ChainTransfersResolvers<ContextType = GqlContext, ParentType extends
 
 export type ChainTurnoverResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainTurnover'] = ResolversParentTypes['ChainTurnover']> = ResolversObject<{
   comparable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  covered_days?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   end_date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   network?: Resolver<ResolversTypes['ChainTurnoverNetwork'], ParentType, ContextType>;
+  requested_days?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stability_distribution?: Resolver<Maybe<ResolversTypes['ChainTurnoverStabilityDistribution']>, ParentType, ContextType>;
   start_date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   subnets?: Resolver<Array<ResolversTypes['ChainTurnoverSubnet']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  window_truncated?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
 export type ChainTurnoverNetworkResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainTurnoverNetwork'] = ResolversParentTypes['ChainTurnoverNetwork']> = ResolversObject<{

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6996,15 +6996,21 @@ export type SubnetMover = {
 
 export type SubnetMovers = {
   __typename?: 'SubnetMovers';
+  /** Days actually spanned between start_date and end_date. Null when either bound is unresolvable. */
+  covered_days?: Maybe<Scalars['Int']['output']>;
   end_date?: Maybe<Scalars['String']['output']>;
   movers: Array<SubnetMover>;
   /** Network-wide boundary totals for the movers window, summed across every ranked subnet (not just the returned page). */
   network: SubnetMoversNetwork;
+  /** Days the requested window asked for (7, 30 or 90). Null when no window was resolved. */
+  requested_days?: Maybe<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
   sort: Scalars['String']['output'];
   start_date?: Maybe<Scalars['String']['output']>;
   subnet_count: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
+  /** True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: every figure here is a DELTA between the window's endpoints, so a shortened span understates each change -- and the leaderboard is ORDERED by that understated delta, so truncation reorders it, not just shrinks it. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+  window_truncated?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Network-wide boundary totals for the movers window, summed across every ranked subnet (not just the returned page). */
@@ -13545,14 +13551,17 @@ export type SubnetMoverResolvers<ContextType = GqlContext, ParentType extends Re
 }>;
 
 export type SubnetMoversResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMovers'] = ResolversParentTypes['SubnetMovers']> = ResolversObject<{
+  covered_days?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   end_date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   movers?: Resolver<Array<ResolversTypes['SubnetMover']>, ParentType, ContextType>;
   network?: Resolver<ResolversTypes['SubnetMoversNetwork'], ParentType, ContextType>;
+  requested_days?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   start_date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  window_truncated?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
 export type SubnetMoversNetworkResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMoversNetwork'] = ResolversParentTypes['SubnetMoversNetwork']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12074,6 +12074,8 @@ export interface components {
             window?: string | null;
         };
         SubnetMoversArtifact: {
+            /** @description Days actually spanned between start_date and end_date. Null when either bound is unresolvable. */
+            covered_days: number | null;
             end_date: string | null;
             movers: {
                 emission_delta_alpha: number;
@@ -12112,12 +12114,16 @@ export interface components {
                 total_validators_start: number;
                 unchanged: number;
             };
+            /** @description Days the requested window asked for (7, 30 or 90). Null when no window was resolved. */
+            requested_days: number | null;
             schema_version: number;
             /** @enum {string} */
             sort: "stake" | "emission" | "validators" | "neurons";
             start_date: string | null;
             subnet_count: number;
             window: ("7d" | "30d" | "90d") | null;
+            /** @description True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: every figure here is a DELTA between the window's endpoints, so a shortened span understates each change -- and the leaderboard is ORDERED by that understated delta, so truncation reorders it, not just shrinks it. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+            window_truncated: boolean | null;
         };
         /** @description One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope. */
         SubnetOhlcArtifact: {
@@ -50359,6 +50365,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "covered_days": 1,
                      *         "end_date": "2026-06-01",
                      *         "movers": [
                      *           {
@@ -50395,11 +50402,13 @@ export interface operations {
                      *           "total_validators_start": 1,
                      *           "unchanged": 1
                      *         },
+                     *         "requested_days": 1,
                      *         "schema_version": 1,
                      *         "sort": "stake",
                      *         "start_date": "2026-06-01",
                      *         "subnet_count": 1,
-                     *         "window": "7d"
+                     *         "window": "7d",
+                     *         "window_truncated": false
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7325,6 +7325,8 @@ export interface components {
         ChainTurnoverArtifact: {
             /** @description False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable. */
             comparable: boolean;
+            /** @description Days actually spanned between start_date and end_date. Null when either bound is unresolvable. */
+            covered_days: number | null;
             /** @description End snapshot date; null on a cold store. */
             end_date: string | null;
             /** @description Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network. */
@@ -7338,6 +7340,8 @@ export interface components {
                 validators_exited: number;
                 validators_start: number;
             };
+            /** @description Days the requested window asked for (7, 30 or 90). Null when the label is not one this route serves. */
+            requested_days: number | null;
             schema_version: number;
             /** @description Null when no subnet had a stability score in the window (nothing to distribute). */
             stability_distribution: {
@@ -7363,6 +7367,8 @@ export interface components {
                 validators_start: number;
             }[];
             window: ("7d" | "30d" | "90d") | null;
+            /** @description True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a network that replaced its whole validator set over a quarter reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+            window_truncated: boolean | null;
         };
         /** @description An unsigned 64-bit integer read from chain storage. Published as Float in GraphQL: the runtime's range exceeds that of GraphQL's Int. */
         ChainU64: number;
@@ -29616,6 +29622,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "comparable": false,
+                     *         "covered_days": 1,
                      *         "end_date": "2026-06-01",
                      *         "network": {
                      *           "stability_score": 100,
@@ -29625,6 +29632,7 @@ export interface operations {
                      *           "validators_exited": 1,
                      *           "validators_start": 1
                      *         },
+                     *         "requested_days": 1,
                      *         "schema_version": 1,
                      *         "stability_distribution": {
                      *           "count": 1,
@@ -29649,7 +29657,8 @@ export interface operations {
                      *             "validators_start": 1
                      *           }
                      *         ],
-                     *         "window": "7d"
+                     *         "window": "7d",
+                     *         "window_truncated": false
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10715,6 +10715,7 @@
       "SubnetMoversArtifactResponse": {
         "value": {
           "data": {
+            "covered_days": 1,
             "end_date": "2026-06-01",
             "movers": [
               {
@@ -10751,11 +10752,13 @@
               "total_validators_start": 1,
               "unchanged": 1
             },
+            "requested_days": 1,
             "schema_version": 1,
             "sort": "stake",
             "start_date": "2026-06-01",
             "subnet_count": 1,
-            "window": "7d"
+            "window": "7d",
+            "window_truncated": false
           },
           "meta": {
             "artifact_path": "example",
@@ -53598,6 +53601,19 @@
       "SubnetMoversArtifact": {
         "additionalProperties": false,
         "properties": {
+          "covered_days": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Days actually spanned between start_date and end_date. Null when either bound is unresolvable."
+          },
           "end_date": {
             "anyOf": [
               {
@@ -53813,6 +53829,19 @@
             ],
             "type": "object"
           },
+          "requested_days": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Days the requested window asked for (7, 30 or 90). Null when no window was resolved."
+          },
           "schema_version": {
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
@@ -53857,6 +53886,17 @@
                 "type": "null"
               }
             ]
+          },
+          "window_truncated": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: every figure here is a DELTA between the window's endpoints, so a shortened span understates each change -- and the leaderboard is ORDERED by that understated delta, so truncation reorders it, not just shrinks it. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete."
           }
         },
         "required": [
@@ -53864,6 +53904,9 @@
           "window",
           "start_date",
           "end_date",
+          "covered_days",
+          "requested_days",
+          "window_truncated",
           "sort",
           "subnet_count",
           "network",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4148,6 +4148,7 @@
         "value": {
           "data": {
             "comparable": false,
+            "covered_days": 1,
             "end_date": "2026-06-01",
             "network": {
               "stability_score": 100,
@@ -4157,6 +4158,7 @@
               "validators_exited": 1,
               "validators_start": 1
             },
+            "requested_days": 1,
             "schema_version": 1,
             "stability_distribution": {
               "count": 1,
@@ -4181,7 +4183,8 @@
                 "validators_start": 1
               }
             ],
-            "window": "7d"
+            "window": "7d",
+            "window_truncated": false
           },
           "meta": {
             "artifact_path": "example",
@@ -26743,6 +26746,19 @@
             "description": "False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable.",
             "type": "boolean"
           },
+          "covered_days": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Days actually spanned between start_date and end_date. Null when either bound is unresolvable."
+          },
           "end_date": {
             "anyOf": [
               {
@@ -26815,6 +26831,19 @@
               "stability_score"
             ],
             "type": "object"
+          },
+          "requested_days": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Days the requested window asked for (7, 30 or 90). Null when the label is not one this route serves."
           },
           "schema_version": {
             "maximum": 9007199254740991,
@@ -26985,6 +27014,17 @@
                 "type": "null"
               }
             ]
+          },
+          "window_truncated": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a network that replaced its whole validator set over a quarter reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete."
           }
         },
         "required": [
@@ -26992,6 +27032,9 @@
           "window",
           "start_date",
           "end_date",
+          "covered_days",
+          "requested_days",
+          "window_truncated",
           "comparable",
           "subnet_count",
           "network",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12074,6 +12074,8 @@ export interface components {
             window?: string | null;
         };
         SubnetMoversArtifact: {
+            /** @description Days actually spanned between start_date and end_date. Null when either bound is unresolvable. */
+            covered_days: number | null;
             end_date: string | null;
             movers: {
                 emission_delta_alpha: number;
@@ -12112,12 +12114,16 @@ export interface components {
                 total_validators_start: number;
                 unchanged: number;
             };
+            /** @description Days the requested window asked for (7, 30 or 90). Null when no window was resolved. */
+            requested_days: number | null;
             schema_version: number;
             /** @enum {string} */
             sort: "stake" | "emission" | "validators" | "neurons";
             start_date: string | null;
             subnet_count: number;
             window: ("7d" | "30d" | "90d") | null;
+            /** @description True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: every figure here is a DELTA between the window's endpoints, so a shortened span understates each change -- and the leaderboard is ORDERED by that understated delta, so truncation reorders it, not just shrinks it. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+            window_truncated: boolean | null;
         };
         /** @description One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope. */
         SubnetOhlcArtifact: {
@@ -50359,6 +50365,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "covered_days": 1,
                      *         "end_date": "2026-06-01",
                      *         "movers": [
                      *           {
@@ -50395,11 +50402,13 @@ export interface operations {
                      *           "total_validators_start": 1,
                      *           "unchanged": 1
                      *         },
+                     *         "requested_days": 1,
                      *         "schema_version": 1,
                      *         "sort": "stake",
                      *         "start_date": "2026-06-01",
                      *         "subnet_count": 1,
-                     *         "window": "7d"
+                     *         "window": "7d",
+                     *         "window_truncated": false
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7325,6 +7325,8 @@ export interface components {
         ChainTurnoverArtifact: {
             /** @description False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable. */
             comparable: boolean;
+            /** @description Days actually spanned between start_date and end_date. Null when either bound is unresolvable. */
+            covered_days: number | null;
             /** @description End snapshot date; null on a cold store. */
             end_date: string | null;
             /** @description Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network. */
@@ -7338,6 +7340,8 @@ export interface components {
                 validators_exited: number;
                 validators_start: number;
             };
+            /** @description Days the requested window asked for (7, 30 or 90). Null when the label is not one this route serves. */
+            requested_days: number | null;
             schema_version: number;
             /** @description Null when no subnet had a stability score in the window (nothing to distribute). */
             stability_distribution: {
@@ -7363,6 +7367,8 @@ export interface components {
                 validators_start: number;
             }[];
             window: ("7d" | "30d" | "90d") | null;
+            /** @description True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a network that replaced its whole validator set over a quarter reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete. */
+            window_truncated: boolean | null;
         };
         /** @description An unsigned 64-bit integer read from chain storage. Published as Float in GraphQL: the runtime's range exceeds that of GraphQL's Int. */
         ChainU64: number;
@@ -29616,6 +29622,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "comparable": false,
+                     *         "covered_days": 1,
                      *         "end_date": "2026-06-01",
                      *         "network": {
                      *           "stability_score": 100,
@@ -29625,6 +29632,7 @@ export interface operations {
                      *           "validators_exited": 1,
                      *           "validators_start": 1
                      *         },
+                     *         "requested_days": 1,
                      *         "schema_version": 1,
                      *         "stability_distribution": {
                      *           "count": 1,
@@ -29649,7 +29657,8 @@ export interface operations {
                      *             "validators_start": 1
                      *           }
                      *         ],
-                     *         "window": "7d"
+                     *         "window": "7d",
+                     *         "window_truncated": false
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas-src/routes/chain-turnover.ts
+++ b/schemas-src/routes/chain-turnover.ts
@@ -29,6 +29,24 @@ export const ChainTurnoverArtifactSchema = z
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .nullable()
       .describe("End snapshot date; null on a cold store."),
+    covered_days: z
+      .int()
+      .nullable()
+      .describe(
+        "Days actually spanned between start_date and end_date. Null when either bound is unresolvable.",
+      ),
+    requested_days: z
+      .int()
+      .nullable()
+      .describe(
+        "Days the requested window asked for (7, 30 or 90). Null when the label is not one this route serves.",
+      ),
+    window_truncated: z
+      .boolean()
+      .nullable()
+      .describe(
+        "True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: turnover compares the window's endpoints, so a shortened span reports LOWER churn and HIGHER stability -- a network that replaced its whole validator set over a quarter reads as a calm month. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete.",
+      ),
     comparable: z
       .boolean()
       .describe(

--- a/schemas-src/routes/subnet-movers.ts
+++ b/schemas-src/routes/subnet-movers.ts
@@ -89,6 +89,24 @@ export const SubnetMoversArtifactSchema = z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .nullable(),
+    covered_days: z
+      .int()
+      .nullable()
+      .describe(
+        "Days actually spanned between start_date and end_date. Null when either bound is unresolvable.",
+      ),
+    requested_days: z
+      .int()
+      .nullable()
+      .describe(
+        "Days the requested window asked for (7, 30 or 90). Null when no window was resolved.",
+      ),
+    window_truncated: z
+      .boolean()
+      .nullable()
+      .describe(
+        "True when covered_days is short of requested_days because the store does not reach back that far. It matters in ONE direction: every figure here is a DELTA between the window's endpoints, so a shortened span understates each change -- and the leaderboard is ORDERED by that understated delta, so truncation reorders it, not just shrinks it. NULL when the bounds could not be resolved at all, never false, which would assert a window nobody measured was complete.",
+      ),
     sort: z.enum(SUBNET_MOVERS_MOVERS_SORTS_VALUES),
     subnet_count: z.int().min(0),
     network: MoversNetworkSummarySchema,

--- a/src/chain-turnover.ts
+++ b/src/chain-turnover.ts
@@ -15,6 +15,10 @@ import {
   CHAIN_TURNOVER_LIMIT_DEFAULT,
   CHAIN_TURNOVER_LIMIT_MAX,
 } from "./route-limits.ts";
+// Shared with the per-subnet family rather than reimplemented: the two routes
+// answer the same question at different scopes, and a second copy of the
+// truncation rule would be free to drift from the one the schema documents.
+import { windowCoverage } from "./turnover.ts";
 export { CHAIN_TURNOVER_LIMIT_DEFAULT, CHAIN_TURNOVER_LIMIT_MAX };
 
 // The neuron_daily columns the handler reads — its store read contract. `hotkey` is public
@@ -181,6 +185,23 @@ export interface ChainTurnoverResult {
   window: string | null;
   start_date: string | null;
   end_date: string | null;
+  /**
+   * Days actually spanned, and the days asked for (#10798, #11360).
+   *
+   * `neuron_daily` is ~36 days deep, so `?window=90d` was answered with 36 days
+   * and labelled `"90d"` -- measured on production 2026-08-15, start_date came
+   * back as the store floor 2026-07-10 rather than 90 days before the end,
+   * beside `comparable: true` and a network `stability_score` computed over a
+   * third of the claimed span.
+   *
+   * It matters in ONE direction, which is why silence was the wrong default:
+   * turnover compares the window's ENDPOINTS, so a shortened span reports LOWER
+   * churn and HIGHER stability. A network that replaced its whole validator set
+   * over a quarter reads as a calm month.
+   */
+  covered_days: number | null;
+  requested_days: number | null;
+  window_truncated: boolean | null;
   comparable: boolean;
   subnet_count: number;
   network: ChainTurnoverNetwork;
@@ -217,6 +238,18 @@ export function buildChainTurnover(
     window: window ?? null,
     start_date: startDate ?? null,
     end_date: endDate ?? null,
+    // Spread into BOTH the empty and populated results below, so a cold store
+    // reports the same shape rather than omitting the fields exactly when the
+    // window is least trustworthy. Requested days come from the window table
+    // rather than from the caller's string: an unsupported label resolves to
+    // null, which windowCoverage reports as "unknowable" instead of guessing.
+    ...windowCoverage(
+      startDate,
+      endDate,
+      window != null && Object.hasOwn(CHAIN_TURNOVER_WINDOWS, window)
+        ? CHAIN_TURNOVER_WINDOWS[window]
+        : null,
+    ),
   };
   // Clamp limit to a whole number in [0, MAX] so a direct caller cannot make slice() behave
   // oddly (the HTTP layer already validates 1..MAX; this keeps the pure builder aligned).

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -334,9 +334,12 @@ export function buildMovers(
     ...windowCoverage(
       typeof startDate === "string" ? startDate : null,
       typeof endDate === "string" ? endDate : null,
-      normalizedWindow == null
-        ? null
-        : (MOVERS_WINDOWS[normalizedWindow] ?? null),
+      // No `?? null` on the lookup: `normalizedWindow` is either null or a key
+      // this table defines -- an unrecognised label was already resolved to
+      // DEFAULT_MOVERS_WINDOW above -- so a fallback here would be unreachable,
+      // and a test written to reach it could only assert the code's own
+      // assumption back at it.
+      normalizedWindow == null ? null : MOVERS_WINDOWS[normalizedWindow],
     ),
     sort: normalizedSort,
     subnet_count: ranked.length,

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -1,6 +1,9 @@
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
 import { MOVERS_LIMIT_DEFAULT, MOVERS_LIMIT_MAX } from "./route-limits.ts";
+// Shared with the turnover family rather than reimplemented: same rule, one
+// definition, so the truncation contract cannot drift between routes.
+import { windowCoverage } from "./turnover.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import {
   round9OrZero,
@@ -312,6 +315,29 @@ export function buildMovers(
     window: normalizedWindow,
     start_date: startDate ?? null,
     end_date: endDate ?? null,
+    // #10798/#11360/#11365. `neuron_daily` is ~36 days deep, so `?window=90d`
+    // was answered with 36 days and labelled "90d" -- measured on production
+    // 2026-08-15, start_date came back as the store floor 2026-07-10 rather
+    // than 90 days before the end, while `?window=30d` was genuinely covered.
+    //
+    // It matters in ONE direction, which is why silence was the wrong default:
+    // movers reports DELTAS between the window's endpoints, so a shortened span
+    // compares closer dates and understates every change it ranks by. A subnet
+    // that doubled its stake over a quarter reads as a quiet month, and the
+    // leaderboard is ORDERED by that understated delta.
+    //
+    // Uses the window resolved above rather than the caller's raw string, so an
+    // unsupported label reports the default's length instead of guessing.
+    // Narrowed here rather than loosening windowCoverage: this builder takes its
+    // dates as `unknown` on purpose, and a non-string bound is unusable rather
+    // than merely unparsed -- which windowCoverage already reports as null.
+    ...windowCoverage(
+      typeof startDate === "string" ? startDate : null,
+      typeof endDate === "string" ? endDate : null,
+      normalizedWindow == null
+        ? null
+        : (MOVERS_WINDOWS[normalizedWindow] ?? null),
+    ),
     sort: normalizedSort,
     subnet_count: ranked.length,
     network: buildNetworkSummary(

--- a/tests/chain-turnover.test.ts
+++ b/tests/chain-turnover.test.ts
@@ -503,3 +503,77 @@ describe("GET /api/v1/chain/turnover", () => {
 // /api/v1/chain/turnover now busts on the shared health-cron `last_run_at` KV
 // stamp instead, exercised end-to-end by the "GET /api/v1/chain/turnover"
 // describe block above.
+
+describe("window coverage — a short store must not read as a calm quarter", () => {
+  // #10798/#11360. Measured on production 2026-08-15: `?window=90d` returned
+  // start_date 2026-07-10 -- the store floor, not 90 days back -- beside
+  // `comparable: true` and a network stability_score computed over 36 days.
+  // The bias runs ONE way: a shortened span compares closer endpoints, so it
+  // reports lower churn and higher stability than the window claims to measure.
+
+  test("a 90d window answered with 36 days is flagged, not silently served", () => {
+    const data = buildChainTurnover(ROWS, {
+      window: "90d",
+      startDate: "2026-07-10",
+      endDate: "2026-08-15",
+    });
+    assert.equal(data.covered_days, 36);
+    assert.equal(data.requested_days, 90);
+    assert.equal(data.window_truncated, true);
+  });
+
+  test("a window the store fully covers is not flagged", () => {
+    // The positive control: a detector that flagged everything would pass the
+    // test above while saying nothing.
+    const data = buildChainTurnover(ROWS, {
+      window: "30d",
+      startDate: "2026-07-16",
+      endDate: "2026-08-15",
+    });
+    assert.equal(data.covered_days, 30);
+    assert.equal(data.requested_days, 30);
+    assert.equal(data.window_truncated, false);
+  });
+
+  test("an unresolvable bound is null, never false", () => {
+    // `false` would assert a window nobody measured was complete.
+    const data = buildChainTurnover([], {
+      window: "90d",
+      startDate: null,
+      endDate: null,
+    });
+    assert.equal(data.comparable, false);
+    assert.equal(data.covered_days, null);
+    assert.equal(data.requested_days, 90);
+    assert.equal(data.window_truncated, null);
+  });
+
+  test("the COLD result carries the fields too", () => {
+    // The empty and populated results share one `base`, so a cold store cannot
+    // omit them exactly when the window is least trustworthy.
+    const cold = buildChainTurnover(null, {
+      window: "7d",
+      startDate: "2026-08-14",
+      endDate: "2026-08-15",
+    });
+    assert.equal(cold.comparable, false);
+    assert.equal(cold.covered_days, 1);
+    assert.equal(cold.requested_days, 7);
+    assert.equal(cold.window_truncated, true);
+  });
+
+  test("an unsupported label reports requested_days null rather than guessing", () => {
+    const data = buildChainTurnover(ROWS, {
+      window: "1y",
+      startDate: "2026-07-10",
+      endDate: "2026-08-15",
+    });
+    assert.equal(data.requested_days, null);
+    assert.equal(data.covered_days, 36);
+    assert.equal(
+      data.window_truncated,
+      false,
+      "a window with no declared length cannot be short of itself",
+    );
+  });
+});

--- a/tests/movers.test.ts
+++ b/tests/movers.test.ts
@@ -702,3 +702,68 @@ describe("loadSubnetMovers", () => {
     assert.equal(data.subnet_count, 0);
   });
 });
+
+describe("window coverage — a truncated span reorders the leaderboard", () => {
+  // #10798/#11360/#11365. Measured on production 2026-08-15:
+  // /api/v1/subnets/movers?window=90d returned start_date 2026-07-10 -- the
+  // store floor, not 90 days back -- while ?window=30d was genuinely covered.
+  //
+  // This route is the sharper case of the family. Every figure it publishes is
+  // a DELTA between the window's endpoints, and the leaderboard is ORDERED by
+  // that delta, so a shortened span does not merely shrink the numbers: it can
+  // change which subnets rank at all.
+
+  test("a 90d window answered with 36 days is flagged", () => {
+    const data = buildMovers([], [], {
+      window: "90d",
+      startDate: "2026-07-10",
+      endDate: "2026-08-15",
+    });
+    assert.equal(data.covered_days, 36);
+    assert.equal(data.requested_days, 90);
+    assert.equal(data.window_truncated, true);
+  });
+
+  test("a fully covered window is not flagged", () => {
+    // Positive control: a check that flagged everything would pass the case
+    // above while saying nothing.
+    const data = buildMovers([], [], {
+      window: "30d",
+      startDate: "2026-07-16",
+      endDate: "2026-08-15",
+    });
+    assert.equal(data.covered_days, 30);
+    assert.equal(data.window_truncated, false);
+  });
+
+  test("unresolvable bounds are null, never false", () => {
+    const data = buildMovers([], [], { window: "90d" });
+    assert.equal(data.covered_days, null);
+    assert.equal(data.requested_days, 90);
+    assert.equal(data.window_truncated, null);
+  });
+
+  test("a non-string bound is unusable, not silently parsed", () => {
+    // This builder takes its dates as `unknown` by contract.
+    const data = buildMovers([], [], {
+      window: "30d",
+      startDate: 20260716,
+      endDate: "2026-08-15",
+    });
+    assert.equal(data.covered_days, null);
+    assert.equal(data.window_truncated, null);
+  });
+
+  test("an unsupported label resolves to the default's length, not a guess", () => {
+    // buildMovers normalizes an unknown window to 30d, so the reported
+    // requested_days must describe what was actually measured.
+    const data = buildMovers([], [], {
+      window: "bogus",
+      startDate: "2026-07-16",
+      endDate: "2026-08-15",
+    });
+    assert.equal(data.window, "30d");
+    assert.equal(data.requested_days, 30);
+    assert.equal(data.window_truncated, false);
+  });
+});


### PR DESCRIPTION
Finishes #10798's remaining constraint — that the 90d readers still clamp silently. #11360 fixed the per-subnet turnover route; these are the two siblings with the same defect.

## Measured on production, 2026-08-15

```
GET /api/v1/chain/turnover?window=90d
  window "90d"   start_date 2026-07-10   comparable true   stability_score 55

GET /api/v1/subnets/movers?window=90d
  window "90d"   start_date 2026-07-10   total_stake_delta_alpha 5785285.36
```

`neuron_daily` is ~36 days deep. Both loaders resolve bounds with `MIN(snapshot_date)` over the requested span, so whenever the window is deeper than the store, `MIN` returns the floor. 90 days before `2026-08-15` is `2026-05-17`; both answers start `2026-07-10`.

`?window=30d` is genuinely covered on both (`2026-07-16`), which is what makes the 90d case easy to miss.

## The error always flatters the answer

Both routes compare the window's **endpoints**, so a shortened span compares closer dates:

- **chain/turnover** reports **lower churn and higher stability**. A network that replaced its whole validator set over a quarter reads as a calm month — while asserting `comparable: true`.
- **subnets/movers** is the sharper case: every figure is a **delta**, and the leaderboard is **ordered by that delta**. Truncation does not merely shrink the numbers, it can change *which subnets rank at all*.

That one-way bias is why silence was the wrong default.

## What both publish

`covered_days` / `requested_days` / `window_truncated`, through the same `windowCoverage` helper from `src/turnover.ts` rather than three copies of the rule.

Deliberate choices, each pinned by a test:

- **The cold result carries the fields too** (chain-turnover spreads them into the shared `base`) — omitting them exactly when the window is least trustworthy is the shape worth avoiding.
- **`window_truncated` is `null`, never `false`, when a bound is unresolvable.** `false` would assert a window nobody measured was complete.
- **Dates are narrowed at the movers call site** rather than loosening the helper: `buildMovers` takes its bounds as `unknown` by contract, and a non-string bound is unusable rather than merely unparsed.
- **`requested_days` reports the RESOLVED window**, because `buildMovers` normalizes an unknown label to `30d` — reporting 90 for a window that measured 30 days would be a second lie on top of the first.

## Scoping: two routes, not four

#10798 says four 90d readers clamp silently. Checked all of them against production:

| route | clamps? | visible to a caller? |
| --- | --- | --- |
| `/chain/turnover` | yes | **no** — fixed here |
| `/subnets/movers` | yes | **no** — fixed here |
| `/chain/concentration/history` | yes | **yes** — publishes `point_count: 36` |
| `/subnets/{netuid}/concentration/history` | same builder | yes |
| `/chain/concentration`, `/chain/concentration/subnets`, `/subnets/{netuid}/concentration` | n/a | no `window` parameter |

The history routes return a time series and publish `point_count`, `oldest_day` and `newest_day`, so a caller can see they asked for 90 days and got 36. The two fixed here returned a single derived figure with no such clue.

## The MCP mirrors need no change

`GetChainTurnoverOutputSchema` is an alias of `ChainTurnoverArtifactSchema`, and movers mirrors likewise — they inherit the fields rather than hand-copying them. That is what keeps this from becoming a `response_schema_drift`, the failure #11354 fixed.

## What this does not do

#10798 records a broader constraint: `neuron_daily` has seven consumers, several reaching back further than a 30-day floor would keep. This makes two more of them honest about their coverage. It does not clear the constraint, and it is not a prune.

## Verification

- production measurements above, each re-checked against `?window=30d` as a control
- `tsc --noEmit`, `prettier --check`, `eslint` clean
- 35 tests in `chain-turnover.test.ts` + 39 in `movers.test.ts`, full suite green
- `validate:contract-drift`, `validate:schemas`, `validate:openapi`, `validate:single-schema-source`, `validate:schema-shape-duplicates`, `validate:mcp-input-parity`, `validate:tool-route-divergence` pass
- regenerated `openapi.json`, `types.d.ts`, GraphQL schema/types and `packages/contract` committed in the same change
