### PR TITLE
fix(watchdog): count only axons that point somewhere routable

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -107,6 +107,42 @@ export const AXON_FLEET_WIDE_FLAGS = 4;
 /** Most subnets named in one detail string, so a fleet event stays readable. */
 export const AXON_MAX_LISTED = 8;
 
+/**
+ * Address ranges an announced axon can carry that nobody can route to.
+ *
+ * ONE PATTERN, used to build the SQL predicate and available as a RegExp for
+ * tests, so the rule cannot drift between where it is enforced and where it is
+ * described. Covers RFC 5737 documentation space, RFC 1918 private space,
+ * loopback, and the unspecified `0.0.0.0/8`.
+ *
+ * MEASURED 2026-08-16, this is not hypothetical: 347 of 6,532 announced axons
+ * (5.3%) sit in these ranges, and 246 of those miners earn incentive. SN33 is
+ * almost all of it -- 247 of its 251 announcements are `192.0.2.1`, a single
+ * RFC 5737 documentation address, and those miners take 99.82% of the subnet's
+ * incentive while the four announcing routable addresses earn nothing (#11373).
+ *
+ * COUNTING THEM AS ANNOUNCING MAKES THIS WATCHDOG BLIND in the one direction it
+ * exists to watch: a subnet could lose every real endpoint and read as
+ * perfectly healthy while its placeholder count held steady.
+ */
+export const UNROUTABLE_AXON_PATTERN =
+  "^(0\\.|10\\.|127\\.|192\\.168\\.|192\\.0\\.2\\.|198\\.51\\.100\\.|203\\.0\\.113\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.)";
+
+/** SQL fragment: the axon is present AND points somewhere routable. */
+export const ROUTABLE_AXON_SQL = `axon IS NOT NULL AND axon <> '' AND split_part(axon, ':', 1) !~ '${UNROUTABLE_AXON_PATTERN}'`;
+
+/** The same rule in JS, for callers holding a row rather than writing SQL. */
+export function isRoutableAxon(axon: unknown): boolean {
+  if (typeof axon !== "string" || axon === "") return false;
+  // `split(":", 1).join("")` rather than indexing: `split` always yields at
+  // least one element, so a `?? ""` guard on `[0]` would be a branch nothing
+  // could reach, and a test written to reach it could only assert the code's
+  // own assumption back at it.
+  const ip = axon.split(":", 1).join("");
+  if (ip === "") return false;
+  return !new RegExp(UNROUTABLE_AXON_PATTERN).test(ip);
+}
+
 /** One subnet-day, as read from `neuron_daily`. */
 export interface AxonDay {
   date: string;
@@ -329,8 +365,8 @@ export async function loadAxonLossMechanisms(
   try {
     const rows = (await db.query(
       "WITH seq AS (SELECT netuid, uid, snapshot_date, hotkey, " +
-        "(axon IS NOT NULL) AS has_axon, " +
-        "LAG(axon IS NOT NULL) OVER w AS prev_has, " +
+        `(${ROUTABLE_AXON_SQL}) AS has_axon, ` +
+        `LAG(${ROUTABLE_AXON_SQL}) OVER w AS prev_has, ` +
         "LAG(hotkey) OVER w AS prev_hotkey, LAG(axon) OVER w AS prev_axon " +
         "FROM neuron_daily " +
         `WHERE snapshot_date >= ? AND netuid IN (${ids.map(() => "?").join(",")}) ` +
@@ -388,7 +424,7 @@ export async function runAxonAnnouncementWatchdog(
     // days, and the answer is two integers per subnet-day.
     const rows = await db.query(
       "SELECT netuid, snapshot_date AS date, " +
-        "COUNT(*) FILTER (WHERE axon IS NOT NULL AND axon <> '') AS with_axon, " +
+        `COUNT(*) FILTER (WHERE ${ROUTABLE_AXON_SQL}) AS with_axon, ` +
         "COUNT(*) AS neurons FROM neuron_daily " +
         "WHERE snapshot_date >= ? GROUP BY netuid, snapshot_date " +
         "ORDER BY netuid, snapshot_date",

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -24,6 +24,8 @@ import {
   evaluateSubnetAxons,
   groupAxonDays,
   isFleetWide,
+  isRoutableAxon,
+  ROUTABLE_AXON_SQL,
   classifyAxonMechanism,
   loadAxonLossMechanisms,
   isoDaysAgo,
@@ -1036,5 +1038,70 @@ describe("IP concentration — one host, or the subnet", () => {
       q.text.includes("INSERT INTO lane_health"),
     );
     assert.match(String(insert?.values[3]), /ALL FROM ONE ADDRESS/);
+  });
+});
+
+describe("routable axons only (#11373)", () => {
+  // Measured 2026-08-16: 347 of 6,532 announced axons (5.3%) point at ranges
+  // nobody can route to, and 246 of those miners earn. SN33 is almost all of
+  // it -- 247 of 251 announcements are `192.0.2.1`, an RFC 5737 documentation
+  // address, taking 99.82% of the subnet's incentive.
+  //
+  // Counting those as announcing made this watchdog blind in the one direction
+  // it exists to watch: a subnet could lose every real endpoint and read as
+  // healthy while its placeholder count held.
+
+  test("the reserved and private ranges are not routable", () => {
+    for (const axon of [
+      "192.0.2.1:8091", // RFC 5737 TEST-NET-1 -- the SN33 case
+      "198.51.100.7:8091", // TEST-NET-2
+      "203.0.113.9:8091", // TEST-NET-3
+      "127.0.0.1:8091", // loopback
+      "10.0.0.5:8091", // RFC 1918
+      "192.168.1.1:8091", // RFC 1918
+      "172.16.0.1:8091", // RFC 1918 lower bound
+      "172.31.255.254:8091", // RFC 1918 upper bound
+      "0.0.0.0:0", // unspecified
+    ]) {
+      assert.equal(isRoutableAxon(axon), false, `${axon} must not be routable`);
+    }
+  });
+
+  test("real addresses ARE routable, including the 172.x boundary", () => {
+    for (const axon of [
+      "152.53.149.254:8091", // SN101's shared host
+      "3.33.133.240:8091",
+      "172.32.0.1:8091", // just outside RFC 1918 -- must stay routable
+      "172.15.0.1:8091", // just below it
+      "193.0.2.1:8091", // one octet off TEST-NET-1
+    ]) {
+      assert.equal(isRoutableAxon(axon), true, `${axon} must be routable`);
+    }
+  });
+
+  test("absent or malformed is not routable, and does not throw", () => {
+    for (const axon of [null, undefined, "", 42, {}, ":8091"]) {
+      assert.equal(isRoutableAxon(axon), false);
+    }
+  });
+
+  test("both reads share ONE predicate, so they cannot disagree", () => {
+    // The rule is enforced in SQL; a second copy would be free to drift from
+    // the one the JS predicate documents and the tests above pin.
+    assert.match(ROUTABLE_AXON_SQL, /axon IS NOT NULL/);
+    assert.match(ROUTABLE_AXON_SQL, /split_part\(axon, ':', 1\) !~/);
+    assert.match(ROUTABLE_AXON_SQL, /192\\\.0\\\.2\\\./);
+  });
+
+  test("the predicate the JS mirrors is the one the SQL embeds", () => {
+    // Same source string on both sides -- if the pattern is retuned, both move.
+    const embedded = ROUTABLE_AXON_SQL.match(/!~ '(.+)'$/)?.[1];
+    assert.ok(embedded, "the SQL carries the pattern inline");
+    assert.equal(
+      new RegExp(embedded).test("192.0.2.1"),
+      true,
+      "the embedded pattern matches what isRoutableAxon rejects",
+    );
+    assert.equal(new RegExp(embedded).test("152.53.149.254"), false);
   });
 });


### PR DESCRIPTION
Closes #11373

The watchdog counted an announced axon as an announcement regardless of where it pointed. Measured 2026-08-16, **5.3% of announced axons point at ranges nobody can route to**, and 246 of those miners earn incentive.

| class | miners | subnets | earning |
| --- | --- | --- | --- |
| reserved-documentation (RFC 5737) | 338 | 4 | **245** |
| loopback (`127.0.0.0/8`) | 5 | 1 | 0 |
| private (RFC 1918) | 1 | 1 | 1 |
| other | 3 | 3 | 0 |

## SN33 is almost all of it

```
192.0.2.1          247 miners   245 earning   18 coldkeys   incentive share 0.9982
136.119.106.31       1 miner      0 earning
192.150.253.122      1 miner      0 earning
52.52.136.92         1 miner      0 earning
54.228.70.29         1 miner      0 earning
```

`192.0.2.0/24` is TEST-NET-1, reserved by RFC 5737 for documentation. On SN33 the miners announcing a placeholder take **99.82% of the subnet's incentive**, and the four announcing real addresses earn **nothing**.

## Why it matters here specifically

Counting placeholders as announcing made this watchdog **blind in the one direction it exists to watch**: a subnet could lose every real endpoint and read as perfectly healthy while its placeholder count held steady.

## No phantom alarm — checked before shipping, not after

Redefining "announcing" is exactly the kind of change that manufactures an event. The baseline comes from the same query as the day under test, so filtering both moves them together:

| subnet | before | after (08-14 / 15 / 16) | effect |
| --- | --- | --- | --- |
| **33** | 251 | **4 / 4 / 4** | stable, and now below `AXON_BASELINE_FLOOR` — stops being evaluated rather than reporting a 98% collapse |
| **126** | 249 | **166 / 166 / 166** | stable |
| 25 | 13/14/14 | unchanged | already routable |
| 101 | 128/125/124 | unchanged | already routable |

## One predicate, two reads

The pattern is a single constant used to build the SQL for both the main read and the mechanism read, and exposed as `isRoutableAxon` for callers holding a row. A second copy of the rule would be free to drift from the one the tests pin.

The `172.16–31` boundary is pinned in both directions — `172.16.0.1` and `172.31.255.254` are not routable; `172.15.0.1` and `172.32.0.1` are.

## Verified

- the generated SQL executed against production Neon, not just the mock
- `tsc --noEmit`, `prettier --check`, `eslint` clean
- 75 tests in this file; full suite green
- patch coverage by diff intersection: **6/6 lines, 6/6 branches, 100%**

## Correction carried

This also corrects a figure I quoted in #11371 and in several places: "~22% of neurons announce an axon" is really **~21% announcing a routable one**. Network-wide the gap is small; on SN33 it is total.

Deliberately **not** in scope: publishing `axon_routable` on the API. #11373 proposes that, and #11371 depends on it — this PR fixes the watchdog's own blindness, which is the part that was actively misreporting.
