### PR TITLE
feat(watchdog): name the blast radius — how many addresses went dark

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -147,6 +147,19 @@ export interface AxonFinding {
   lossesViaReuse: number | null;
   /** Axon losses where the same hotkey stopped announcing. Null until measured. */
   lossesSameHotkey: number | null;
+  /**
+   * Distinct IPs the withdrawn axons were announcing from. Null until measured.
+   *
+   * THE DIAGNOSTIC THAT NAMES THE BLAST RADIUS. SN101's 2026-08-11 event read
+   * as "75 of 256 miners went dark" -- 29% of the metagraph, and subnet-shaped.
+   * All 75 were announcing from ONE address (152.53.149.254, four coldkeys), so
+   * it was a single operator's host, not the subnet changing behaviour.
+   *
+   * 1 means one host or one operator, and probably nobody has noticed. N means
+   * a genuine subnet-wide change. They ask for completely different responses,
+   * and the count is the cheapest thing that separates them.
+   */
+  lossesDistinctIps: number | null;
 }
 
 /** Median of a list, on a copy — the caller's array is never reordered. */
@@ -206,6 +219,7 @@ export function evaluateSubnetAxons(
     // "zero" -- see classifyAxonMechanism.
     lossesViaReuse: null,
     lossesSameHotkey: null,
+    lossesDistinctIps: null,
   };
 }
 
@@ -239,7 +253,12 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
           : f.kind === "churn-replaced"
             ? `, churn-replaced: ${f.lossesViaReuse ?? 0} of ${(f.lossesViaReuse ?? 0) + (f.lossesSameHotkey ?? 0)} losses were deregistrations`
             : f.lossesSameHotkey !== null
-              ? `, ${f.lossesSameHotkey} miner(s) stopped announcing`
+              ? `, ${f.lossesSameHotkey} miner(s) stopped announcing` +
+                (f.lossesDistinctIps === null
+                  ? ""
+                  : f.lossesDistinctIps === 1
+                    ? " -- ALL FROM ONE ADDRESS, so this is one host rather than the subnet"
+                    : ` from ${f.lossesDistinctIps} addresses`)
               : "") +
         ")",
     )
@@ -295,8 +314,16 @@ export async function loadAxonLossMechanisms(
     | undefined,
   netuids: readonly number[],
   sinceDate: string,
-): Promise<Record<number, { viaReuse: number; sameHotkey: number }>> {
-  const out: Record<number, { viaReuse: number; sameHotkey: number }> = {};
+): Promise<
+  Record<
+    number,
+    { viaReuse: number; sameHotkey: number; distinctIps: number | null }
+  >
+> {
+  const out: Record<
+    number,
+    { viaReuse: number; sameHotkey: number; distinctIps: number | null }
+  > = {};
   const ids = (netuids ?? []).filter((n) => Number.isSafeInteger(n) && n >= 0);
   if (!db?.query || ids.length === 0) return out;
   try {
@@ -304,12 +331,15 @@ export async function loadAxonLossMechanisms(
       "WITH seq AS (SELECT netuid, uid, snapshot_date, hotkey, " +
         "(axon IS NOT NULL) AS has_axon, " +
         "LAG(axon IS NOT NULL) OVER w AS prev_has, " +
-        "LAG(hotkey) OVER w AS prev_hotkey FROM neuron_daily " +
+        "LAG(hotkey) OVER w AS prev_hotkey, LAG(axon) OVER w AS prev_axon " +
+        "FROM neuron_daily " +
         `WHERE snapshot_date >= ? AND netuid IN (${ids.map(() => "?").join(",")}) ` +
         "WINDOW w AS (PARTITION BY netuid, uid ORDER BY snapshot_date)) " +
         "SELECT netuid, " +
         "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey IS DISTINCT FROM prev_hotkey) AS via_reuse, " +
-        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS same_hotkey " +
+        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS same_hotkey, " +
+        "COUNT(DISTINCT split_part(prev_axon, ':', 1)) FILTER " +
+        "(WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS distinct_ips " +
         "FROM seq GROUP BY netuid",
       [sinceDate, ...ids],
     )) as Record<string, unknown>[];
@@ -317,9 +347,16 @@ export async function loadAxonLossMechanisms(
       const netuid = Number(row?.netuid);
       const viaReuse = Number(row?.via_reuse ?? 0);
       const sameHotkey = Number(row?.same_hotkey ?? 0);
+      const ips = Number(row?.distinct_ips);
       if (!Number.isFinite(netuid)) continue;
       if (!Number.isFinite(viaReuse) || !Number.isFinite(sameHotkey)) continue;
-      out[netuid] = { viaReuse, sameHotkey };
+      out[netuid] = {
+        viaReuse,
+        sameHotkey,
+        // Null rather than 0 when unreadable: "no addresses" and "we did not
+        // count the addresses" are different, and only one of them is a fact.
+        distinctIps: Number.isFinite(ips) ? ips : null,
+      };
     }
   } catch {
     // Unmeasured, not zero. The caller keeps each finding's default kind.
@@ -383,6 +420,7 @@ export async function runAxonAnnouncementWatchdog(
     if (!counts) continue;
     finding.lossesViaReuse = counts.viaReuse;
     finding.lossesSameHotkey = counts.sameHotkey;
+    finding.lossesDistinctIps = counts.distinctIps;
     // Turnover is decided by the neuron count and is not up for revision here:
     // a subnet that emptied is not "churn" at any ratio.
     if (finding.kind !== "subnet-turned-over") {

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -180,6 +180,7 @@ describe("the fleet-wide guard", () => {
     kind: "announcements-withdrawn",
     lossesViaReuse: null,
     lossesSameHotkey: null,
+    lossesDistinctIps: null,
   });
 
   test("three subnets is the observed independent maximum, so not fleet-wide", () => {
@@ -653,6 +654,7 @@ describe("mechanism — WHAT happened, not just how much (#11369)", () => {
       kind: "churn-replaced",
       lossesViaReuse: 67,
       lossesSameHotkey: 0,
+      lossesDistinctIps: null,
     };
     const detail = axonDetail([churn]);
     assert.match(detail, /SN25 14\/80 axons/);
@@ -674,6 +676,7 @@ describe("mechanism — WHAT happened, not just how much (#11369)", () => {
       kind: "announcements-withdrawn",
       lossesViaReuse: 64,
       lossesSameHotkey: 75,
+      lossesDistinctIps: null,
     };
     assert.match(axonDetail([withdrawn]), /75 miner\(s\) stopped announcing/);
   });
@@ -691,8 +694,8 @@ describe("loadAxonLossMechanisms", () => {
     pg.control.answers.push({
       match: /FROM seq/,
       rows: [
-        { netuid: 25, via_reuse: 67, same_hotkey: 0 },
-        { netuid: 101, via_reuse: 64, same_hotkey: 75 },
+        { netuid: 25, via_reuse: 67, same_hotkey: 0, distinct_ips: 0 },
+        { netuid: 101, via_reuse: 64, same_hotkey: 75, distinct_ips: 1 },
       ],
     });
     const out = await loadAxonLossMechanisms(
@@ -700,18 +703,24 @@ describe("loadAxonLossMechanisms", () => {
       [25, 101],
       "2026-08-08",
     );
-    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0 });
-    assert.deepEqual(out[101], { viaReuse: 64, sameHotkey: 75 });
+    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0, distinctIps: 0 });
+    assert.deepEqual(out[101], {
+      viaReuse: 64,
+      sameHotkey: 75,
+      distinctIps: 1,
+    });
   });
 
   test("int8 counts arrive as STRINGS and are still counted", async () => {
     // Same Postgres shape as the main read: COUNT(*) is int8.
     pg.control.answers.push({
       match: /FROM seq/,
-      rows: [{ netuid: 25, via_reuse: "67", same_hotkey: "0" }],
+      rows: [
+        { netuid: 25, via_reuse: "67", same_hotkey: "0", distinct_ips: "0" },
+      ],
     });
     const out = await loadAxonLossMechanisms(pgLaneDb(), [25], "2026-08-08");
-    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0 });
+    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0, distinctIps: 0 });
   });
 
   test("no netuids asks nothing at all", async () => {
@@ -758,6 +767,7 @@ describe("mechanism — the defensive edges", () => {
       kind: "churn-replaced",
       lossesViaReuse: null,
       lossesSameHotkey: null,
+      lossesDistinctIps: null,
     };
     assert.match(axonDetail([half]), /churn-replaced: 0 of 0 losses/);
   });
@@ -786,9 +796,9 @@ describe("mechanism — the defensive edges", () => {
     pg.control.answers.push({
       match: /FROM seq/,
       rows: [
-        { netuid: "nope", via_reuse: 1, same_hotkey: 0 },
-        { netuid: 25, via_reuse: "x", same_hotkey: 0 },
-        { netuid: 26, via_reuse: 4, same_hotkey: 1 },
+        { netuid: "nope", via_reuse: 1, same_hotkey: 0, distinct_ips: 1 },
+        { netuid: 25, via_reuse: "x", same_hotkey: 0, distinct_ips: 1 },
+        { netuid: 26, via_reuse: 4, same_hotkey: 1, distinct_ips: 1 },
       ],
     });
     const out = await loadAxonLossMechanisms(
@@ -919,5 +929,112 @@ describe("the tick reports the mechanism it measured", () => {
     })) as { findings: AxonFinding[] };
     assert.equal(result.findings[0].kind, "subnet-turned-over");
     assert.match(verdict(), /the subnet turned over/);
+  });
+});
+
+describe("IP concentration — one host, or the subnet", () => {
+  // SN101's 2026-08-11 event read as "75 of 256 miners went dark" -- 29% of the
+  // metagraph, and subnet-shaped. All 75 announced from 152.53.149.254 across
+  // four coldkeys, so it was one operator's host. Verified against production
+  // 2026-08-16: the same query returns same_hotkey 75, distinct_ips 1.
+  const withdrawal = (ips: number | null): AxonFinding => ({
+    netuid: 101,
+    date: "2026-08-16",
+    withAxon: 125,
+    baseline: 223,
+    ratio: 0.56,
+    neurons: 256,
+    neuronBaseline: 256,
+    kind: "announcements-withdrawn",
+    lossesViaReuse: 64,
+    lossesSameHotkey: 75,
+    lossesDistinctIps: ips,
+  });
+
+  test("one address says it is a host, not the subnet", () => {
+    const detail = axonDetail([withdrawal(1)]);
+    assert.match(detail, /75 miner\(s\) stopped announcing/);
+    assert.match(detail, /ALL FROM ONE ADDRESS/);
+    assert.match(detail, /one host rather than the subnet/);
+  });
+
+  test("many addresses reads as a genuine subnet-wide change", () => {
+    const detail = axonDetail([withdrawal(63)]);
+    assert.match(detail, /75 miner\(s\) stopped announcing from 63 addresses/);
+    assert.doesNotMatch(detail, /ONE ADDRESS/);
+  });
+
+  test("unmeasured says nothing rather than implying one host", () => {
+    // Null is "we did not count", and must not read as concentration.
+    const detail = axonDetail([withdrawal(null)]);
+    assert.match(detail, /75 miner\(s\) stopped announcing\)/);
+    assert.doesNotMatch(detail, /address/);
+  });
+
+  test("churn findings do not claim an address count", () => {
+    // Churn losses are deregistrations; the outgoing miner's address is not
+    // the story, and printing it would imply a host failed.
+    const churn: AxonFinding = {
+      ...withdrawal(1),
+      netuid: 25,
+      kind: "churn-replaced",
+      lossesViaReuse: 67,
+      lossesSameHotkey: 0,
+    };
+    const detail = axonDetail([churn]);
+    assert.match(detail, /churn-replaced: 67 of 67/);
+    assert.doesNotMatch(detail, /ONE ADDRESS/);
+  });
+
+  test("the read carries distinct_ips through, and null when unreadable", async () => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.answers.push({
+      match: /FROM seq/,
+      rows: [
+        { netuid: 101, via_reuse: 65, same_hotkey: 75, distinct_ips: 1 },
+        { netuid: 9, via_reuse: 1, same_hotkey: 2, distinct_ips: "nope" },
+      ],
+    });
+    const out = await loadAxonLossMechanisms(
+      pgLaneDb(),
+      [101, 9],
+      "2026-08-08",
+    );
+    assert.equal(out[101].distinctIps, 1);
+    assert.equal(
+      out[9].distinctIps,
+      null,
+      "unreadable is null, never 0 -- 'no addresses' is a different claim",
+    );
+  });
+
+  test("the tick reports the concentration end to end", async () => {
+    pg.control.queries.length = 0;
+    pg.control.answers.length = 0;
+    pg.control.answers.push({
+      match: /FROM seq/,
+      rows: [{ netuid: 101, via_reuse: 0, same_hotkey: 75, distinct_ips: 1 }],
+    });
+    pg.control.answers.push({
+      match: /FROM neuron_daily/,
+      rows: then(flat(8, 223), [125, 256]).map((d) => ({
+        netuid: 101,
+        date: d.date,
+        with_axon: d.withAxon,
+        neurons: d.neurons,
+      })),
+    });
+    pg.control.answers.push({ match: /.*/, rows: [] });
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async () => true) as never,
+    })) as { findings: AxonFinding[] };
+    assert.equal(result.findings[0].kind, "announcements-withdrawn");
+    assert.equal(result.findings[0].lossesDistinctIps, 1);
+    const insert = pg.control.queries.find((q) =>
+      q.text.includes("INSERT INTO lane_health"),
+    );
+    assert.match(String(insert?.values[3]), /ALL FROM ONE ADDRESS/);
   });
 });


### PR DESCRIPTION
Falls out of finally root-causing #11328. The watchdog can now say the one thing that separates "somebody's box died" from "the subnet changed", and it costs one `split_part` over rows it already reads.

## The event this exists for

SN101's 2026-08-11 withdrawal read as **75 of 256 miners going dark** — 29% of the metagraph, which is subnet-shaped and was investigated as such for a long time. Grouping those 75 by the address they had been announcing:

```
shared IP           152.53.149.254
UIDs                75
distinct coldkeys    4
distinct IPs         1
```

One operator's fleet behind one address. Not the subnet. None has announced again in the five days since, and 59 of the 75 still earn incentive — a combined 3.8%.

Nothing in the fleet reported the IP concentration that made 29% of a subnet a single point of failure.

## What it adds

`lossesDistinctIps` on the finding, and one clause in the detail:

- **1 address** → `ALL FROM ONE ADDRESS, so this is one host rather than the subnet`
- **N addresses** → `from N addresses`
- **unmeasured** → says nothing, rather than implying concentration

That sentence is the difference between paging someone to look at a subnet and telling them one operator's host is down.

## Deliberate limits

- **Only on withdrawal findings.** A churn loss is a deregistration; the outgoing miner's address is not the story, and printing it would imply a host failed when nobody's did.
- **Null is "not counted", never 0.** "No addresses" and "we did not count the addresses" are different claims and only one of them is a fact.
- No new query — the same grouped read #11370 added, with one extra aggregate.

## Verified against production

The exact SQL, run over the watchdog's real 8-day window:

```
netuid   via_reuse   same_hotkey   distinct_ips
    25          67             0              0
   101          65            75              1     <- the event
   102          43             0              0
```

SN101 reproduces at 75 withdrawals from 1 address; SN25 and SN102 correctly report no withdrawals at all, so no address claim is made about them.

- `tsc --noEmit`, `prettier --check`, `eslint` clean
- 70 tests in this file; full suite **21,549 passing**
- patch coverage by diff intersection: **4/4 lines, 6/6 branches, 100%**

## Note

The axon endpoint is public on-chain data that this API already serves, so naming it in an alarm detail discloses nothing new.
