### PR TITLE
fix(ui): a zod-v3 adapter under zod 4 made every route's search type `{}`

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -42,7 +42,6 @@
     "@tanstack/react-start": "^1.168.40",
     "@tanstack/react-virtual": "^3.14.9",
     "@tanstack/router-plugin": "^1.168.27",
-    "@tanstack/zod-adapter": "^1.167.0",
     "clsx": "^2.1.1",
     "fumadocs-core": "^16.11.5",
     "fumadocs-mdx": "^15.2.2",

--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -65,13 +65,13 @@ export function DriftActivity({ schemas, fromPath }: Props) {
   const openDrift = (id: string) =>
     navigate({
       to: "/apis/schemas",
-      search: (prev: Record<string, unknown>) => ({ ...prev, driftDetail: id }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, driftDetail: id }),
       replace: true,
     });
   const openInExplorer = (id: string) =>
     navigate({
       to: "/apis/schemas",
-      search: (prev: Record<string, unknown>) => ({ ...prev, open: id, drift: "all" }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, open: id, drift: "all" }),
       replace: true,
     });
 

--- a/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/incidents-timeline.tsx
@@ -234,9 +234,10 @@ export function IncidentsTimeline({ className }: { className?: string }) {
                   {pool ? (
                     <Link
                       to="/apis/endpoints"
-                      search={(prev: Record<string, unknown>) =>
-                        ({ ...prev, q: pool.name ?? pool.id }) as never
-                      }
+                      search={(prev: Record<string, unknown>) => ({
+                        ...prev,
+                        q: pool.name ?? pool.id,
+                      })}
                       className="inline-flex items-center gap-1 rounded border border-border bg-paper px-2 py-1 mg-type-caption text-ink-muted hover:text-accent hover:border-accent/40"
                     >
                       pool · {pool.name ?? pool.id}

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -140,7 +140,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
 
   const onOpen = (s: SchemaInfo) => {
     if (setOpenSchema) setOpenSchema(s.id);
-    else navigate({ to: "/apis/schemas", search: { open: s.id } as never, replace: false });
+    else navigate({ to: "/apis/schemas", search: { open: s.id }, replace: false });
   };
 
   return (

--- a/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/what-changed-feed.tsx
@@ -245,11 +245,7 @@ function DigestRow({ item }: { item: DigestItem }) {
   return (
     <li className="group">
       {item.href ? (
-        <Link
-          to={item.href.to}
-          params={item.href.params as never}
-          className="flex items-start gap-2.5"
-        >
+        <Link to={item.href.to} params={item.href.params} className="flex items-start gap-2.5">
           {body}
         </Link>
       ) : (

--- a/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
@@ -49,7 +49,7 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
           const heavy = share >= 20;
           const filterByAuthor = () =>
             navigate({
-              search: (prev: Record<string, unknown>) => ({ ...prev, author, offset: 0 }) as never,
+              search: (prev: Record<string, unknown>) => ({ ...prev, author, offset: 0 }),
               resetScroll: false,
             });
           return (

--- a/apps/ui/src/components/metagraphed/chain-stake-flow-sankey.tsx
+++ b/apps/ui/src/components/metagraphed/chain-stake-flow-sankey.tsx
@@ -83,7 +83,7 @@ export function ChainStakeFlowSankey({
         formatValue={(v) => formatTao(v)}
         onNodeSelect={(nodeId) => {
           const target = resolveSankeyNode(nodeId);
-          if (target) navigate({ to: target.to as never, params: target.params as never });
+          if (target) navigate({ to: target.to, params: target.params });
         }}
       />
     </ChartCard>

--- a/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/latency-heatmap.tsx
@@ -339,12 +339,10 @@ function Cell({ cell }: { cell: Cell }) {
               </Link>
               <Link
                 to="/apis/endpoints"
-                search={
-                  {
-                    provider: cell.provider,
-                    category: KIND_TO_CATEGORY[cell.kind] ?? "all",
-                  } as never
-                }
+                search={{
+                  provider: cell.provider,
+                  category: KIND_TO_CATEGORY[cell.kind] ?? "all",
+                }}
                 className="sm:ml-auto inline-flex items-center gap-1 rounded border border-border bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted hover:text-accent hover:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
                 aria-label={`Open endpoints filtered to ${cell.provider} ${cell.kind}`}
               >
@@ -359,7 +357,7 @@ function Cell({ cell }: { cell: Cell }) {
                       <Link
                         to="/subnets/$netuid"
                         params={{ netuid: n }}
-                        search={{ tab: "endpoints" } as never}
+                        search={{ tab: "endpoints" }}
                         hash="endpoints"
                         className="inline-flex h-6 items-center rounded border border-border bg-paper px-2 mg-type-data-sm text-ink hover:border-accent/60 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
                         aria-label={`Jump to subnet ${n} endpoints`}
@@ -381,7 +379,7 @@ function Cell({ cell }: { cell: Cell }) {
                     <TooltipTrigger asChild>
                       <Link
                         to="/apis/endpoints"
-                        search={{ q: p } as never}
+                        search={{ q: p }}
                         hash={`pool-${p}`}
                         className="inline-flex h-6 max-w-[16ch] items-center truncate rounded border border-border bg-paper px-2 mg-type-data-sm text-ink hover:border-accent/60 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 transition-colors"
                         aria-label={`Scroll to pool ${p} in endpoints`}

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -646,8 +646,8 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
       onOpenChange(false);
       router.navigate({
         to: target.to,
-        params: target.params as never,
-        search: (target.search ?? {}) as never,
+        params: target.params,
+        search: target.search ?? {},
       });
     },
     [router, onOpenChange, debounced],
@@ -748,14 +748,14 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
     pushRecent(debounced);
     trackAction("filter:subnets");
     onOpenChange(false);
-    navigate({ to: "/subnets", search: { q: debounced } as never });
+    navigate({ to: "/subnets", search: { q: debounced } });
   }, [debounced, navigate, onOpenChange]);
 
   const filterEndpointsByQuery = useCallback(() => {
     pushRecent(debounced);
     trackAction("filter:endpoints");
     onOpenChange(false);
-    navigate({ to: "/apis/endpoints", search: { q: debounced } as never });
+    navigate({ to: "/apis/endpoints", search: { q: debounced } });
   }, [debounced, navigate, onOpenChange]);
 
   return (

--- a/apps/ui/src/components/metagraphed/continue-exploring.tsx
+++ b/apps/ui/src/components/metagraphed/continue-exploring.tsx
@@ -141,7 +141,7 @@ export function ContinueExploring() {
               <li key={q}>
                 <Link
                   to="/subnets"
-                  search={{ q } as never}
+                  search={{ q }}
                   className="group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 mg-type-caption text-ink hover:border-accent/40 hover:text-accent transition-colors"
                 >
                   <Search className="size-3 text-ink-muted group-hover:text-accent transition-colors" />

--- a/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.tsx
+++ b/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.tsx
@@ -35,7 +35,7 @@ function LiveRowLink({ item, onNavigate, registerItem, itemIndex }: MegaMenuLive
   return (
     <Link
       to={item.to}
-      params={item.params as never}
+      params={item.params}
       onClick={onNavigate}
       ref={(el: HTMLAnchorElement | null) => registerItem(el, itemIndex)}
       className={LIVE_LINK_CLASS}

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
@@ -285,7 +285,7 @@ export function MegaPanelBody({
                 <li key={`${l.to}-${l.label}`}>
                   <Link
                     to={l.to}
-                    search={(l.search ?? undefined) as never}
+                    search={l.search ?? undefined}
                     onClick={onNavigate}
                     ref={(el: HTMLAnchorElement | null) => registerItem(el, i)}
                     className="group/link block rounded-md px-2 py-1.5 -mx-2 hover:bg-surface/70 focus:bg-surface/70 focus:outline-none transition-colors"
@@ -387,7 +387,7 @@ export function MegaPanelBody({
                 <li key={l.label}>
                   <Link
                     to={l.to}
-                    search={(l.search ?? undefined) as never}
+                    search={l.search ?? undefined}
                     onClick={onNavigate}
                     ref={(el: HTMLAnchorElement | null) => registerItem(el, i)}
                     className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 mg-type-caption text-ink-muted hover:text-ink-strong hover:border-accent/50 focus:border-accent/60 focus:outline-none transition-colors"
@@ -527,7 +527,7 @@ export function MobileMegaMenuBody({ onNavigate }: { onNavigate?: () => void }) 
                         <li key={`${l.to}-${l.label}`}>
                           <Link
                             to={l.to}
-                            search={(l.search ?? undefined) as never}
+                            search={l.search ?? undefined}
                             onClick={onNavigate}
                             className="block rounded-md px-2 py-2 text-sm text-ink-strong hover:bg-surface/70"
                             preload="intent"
@@ -549,7 +549,7 @@ export function MobileMegaMenuBody({ onNavigate }: { onNavigate?: () => void }) 
                           <li key={l.label}>
                             <Link
                               to={l.to}
-                              search={(l.search ?? undefined) as never}
+                              search={l.search ?? undefined}
                               onClick={onNavigate}
                               className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 mg-type-caption text-ink-muted hover:text-ink-strong"
                               preload="intent"

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -342,14 +342,14 @@ export function NavOmnibox({ onOpenPalette }: Props) {
     if (debounced) pushRecent(debounced);
     setOpen(false);
     if (item.kind === "action") {
-      navigate({ to: "/subnets", search: { q: debounced } as never });
+      navigate({ to: "/subnets", search: { q: debounced } });
       return;
     }
     if (item.kind === "nav") {
       navigate({
-        to: item.to as never,
-        params: (item.params ?? {}) as never,
-        search: (item.search ?? {}) as never,
+        to: item.to,
+        params: item.params ?? {},
+        search: item.search ?? {},
       });
       return;
     }

--- a/apps/ui/src/components/metagraphed/neuron-table.test.ts
+++ b/apps/ui/src/components/metagraphed/neuron-table.test.ts
@@ -11,12 +11,12 @@ import { NUMERIC_FIELDS } from "./neuron-table";
  */
 describe("NeuronTable sort-field invariant", () => {
   it("never makes the sponsored-placement pin sortable", () => {
-    expect(NUMERIC_FIELDS.has("featured" as never)).toBe(false);
+    expect(NUMERIC_FIELDS.has("featured")).toBe(false);
   });
 
   it("never makes any other likely sponsor/partnership field sortable", () => {
     for (const field of ["sponsored", "partner", "partnership", "promoted"]) {
-      expect(NUMERIC_FIELDS.has(field as never)).toBe(false);
+      expect(NUMERIC_FIELDS.has(field)).toBe(false);
     }
   });
 
@@ -32,7 +32,7 @@ describe("NeuronTable sort-field invariant", () => {
       "validator_trust",
       "take",
     ]) {
-      expect(NUMERIC_FIELDS.has(field as never)).toBe(true);
+      expect(NUMERIC_FIELDS.has(field)).toBe(true);
     }
   });
 });

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -37,7 +37,17 @@ type NeuronTableVariant = "miner" | "validator";
 // has no `featured` member, so it can't be added here without a type error;
 // neuron-table.test.ts also asserts this set never contains "featured" at
 // runtime as a second line of defense if that type is ever loosened.
-export const NUMERIC_FIELDS = new Set<SortField>([
+/**
+ * The columns this table sorts numerically.
+ *
+ * Constructed as `Set<SortField>` so the membership list below stays checked
+ * against the column union, but EXPOSED as `ReadonlySet<string>` because the
+ * field being asked about arrives from the URL and is a string until something
+ * proves otherwise. Typing the query side as `SortField` did not make the
+ * lookup safer -- it just meant callers asserted, including the test whose
+ * entire job is asking whether "featured" is in here.
+ */
+export const NUMERIC_FIELDS: ReadonlySet<string> = new Set<SortField>([
   "uid",
   "stake_tao",
   "emission_tao",

--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -142,7 +142,7 @@ export function RegistryTicker() {
 
           <Link
             to="/subnets"
-            search={{ curation: "verified" } as never}
+            search={{ curation: "verified" }}
             className="hidden lg:inline-flex items-baseline gap-1.5 shrink-0 hover:opacity-80 transition-opacity"
           >
             <span className="text-ink-muted">curated</span>

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -44,7 +44,11 @@ export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
     (next: number | null) => {
       navigate({
         to: ".",
-        search: (prev: Record<string, unknown>) => ({
+        // `prev` is INFERRED. Annotating it as Record<string, unknown> was
+        // what made this reducer's return type lose every other search field,
+        // which the router then rejected -- silently, until its search types
+        // started resolving.
+        search: (prev) => ({
           ...prev,
           compare: next == null ? undefined : next,
         }),

--- a/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
@@ -103,7 +103,7 @@ export function SubnetsSavedViews() {
           if (v === undefined) delete next[k];
           else next[k] = v;
         }
-        return next as never;
+        return next;
       },
       replace: true,
     });

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -18,7 +18,14 @@ export function ariaSort(
   return order === "asc" ? "ascending" : "descending";
 }
 
-export function SortHeader({
+/**
+ * `TField` is inferred from the table's own `onSort`, so a `field` that is not
+ * one of that table's sortable columns is a compile error. It used to be
+ * `string` on both, which meant a typo compiled and then did nothing visible:
+ * the router's search schema `.catch()`es an unknown sort back to its default,
+ * so the column simply never sorted and nothing said why.
+ */
+export function SortHeader<TField extends string>({
   label,
   field,
   active,
@@ -27,10 +34,10 @@ export function SortHeader({
   align = "left",
 }: {
   label: string;
-  field: string;
+  field: TField;
   active?: boolean;
   order?: "asc" | "desc";
-  onSort: (field: string) => void;
+  onSort: (field: TField) => void;
   align?: "left" | "right";
 }) {
   const sortHint = active ? `, sorted ${order === "asc" ? "ascending" : "descending"}` : "";

--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -19,6 +19,7 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { statPhase } from "@/lib/metagraphed/stat-phase";
 import { exitTotals, quotePhase, type PositionQuoteState } from "@/lib/metagraphed/position-totals";
 import type { SubnetEconomics } from "@/lib/metagraphed/types";
+import { readKey, readNumber, readString } from "@/lib/metagraphed/read-key";
 
 /** One row of the portfolio, unified across the hotkey-owned and delegated feeds. */
 export interface UnifiedPosition {
@@ -39,9 +40,18 @@ export interface UnifiedPosition {
 
 /** #5243: fold the two position feeds into one spot-sorted list, deriving each
  *  alpha holding from the per-subnet price so an exit quote can be requested. */
+/**
+ * `object` and not `Record<string, unknown>`, because that is what the callers
+ * hold. Both position lists arrive as typed interface arrays, and an interface
+ * has no implicit index signature -- so the previous signature obliged every
+ * caller to assert its way in, which is what
+ * `as unknown as Record<string, unknown>[]` was doing one line up from here.
+ * Nothing about the body wanted a record: every field is read through a
+ * `typeof` guard already.
+ */
 export function buildUnifiedPositions(
-  ownedPositions: ReadonlyArray<Record<string, unknown>>,
-  delegatedPositions: ReadonlyArray<Record<string, unknown>>,
+  ownedPositions: ReadonlyArray<object>,
+  delegatedPositions: ReadonlyArray<object>,
   priceByNetuid: ReadonlyMap<number, number>,
 ): UnifiedPosition[] {
   const derive = (netuid: number, spotTao: number) => {
@@ -49,27 +59,28 @@ export function buildUnifiedPositions(
     return netuid === 0 || !price || price <= 0 ? null : spotTao / price;
   };
   const owned = ownedPositions.map((p, i) => {
-    const netuid = Number(p.netuid);
-    const spotTao = typeof p.stake_tao === "number" ? p.stake_tao : 0;
+    const netuid = Number(readKey(p, "netuid"));
+    const spotTao = readNumber(p, "stake_tao") ?? 0;
     return {
-      key: `owned-${netuid}-${p.uid ?? i}`,
+      key: `owned-${netuid}-${readKey(p, "uid") ?? i}`,
       source: "owned" as const,
       netuid,
-      hotkey: typeof p.hotkey === "string" ? p.hotkey : null,
+      hotkey: readString(p, "hotkey") ?? null,
       spotTao,
-      yield: typeof p.yield === "number" ? p.yield : null,
+      yield: readNumber(p, "yield") ?? null,
       alpha: derive(netuid, spotTao),
       isRoot: netuid === 0,
     };
   });
   const delegated = delegatedPositions.map((p, i) => {
-    const netuid = Number(p.netuid);
-    const spotTao = typeof p.stake_tao === "number" ? p.stake_tao : 0;
+    const netuid = Number(readKey(p, "netuid"));
+    const spotTao = readNumber(p, "stake_tao") ?? 0;
+    const hotkey = readString(p, "hotkey") ?? null;
     return {
-      key: `deleg-${typeof p.hotkey === "string" ? p.hotkey : i}-${netuid}`,
+      key: `deleg-${hotkey ?? i}-${netuid}`,
       source: "delegated" as const,
       netuid,
-      hotkey: typeof p.hotkey === "string" ? p.hotkey : null,
+      hotkey,
       spotTao,
       yield: null,
       alpha: derive(netuid, spotTao),
@@ -97,11 +108,7 @@ export function YourPositionsPanel({ address }: { address: string }) {
 
   const positions = useMemo(
     () =>
-      buildUnifiedPositions(
-        (portfolio.positions ?? []) as Record<string, unknown>[],
-        (nominator.positions ?? []) as unknown as Record<string, unknown>[],
-        priceByNetuid,
-      ),
+      buildUnifiedPositions(portfolio.positions ?? [], nominator.positions ?? [], priceByNetuid),
     [portfolio, nominator, priceByNetuid],
   );
 

--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -437,7 +437,7 @@ describe("acquireSharedChainStream", () => {
         deliver: (p: unknown) => seen.push(p),
         cancel: () => {},
         ...overrides,
-      } as never,
+      },
     };
   }
 
@@ -454,7 +454,7 @@ describe("acquireSharedChainStream", () => {
     const src = fakeSource();
     const open = () => {
       opened += 1;
-      return src as never;
+      return src;
     };
     const a = subscriber(["blocks"]);
     const b = subscriber(["account_events"]);
@@ -476,7 +476,7 @@ describe("acquireSharedChainStream", () => {
     const src = fakeSource();
     const open = () => {
       opened += 1;
-      return src as never;
+      return src;
     };
     const a = subscriber(["blocks"]);
     const b = subscriber(["blocks"]);
@@ -494,7 +494,7 @@ describe("acquireSharedChainStream", () => {
     const src = fakeSource();
     const open = () => {
       opened += 1;
-      return src as never;
+      return src;
     };
     const a = subscriber(["blocks"]);
     const b = subscriber(["account_events"]);
@@ -511,8 +511,8 @@ describe("acquireSharedChainStream", () => {
     const src = fakeSource();
     const a = subscriber(["blocks"]);
     const b = subscriber(["blocks"]);
-    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
-    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
+    const releaseA = acquireSharedChainStream(() => src, a.sub);
+    const releaseB = acquireSharedChainStream(() => src, b.sub);
     releaseA();
     expectEq(src.closed, 0, "unmounting one consumer closed the shared socket");
     releaseB();
@@ -526,8 +526,8 @@ describe("acquireSharedChainStream", () => {
     const src = fakeSource();
     const a = subscriber(["blocks"]);
     const b = subscriber(["account_events"]);
-    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
-    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
+    const releaseA = acquireSharedChainStream(() => src, a.sub);
+    const releaseB = acquireSharedChainStream(() => src, b.sub);
     src.emit({ table: "blocks", block_number: 1 });
     src.emit({ table: "account_events", id: 7 });
     expectEq(a.seen, [{ table: "blocks", block_number: 1 }]);
@@ -543,7 +543,7 @@ describe("acquireSharedChainStream", () => {
   it("a frame for no subscribed topic is dropped by everyone", () => {
     const src = fakeSource();
     const a = subscriber(["blocks"]);
-    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
+    const releaseA = acquireSharedChainStream(() => src, a.sub);
     src.emit({ table: "something_else", id: 1 });
     expectEq(a.seen, []);
     releaseA();
@@ -555,8 +555,8 @@ describe("acquireSharedChainStream", () => {
       getMatches: () => (p: unknown) => (p as { block_number: number }).block_number > 5,
     });
     const b = subscriber(["blocks"]);
-    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
-    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
+    const releaseA = acquireSharedChainStream(() => src, a.sub);
+    const releaseB = acquireSharedChainStream(() => src, b.sub);
     src.emit({ table: "blocks", block_number: 1 });
     src.emit({ table: "blocks", block_number: 9 });
     expectEq(a.seen, [{ table: "blocks", block_number: 9 }]);
@@ -571,10 +571,10 @@ describe("acquireSharedChainStream", () => {
   it("a late subscriber is told the connection is already open", () => {
     const src = fakeSource();
     const a = subscriber(["blocks"]);
-    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
+    const releaseA = acquireSharedChainStream(() => src, a.sub);
     src.open();
     const b = subscriber(["blocks"]);
-    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
+    const releaseB = acquireSharedChainStream(() => src, b.sub);
     expectEq(b.statuses.at(-1), "open");
     releaseA();
     releaseB();
@@ -584,8 +584,8 @@ describe("acquireSharedChainStream", () => {
     const src = fakeSource();
     const a = subscriber(["blocks"]);
     const b = subscriber(["blocks"]);
-    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
-    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
+    const releaseA = acquireSharedChainStream(() => src, a.sub);
+    const releaseB = acquireSharedChainStream(() => src, b.sub);
     releaseA();
     src.emit({ table: "blocks", block_number: 2 });
     expectEq(a.seen, [], "an unmounted consumer still received a frame");

--- a/apps/ui/src/lib/metagraphed/alpha-usd.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/alpha-usd.functions.test.ts
@@ -103,7 +103,7 @@ describe("USD coverage on a series", () => {
 
   test("a missing or malformed payload renders TAO only", () => {
     for (const bad of [null, undefined, 42, "x", []]) {
-      const c = alphaUsdCoverage(bad as never);
+      const c = alphaUsdCoverage(bad);
       expect(c.available).toBe(false);
       expect(c.caption).toBeNull();
       expect(c.unavailableLabel).toBe("USD unavailable");
@@ -129,7 +129,7 @@ describe("USD coverage on a series", () => {
     // A garbled count must not produce "USD covers -1 of 90 points".
     for (const bad of [-1, Number.NaN, "many", null]) {
       const c = alphaUsdCoverage({
-        priced_candle_count: bad as never,
+        priced_candle_count: bad,
         candle_count: 90,
       });
       expect(c.available).toBe(false);

--- a/apps/ui/src/lib/metagraphed/alpha-usd.functions.ts
+++ b/apps/ui/src/lib/metagraphed/alpha-usd.functions.ts
@@ -30,6 +30,8 @@
 // All three are decided here, as pure functions over what the API already
 // states, so a component cannot render a USD figure by forgetting to ask.
 
+import { readKey, readString } from "./read-key";
+
 /** What a series payload states about its own USD coverage. */
 export interface AlphaUsdSeriesLike {
   /** Oldest point carrying USD, ISO. Null when none does. */
@@ -109,7 +111,16 @@ const asDate = (v: unknown): string | null => {
  * where USD begins, which is exactly the decision #10382 moved server-side so
  * that every surface answers it the same way.
  */
-export function alphaUsdCoverage(series: AlphaUsdSeriesLike | null | undefined): AlphaUsdCoverage {
+/**
+ * `unknown`, because that is what this receives.
+ *
+ * The body already opened with `if (!series || typeof series !== "object")`,
+ * so it was written for arbitrary input -- but the signature promised
+ * `AlphaUsdSeriesLike`, and its own test feeds it `42`, `"x"` and `[]` to
+ * prove the guard works. The test could only do that by asserting, which meant
+ * the guard's real contract lived in the test rather than in the type.
+ */
+export function alphaUsdCoverage(series: unknown): AlphaUsdCoverage {
   const none: AlphaUsdCoverage = {
     available: false,
     unavailableLabel: alphaUsdUnavailableLabel(undefined),
@@ -121,16 +132,23 @@ export function alphaUsdCoverage(series: AlphaUsdSeriesLike | null | undefined):
   };
   if (!series || typeof series !== "object") return none;
 
-  const priced = int(series.priced_candle_count ?? series.priced_day_count);
-  const total = int(series.candle_count ?? series.day_count);
-  const from = asDate(series.usd_available_from_iso) ?? asDate(series.usd_available_from);
+  const priced = int(readKey(series, "priced_candle_count") ?? readKey(series, "priced_day_count"));
+  const total = int(readKey(series, "candle_count") ?? readKey(series, "day_count"));
+  const from =
+    asDate(readKey(series, "usd_available_from_iso")) ??
+    asDate(readKey(series, "usd_available_from"));
+  // Checked, not assumed: alphaUsdUnavailableLabel switches on known reason
+  // strings and falls through to a generic label, so a non-string here would
+  // have been switched on and silently produced the generic message as though
+  // the payload had said nothing at all.
+  const unavailable = readString(series, "usd_unavailable");
 
   // A stated reason wins over any count. A payload that names why it could not
   // price must not be rendered as a series that merely happens to be empty.
-  if (series.usd_unavailable) {
+  if (unavailable) {
     return {
       ...none,
-      unavailableLabel: alphaUsdUnavailableLabel(series.usd_unavailable),
+      unavailableLabel: alphaUsdUnavailableLabel(unavailable),
       totalCount: total,
     };
   }

--- a/apps/ui/src/lib/metagraphed/palette-analytics.ts
+++ b/apps/ui/src/lib/metagraphed/palette-analytics.ts
@@ -106,7 +106,21 @@ export function resetAnalytics(): void {
   }
 }
 
+/**
+ * The debug hook, DECLARED rather than asserted onto `window`.
+ *
+ * A module augmentation is what TypeScript provides for exactly this, and it
+ * has a property the assertion did not: the declaration is visible to anyone
+ * who types `window.__mgPaletteAnalytics` in this codebase, so the hook is
+ * discoverable instead of being a string that only appears here.
+ */
+declare global {
+  interface Window {
+    /** Dev-only: dump the palette's usage counters from the console. */
+    __mgPaletteAnalytics?: () => PaletteAnalytics;
+  }
+}
+
 if (typeof window !== "undefined") {
-  (window as unknown as { __mgPaletteAnalytics?: () => PaletteAnalytics }).__mgPaletteAnalytics =
-    getAnalytics;
+  window.__mgPaletteAnalytics = getAnalytics;
 }

--- a/apps/ui/src/lib/metagraphed/queries.blocks-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.blocks-summary.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResult } from "./client";
 import { apiFetch } from "./client";
 import { blocksSummaryQuery, normalizeBlocksSummary } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -16,22 +17,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/blocks/summary",
   });
-}
-
-// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
-// options object; each call site keeps its own precise data type).
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 describe("normalizeBlocksSummary", () => {

--- a/apps/ui/src/lib/metagraphed/queries.chain-alpha-volume.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-alpha-volume.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResult } from "./client";
 import { apiFetch } from "./client";
 import { normalizeChainAlphaVolume, chainAlphaVolumeQuery } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -16,21 +17,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/chain/alpha-volume",
   });
-}
-
-// Mirrors queries.subnet-ohlc.test.ts's own runQuery helper.
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 const RAW_NETWORK = {

--- a/apps/ui/src/lib/metagraphed/queries.network-parameters.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.network-parameters.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResult } from "./client";
 import { apiFetch } from "./client";
 import { networkParametersQuery } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -16,22 +17,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/network/parameters",
   });
-}
-
-// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
-// options object; each call site keeps its own precise data type).
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 describe("networkParametersQuery (#6997)", () => {

--- a/apps/ui/src/lib/metagraphed/queries.subnet-conviction.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-conviction.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeSubnetConvictionEntry,
   subnetConvictionQuery,
 } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -20,21 +21,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/subnets/7/conviction",
   });
-}
-
-// Mirrors queries.subnet-ohlc.test.ts's own runQuery helper.
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 const RAW_ENTRY = {

--- a/apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-event-summary.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResult } from "./client";
 import { apiFetch } from "./client";
 import { normalizeSubnetEventSummary, subnetEventSummaryQuery } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -16,20 +17,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/subnets/7",
   });
-}
-
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 describe("normalizeSubnetEventSummary", () => {

--- a/apps/ui/src/lib/metagraphed/queries.subnet-holders.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-holders.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResult } from "./client";
 import { apiFetch } from "./client";
 import { normalizeSubnetHolderEntry, normalizeSubnetHolders, subnetHoldersQuery } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -28,20 +29,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/subnets/74/holders",
   });
-}
-
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 const RAW_ENTRY = {

--- a/apps/ui/src/lib/metagraphed/queries.subnet-ohlc.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-ohlc.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResult } from "./client";
 import { apiFetch } from "./client";
 import { normalizeSubnetOhlc, normalizeSubnetOhlcCandle, subnetOhlcQuery } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -16,23 +17,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/subnets/7/ohlc",
   });
-}
-
-// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
-// options object; each call site keeps its own precise data type), mirroring
-// queries.subnet-registrations.test.ts's own runQuery helper.
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 const RAW_CANDLE = {

--- a/apps/ui/src/lib/metagraphed/queries.subnet-ownership-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-ownership-history.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeSubnetOwnershipHistory,
   subnetOwnershipHistoryQuery,
 } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -20,21 +21,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/subnets/7/ownership-history",
   });
-}
-
-// Mirrors queries.subnet-ohlc.test.ts's own runQuery helper.
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 const RAW_CHANGE = {

--- a/apps/ui/src/lib/metagraphed/queries.subnet-registrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-registrations.test.ts
@@ -7,6 +7,7 @@ import {
   subnetDeregistrationsQuery,
   subnetRegistrationsQuery,
 } from "./queries";
+import { runQuery } from "./run-query";
 
 vi.mock("./client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./client")>();
@@ -21,22 +22,6 @@ function resolveWith(data: unknown): void {
     meta: {} as ApiResult<unknown>["meta"],
     url: "/api/v1/subnets/7",
   });
-}
-
-// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
-// options object; each call site keeps its own precise data type).
-function runQuery<
-  O extends {
-    queryKey: readonly unknown[];
-    queryFn?: (context: never) => unknown;
-  },
->(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
-  if (!opts.queryFn) throw new Error("expected a queryFn");
-  return opts.queryFn({
-    signal: new AbortController().signal,
-    queryKey: opts.queryKey,
-    meta: undefined,
-  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
 }
 
 describe("normalizeSubnetRegistrations", () => {

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1760,6 +1760,42 @@ function firstString(...values: unknown[]): string | undefined {
   return values.find((value): value is string => typeof value === "string");
 }
 
+/**
+ * The distribution block, normalized like every other field beside it.
+ *
+ * `isRecord(x) ? (x as unknown as ChainAlphaVolumeDistribution) : null` proved
+ * only that the value was an object and then claimed eight required numbers
+ * about it. Every one of those is rendered into a percentile chart, so a
+ * missing `p90` from a partial upstream response reached the axis as
+ * `undefined` rather than the null this function was built to return.
+ */
+function normalizeChainAlphaVolumeDistribution(raw: unknown): ChainAlphaVolumeDistribution | null {
+  if (!isRecord(raw)) return null;
+  const count = firstFiniteNumber(raw.count);
+  const mean = firstFiniteNumber(raw.mean);
+  const min = firstFiniteNumber(raw.min);
+  const p25 = firstFiniteNumber(raw.p25);
+  const median = firstFiniteNumber(raw.median);
+  const p75 = firstFiniteNumber(raw.p75);
+  const p90 = firstFiniteNumber(raw.p90);
+  const max = firstFiniteNumber(raw.max);
+  // All or nothing: a half-populated distribution plots a chart with gaps that
+  // read as real zeroes.
+  if (
+    count === undefined ||
+    mean === undefined ||
+    min === undefined ||
+    p25 === undefined ||
+    median === undefined ||
+    p75 === undefined ||
+    p90 === undefined ||
+    max === undefined
+  ) {
+    return null;
+  }
+  return { count, mean, min, p25, median, p75, p90, max };
+}
+
 function firstFiniteNumber(...values: unknown[]): number | undefined {
   return values.find(
     (value): value is number => typeof value === "number" && Number.isFinite(value),
@@ -5184,9 +5220,7 @@ export function normalizeChainAlphaVolume(raw: unknown): ChainAlphaVolume {
     observed_at: firstString(d.observed_at) ?? null,
     subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
     network: normalizeChainAlphaVolumeNetwork(d.network),
-    volume_distribution: isRecord(d.volume_distribution)
-      ? (d.volume_distribution as unknown as ChainAlphaVolumeDistribution)
-      : null,
+    volume_distribution: normalizeChainAlphaVolumeDistribution(d.volume_distribution),
     subnets: Array.isArray(d.subnets) ? (d.subnets as SubnetAlphaVolume[]) : [],
   };
 }

--- a/apps/ui/src/lib/metagraphed/run-query.ts
+++ b/apps/ui/src/lib/metagraphed/run-query.ts
@@ -1,0 +1,47 @@
+import { QueryClient, type QueryFunctionContext, type QueryKey } from "@tanstack/react-query";
+
+/**
+ * Invoke a `queryOptions()` object's `queryFn` directly, without mounting a
+ * provider.
+ *
+ * ## Why this is shared
+ *
+ * The same fifteen lines were copy-pasted into nine `queries.*.test.ts` files.
+ * Every copy typed the `queryFn` option's context parameter as `never` and
+ * then passed a context object into it — and since nothing is assignable to
+ * `never`, every copy also needed an assertion on the argument. Each file had
+ * written an assertion to satisfy a signature that same file had written.
+ *
+ * The `never` was doing a real job: letting one helper accept a `queryFn`
+ * whatever its context type. `QueryFunctionContext<TKey>` does that job
+ * properly, because `TKey` is inferred from the `queryKey` the caller already
+ * hands over.
+ *
+ * ## What the assertion was hiding
+ *
+ * Asserting to `never` accepts every value, so the context these tests
+ * supplied was never checked against the one TanStack Query actually passes.
+ * It was missing `client`, which is REQUIRED and has been since v5 — a
+ * `queryFn` that reads it (to seed a related key, or to read `defaultOptions`)
+ * works in the app and gets `undefined` in every one of these tests. Building
+ * the context against its real type is what surfaced that.
+ */
+export function runQuery<TKey extends QueryKey, TResult>(options: {
+  queryKey: TKey;
+  queryFn?: (context: QueryFunctionContext<TKey>) => TResult;
+}): TResult {
+  const { queryFn, queryKey } = options;
+  if (!queryFn) {
+    throw new Error("runQuery: these options carry no queryFn to invoke");
+  }
+  return queryFn({
+    // A real client and a real controller, not stubs. A query function that
+    // forwards `signal` into fetch needs a genuine AbortSignal, and a test
+    // that hands it a fake is asserting cancellation against something that
+    // could never cancel anything.
+    client: new QueryClient(),
+    signal: new AbortController().signal,
+    queryKey,
+    meta: undefined,
+  });
+}

--- a/apps/ui/src/lib/metagraphed/search-schema-catch-equivalence.test.ts
+++ b/apps/ui/src/lib/metagraphed/search-schema-catch-equivalence.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+/**
+ * `@tanstack/zod-adapter`'s `fallback()` was removed in favour of zod's own
+ * `.catch()`, across 111 call sites in 21 route search schemas. This pins the
+ * claim that made that safe: the two parse identically.
+ *
+ * `legacyFallback` below is the adapter's ACTUAL runtime implementation, read
+ * from its published dist and reproduced here --
+ * `z.custom().pipe(schema.catch(value))`. The `z.custom()` prefix was a no-op
+ * at runtime and existed only to widen the pipeline's input type, which is
+ * precisely what broke inference under zod 4 (its declared return type named
+ * `z.ZodPipeline` and `z.ZodTypeDef`, neither of which exists in v4, so
+ * `fallback()` returned `any` and collapsed every route's search type to
+ * `{ [x: string]: any }`).
+ *
+ * The dependency is gone, so this reimplements it rather than importing it.
+ * If a future zod release changes `.catch()` semantics, this fails and names
+ * the input class that diverged.
+ */
+const legacyFallback = <T extends z.ZodType>(schema: T, value: unknown) =>
+  z.custom().pipe(schema.catch(value as never));
+
+describe("fallback() vs .catch() are the same parse", () => {
+  const cases: Array<[string, unknown]> = [
+    ["valid in range", 42],
+    ["below min", 0],
+    ["above max", 5000],
+    ["wrong type", "abc"],
+    ["null", null],
+    ["missing", undefined],
+    ["NaN", Number.NaN],
+    ["numeric string", "42"],
+  ];
+
+  it("agrees on every input, with .default() on top", () => {
+    const before = z.object({
+      limit: legacyFallback(z.number().int().min(1).max(100), 50).default(50),
+    });
+    const after = z.object({
+      limit: z.number().int().min(1).max(100).catch(50).default(50),
+    });
+    for (const [name, input] of cases) {
+      const a = before.safeParse({ limit: input });
+      const b = after.safeParse({ limit: input });
+      expect(b.success, `${name}: success differs`).toBe(a.success);
+      expect(b.data, `${name}: data differs`).toEqual(a.data);
+    }
+  });
+
+  it("agrees for a string field too", () => {
+    const before = z.object({ q: legacyFallback(z.string(), "").default("") });
+    const after = z.object({ q: z.string().catch("").default("") });
+    for (const [name, input] of cases) {
+      expect(after.safeParse({ q: input }).data, name).toEqual(before.safeParse({ q: input }).data);
+    }
+  });
+
+  it("agrees for an enum field", () => {
+    const V = ["table", "grid"] as const;
+    const before = z.object({ v: legacyFallback(z.enum(V), "table").default("table") });
+    const after = z.object({ v: z.enum(V).catch("table").default("table") });
+    for (const [name, input] of [...cases, ["valid enum", "grid"] as [string, unknown]]) {
+      expect(after.safeParse({ v: input }).data, name).toEqual(before.safeParse({ v: input }).data);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/surface-call.ts
+++ b/apps/ui/src/lib/metagraphed/surface-call.ts
@@ -1,4 +1,5 @@
 import { API_BASE } from "./config";
+import { readKey, readNumber, readString } from "./read-key";
 
 /**
  * Calls a catalogued subnet surface through the registry's existing guarded
@@ -119,7 +120,56 @@ export async function callSubnetSurface(
     };
   }
 
-  return { ok: true, result: structured as unknown as SurfaceCallResult };
+  const result = surfaceCallResult(structured);
+  if (!result) {
+    return {
+      ok: false,
+      error: {
+        code: "bad_response",
+        message: "The surface answered in a shape this client cannot read.",
+      },
+    };
+  }
+  return { ok: true, result };
+}
+
+/**
+ * The call result, PARSED.
+ *
+ * This is a third-party subnet's answer relayed through the MCP tool, so its
+ * shape is a promise someone else keeps. The assertion this replaces claimed
+ * seven required fields about a `Record<string, unknown>`, and the playground
+ * renders every one of them: a missing `status_code` made `>= 200` false and
+ * painted the response amber as though it had failed, and a missing
+ * `latency_ms` rendered the literal text "undefined ms" next to it.
+ *
+ * `body` stays `unknown` on purpose -- it is whatever the surface returned,
+ * and the renderer stringifies it into a text node rather than trusting it.
+ */
+function surfaceCallResult(structured: Record<string, unknown>): SurfaceCallResult | null {
+  const surface_id = readString(structured, "surface_id");
+  const url = readString(structured, "url");
+  const status_code = readNumber(structured, "status_code");
+  const latency_ms = readNumber(structured, "latency_ms");
+  if (
+    surface_id === undefined ||
+    url === undefined ||
+    status_code === undefined ||
+    latency_ms === undefined
+  ) {
+    return null;
+  }
+  return {
+    surface_id,
+    url,
+    status_code,
+    latency_ms,
+    // Optional in practice: absent is a real answer for a response with no
+    // content type, and `truncated` absent means it was not truncated.
+    content_type: readString(structured, "content_type") ?? null,
+    truncated: readKey(structured, "truncated") === true,
+    body: readKey(structured, "body"),
+  };
 }
 
 /**

--- a/apps/ui/src/lib/metagraphed/surface-filters.ts
+++ b/apps/ui/src/lib/metagraphed/surface-filters.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { fallback } from "@tanstack/zod-adapter";
 
 import { tableSearchSchema, matchesQuery } from "@/lib/metagraphed/url-state";
 import type { Surface } from "@/lib/metagraphed/types";
@@ -11,9 +10,9 @@ import type { Surface } from "@/lib/metagraphed/types";
  * `tableSearchSchema` — so the sibling /subnets route's schema stays lean.
  */
 export const surfacesSearchSchema = tableSearchSchema.extend({
-  public_safe: fallback(z.string(), "").default(""),
-  auth: fallback(z.string(), "").default(""),
-  rate_limited: fallback(z.string(), "").default(""),
+  public_safe: z.string().catch("").default(""),
+  auth: z.string().catch("").default(""),
+  rate_limited: z.string().catch("").default(""),
 });
 
 export type SurfacesSearch = z.infer<typeof surfacesSearchSchema>;

--- a/apps/ui/src/lib/metagraphed/url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { fallback } from "@tanstack/zod-adapter";
 import {
   joinEconomics,
   joinHealth,
@@ -189,18 +188,19 @@ describe("stripDefaultSearchParams (#8628)", () => {
   // The middleware's real contract is ({ search, next, meta }) => result,
   // where `next` is the continuation returning the search to filter. Modelled
   // on the implementation in @tanstack/router-core rather than guessed at.
-  const apply = <T extends z.ZodObject>(schema: T, search: object) =>
-    stripDefaultSearchParams(schema)({
-      search,
-      next: (s: object) => s,
-    } as never) as Record<string, unknown>;
+  // `search` is typed as the schema's own output now that the schema infers --
+  // it used to be `object` with the argument asserted past the mismatch, which
+  // meant this helper could hand the middleware a shape the middleware would
+  // never see, and the tests below would still pass.
+  const apply = <T extends z.ZodObject>(schema: T, search: z.output<T>): Record<string, unknown> =>
+    stripDefaultSearchParams(schema)({ search, next: (s) => s });
 
   it("derives the defaults from the schema rather than a hand-written list", () => {
     // The whole point: nothing here names a default. A changed default must
     // change what gets stripped, with no second place to update.
     const schema = z.object({
-      a: fallback(z.string(), "hello").default("hello"),
-      b: fallback(z.number(), 42).default(42),
+      a: z.string().catch("hello").default("hello"),
+      b: z.number().catch(42).default(42),
     });
     expect(apply(schema, { a: "hello", b: 42 })).toEqual({});
   });

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -1,28 +1,27 @@
 import { z } from "zod";
 import { stripSearchParams } from "@tanstack/react-router";
-import { fallback } from "@tanstack/zod-adapter";
 
 /** Common URL-driven table state schema for /subnets and /surfaces. */
 export const tableSearchSchema = z.object({
-  q: fallback(z.string(), "").default(""),
-  sort: fallback(z.string(), "").default(""),
-  order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
+  q: z.string().catch("").default(""),
+  sort: z.string().catch("").default(""),
+  order: z.enum(["asc", "desc"]).catch("asc").default("asc"),
   // Server-driven cursor pagination. `limit` = page size sent to API;
   // `cursor` is an opaque token returned in meta.pagination.next_cursor.
-  limit: fallback(z.number().int().min(5).max(200), 25).default(25),
-  cursor: fallback(z.string(), "").default(""),
+  limit: z.number().int().min(5).max(200).catch(25).default(25),
+  cursor: z.string().catch("").default(""),
   // Legacy client-side pagination kept for back-compat with older callers.
-  page: fallback(z.number().int().min(1), 1).default(1),
-  pageSize: fallback(z.number().int().min(5).max(200), 25).default(25),
-  curation: fallback(z.string(), "").default(""),
-  health: fallback(z.string(), "").default(""),
-  kind: fallback(z.string(), "").default(""),
-  stale: fallback(z.string(), "").default(""),
-  provider: fallback(z.string(), "").default(""),
-  netuid: fallback(z.string(), "").default(""),
+  page: z.number().int().min(1).catch(1).default(1),
+  pageSize: z.number().int().min(5).max(200).catch(25).default(25),
+  curation: z.string().catch("").default(""),
+  health: z.string().catch("").default(""),
+  kind: z.string().catch("").default(""),
+  stale: z.string().catch("").default(""),
+  provider: z.string().catch("").default(""),
+  netuid: z.string().catch("").default(""),
   // #9: agent-catalog capability filters (applied client-side over joined rows).
-  serviceKind: fallback(z.string(), "").default(""),
-  readiness: fallback(z.string(), "").default(""),
+  serviceKind: z.string().catch("").default(""),
+  readiness: z.string().catch("").default(""),
   // #6270: root-subnet inclusion toggle for /subnets, applied client-side over
   // the `subnet_type` the list response already returns. A boolean defaulting
   // to true (the endpoints route's `callable` toggle shape) rather than the ""
@@ -35,18 +34,18 @@ export const tableSearchSchema = z.object({
   // live — ?status=inactive returns 0). A client-side inactive filter could
   // only narrow rows the server already sent, so it would be inert by
   // construction; it belongs here only once that route serves non-active rows.
-  includeRoot: fallback(z.boolean(), true).default(true),
+  includeRoot: z.boolean().catch(true).default(true),
   // #8248: client-only "Watched" quick-tab -- narrows the list to rows
   // starred in the localStorage watchlist (lib/metagraphed/watchlist.ts).
   // Optional/additive so pages that don't offer a watchlist never set it.
-  watched: fallback(z.boolean(), false).default(false),
+  watched: z.boolean().catch(false).default(false),
   // #8248: domains rollup chip filter (subnets belonging to a capability
   // domain from GET /api/v1/domains). Optional/additive, same as `watched`.
-  domain: fallback(z.string(), "").default(""),
+  domain: z.string().catch("").default(""),
   // Layout state for list routes that support multiple views + row density.
   // Additive + optional with safe fallbacks so the toggles persist in the URL.
-  view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),
-  density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
+  view: z.enum(["table", "grid", "matrix"]).catch("table").default("table"),
+  density: z.enum(["comfortable", "compact"]).catch("comfortable").default("comfortable"),
 });
 
 /**

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -1894,6 +1894,13 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
 // The route's own published windows (#10994).
 const STAKE_FLOW_WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/accounts/{ss58}/stake-flow"].window;
 
+/** A predicate, so the check NARROWS. `(X as readonly string[]).includes(v)`
+ *  answers the question and then throws the answer away, leaving `v` a string
+ *  that only an assertion could pass to a union-typed setter. */
+function isStakeFlowWindow(value: string): value is (typeof STAKE_FLOW_WINDOWS)[number] {
+  return STAKE_FLOW_WINDOWS.some((window) => window === value);
+}
+
 // Direction label → tone, reusing the health-ok/warn/muted convention the
 // transfers section uses for sent/received direction. `exiting` and `churning`
 // were amber-500 vs amber-400 -- a shade split the health-* scale doesn't carry,
@@ -1920,9 +1927,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
     <SelectFilter
       label="Window"
       value={window}
-      onChange={(v) =>
-        setWindow((STAKE_FLOW_WINDOWS as readonly string[]).includes(v) ? (v as never) : "30d")
-      }
+      onChange={(v) => setWindow(isStakeFlowWindow(v) ? v : "30d")}
       options={STAKE_FLOW_WINDOWS.map((w) => ({ value: w, label: w }))}
     />
   );
@@ -3131,7 +3136,7 @@ function AccountEventsSection({
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });

--- a/apps/ui/src/routes/-admin-changes-index-page.tsx
+++ b/apps/ui/src/routes/-admin-changes-index-page.tsx
@@ -57,7 +57,7 @@ export function AdminChangesTable() {
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });

--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -201,7 +201,7 @@ function BlocksTable() {
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });

--- a/apps/ui/src/routes/-chain-analytics-page.tsx
+++ b/apps/ui/src/routes/-chain-analytics-page.tsx
@@ -109,7 +109,7 @@ export function ChainAnalyticsPage() {
               aria-selected={w === search.window}
               onClick={() =>
                 navigate({
-                  search: (prev: Record<string, unknown>) => ({ ...prev, window: w }) as never,
+                  search: (prev: Record<string, unknown>) => ({ ...prev, window: w }),
                   resetScroll: false,
                 })
               }

--- a/apps/ui/src/routes/-chain-emissions-page.tsx
+++ b/apps/ui/src/routes/-chain-emissions-page.tsx
@@ -31,7 +31,7 @@ function EmissionsBody() {
 
   const setSearch = (patch: Partial<EmissionTableSearch>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       resetScroll: false,
     });
 

--- a/apps/ui/src/routes/-chain-governance-page.tsx
+++ b/apps/ui/src/routes/-chain-governance-page.tsx
@@ -61,7 +61,7 @@ export function ChainGovernancePage() {
 
   const setView = (next: GovernanceView) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, view: next }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, view: next }),
       resetScroll: false,
     });
 

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -602,8 +602,10 @@ function EndpointsTable() {
   const expandedId = search.endpoint || null;
   const toggleExpanded = (id: string) =>
     navigate({
-      search: (prev: Record<string, unknown>) =>
-        ({ ...prev, endpoint: prev.endpoint === id ? "" : id }) as never,
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        endpoint: prev.endpoint === id ? "" : id,
+      }),
       resetScroll: false,
       replace: true,
     });
@@ -624,15 +626,14 @@ function EndpointsTable() {
     if (next.has(id)) next.delete(id);
     else if (next.size < COMPARE_MAX) next.add(id);
     navigate({
-      search: (prev: Record<string, unknown>) =>
-        ({ ...prev, compare: Array.from(next).join(",") }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, compare: Array.from(next).join(",") }),
       resetScroll: false,
       replace: true,
     });
   };
   const clearCompare = () =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, compare: "" }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, compare: "" }),
       resetScroll: false,
       replace: true,
     });
@@ -653,8 +654,11 @@ function EndpointsTable() {
         ].includes(k),
       ) && patch.page == null;
     navigate({
-      search: (prev: Record<string, unknown>) =>
-        ({ ...prev, ...patch, ...(resetsPage ? { page: 1 } : {}) }) as never,
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        ...patch,
+        ...(resetsPage ? { page: 1 } : {}),
+      }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
       replace: true,
@@ -803,7 +807,7 @@ function EndpointsTable() {
   // callable-only default (true).
   const resetAll = () =>
     navigate({
-      search: { pageSize: search.pageSize, view: search.view } as never,
+      search: { pageSize: search.pageSize, view: search.view },
       replace: true,
     });
 

--- a/apps/ui/src/routes/-events-index-page.tsx
+++ b/apps/ui/src/routes/-events-index-page.tsx
@@ -16,7 +16,7 @@ export function EventsPage() {
 
   const onFilter = (patch: { pallet?: string; method?: string; noise?: boolean }) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }),
       resetScroll: false,
     });
 

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -128,7 +128,7 @@ function PreviewHeader({
       <h3 className="mg-type-label uppercase text-ink-muted">{title}</h3>
       <Link
         to={to}
-        search={search as never}
+        search={search}
         className="mg-type-data text-ink-muted transition-colors hover:text-accent hover:underline"
       >
         View all →

--- a/apps/ui/src/routes/-extrinsics-index-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-index-page.tsx
@@ -137,7 +137,7 @@ function ExtrinsicsTable() {
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -380,12 +380,11 @@ function MissingKindsAtAGlance() {
                   else next.add(k);
                   const wasEmpty = activeMissing.size === 0;
                   navigate({
-                    search: (prev: Record<string, unknown>) =>
-                      ({
-                        ...prev,
-                        missing: Array.from(next).join(","),
-                        ...(wasEmpty ? { status: "open", sort: "priority" } : {}),
-                      }) as never,
+                    search: (prev: Record<string, unknown>) => ({
+                      ...prev,
+                      missing: Array.from(next).join(","),
+                      ...(wasEmpty ? { status: "open", sort: "priority" } : {}),
+                    }),
                     replace: true,
                   });
                   focusOpenGaps();
@@ -436,7 +435,7 @@ function MissingKindsAtAGlance() {
             type="button"
             onClick={() =>
               navigate({
-                search: (prev: Record<string, unknown>) => ({ ...prev, missing: "" }) as never,
+                search: (prev: Record<string, unknown>) => ({ ...prev, missing: "" }),
                 replace: true,
               })
             }
@@ -472,7 +471,7 @@ function OpenGapsSection() {
 
   const setSearch = (patch: Partial<typeof search>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
       replace: true,
@@ -567,7 +566,7 @@ function OpenGapsSection() {
       />
       <ResetFiltersButton
         active={hasFilters}
-        onReset={() => navigate({ search: {} as never, replace: true })}
+        onReset={() => navigate({ search: {}, replace: true })}
       />
       <span className="ml-auto mg-type-data-sm text-ink-muted">
         {sorted.length} of {rows.length}

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -67,12 +67,8 @@ export function HealthPage() {
   // #1117: push a refresh on each registry publish, on top of the poll interval.
   useRegistryEvents();
 
-  // `search.view` is cast here because `fallback().default()` (zod-adapter,
-  // pinned to zod v3 types) loses its literal-union output type under this
-  // repo's zod v4 — a pre-existing gap shared by every other route's search
-  // schema, just not one any of them happens to index a Record with.
   const activeSectionId =
-    VIEW_SECTION_ID[search.view as HealthView] ?? (search.status !== "all" ? "incidents" : null);
+    VIEW_SECTION_ID[search.view] ?? (search.status !== "all" ? "incidents" : null);
   const sectionRing = (id: string) =>
     activeSectionId === id ? "ring-1 ring-accent/40 rounded-xl" : undefined;
 
@@ -596,7 +592,7 @@ function Incidents({ interval }: { interval: number | false }) {
   const filter = search.status;
   const setFilter = (next: StateFilter) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, status: next }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, status: next }),
       resetScroll: false,
     });
   const [showAll, setShowAll] = useState(false);

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -50,6 +50,13 @@ import { providerSortKeys } from "./apis.providers";
 import { ApisTabActions } from "./-apis-hub";
 import { cancelIdle, requestIdle } from "@/lib/metagraphed/idle";
 
+/** The layouts this route offers, and the two its search schema accepts. */
+const PROVIDER_VIEWS = ["table", "grid"] as const;
+
+function isProviderView(value: string): value is (typeof PROVIDER_VIEWS)[number] {
+  return PROVIDER_VIEWS.some((view) => view === value);
+}
+
 export function ProvidersPage() {
   const search = useSearch({ from: "/apis/providers" }) as ProvidersSearch;
   const navigate = useNavigate({ from: "/apis/providers" });
@@ -57,7 +64,7 @@ export function ProvidersPage() {
   const filtersActive = Boolean(
     search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
   );
-  const onReset = () => navigate({ search: { view: search.view } as never, replace: true });
+  const onReset = () => navigate({ search: { view: search.view }, replace: true });
   // This page fetches the full provider list once and filters/sorts client-side,
   // so the CSV export hits the backend route directly (full provider snapshot, no
   // client filters) — same shape as endpoints.tsx. Forwarding the page's own
@@ -71,13 +78,21 @@ export function ProvidersPage() {
       <ApisTabActions>
         <ViewModeToggle
           value={view}
-          options={["table", "grid"]}
-          onChange={(v) =>
+          options={[...PROVIDER_VIEWS]}
+          onChange={(v) => {
+            // ui-kit's ViewMode is "table" | "grid" | "matrix"; this toggle is
+            // configured with two of the three, and this route's search schema
+            // accepts exactly those two. The guard cannot fail as configured --
+            // it exists so that adding a third option here without widening the
+            // schema is a no-op rather than a value the schema silently
+            // `.catch()`es back to its default, which looks identical to the
+            // user and leaves a wrong ?view= in a shared URL.
+            if (!isProviderView(v)) return;
             navigate({
-              search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
+              search: (prev) => ({ ...prev, view: v }),
               replace: true,
-            })
-          }
+            });
+          }}
         />
         <ActionBar>
           <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
@@ -170,7 +185,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
   const navigate = useNavigate({ from: "/apis/providers" });
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       replace: true,
     });
 

--- a/apps/ui/src/routes/-revenue-page.tsx
+++ b/apps/ui/src/routes/-revenue-page.tsx
@@ -73,14 +73,17 @@ export function RevenuePage() {
     [rows, search.sort, search.dir, search.provenance],
   );
 
-  const onSort = (field: string) =>
+  // `field` is the route's own sort union, not `string`, and `prev` is
+  // inferred. Both used to be widened by hand, which meant the reducer
+  // returned an object the route's search schema would have rejected -- and
+  // nothing checked it, because the route's search types did not resolve.
+  const onSort = (field: CoverageSortField) =>
     navigate({
-      search: (prev: { sort?: string; dir?: "asc" | "desc" }) =>
-        ({
-          ...prev,
-          sort: field,
-          dir: prev.sort === field && prev.dir === "desc" ? "asc" : "desc",
-        }) as never,
+      search: (prev) => ({
+        ...prev,
+        sort: field,
+        dir: prev.sort === field && prev.dir === "desc" ? "asc" : "desc",
+      }),
     });
 
   if (q.isError) {
@@ -116,7 +119,7 @@ export function RevenuePage() {
         <span className="mg-type-caption text-ink-muted">Provenance</span>
         <button
           type="button"
-          onClick={() => navigate({ search: (p) => ({ ...p, provenance: "" }) as never })}
+          onClick={() => navigate({ search: (p) => ({ ...p, provenance: "" }) })}
           className={`rounded-full border px-3 py-1 mg-type-caption ${
             search.provenance ? "border-border/80 text-ink-muted" : "border-accent text-ink-strong"
           }`}
@@ -129,7 +132,7 @@ export function RevenuePage() {
             type="button"
             onClick={() =>
               navigate({
-                search: (p) => ({ ...p, provenance: option.value }) as never,
+                search: (p) => ({ ...p, provenance: option.value }),
               })
             }
             className={`rounded-full border px-3 py-1 mg-type-caption ${

--- a/apps/ui/src/routes/-root-views.tsx
+++ b/apps/ui/src/routes/-root-views.tsx
@@ -60,7 +60,7 @@ export function NotFoundComponent() {
     if (Number.isFinite(n) && n >= 0 && n <= 1024) {
       router.navigate({ to: "/subnets/$netuid", params: { netuid: n } });
     } else {
-      router.navigate({ to: "/subnets", search: { q: raw } as never });
+      router.navigate({ to: "/subnets", search: { q: raw } });
     }
   };
 

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -154,14 +154,14 @@ function SchemaDriftDetailHost() {
       onOpenChange={(o) => {
         if (!o) {
           navigate({
-            search: (p: Record<string, unknown>) => ({ ...p, driftDetail: "" }) as never,
+            search: (p: Record<string, unknown>) => ({ ...p, driftDetail: "" }),
             replace: true,
           });
         }
       }}
       onOpenInExplorer={(id) =>
         navigate({
-          search: (p: Record<string, unknown>) => ({ ...p, driftDetail: "", open: id }) as never,
+          search: (p: Record<string, unknown>) => ({ ...p, driftDetail: "", open: id }),
           replace: true,
         })
       }
@@ -346,7 +346,7 @@ function SchemaExplorer() {
   const setSearch = useCallback(
     (patch: Partial<typeof search>) =>
       navigate({
-        search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+        search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
         // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
         resetScroll: false,
         replace: true,
@@ -519,7 +519,7 @@ function SchemaViewer({ schema }: { schema: SchemaInfo }) {
               type="button"
               onClick={() =>
                 navigate({
-                  search: (p: Record<string, unknown>) => ({ ...p, open: "" }) as never,
+                  search: (p: Record<string, unknown>) => ({ ...p, open: "" }),
                   replace: true,
                 })
               }

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -206,12 +206,12 @@ export function SubnetsPage() {
     !search.includeRoot;
   const onReset = () =>
     navigate({
-      search: { view: search.view } as never,
+      search: { view: search.view },
       replace: true,
     });
   const setView = (v: ViewMode) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, view: v }),
       replace: true,
     });
   const isMobile = useIsMobile();
@@ -223,17 +223,17 @@ export function SubnetsPage() {
         : "comfortable";
   const setDensity = (d: Density) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }),
       replace: true,
     });
   const setSection = (section: "registry" | "rankings") =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, section }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, section }),
       resetScroll: false,
     });
   const setWindow = (window: "7d" | "30d") =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, window }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, window }),
       replace: true,
       resetScroll: false,
     });
@@ -475,8 +475,10 @@ function SubnetsDomainsRollup() {
               type="button"
               onClick={() =>
                 navigate({
-                  search: (prev: Record<string, unknown>) =>
-                    ({ ...prev, domain: active ? "" : d.domain }) as never,
+                  search: (prev: Record<string, unknown>) => ({
+                    ...prev,
+                    domain: active ? "" : d.domain,
+                  }),
                   replace: true,
                 })
               }
@@ -621,19 +623,18 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });
 
   const onSort = (field: string) =>
     navigate({
-      search: (prev: { sort?: string; order?: "asc" | "desc" }) =>
-        ({
-          ...prev,
-          sort: field,
-          order: prev.sort === field && prev.order === "asc" ? "desc" : "asc",
-        }) as never,
+      search: (prev: { sort?: string; order?: "asc" | "desc" }) => ({
+        ...prev,
+        sort: field,
+        order: prev.sort === field && prev.order === "asc" ? "desc" : "asc",
+      }),
     });
 
   const filtersActive = !!(
@@ -1024,7 +1025,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           activeFilterCount > 0
             ? () =>
                 navigate({
-                  search: { view: search.view } as never,
+                  search: { view: search.view },
                   replace: true,
                 })
             : undefined
@@ -1119,7 +1120,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
               chipItems.length > 1
                 ? () =>
                     navigate({
-                      search: { view: search.view } as never,
+                      search: { view: search.view },
                       replace: true,
                     })
                 : undefined

--- a/apps/ui/src/routes/-sudo-index-page.tsx
+++ b/apps/ui/src/routes/-sudo-index-page.tsx
@@ -71,7 +71,7 @@ export function SudoTable() {
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });

--- a/apps/ui/src/routes/-surfaces-page.tsx
+++ b/apps/ui/src/routes/-surfaces-page.tsx
@@ -71,7 +71,7 @@ export function SurfacesPage() {
   const onReset = () =>
     navigate({
       // Keep page size and view on reset so the chosen layout survives.
-      search: { limit: search.limit, view: search.view } as never,
+      search: { limit: search.limit, view: search.view },
       replace: true,
     });
   const viewMode: "table" | "grid" = search.view === "grid" ? "grid" : "table";
@@ -96,7 +96,7 @@ export function SurfacesPage() {
             options={["table", "grid"]}
             onChange={(v) =>
               navigate({
-                search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) as never,
+                search: (prev: Record<string, unknown>) => ({ ...prev, view: v }),
                 replace: true,
               })
             }
@@ -225,20 +225,19 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });
 
   const onSort = (field: string) =>
     navigate({
-      search: (prev: { sort?: string; order?: "asc" | "desc" }) =>
-        ({
-          ...prev,
-          sort: field,
-          order: prev.sort === field && prev.order === "asc" ? "desc" : "asc",
-          cursor: "",
-        }) as never,
+      search: (prev: { sort?: string; order?: "asc" | "desc" }) => ({
+        ...prev,
+        sort: field,
+        order: prev.sort === field && prev.order === "asc" ? "desc" : "asc",
+        cursor: "",
+      }),
     });
 
   const filtered = all.filter((s) => matchesSurfaceFilters(s, search));

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -260,7 +260,7 @@ function NominatorsSection({ hotkey }: { hotkey: string }) {
 
   const setSearch = (patch: Partial<ValidatorNominatorsSearch>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; do not scroll to top on each keystroke (#3691).
       resetScroll: false,
     });

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -68,7 +68,7 @@ export function ValidatorsPage() {
   });
   const onDensityChange = (d: Density) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }),
       replace: true,
     });
   return (
@@ -144,7 +144,7 @@ function ValidatorsDirectory({
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }) as never,
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
       // Patch in-page search/filter state only; no scroll-to-top per keystroke (#3691).
       resetScroll: false,
       replace: true,
@@ -152,12 +152,11 @@ function ValidatorsDirectory({
 
   const onSort = (field: string) =>
     navigate({
-      search: (prev: Record<string, unknown>) =>
-        ({
-          ...prev,
-          sort: field,
-          order: prev.sort === field && prev.order === "desc" ? "asc" : "desc",
-        }) as never,
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        sort: field,
+        order: prev.sort === field && prev.order === "desc" ? "asc" : "desc",
+      }),
       replace: true,
     });
 

--- a/apps/ui/src/routes/admin-changes.index.tsx
+++ b/apps/ui/src/routes/admin-changes.index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/admin-changes/")({
   beforeLoad: ({ search }) => {
     throw redirect({
       to: "/chain/governance",
-      search: { ...(search as Record<string, unknown>), view: "admin" } as never,
+      search: { ...(search as Record<string, unknown>), view: "admin" },
       replace: true,
       // 301, not the 307 default: this route is permanently retired. A
       // temporary redirect tells a search engine to keep the old URL and

--- a/apps/ui/src/routes/apis.endpoints.tsx
+++ b/apps/ui/src/routes/apis.endpoints.tsx
@@ -2,46 +2,46 @@ import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { RoutePending } from "@/components/metagraphed/primitives";
 import { EndpointsPage } from "./-endpoints-page";
 import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 const endpointsSearchSchema = z.object({
-  q: fallback(z.string(), "").default(""),
-  category: fallback(z.enum(["all", "rpc", "wss", "api", "sse", "data", "other"]), "all").default(
-    "all",
-  ),
-  provider: fallback(z.string(), "").default(""),
-  health: fallback(z.string(), "").default(""),
-  netuid: fallback(z.string(), "").default(""),
-  region: fallback(z.string(), "").default(""),
-  eligibility: fallback(z.string(), "").default(""),
+  q: z.string().catch("").default(""),
+  category: z
+    .enum(["all", "rpc", "wss", "api", "sse", "data", "other"])
+    .catch("all")
+    .default("all"),
+  provider: z.string().catch("").default(""),
+  health: z.string().catch("").default(""),
+  netuid: z.string().catch("").default(""),
+  region: z.string().catch("").default(""),
+  eligibility: z.string().catch("").default(""),
   // "Callable only" hides non-callable directory links (category "other") by
   // default so the table answers "what can I call?" rather than burying it
   // under reference URLs. Persisted in the URL so the view is shareable.
-  callable: fallback(z.boolean(), true).default(true),
-  sort: fallback(
-    z.enum(["netuid", "kind", "provider", "region", "health", "latency", "probed"]),
-    "netuid",
-  ).default("netuid"),
-  order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
-  page: fallback(z.number().int().min(1), 1).default(1),
-  pageSize: fallback(z.number().int().min(10).max(200), 25).default(25),
-  view: fallback(z.enum(["table", "grid"]), "table").default("table"),
+  callable: z.boolean().catch(true).default(true),
+  sort: z
+    .enum(["netuid", "kind", "provider", "region", "health", "latency", "probed"])
+    .catch("netuid")
+    .default("netuid"),
+  order: z.enum(["asc", "desc"]).catch("asc").default("asc"),
+  page: z.number().int().min(1).catch(1).default(1),
+  pageSize: z.number().int().min(10).max(200).catch(25).default(25),
+  view: z.enum(["table", "grid"]).catch("table").default("table"),
   // #3976: ProxyUsagePanel's 7d/30d window is URL-backed (like /explorer) so a
   // shared /endpoints link restores the same window and back/forward works.
-  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  window: z.enum(["7d", "30d"]).catch("7d").default("7d"),
   // Deep-linkable expanded endpoint row. Empty string = collapsed.
-  endpoint: fallback(z.string(), "").default(""),
+  endpoint: z.string().catch("").default(""),
   // Comma-separated endpoint IDs selected for side-by-side comparison.
-  compare: fallback(z.string(), "").default(""),
+  compare: z.string().catch("").default(""),
 });
 
 export type EndpointsSearch = z.infer<typeof endpointsSearchSchema>;
 
 export const Route = createFileRoute("/apis/endpoints")({
-  validateSearch: zodValidator(endpointsSearchSchema),
+  validateSearch: endpointsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(endpointsSearchSchema)] },
   head: () => ({
     meta: hubMeta("/apis/endpoints"),

--- a/apps/ui/src/routes/apis.providers.tsx
+++ b/apps/ui/src/routes/apis.providers.tsx
@@ -1,7 +1,6 @@
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { RoutePending } from "@/components/metagraphed/primitives";
 import { ProvidersPage } from "./-providers-index-page";
 import { hubMeta } from "@/lib/metagraphed/hub-copy";
@@ -15,16 +14,16 @@ export const providersSearchSchema = z.object({
   // #8303: the audit measured an 11,900px wall of 136 provider cards. The
   // table view already existed -- this was only ever the DEFAULT. Flipped
   // rather than rebuilt; the grid stays one toggle away.
-  view: fallback(z.enum(["grid", "table"]), "table").default("table"),
-  q: fallback(z.string(), "").default(""),
-  kind: fallback(z.string(), "").default(""),
+  view: z.enum(["grid", "table"]).catch("table").default("table"),
+  q: z.string().catch("").default(""),
+  kind: z.string().catch("").default(""),
   // `high` is a nav shortcut for official + provider-claimed (see nav-mega-menu-data).
-  authority: fallback(z.string(), "").default(""),
-  sort: fallback(z.enum(providerSortKeys), "name").default("name"),
+  authority: z.string().catch("").default(""),
+  sort: z.enum(providerSortKeys).catch("name").default("name"),
 });
 
 export const Route = createFileRoute("/apis/providers")({
-  validateSearch: zodValidator(providersSearchSchema),
+  validateSearch: providersSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(providersSearchSchema)] },
   head: () => ({
     meta: hubMeta("/apis/providers"),

--- a/apps/ui/src/routes/apis.schemas.tsx
+++ b/apps/ui/src/routes/apis.schemas.tsx
@@ -1,15 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
-import { fallback } from "@tanstack/zod-adapter";
 import { z } from "zod";
 import { SchemasPage } from "./-schemas-page";
 import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 const schemasSearchSchema = z.object({
-  drift: fallback(z.enum(["all", "drift", "stable"]), "all").default("all"),
-  q: fallback(z.string(), "").default(""),
-  open: fallback(z.string(), "").default(""),
-  driftDetail: fallback(z.string(), "").default(""),
+  drift: z.enum(["all", "drift", "stable"]).catch("all").default("all"),
+  q: z.string().catch("").default(""),
+  open: z.string().catch("").default(""),
+  driftDetail: z.string().catch("").default(""),
 });
 
 export const Route = createFileRoute("/apis/schemas")({

--- a/apps/ui/src/routes/chain.analytics.tsx
+++ b/apps/ui/src/routes/chain.analytics.tsx
@@ -1,17 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ChainAnalyticsPage } from "./-chain-analytics-page";
 
 const analyticsSearchSchema = z.object({
-  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  window: z.enum(["7d", "30d"]).catch("7d").default("7d"),
 });
 
 export type AnalyticsSearch = z.infer<typeof analyticsSearchSchema>;
 
 export const Route = createFileRoute("/chain/analytics")({
-  validateSearch: zodValidator(analyticsSearchSchema),
+  validateSearch: analyticsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(analyticsSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/chain.blocks.tsx
+++ b/apps/ui/src/routes/chain.blocks.tsx
@@ -1,25 +1,24 @@
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { BlocksPage } from "./-blocks-index-page";
 
 const blocksSearchSchema = z.object({
-  limit: fallback(z.number().int().min(1).max(100), 50).default(50),
-  offset: fallback(z.number().int().min(0), 0).default(0),
+  limit: z.number().int().min(1).max(100).catch(50).default(50),
+  offset: z.number().int().min(0).catch(0).default(0),
   // Server-side filters wired to the /api/v1/blocks conjunctive set.
-  author: fallback(z.string(), "").default(""),
-  spec_version: fallback(z.string(), "").default(""),
-  block_start: fallback(z.string(), "").default(""),
-  block_end: fallback(z.string(), "").default(""),
-  min_extrinsics: fallback(z.string(), "").default(""),
-  min_events: fallback(z.string(), "").default(""),
+  author: z.string().catch("").default(""),
+  spec_version: z.string().catch("").default(""),
+  block_start: z.string().catch("").default(""),
+  block_end: z.string().catch("").default(""),
+  min_extrinsics: z.string().catch("").default(""),
+  min_events: z.string().catch("").default(""),
 });
 
 export type BlocksSearch = z.infer<typeof blocksSearchSchema>;
 
 export const Route = createFileRoute("/chain/blocks")({
-  validateSearch: zodValidator(blocksSearchSchema),
+  validateSearch: blocksSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(blocksSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/chain.emissions.tsx
+++ b/apps/ui/src/routes/chain.emissions.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ChainEmissionsPage } from "./-chain-emissions-page";
 import { EMISSION_SORT_KEYS } from "@/lib/metagraphed/emission-pipeline";
 
@@ -9,11 +8,11 @@ import { EMISSION_SORT_KEYS } from "@/lib/metagraphed/emission-pipeline";
 // ("the subnets the gate took the most from") is shareable — the same reason
 // /chain/governance puts its `view` toggle there.
 const emissionsSearchSchema = z.object({
-  state: fallback(z.enum(["all", "eligible", "disabled", "ineligible"]), "all").default("all"),
-  sort: fallback(z.enum(EMISSION_SORT_KEYS), "final_share").default("final_share"),
-  dir: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
-  limit: fallback(z.number().int().min(1).max(200), 50).default(50),
-  netuid: fallback(z.string(), "").default(""),
+  state: z.enum(["all", "eligible", "disabled", "ineligible"]).catch("all").default("all"),
+  sort: z.enum(EMISSION_SORT_KEYS).catch("final_share").default("final_share"),
+  dir: z.enum(["asc", "desc"]).catch("desc").default("desc"),
+  limit: z.number().int().min(1).max(200).catch(50).default(50),
+  netuid: z.string().catch("").default(""),
 });
 
 export type EmissionsSearch = z.infer<typeof emissionsSearchSchema>;
@@ -22,7 +21,7 @@ const DESCRIPTION =
   "Where each block's TAO goes: every Bittensor subnet's emission share decomposed from price share through the miner-burn weighting and the gate, plus the split between pool liquidity injection and chain buys.";
 
 export const Route = createFileRoute("/chain/emissions")({
-  validateSearch: zodValidator(emissionsSearchSchema),
+  validateSearch: emissionsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(emissionsSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/chain.events.tsx
+++ b/apps/ui/src/routes/chain.events.tsx
@@ -1,27 +1,26 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { EventsPage } from "./-events-index-page";
 
 const eventsSearchSchema = z.object({
   // Server-side filters wired to the /api/v1/chain-events feed. `method` is only
   // meaningful alongside a `pallet`, matching the embedded explorer feed (#6268).
-  pallet: fallback(z.string(), "").default(""),
-  method: fallback(z.string(), "").default(""),
-  cursor: fallback(z.string(), "").default(""),
+  pallet: z.string().catch("").default(""),
+  method: z.string().catch("").default(""),
+  cursor: z.string().catch("").default(""),
   // #8253: hide the high-volume plumbing events (ExtrinsicSuccess /
   // ExtrinsicFailed / TransactionFeePaid) that were 68% of the unfiltered
   // feed when measured live. Defaults ON -- the URL param exists so the
   // firehose stays reachable and shareable, not because the noisy view is a
   // reasonable default.
-  noise: fallback(z.boolean(), false).default(false),
+  noise: z.boolean().catch(false).default(false),
 });
 
 export type EventsSearch = z.infer<typeof eventsSearchSchema>;
 
 export const Route = createFileRoute("/chain/events")({
-  validateSearch: zodValidator(eventsSearchSchema),
+  validateSearch: eventsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(eventsSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/chain.extrinsics.tsx
+++ b/apps/ui/src/routes/chain.extrinsics.tsx
@@ -1,23 +1,22 @@
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ExtrinsicsPage } from "./-extrinsics-index-page";
 
 const extrinsicsSearchSchema = z.object({
-  limit: fallback(z.number().int().min(1).max(100), 50).default(50),
-  offset: fallback(z.number().int().min(0), 0).default(0),
+  limit: z.number().int().min(1).max(100).catch(50).default(50),
+  offset: z.number().int().min(0).catch(0).default(0),
   // Server-side filters (#265) wired to the /api/v1/extrinsics conjunctive set.
-  signer: fallback(z.string(), "").default(""),
-  call_module: fallback(z.string(), "").default(""),
-  call_function: fallback(z.string(), "").default(""),
-  success: fallback(z.enum(["", "true", "false"]), "").default(""),
+  signer: z.string().catch("").default(""),
+  call_module: z.string().catch("").default(""),
+  call_function: z.string().catch("").default(""),
+  success: z.enum(["", "true", "false"]).catch("").default(""),
 });
 
 export type ExtrinsicsSearch = z.infer<typeof extrinsicsSearchSchema>;
 
 export const Route = createFileRoute("/chain/extrinsics")({
-  validateSearch: zodValidator(extrinsicsSearchSchema),
+  validateSearch: extrinsicsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(extrinsicsSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/chain.governance.tsx
+++ b/apps/ui/src/routes/chain.governance.tsx
@@ -1,24 +1,23 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ChainGovernancePage } from "./-chain-governance-page";
 
 // /sudo and /admin-changes shipped BYTE-IDENTICAL search schemas, which is part
 // of why they merge cleanly (#8291). The only addition is `view`, the source
 // toggle — in the URL so either half stays shareable.
 const governanceSearchSchema = z.object({
-  view: fallback(z.enum(["sudo", "admin"]), "sudo").default("sudo"),
-  limit: fallback(z.number().int().min(1).max(100), 50).default(50),
-  offset: fallback(z.number().int().min(0), 0).default(0),
-  call_function: fallback(z.string(), "").default(""),
-  success: fallback(z.enum(["", "true", "false"]), "").default(""),
+  view: z.enum(["sudo", "admin"]).catch("sudo").default("sudo"),
+  limit: z.number().int().min(1).max(100).catch(50).default(50),
+  offset: z.number().int().min(0).catch(0).default(0),
+  call_function: z.string().catch("").default(""),
+  success: z.enum(["", "true", "false"]).catch("").default(""),
 });
 
 export type GovernanceSearch = z.infer<typeof governanceSearchSchema>;
 
 export const Route = createFileRoute("/chain/governance")({
-  validateSearch: zodValidator(governanceSearchSchema),
+  validateSearch: governanceSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(governanceSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/chain.index.tsx
+++ b/apps/ui/src/routes/chain.index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ExplorerPage } from "./-explorer-page";
 import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
@@ -12,13 +11,13 @@ import { hubMeta } from "@/lib/metagraphed/hub-copy";
  * glance rather than a redirect into one of its tabs.
  */
 const overviewSearchSchema = z.object({
-  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  window: z.enum(["7d", "30d"]).catch("7d").default("7d"),
 });
 
 export type ChainOverviewSearch = z.infer<typeof overviewSearchSchema>;
 
 export const Route = createFileRoute("/chain/")({
-  validateSearch: zodValidator(overviewSearchSchema),
+  validateSearch: overviewSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(overviewSearchSchema)] },
   head: () => ({
     meta: hubMeta("/chain"),

--- a/apps/ui/src/routes/contribute.tsx
+++ b/apps/ui/src/routes/contribute.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { GapsPage } from "./-gaps-page";
 
 export const STATUS_OPTIONS = ["all", "open", "in-review", "resolved", "wont-fix"] as const;
@@ -27,17 +26,17 @@ export const MISSING_KINDS = [
 export const SORT_OPTIONS = ["priority", "netuid", "updated"] as const;
 
 const searchSchema = z.object({
-  status: fallback(z.enum(STATUS_OPTIONS), "all").default("all"),
-  target: fallback(z.enum(TARGET_OPTIONS), "all").default("all"),
-  missing: fallback(z.string(), "").default(""), // comma-separated
-  q: fallback(z.string(), "").default(""),
-  sort: fallback(z.enum(SORT_OPTIONS), "priority").default("priority"),
+  status: z.enum(STATUS_OPTIONS).catch("all").default("all"),
+  target: z.enum(TARGET_OPTIONS).catch("all").default("all"),
+  missing: z.string().catch("").default(""), // comma-separated
+  q: z.string().catch("").default(""),
+  sort: z.enum(SORT_OPTIONS).catch("priority").default("priority"),
 });
 
 export type ContributeSearch = z.infer<typeof searchSchema>;
 
 export const Route = createFileRoute("/contribute")({
-  validateSearch: zodValidator(searchSchema),
+  validateSearch: searchSchema,
   search: { middlewares: [stripDefaultSearchParams(searchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/feed-autodiscovery.render.test.tsx
+++ b/apps/ui/src/routes/feed-autodiscovery.render.test.tsx
@@ -64,9 +64,27 @@ function alternatesFrom(links: HeadLink[]) {
   return renderAlternates(links).tags;
 }
 
+/**
+ * A route `head()` context, faked down to the fields these heads read.
+ *
+ * `AssetFnContextOptions` carries ten type parameters and a full router match;
+ * a unit process cannot construct one, and does not need to -- these head
+ * functions read `params`, `loaderData` and `match`. So the assertion IS the
+ * mechanism here, the same way it is for a `KVNamespace` fixture.
+ *
+ * What it is not is `as never` scattered across eight call sites. `never`
+ * accepts every value, so it also stopped the compiler checking the fields the
+ * head function DOES read -- and one of these tests deliberately passes
+ * `netuid: "not-a-number"`, which only reads as deliberate when the fake is
+ * named in one place and every call site is otherwise checked.
+ */
+function headContext<TFields extends object>(fields: TFields): never {
+  return fields as unknown as never;
+}
+
 describe("feed autodiscovery in rendered markup (#8703)", () => {
   it("the root layout advertises the registry feed as RSS and Atom", async () => {
-    const head = await RootRoute.options.head?.({} as never);
+    const head = await RootRoute.options.head?.(headContext({}));
     const alternates = alternatesFrom((head?.links ?? []) as HeadLink[]);
     expect(alternates).toHaveLength(2);
     expect(alternates.map((tag) => tag.type).sort()).toEqual([
@@ -79,10 +97,12 @@ describe("feed autodiscovery in rendered markup (#8703)", () => {
   });
 
   it("a subnet page advertises that subnet's own feed", async () => {
-    const head = await SubnetRoute.options.head?.({
-      params: { netuid: 8 },
-      loaderData: { name: "Chutes", health: "healthy" },
-    } as never);
+    const head = await SubnetRoute.options.head?.(
+      headContext({
+        params: { netuid: 8 },
+        loaderData: { name: "Chutes", health: "healthy" },
+      }),
+    );
     const alternates = alternatesFrom((head?.links ?? []) as HeadLink[]);
     expect(alternates).toHaveLength(2);
     for (const tag of alternates) {
@@ -96,10 +116,9 @@ describe("feed autodiscovery in rendered markup (#8703)", () => {
   it("pairs each media type with the matching suffix", async () => {
     // A reader that requests the Atom alternate and receives RSS silently
     // fails to parse it, which looks like an empty feed rather than an error.
-    const head = await SubnetRoute.options.head?.({
-      params: { netuid: 64 },
-      loaderData: null,
-    } as never);
+    const head = await SubnetRoute.options.head?.(
+      headContext({ params: { netuid: 64 }, loaderData: null }),
+    );
     for (const tag of alternatesFrom((head?.links ?? []) as HeadLink[])) {
       const expectedSuffix = tag.type === "application/rss+xml" ? ".rss" : ".atom";
       expect(tag.href?.endsWith(expectedSuffix)).toBe(true);
@@ -109,11 +128,8 @@ describe("feed autodiscovery in rendered markup (#8703)", () => {
   it("emits absolute hrefs a reader can resolve on its own", async () => {
     // A feed reader has no page context, so a site-relative href is unusable.
     const heads = await Promise.all([
-      RootRoute.options.head?.({} as never),
-      SubnetRoute.options.head?.({
-        params: { netuid: 8 },
-        loaderData: null,
-      } as never),
+      RootRoute.options.head?.(headContext({})),
+      SubnetRoute.options.head?.(headContext({ params: { netuid: 8 }, loaderData: null })),
     ]);
     for (const head of heads) {
       for (const tag of alternatesFrom((head?.links ?? []) as HeadLink[])) {
@@ -126,24 +142,22 @@ describe("feed autodiscovery in rendered markup (#8703)", () => {
     // #8624 made these paths return noindex not-found metadata; handing a
     // reader a feed URL for netuid 99999 would be a permanent empty
     // subscription. Both the malformed and the absent case must stay bare.
-    const malformed = await SubnetRoute.options.head?.({
-      params: { netuid: "not-a-number" },
-      loaderData: null,
-    } as never);
+    const malformed = await SubnetRoute.options.head?.(
+      headContext({ params: { netuid: "not-a-number" }, loaderData: null }),
+    );
     expect(alternatesFrom((malformed?.links ?? []) as HeadLink[])).toEqual([]);
 
     // #11204: the absent case is signalled by the MATCH now, not by loaderData.
     // The loader throws notFound() so the SSR request answers 404 rather than
     // 200, which means head() sees a not-found match and no loader data at all.
-    const missing = await SubnetRoute.options.head?.({
-      params: { netuid: 99999 },
-      match: { status: "notFound" },
-    } as never);
+    const missing = await SubnetRoute.options.head?.(
+      headContext({ params: { netuid: 99999 }, match: { status: "notFound" } }),
+    );
     expect(alternatesFrom((missing?.links ?? []) as HeadLink[])).toEqual([]);
   });
 
   it("renders well-formed link markup", async () => {
-    const head = await RootRoute.options.head?.({} as never);
+    const head = await RootRoute.options.head?.(headContext({}));
     const { markup } = renderAlternates((head?.links ?? []) as HeadLink[]);
     expect(markup).toContain('rel="alternate"');
     expect(markup).toContain('type="application/rss+xml"');

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { HealthPage } from "./-health-page";
 
 // Mirrors the Health mega-menu ops deep-links (nav-mega-menu-data.ts
@@ -16,14 +15,14 @@ const HEALTH_STATUSES = ["all", "down", "warn", "resolved"] as const;
 export type StateFilter = (typeof HEALTH_STATUSES)[number];
 
 const healthSearchSchema = z.object({
-  view: fallback(z.enum(HEALTH_VIEWS), "").default(""),
-  status: fallback(z.enum(HEALTH_STATUSES), "all").default("all"),
+  view: z.enum(HEALTH_VIEWS).catch("").default(""),
+  status: z.enum(HEALTH_STATUSES).catch("all").default("all"),
 });
 
 export type HealthSearch = z.infer<typeof healthSearchSchema>;
 
 export const Route = createFileRoute("/health")({
-  validateSearch: zodValidator(healthSearchSchema),
+  validateSearch: healthSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(healthSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 
 export const leaderboardsSearchSchema = z.object({
-  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  window: z.enum(["7d", "30d"]).catch("7d").default("7d"),
 });
 
 // #8311: /leaderboards retired into /subnets?section=rankings. Every board
@@ -12,7 +11,7 @@ export const leaderboardsSearchSchema = z.object({
 // separate top-level route. `window` is forwarded so an existing shared link
 // lands on the same range it named.
 export const Route = createFileRoute("/leaderboards")({
-  validateSearch: zodValidator(leaderboardsSearchSchema),
+  validateSearch: leaderboardsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(leaderboardsSearchSchema)] },
   beforeLoad: ({ search }) => {
     throw redirect({

--- a/apps/ui/src/routes/revenue.tsx
+++ b/apps/ui/src/routes/revenue.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { RevenuePage } from "./-revenue-page";
 import { COVERAGE_SORT_FIELDS } from "@/lib/metagraphed/coverage-leaderboard-model";
 
@@ -16,12 +15,12 @@ import { COVERAGE_SORT_FIELDS } from "@/lib/metagraphed/coverage-leaderboard-mod
 // was measured but whose emission failed to price sorts to the BOTTOM of a
 // table it legitimately belongs in — ranked last on a column it cannot answer.
 const revenueSearchSchema = z.object({
-  sort: fallback(z.enum(COVERAGE_SORT_FIELDS), "revenue_usd").default("revenue_usd"),
-  dir: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
+  sort: z.enum(COVERAGE_SORT_FIELDS).catch("revenue_usd").default("revenue_usd"),
+  dir: z.enum(["asc", "desc"]).catch("desc").default("desc"),
   // Empty means every tier, which is the default: the counts beside each tier
   // are how a reader learns the headline-eligible set is two subnets wide, and
   // defaulting to a filtered view would hide exactly that.
-  provenance: fallback(z.string(), "").default(""),
+  provenance: z.string().catch("").default(""),
 });
 
 export type RevenueSearch = z.infer<typeof revenueSearchSchema>;
@@ -30,7 +29,7 @@ const DESCRIPTION =
   "What every Bittensor subnet earns from outside the network, against the TAO the network emits to it. Only chain-verified and probe-derived readings reach the ratio; subnets with no observable external revenue are listed separately rather than ranked as zero.";
 
 export const Route = createFileRoute("/revenue")({
-  validateSearch: zodValidator(revenueSearchSchema),
+  validateSearch: revenueSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(revenueSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,7 +1,6 @@
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { StatusPage } from "./-status-page";
 
 // #3977: the probe-history drill-down's date + its nested table controls are
@@ -14,18 +13,18 @@ const SURFACE_SORT_FIELDS = ["netuid", "provider", "kind", "status", "latency_ms
 export type StatusSearch = z.infer<typeof statusSearchSchema>;
 
 export const statusSearchSchema = z.object({
-  date: fallback(z.string(), "").default(""),
-  kind: fallback(z.string(), "").default(""),
-  status: fallback(z.string(), "").default(""),
-  sort: fallback(z.enum(SURFACE_SORT_FIELDS), "status").default("status"),
-  order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
+  date: z.string().catch("").default(""),
+  kind: z.string().catch("").default(""),
+  status: z.string().catch("").default(""),
+  sort: z.enum(SURFACE_SORT_FIELDS).catch("status").default("status"),
+  order: z.enum(["asc", "desc"]).catch("asc").default("asc"),
   // #3976: RecentIncidents' 7d/30d window is URL-backed (like /explorer) so a
   // shared /status link restores the same window and back/forward works.
-  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  window: z.enum(["7d", "30d"]).catch("7d").default("7d"),
 });
 
 export const Route = createFileRoute("/status")({
-  validateSearch: zodValidator(statusSearchSchema),
+  validateSearch: statusSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(statusSearchSchema)] },
   head: () => ({
     meta: [

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -22,18 +22,36 @@ export type SearchParams = {
   uid?: number;
   ev_kind?: string;
   window?: "7d" | "30d" | "90d";
+  /**
+   * Peer netuid for SubnetCompareDrawer.
+   *
+   * It was missing, and `validateSearch` REPLACES the search object rather
+   * than patching it -- so every key not listed here is dropped. The drawer
+   * writes `?compare=`, this function discarded it on the very next parse, and
+   * the comparison the drawer's own doc comment calls "shareable and survives
+   * page reloads" did neither.
+   */
+  compare?: number;
 };
 
 export const Route = createFileRoute("/subnets/$netuid")({
   validateSearch: (s: Record<string, unknown>): SearchParams => {
     const uidNum = Number(s.uid);
     const win = s.window;
+    // Number() coerces the string a URL always delivers, and NaN falls through
+    // to undefined -- so `?compare=7` and a programmatic `compare: 7` both
+    // land as 7, which is what the drawer reads back.
+    const compareNum = Number(s.compare);
     return {
       tab: typeof s.tab === "string" ? s.tab : undefined,
       sev: typeof s.sev === "string" ? s.sev : undefined,
       uid: Number.isInteger(uidNum) && uidNum >= 0 ? uidNum : undefined,
       ev_kind: typeof s.ev_kind === "string" && s.ev_kind ? s.ev_kind : undefined,
       window: win === "7d" || win === "30d" || win === "90d" ? win : undefined,
+      compare:
+        s.compare != null && Number.isInteger(compareNum) && compareNum >= 0
+          ? compareNum
+          : undefined,
     };
   },
   parseParams: ({ netuid }) => {

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -1,7 +1,6 @@
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { tableSearchSchema } from "@/lib/metagraphed/url-state";
 import { SubnetsPage } from "./-subnets-index-page";
 import { hubMeta } from "@/lib/metagraphed/hub-copy";
@@ -14,12 +13,12 @@ import { hubMeta } from "@/lib/metagraphed/hub-copy";
 export type SubnetsSearch = z.infer<typeof subnetsSearchSchema>;
 
 export const subnetsSearchSchema = tableSearchSchema.extend({
-  section: fallback(z.enum(["registry", "rankings"]), "registry").default("registry"),
-  window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  section: z.enum(["registry", "rankings"]).catch("registry").default("registry"),
+  window: z.enum(["7d", "30d"]).catch("7d").default("7d"),
 });
 
 export const Route = createFileRoute("/subnets/")({
-  validateSearch: zodValidator(subnetsSearchSchema),
+  validateSearch: subnetsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(subnetsSearchSchema)] },
   head: () => ({
     meta: hubMeta("/subnets"),

--- a/apps/ui/src/routes/sudo.index.tsx
+++ b/apps/ui/src/routes/sudo.index.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute("/sudo/")({
   beforeLoad: ({ search }) => {
     throw redirect({
       to: "/chain/governance",
-      search: { ...(search as Record<string, unknown>), view: "sudo" } as never,
+      search: { ...(search as Record<string, unknown>), view: "sudo" },
       replace: true,
       // 301, not the 307 default: this route is permanently retired. A
       // temporary redirect tells a search engine to keep the old URL and

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading } from "@/components/metagraphed/states";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
@@ -24,17 +23,17 @@ const NOMINATOR_ENUMS = QUERY_PARAMETER_ENUMS["/api/v1/validators/{hotkey}/nomin
 const validatorDetailSearchSchema = z.object({
   // #8251: which detail tab is active (Per-subnet performance / Nominators /
   // History) — same `tab` convention subnets.$netuid.tsx uses.
-  tab: fallback(z.string(), "subnets").default("subnets"),
+  tab: z.string().catch("subnets").default("subnets"),
   // The nominators route's own published enums (#10994).
-  window: fallback(z.enum(NOMINATOR_ENUMS.window), "30d").default("30d"),
-  sort: fallback(z.enum(NOMINATOR_ENUMS.sort), "net_staked").default("net_staked"),
-  limit: fallback(z.number().int().min(1).max(100), 20).default(20),
-  offset: fallback(z.number().int().min(0), 0).default(0),
-  coldkey: fallback(z.string(), "").default(""),
+  window: z.enum(NOMINATOR_ENUMS.window).catch("30d").default("30d"),
+  sort: z.enum(NOMINATOR_ENUMS.sort).catch("net_staked").default("net_staked"),
+  limit: z.number().int().min(1).max(100).catch(20).default(20),
+  offset: z.number().int().min(0).catch(0).default(0),
+  coldkey: z.string().catch("").default(""),
 });
 
 export const Route = createFileRoute("/validators/$hotkey")({
-  validateSearch: zodValidator(validatorDetailSearchSchema),
+  validateSearch: validatorDetailSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(validatorDetailSearchSchema)] },
   // #6429: validate the hotkey at the router level, matching blocks.$ref.tsx
   // (#3422) and subnets.$netuid.tsx. parseParams runs before head()/the loader,

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -1,7 +1,6 @@
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ValidatorsPage } from "./-validators-index-page";
 import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
@@ -13,26 +12,26 @@ import { hubMeta } from "@/lib/metagraphed/hub-copy";
 export type ValidatorsSearch = z.infer<typeof validatorsSearchSchema>;
 
 export const validatorsSearchSchema = z.object({
-  q: fallback(z.string(), "").default(""),
+  q: z.string().catch("").default(""),
   // #8256: "Watched" quick filter, matching the /subnets index convention.
   // A search param (not component state) so a filtered view is shareable and
   // survives a reload.
-  watched: fallback(z.boolean(), false).default(false),
+  watched: z.boolean().catch(false).default(false),
   // Cluster an operator's keys adjacent under its best-ranked row, so a team
   // running several validators (Ventura Labs, Yuma, …) reads as one entry
   // with a ×N chip instead of the same name repeated at every rank. On by
   // default; the toggle exists for anyone who wants the raw flat ranking.
-  grouped: fallback(z.boolean(), true).default(true),
-  sort: fallback(z.string(), "total_stake_tao").default("total_stake_tao"),
+  grouped: z.boolean().catch(true).default(true),
+  sort: z.string().catch("total_stake_tao").default("total_stake_tao"),
   // #5344: bring Validators up to the canonical ranked-list interaction model
   // (Subnets) — a sort DIRECTION toggled by clicking a column header, and a row
   // density control — instead of a bare, single-direction <select>.
-  order: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
-  density: fallback(z.enum(["compact", "comfortable"]), "comfortable").default("comfortable"),
+  order: z.enum(["asc", "desc"]).catch("desc").default("desc"),
+  density: z.enum(["compact", "comfortable"]).catch("comfortable").default("comfortable"),
 });
 
 export const Route = createFileRoute("/validators/")({
-  validateSearch: zodValidator(validatorsSearchSchema),
+  validateSearch: validatorsSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(validatorsSearchSchema)] },
   head: () => ({
     meta: hubMeta("/validators"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "@tanstack/react-start": "^1.168.40",
         "@tanstack/react-virtual": "^3.14.9",
         "@tanstack/router-plugin": "^1.168.27",
-        "@tanstack/zod-adapter": "^1.167.0",
         "clsx": "^2.1.1",
         "fumadocs-core": "^16.11.5",
         "fumadocs-mdx": "^15.2.2",
@@ -8668,23 +8667,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/zod-adapter": {
-      "version": "1.167.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/zod-adapter/-/zod-adapter-1.167.0.tgz",
-      "integrity": "sha512-5Wlm5teSu+pz3KKhfa1ESsiOJXbvV6ITr1vKOQKi9yEdtozp6VefEzxzafLLida97mnL2tmauva/njokQrG5CA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-router": ">=1.43.2",
-        "zod": "^3.23.8"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/scripts/validate-double-assertions.ts
+++ b/scripts/validate-double-assertions.ts
@@ -39,8 +39,8 @@
 //
 // `BUDGETS` is per area (a path prefix) and each entry may only fall. A PR that
 // adds one fails, and a PR that removes one without lowering the budget ALSO
-// fails, so every number tracks reality rather than intent. Five of the six
-// areas are at zero; apps/ui ratchets down toward it.
+// fails, so every number tracks reality rather than intent. All six areas are
+// at zero, which is the point: the budget exists to keep them there.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -55,20 +55,20 @@ import { repoRoot } from "./lib.ts";
  * regression in any of them is a plain failure rather than a number to
  * negotiate.
  *
- * `apps/ui` is the RATCHET. It was invisible to this gate until #11368,
+ * `apps/ui` reached zero too. It was invisible to this gate until #11368,
  * because the file walk filtered on `.endsWith(".ts")` and every route and
  * component in that workspace is `.tsx` -- so the area carrying the most
- * assertions in the repo was the one area never counted. Most of what is left
- * there is two third-party shapes: TanStack Router's typed search/params
- * generics, and @polkadot/api's codecs on a runtime with no augmentation
- * package. Those want per-library helpers rather than a sweep, so the count
- * falls in batches and the ceiling falls with it.
+ * assertions in the repo was the one area never counted. It entered as a
+ * ratchet at 101 and came down 101 -> 83 -> 4 -> 0, the last drop when the
+ * root cause of ~64 of them turned out to be a single dependency: a
+ * zod-v3-typed router adapter under zod 4, which made every route's search
+ * type resolve to `{}`.
  *
- * A ratchet and not an exemption, deliberately: `scripts` spent #11368 falling
- * 54 -> 21 -> 15 -> 6 -> 0 exactly this way. A declared exemption list stops
- * being read the moment it is longer than a screen (see
- * validate-untyped-db-reads.ts's note) and then hides exactly what it names.
- * A number cannot hide anything.
+ * The ratchet is the mechanism to reach for when an area cannot go to zero in
+ * one change -- `scripts` fell 54 -> 21 -> 15 -> 6 -> 0 the same way. A
+ * declared exemption list stops being read the moment it is longer than a
+ * screen (see validate-untyped-db-reads.ts's note) and then hides exactly what
+ * it names. A number cannot hide anything.
  *
  * `tests` is NOT scanned, and that is a judgement rather than an oversight: a
  * unit process cannot construct a `KVNamespace`, `Hyperdrive`,
@@ -83,7 +83,7 @@ export const BUDGETS: Readonly<Record<string, number>> = {
   "schemas-src": 0,
   packages: 0,
   scripts: 0,
-  "apps/ui": 83,
+  "apps/ui": 0,
 };
 
 const SCANNED_DIRS = Object.keys(BUDGETS);

--- a/tests/validate-double-assertions.test.ts
+++ b/tests/validate-double-assertions.test.ts
@@ -119,22 +119,15 @@ describe("areaOf", () => {
 });
 
 describe("BUDGETS", () => {
-  it("holds every SWEPT area at zero", () => {
+  it("holds EVERY area at zero", () => {
     // Not a restatement of the constant: all five were driven to zero by
     // #11339/#11361/#11368, and a nonzero entry here is a silent regression
     // budget -- the thing this gate exists to prevent. If an area ever needs
     // a ratchet again, this is the test that makes reintroducing one a
     // deliberate edit rather than a quiet one.
     for (const [area, budget] of Object.entries(BUDGETS)) {
-      if (area === "apps/ui") continue; // the live ratchet, see BUDGETS
       expect(budget, `${area} has a nonzero budget`).toBe(0);
     }
-  });
-
-  it("keeps apps/ui a ratchet that can only fall", () => {
-    // Named explicitly so raising it is a visible edit to this line rather
-    // than a quiet edit to a number. 83 is where #11368 left it.
-    expect(BUDGETS["apps/ui"]).toBeLessThanOrEqual(83);
   });
 
   it("covers every area a cast could hide in outside tests", () => {


### PR DESCRIPTION
`@tanstack/zod-adapter@1.167.0` declares `peerDependencies: { zod: "^3.23.8" }`; this repo runs zod 4.4.3. Its `fallback()` returns a type naming `z.ZodPipeline` and `z.ZodTypeDef`, neither of which exists in zod 4 — so `fallback()` returned `any`.

**Measured:** `z.infer` on a schema with no `fallback` is `{ limit: number; q: string }`. Add one `fallback()`-wrapped field and the whole object becomes `{ [x: string]: any }`. Every route search schema wrapped every field, so every route's search type was `{}`, `useSearch()` returned `{}`, and ~64 call sites wrote `as never` to work around it.

`-health-page.tsx` already carried a comment diagnosing this exactly, and worked around it locally one cast at a time.

## The fix

`fallback(A, B)` is `z.custom().pipe(A.catch(B))` — read from the adapter's published dist. The `z.custom()` prefix is a runtime no-op that only widened the input type, which is what broke. `A.catch(B)` is the same parse; zod 4 implements Standard Schema, which TanStack Router 1.170 takes directly. 111 sites converted by AST codemod, `zodValidator()` unwrapped at 17, dependency removed.

Equivalence is pinned by a test that reimplements the adapter's real `fallback` and compares both parses across eight input classes for number, string and enum fields.

## Bugs the working types then caught

- **The compare drawer's `?compare=` param has never worked.** `/subnets/$netuid`'s `validateSearch` replaces the search object and omits `compare`. Proven at runtime: `validateSearch({compare: 5, tab: "overview"})` → `{"tab":"overview"}`.
- **A typo'd sort column silently did nothing** — `SortHeader` took `field: string`, and the search schema `.catch()`ed the unknown value back to its default.
- **Nine copies of one test helper** each asserted past a `never` in their own signature; the consolidated version showed the fixture was missing `client`, required since Query v5.

## Result

```
src 0/0  workers 0/0  schemas-src 0/0  packages 0/0  scripts 0/0  apps/ui 0/0
```

Every area the gate scans is at zero. apps/ui typecheck clean, 2324 tests pass; root lint, format and all 55 CI validators pass.