### PR TITLE
fix(watchdog): the axon alarm said miners went dark; they were deregistered

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -126,12 +126,27 @@ export interface AxonFinding {
   neurons: number;
   neuronBaseline: number;
   /**
-   * `announcements-withdrawn`: the miners are still there and stopped
-   * announcing -- the #11328 shape. `subnet-turned-over`: the metagraph itself
-   * emptied, so the missing axons are missing NEURONS and the subnet's
-   * membership is the story.
+   * WHAT happened, which is a different question from how much (#11369).
+   *
+   * - `announcements-withdrawn`: the same miners are still registered and
+   *   stopped announcing. The #11328 shape, and the only one that means
+   *   "somebody's miners went dark".
+   * - `churn-replaced`: the announcing miners were DEREGISTERED and their UIDs
+   *   reused by miners that do not announce. Nobody withdrew anything. Measured
+   *   2026-08-16, this is 100% of SN25's and SN102's losses -- zero same-hotkey
+   *   stops between them -- so labelling those `announcements-withdrawn` states
+   *   the opposite of what happened.
+   * - `subnet-turned-over`: the metagraph itself emptied, so the missing axons
+   *   are missing NEURONS and membership is the story.
+   *
+   * Defaults to `announcements-withdrawn` until the mechanism read runs, which
+   * is the conservative direction: it is the reading that asks for a human.
    */
-  kind: "announcements-withdrawn" | "subnet-turned-over";
+  kind: "announcements-withdrawn" | "churn-replaced" | "subnet-turned-over";
+  /** Axon losses in the window whose UID changed hands. Null until measured. */
+  lossesViaReuse: number | null;
+  /** Axon losses where the same hotkey stopped announcing. Null until measured. */
+  lossesSameHotkey: number | null;
 }
 
 /** Median of a list, on a copy — the caller's array is never reordered. */
@@ -186,6 +201,11 @@ export function evaluateSubnetAxons(
     neurons: latest.neurons,
     neuronBaseline,
     kind: turnedOver ? "subnet-turned-over" : "announcements-withdrawn",
+    // Filled in by the mechanism read, which needs per-UID rows this pure
+    // evaluator is deliberately not given. Null means "not measured", never
+    // "zero" -- see classifyAxonMechanism.
+    lossesViaReuse: null,
+    lossesSameHotkey: null,
   };
 }
 
@@ -216,7 +236,11 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
         `SN${f.netuid} ${f.withAxon}/${f.baseline} axons (${Math.round(f.ratio * 100)}%` +
         (f.kind === "subnet-turned-over"
           ? `, neurons ${f.neurons}/${f.neuronBaseline} -- the subnet turned over`
-          : "") +
+          : f.kind === "churn-replaced"
+            ? `, churn-replaced: ${f.lossesViaReuse ?? 0} of ${(f.lossesViaReuse ?? 0) + (f.lossesSameHotkey ?? 0)} losses were deregistrations`
+            : f.lossesSameHotkey !== null
+              ? `, ${f.lossesSameHotkey} miner(s) stopped announcing`
+              : "") +
         ")",
     )
     .join("; ");
@@ -225,6 +249,82 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
       ? ` (+${findings.length - AXON_MAX_LISTED} more)`
       : "";
   return `${listed}${rest}`;
+}
+
+/**
+ * Which mechanism produced a subnet's axon losses (#11369).
+ *
+ * `sameHotkey` means the registered miner stopped announcing. `viaReuse` means
+ * its UID changed hands -- a deregistration, where the newcomer simply never
+ * served. They look identical in an aggregate count and mean opposite things:
+ * one is somebody's fleet going dark, the other is ordinary registration churn
+ * grinding the announcing set down because replacements do not announce.
+ *
+ * NULL COUNTS LEAVE THE DEFAULT ALONE. An unmeasured mechanism must not be
+ * reported as churn, because churn is the reading that does NOT ask anyone to
+ * go looking; guessing it would turn an unread number into an all-clear.
+ *
+ * A tie resolves to `announcements-withdrawn` for the same reason.
+ */
+export function classifyAxonMechanism(
+  counts: { viaReuse: number | null; sameHotkey: number | null },
+  fallback: AxonFinding["kind"],
+): AxonFinding["kind"] {
+  const reuse = counts?.viaReuse;
+  const same = counts?.sameHotkey;
+  if (typeof reuse !== "number" || typeof same !== "number") return fallback;
+  if (reuse + same === 0) return fallback;
+  return reuse > same ? "churn-replaced" : "announcements-withdrawn";
+}
+
+/**
+ * Split each subnet's axon losses by mechanism, over the same window.
+ *
+ * ONLY FOR SUBNETS ALREADY FLAGGED. The per-UID comparison is the expensive
+ * read here -- 256 rows per subnet per day rather than one -- and on a typical
+ * day the flag list is one to three subnets, so scoping it to those keeps the
+ * cost proportional to what was found rather than to the network.
+ *
+ * `{}` on any failure, which leaves every finding's kind at its default. See
+ * classifyAxonMechanism for why that is the safe direction.
+ */
+export async function loadAxonLossMechanisms(
+  db:
+    | { query?: (t: string, v?: unknown[]) => Promise<unknown[]> }
+    | null
+    | undefined,
+  netuids: readonly number[],
+  sinceDate: string,
+): Promise<Record<number, { viaReuse: number; sameHotkey: number }>> {
+  const out: Record<number, { viaReuse: number; sameHotkey: number }> = {};
+  const ids = (netuids ?? []).filter((n) => Number.isSafeInteger(n) && n >= 0);
+  if (!db?.query || ids.length === 0) return out;
+  try {
+    const rows = (await db.query(
+      "WITH seq AS (SELECT netuid, uid, snapshot_date, hotkey, " +
+        "(axon IS NOT NULL) AS has_axon, " +
+        "LAG(axon IS NOT NULL) OVER w AS prev_has, " +
+        "LAG(hotkey) OVER w AS prev_hotkey FROM neuron_daily " +
+        `WHERE snapshot_date >= ? AND netuid IN (${ids.map(() => "?").join(",")}) ` +
+        "WINDOW w AS (PARTITION BY netuid, uid ORDER BY snapshot_date)) " +
+        "SELECT netuid, " +
+        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey IS DISTINCT FROM prev_hotkey) AS via_reuse, " +
+        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS same_hotkey " +
+        "FROM seq GROUP BY netuid",
+      [sinceDate, ...ids],
+    )) as Record<string, unknown>[];
+    for (const row of rows ?? []) {
+      const netuid = Number(row?.netuid);
+      const viaReuse = Number(row?.via_reuse ?? 0);
+      const sameHotkey = Number(row?.same_hotkey ?? 0);
+      if (!Number.isFinite(netuid)) continue;
+      if (!Number.isFinite(viaReuse) || !Number.isFinite(sameHotkey)) continue;
+      out[netuid] = { viaReuse, sameHotkey };
+    }
+  } catch {
+    // Unmeasured, not zero. The caller keeps each finding's default kind.
+  }
+  return out;
 }
 
 export interface AxonWatchdogDeps {
@@ -267,6 +367,29 @@ export async function runAxonAnnouncementWatchdog(
   }
 
   const findings = evaluateAxonAnnouncements(bySubnet);
+
+  // WHAT happened, not just how much (#11369). Measured 2026-08-16, SN25 and
+  // SN102 had ZERO miners stop announcing -- every loss was a deregistration
+  // whose replacement never served -- so reporting them as withdrawal stated
+  // the opposite of the truth. Scoped to the flagged subnets, so an ordinary
+  // day costs one extra grouped read over one to three netuids.
+  const mechanisms = await loadAxonLossMechanisms(
+    db,
+    findings.map((f) => f.netuid),
+    isoDaysAgo(now(), AXON_BASELINE_DAYS + 1),
+  );
+  for (const finding of findings) {
+    const counts = mechanisms[finding.netuid];
+    if (!counts) continue;
+    finding.lossesViaReuse = counts.viaReuse;
+    finding.lossesSameHotkey = counts.sameHotkey;
+    // Turnover is decided by the neuron count and is not up for revision here:
+    // a subnet that emptied is not "churn" at any ratio.
+    if (finding.kind !== "subnet-turned-over") {
+      finding.kind = classifyAxonMechanism(counts, finding.kind);
+    }
+  }
+
   const fleetWide = isFleetWide(findings);
   const detail = axonDetail(findings);
 
@@ -281,9 +404,14 @@ export async function runAxonAnnouncementWatchdog(
           ? `${findings.length} subnets dropped below their axon baseline on the same day -- ` +
               `that is far more than any observed independent cluster (max 3), so read this as the ` +
               `metagraph capture failing rather than as subnets going dark: ${detail}`
-          : `announced axons collapsed: ${detail} -- these miners are still registered and still ` +
-              `earning, so an axon that stops being published is a reachability change nothing ` +
-              `else in the fleet reports (#11328)`,
+          : findings.every((f) => f.kind === "churn-replaced")
+            ? `announced axons fell through CHURN, not withdrawal: ${detail} -- the announcing ` +
+              `miners were DEREGISTERED and their UIDs reused by miners that never served. ` +
+              `Nobody went dark; the announcing set is ground down one registration at a time, ` +
+              `and it only reverses if serving starts paying on that subnet (#11369)`
+            : `announced axons collapsed: ${detail} -- miners that are still registered and ` +
+              `still earning stopped publishing an axon, so this is a reachability change ` +
+              `nothing else in the fleet reports (#11328)`,
       ),
       route: `watchdog:${AXON_ANNOUNCEMENT_LANE}`,
       errorCode: fleetWide

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -24,6 +24,8 @@ import {
   evaluateSubnetAxons,
   groupAxonDays,
   isFleetWide,
+  classifyAxonMechanism,
+  loadAxonLossMechanisms,
   isoDaysAgo,
   medianOf,
   runAxonAnnouncementWatchdog,
@@ -38,6 +40,13 @@ const flat = (n: number, withAxon: number, neurons = 256): AxonDay[] =>
     withAxon,
     neurons,
   }));
+
+const pgLaneDb = () => ({
+  query: async (t: string, v?: unknown[]) =>
+    (await import("../src/read-store.ts")).readStore(pgMockEnv(), [
+      "neuron_daily",
+    ])!.query!(t, v),
+});
 
 const then = (base: AxonDay[], ...tail: [number, number][]): AxonDay[] => [
   ...base,
@@ -169,6 +178,8 @@ describe("the fleet-wide guard", () => {
     neurons: 256,
     neuronBaseline: 256,
     kind: "announcements-withdrawn",
+    lossesViaReuse: null,
+    lossesSameHotkey: null,
   });
 
   test("three subnets is the observed independent maximum, so not fleet-wide", () => {
@@ -552,5 +563,361 @@ describe("the watchdog tick", () => {
     );
     assert.ok(read);
     assert.equal(read.values[0], "2026-08-07");
+  });
+});
+
+describe("mechanism — WHAT happened, not just how much (#11369)", () => {
+  // Measured 2026-08-16 over the watchdog's own 8-day window, per UID:
+  //   SN25   via_reuse 67  same_hotkey  0   -> churn
+  //   SN102  via_reuse 43  same_hotkey  0   -> churn
+  //   SN101  via_reuse 64  same_hotkey 75   -> withdrawal
+  // SN101 is the #11328 case and must stay `announcements-withdrawn`; the other
+  // two had ZERO miners stop announcing, so calling them withdrawal asserted
+  // the opposite of what happened.
+
+  test("all losses via UID reuse is churn, not withdrawal", () => {
+    assert.equal(
+      classifyAxonMechanism(
+        { viaReuse: 67, sameHotkey: 0 },
+        "announcements-withdrawn",
+      ),
+      "churn-replaced",
+    );
+  });
+
+  test("a majority of same-hotkey stops stays withdrawal (the SN101 shape)", () => {
+    assert.equal(
+      classifyAxonMechanism(
+        { viaReuse: 64, sameHotkey: 75 },
+        "announcements-withdrawn",
+      ),
+      "announcements-withdrawn",
+    );
+  });
+
+  test("a tie resolves to withdrawal — the reading that asks for a human", () => {
+    assert.equal(
+      classifyAxonMechanism(
+        { viaReuse: 5, sameHotkey: 5 },
+        "announcements-withdrawn",
+      ),
+      "announcements-withdrawn",
+    );
+  });
+
+  test("UNMEASURED keeps the default rather than guessing churn", () => {
+    // Churn is the reading that does NOT send anyone looking, so inferring it
+    // from an absent measurement would turn an unread number into an all-clear.
+    for (const counts of [
+      { viaReuse: null, sameHotkey: 3 },
+      { viaReuse: 3, sameHotkey: null },
+      { viaReuse: null, sameHotkey: null },
+    ]) {
+      assert.equal(
+        classifyAxonMechanism(counts, "announcements-withdrawn"),
+        "announcements-withdrawn",
+      );
+    }
+  });
+
+  test("no losses at all keeps the default", () => {
+    assert.equal(
+      classifyAxonMechanism(
+        { viaReuse: 0, sameHotkey: 0 },
+        "announcements-withdrawn",
+      ),
+      "announcements-withdrawn",
+    );
+  });
+
+  test("the fallback is honoured, so turnover is never reclassified", () => {
+    assert.equal(
+      classifyAxonMechanism(
+        { viaReuse: 99, sameHotkey: 0 },
+        "subnet-turned-over",
+      ),
+      "churn-replaced",
+      "the classifier itself is unconditional -- the RUNNER guards turnover",
+    );
+  });
+
+  test("the detail names the mechanism, not just the ratio", () => {
+    const churn: AxonFinding = {
+      netuid: 25,
+      date: "2026-08-16",
+      withAxon: 14,
+      baseline: 80,
+      ratio: 0.175,
+      neurons: 256,
+      neuronBaseline: 256,
+      kind: "churn-replaced",
+      lossesViaReuse: 67,
+      lossesSameHotkey: 0,
+    };
+    const detail = axonDetail([churn]);
+    assert.match(detail, /SN25 14\/80 axons/);
+    assert.match(
+      detail,
+      /churn-replaced: 67 of 67 losses were deregistrations/,
+    );
+  });
+
+  test("a withdrawal detail says how many miners stopped", () => {
+    const withdrawn: AxonFinding = {
+      netuid: 101,
+      date: "2026-08-16",
+      withAxon: 125,
+      baseline: 223,
+      ratio: 0.56,
+      neurons: 256,
+      neuronBaseline: 256,
+      kind: "announcements-withdrawn",
+      lossesViaReuse: 64,
+      lossesSameHotkey: 75,
+    };
+    assert.match(axonDetail([withdrawn]), /75 miner\(s\) stopped announcing/);
+  });
+});
+
+describe("loadAxonLossMechanisms", () => {
+  beforeEach(() => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.rows = null;
+    pg.control.failNext = null;
+  });
+
+  test("groups the split by netuid", async () => {
+    pg.control.answers.push({
+      match: /FROM seq/,
+      rows: [
+        { netuid: 25, via_reuse: 67, same_hotkey: 0 },
+        { netuid: 101, via_reuse: 64, same_hotkey: 75 },
+      ],
+    });
+    const out = await loadAxonLossMechanisms(
+      pgLaneDb(),
+      [25, 101],
+      "2026-08-08",
+    );
+    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0 });
+    assert.deepEqual(out[101], { viaReuse: 64, sameHotkey: 75 });
+  });
+
+  test("int8 counts arrive as STRINGS and are still counted", async () => {
+    // Same Postgres shape as the main read: COUNT(*) is int8.
+    pg.control.answers.push({
+      match: /FROM seq/,
+      rows: [{ netuid: 25, via_reuse: "67", same_hotkey: "0" }],
+    });
+    const out = await loadAxonLossMechanisms(pgLaneDb(), [25], "2026-08-08");
+    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0 });
+  });
+
+  test("no netuids asks nothing at all", async () => {
+    const out = await loadAxonLossMechanisms(pgLaneDb(), [], "2026-08-08");
+    assert.deepEqual(out, {});
+    assert.equal(pg.control.queries.length, 0, "no query for an empty list");
+  });
+
+  test("a failing read is unmeasured, not zero", async () => {
+    pg.control.failNext = new Error("boom");
+    assert.deepEqual(
+      await loadAxonLossMechanisms(pgLaneDb(), [25], "2026-08-08"),
+      {},
+    );
+  });
+
+  test("no store bound yields nothing", async () => {
+    assert.deepEqual(
+      await loadAxonLossMechanisms(null, [25], "2026-08-08"),
+      {},
+    );
+  });
+});
+
+describe("mechanism — the defensive edges", () => {
+  beforeEach(() => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.rows = null;
+    pg.control.failNext = null;
+  });
+
+  test("`?? 0` in the churn detail survives half-measured counts", () => {
+    // Only reachable if a producer ever fills one side and not the other. The
+    // string must still be readable rather than printing `null of null`.
+    const half: AxonFinding = {
+      netuid: 5,
+      date: "2026-08-16",
+      withAxon: 1,
+      baseline: 50,
+      ratio: 0.02,
+      neurons: 256,
+      neuronBaseline: 256,
+      kind: "churn-replaced",
+      lossesViaReuse: null,
+      lossesSameHotkey: null,
+    };
+    assert.match(axonDetail([half]), /churn-replaced: 0 of 0 losses/);
+  });
+
+  test("a null netuid list is treated as empty rather than throwing", () => {
+    assert.doesNotReject(async () => {
+      await loadAxonLossMechanisms(
+        pgLaneDb(),
+        null as unknown as number[],
+        "2026-08-08",
+      );
+    });
+  });
+
+  test("negative and non-integer netuids are filtered out", async () => {
+    const out = await loadAxonLossMechanisms(
+      pgLaneDb(),
+      [-1, 1.5, Number.NaN] as number[],
+      "2026-08-08",
+    );
+    assert.deepEqual(out, {});
+    assert.equal(pg.control.queries.length, 0, "nothing usable, nothing asked");
+  });
+
+  test("malformed rows are skipped, not counted as zero", async () => {
+    pg.control.answers.push({
+      match: /FROM seq/,
+      rows: [
+        { netuid: "nope", via_reuse: 1, same_hotkey: 0 },
+        { netuid: 25, via_reuse: "x", same_hotkey: 0 },
+        { netuid: 26, via_reuse: 4, same_hotkey: 1 },
+      ],
+    });
+    const out = await loadAxonLossMechanisms(
+      pgLaneDb(),
+      [25, 26],
+      "2026-08-08",
+    );
+    assert.deepEqual(Object.keys(out), ["26"]);
+  });
+
+  test("a store returning nothing at all is unmeasured, not a throw", async () => {
+    // The `?? []` guard: `query` promises an array, so this is a store breaking
+    // its contract rather than an ordinary empty result. Same shape the sibling
+    // groupAxonDays guards, and reached the same way.
+    const out = await loadAxonLossMechanisms(
+      { query: async () => null as unknown as unknown[] },
+      [25],
+      "2026-08-08",
+    );
+    assert.deepEqual(out, {});
+  });
+
+  test("an empty result set leaves every finding unmeasured", async () => {
+    pg.control.answers.push({ match: /FROM seq/, rows: [] });
+    assert.deepEqual(
+      await loadAxonLossMechanisms(pgLaneDb(), [25], "2026-08-08"),
+      {},
+    );
+  });
+});
+
+describe("the tick reports the mechanism it measured", () => {
+  beforeEach(() => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.rows = null;
+    pg.control.failNext = null;
+  });
+
+  const rowsFor = (netuid: number, series: AxonDay[]) =>
+    series.map((d) => ({
+      netuid,
+      date: d.date,
+      with_axon: d.withAxon,
+      neurons: d.neurons,
+    }));
+
+  const answer = (
+    days: Record<string, unknown>[],
+    mech: Record<string, unknown>[],
+  ) => {
+    pg.control.answers.push({ match: /FROM seq/, rows: mech });
+    pg.control.answers.push({ match: /FROM neuron_daily/, rows: days });
+    pg.control.answers.push({ match: /.*/, rows: [] });
+  };
+
+  const verdict = () => {
+    const insert = pg.control.queries.find((q) =>
+      q.text.includes("INSERT INTO lane_health"),
+    );
+    assert.ok(insert);
+    return String(insert.values[3]);
+  };
+
+  test("a churn subnet is reported as churn, not as withdrawal", async () => {
+    answer(rowsFor(25, then(flat(8, 80), [14, 256])), [
+      { netuid: 25, via_reuse: 67, same_hotkey: 0 },
+    ]);
+    let captured: Record<string, unknown> | null = null;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    })) as { findings: AxonFinding[] };
+
+    assert.equal(result.findings[0].kind, "churn-replaced");
+    assert.equal(result.findings[0].lossesViaReuse, 67);
+    assert.match(verdict(), /churn-replaced: 67 of 67/);
+    assert.match(
+      String((captured as unknown as { error: Error }).error.message),
+      /fell through CHURN, not withdrawal/,
+      "the message must not claim anyone went dark",
+    );
+  });
+
+  test("a withdrawal subnet keeps the #11328 wording", async () => {
+    answer(rowsFor(101, then(flat(8, 223), [125, 256])), [
+      { netuid: 101, via_reuse: 64, same_hotkey: 75 },
+    ]);
+    let captured: Record<string, unknown> | null = null;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    })) as { findings: AxonFinding[] };
+
+    assert.equal(result.findings[0].kind, "announcements-withdrawn");
+    assert.match(
+      String((captured as unknown as { error: Error }).error.message),
+      /stopped publishing an axon/,
+    );
+  });
+
+  test("an unmeasured mechanism leaves the default and the plain detail", async () => {
+    // The mechanism read returns nothing: the finding stands, unlabelled.
+    answer(rowsFor(25, then(flat(8, 80), [14, 256])), []);
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async () => true) as never,
+    })) as { findings: AxonFinding[] };
+    assert.equal(result.findings[0].kind, "announcements-withdrawn");
+    assert.equal(result.findings[0].lossesViaReuse, null);
+  });
+
+  test("turnover is never reclassified as churn", async () => {
+    // SN103's shape: the metagraph emptied. Even with every loss via reuse --
+    // which is what a mass deregistration looks like -- membership is the story.
+    answer(rowsFor(103, then(flat(8, 252, 256), [0, 2])), [
+      { netuid: 103, via_reuse: 250, same_hotkey: 0 },
+    ]);
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async () => true) as never,
+    })) as { findings: AxonFinding[] };
+    assert.equal(result.findings[0].kind, "subnet-turned-over");
+    assert.match(verdict(), /the subnet turned over/);
   });
 });


### PR DESCRIPTION
Closes #11369

#11364's watchdog is firing correctly on SN25 and SN102, but its label asserts the wrong mechanism — and the two mechanisms send a reader to completely different places.

## Not one miner stopped announcing

Per-UID day-over-day, splitting axon losses by whether the hotkey changed, over the watchdog's own 8-day window:

| subnet | via UID reuse | **same hotkey stopped** | classified |
| --- | --- | --- | --- |
| **25** | 67 | **0** | `churn-replaced` |
| **102** | 43 | **0** | `churn-replaced` |
| 101 | 64 | **75** | `announcements-withdrawn` |

On SN25 and SN102 **every** axon loss is a deregistration whose UID was reused by a miner that never served. Nobody went dark. SN101 — the case #11328 filed — is genuinely withdrawal and still classifies as such.

The old label said the opposite of the truth for both alarming subnets, and the exception message told the reader those miners were "still registered and still earning" when they had been deregistered.

## Why it only goes down

| subnet | UID replacements | replacements that announce |
| --- | --- | --- |
| **25** | 153 | 5 (**3.3%**) |
| **102** | 1,185 | 116 (**9.8%**) |
| 101 | 2,152 | 1,646 (**76.5%**) |

Churn removes an announcer, the newcomer does not announce, and the count ratchets down — which is why the decline is gradual, never recovers, and coexists with a hotkey *count* pinned at 256 while the *set* churns (SN102: 35 distinct sets in 38 days).

That rate tracks whether announcing pays. Excluding burn UIDs: SN25 has **no** earning miners at all (burn takes 100%), SN102's five real earners publish **no endpoint**, and SN101's earners are half its announcers.

**Burn share is not the driver** — tested first and dead: SN25 has burned 100% every day of the window, including every day its axon count sat stable at 89.

## The change

A third `kind`, `churn-replaced`, plus the two counts behind it so a reader can see the split rather than trust the label.

- **Scoped to subnets already flagged** (1–3 on a typical day). The per-UID comparison is 256 rows per subnet per day rather than one, so the cost tracks what was found, not the network.
- **Unmeasured keeps the default.** Churn is the reading that does *not* send anyone looking, so inferring it from an absent measurement would turn an unread number into an all-clear. A tie resolves the same way.
- **Turnover is not up for revision.** A subnet that emptied is not churn at any ratio — the neuron count decides that, and a mass deregistration looks exactly like 100% reuse.

## Verified

The classifier was run against production over the real window and gets all three right, including keeping SN101 as withdrawal. The SQL was executed against Neon directly, not just the mock.

- `tsc --noEmit`, `prettier --check`, `eslint` clean
- 64 tests in this file; full suite **936 files / 21,512 passing**
- patch coverage by diff intersection: **29/29 lines, 44/44 branches, 100%**
- `validate:boundary-casts`, `validate:no-passthrough`, `validate:unreferenced-exports`, `validate:operations`, `validate:lane-topology` pass

## Context worth keeping

Only **~22% of registered neurons network-wide announce an axon**, and 33 of 129 subnets have none. Not announcing is the norm — so "declining" is weak on its own, and the mechanism is what carries the information.
