### PR TITLE
feat(api): publish axon_routable, so an announced endpoint stops implying reachability

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -1899,6 +1899,11 @@ type CompareValidatorsArtifactValidatorsSubnetContext {
   registered_at_block: Int
   is_immunity_period: Boolean!
   axon: String
+
+  """
+  Whether \`axon\` points somewhere on the public internet; null when there is no axon. Carried wherever \`axon\` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator.
+  """
+  axon_routable: Boolean
   take: Float
 }
 
@@ -2234,6 +2239,11 @@ type NeuronState {
   The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541).
   """
   axon: String
+
+  """
+  Whether \`axon\` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when \`axon\` itself is null, because 'not announcing' has no routability to report.
+  """
+  axon_routable: Boolean
   featured: Boolean
 
   """
@@ -4041,6 +4051,11 @@ type NeuronHistoryPoint {
   The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541).
   """
   axon: String
+
+  """
+  Whether \`axon\` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when \`axon\` itself is null, because 'not announcing' has no routability to report.
+  """
+  axon_routable: Boolean
   featured: Boolean
 
   """
@@ -5938,6 +5953,11 @@ type ValidatorSubnet {
   registered_at_block: Int
   is_immunity_period: Boolean
   axon: String
+
+  """
+  Whether \`axon\` points somewhere on the public internet; null when there is no axon. Carried wherever \`axon\` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator.
+  """
+  axon_routable: Boolean
   take: Float
 }
 

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2062,6 +2062,8 @@ export type CompareValidatorsArtifactValidatorsSubnetContext = {
   __typename?: 'CompareValidatorsArtifactValidatorsSubnetContext';
   active: Scalars['Boolean']['output'];
   axon?: Maybe<Scalars['String']['output']>;
+  /** Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator. */
+  axon_routable?: Maybe<Scalars['Boolean']['output']>;
   coldkey?: Maybe<Scalars['String']['output']>;
   consensus?: Maybe<Scalars['Float']['output']>;
   dividends?: Maybe<Scalars['Float']['output']>;
@@ -3155,6 +3157,8 @@ export type NeuronHistoryPoint = {
   active: Scalars['Boolean']['output'];
   /** The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
   axon?: Maybe<Scalars['String']['output']>;
+  /** Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+  axon_routable?: Maybe<Scalars['Boolean']['output']>;
   block_number?: Maybe<Scalars['Int']['output']>;
   captured_at?: Maybe<Scalars['String']['output']>;
   coldkey?: Maybe<Scalars['String']['output']>;
@@ -3192,6 +3196,8 @@ export type NeuronState = {
   active: Scalars['Boolean']['output'];
   /** The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
   axon?: Maybe<Scalars['String']['output']>;
+  /** Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+  axon_routable?: Maybe<Scalars['Boolean']['output']>;
   coldkey?: Maybe<Scalars['String']['output']>;
   consensus?: Maybe<Scalars['Float']['output']>;
   dividends?: Maybe<Scalars['Float']['output']>;
@@ -8295,6 +8301,8 @@ export type ValidatorSubnet = {
   __typename?: 'ValidatorSubnet';
   active?: Maybe<Scalars['Boolean']['output']>;
   axon?: Maybe<Scalars['String']['output']>;
+  /** Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator. */
+  axon_routable?: Maybe<Scalars['Boolean']['output']>;
   coldkey?: Maybe<Scalars['String']['output']>;
   consensus?: Maybe<Scalars['Float']['output']>;
   dividends?: Maybe<Scalars['Float']['output']>;
@@ -10956,6 +10964,7 @@ export type CompareValidatorsArtifactValidatorsColdkeyIdentityResolvers<ContextT
 export type CompareValidatorsArtifactValidatorsSubnetContextResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CompareValidatorsArtifactValidatorsSubnetContext'] = ResolversParentTypes['CompareValidatorsArtifactValidatorsSubnetContext']> = ResolversObject<{
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   axon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  axon_routable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   consensus?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   dividends?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
@@ -11855,6 +11864,7 @@ export type NeuronHistoryResolvers<ContextType = GqlContext, ParentType extends 
 export type NeuronHistoryPointResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['NeuronHistoryPoint'] = ResolversParentTypes['NeuronHistoryPoint']> = ResolversObject<{
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   axon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  axon_routable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   captured_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -11882,6 +11892,7 @@ export type NeuronHistoryPointResolvers<ContextType = GqlContext, ParentType ext
 export type NeuronStateResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['NeuronState'] = ResolversParentTypes['NeuronState']> = ResolversObject<{
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   axon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  axon_routable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   consensus?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   dividends?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
@@ -14558,6 +14569,7 @@ export type ValidatorSetCompositionResolvers<ContextType = GqlContext, ParentTyp
 export type ValidatorSubnetResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ValidatorSubnet'] = ResolversParentTypes['ValidatorSubnet']> = ResolversObject<{
   active?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   axon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  axon_routable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   consensus?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   dividends?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7565,6 +7565,8 @@ export interface components {
                 subnet_context: {
                     active: boolean;
                     axon: string | null;
+                    /** @description Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator. */
+                    axon_routable: boolean | null;
                     coldkey: string | null;
                     consensus: number | null;
                     dividends: number | null;
@@ -9291,6 +9293,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
@@ -9331,6 +9335,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 block_number?: number | null;
                 captured_at?: string | null;
                 coldkey: string | null;
@@ -11982,6 +11988,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
@@ -13085,6 +13093,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
@@ -13703,6 +13713,8 @@ export interface components {
             subnets: {
                 active: boolean;
                 axon: string | null;
+                /** @description Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator. */
+                axon_routable: boolean | null;
                 coldkey: string | null;
                 consensus: number | null;
                 dividends: number | null;
@@ -30456,6 +30468,7 @@ export interface operations {
                      *             "subnet_context": {
                      *               "active": false,
                      *               "axon": "example",
+                     *               "axon_routable": false,
                      *               "coldkey": "example",
                      *               "consensus": 0.5,
                      *               "dividends": 0.5,
@@ -45471,6 +45484,7 @@ export interface operations {
                      *         "neuron": {
                      *           "active": false,
                      *           "axon": "example",
+                     *           "axon_routable": false,
                      *           "coldkey": "example",
                      *           "consensus": 0.5,
                      *           "dividends": 0.5,
@@ -51224,6 +51238,7 @@ export interface operations {
                      *           {
                      *             "active": false,
                      *             "axon": "example",
+                     *             "axon_routable": false,
                      *             "coldkey": "example",
                      *             "consensus": 0.5,
                      *             "dividends": 0.5,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4540,6 +4540,7 @@
                 "subnet_context": {
                   "active": false,
                   "axon": "example",
+                  "axon_routable": false,
                   "coldkey": "example",
                   "consensus": 0.5,
                   "dividends": 0.5,
@@ -6924,6 +6925,7 @@
             "neuron": {
               "active": false,
               "axon": "example",
+              "axon_routable": false,
               "coldkey": "example",
               "consensus": 0.5,
               "dividends": 0.5,
@@ -13504,6 +13506,7 @@
               {
                 "active": false,
                 "axon": "example",
+                "axon_routable": false,
                 "coldkey": "example",
                 "consensus": 0.5,
                 "dividends": 0.5,
@@ -28317,6 +28320,17 @@
                             }
                           ]
                         },
+                        "axon_routable": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator."
+                        },
                         "coldkey": {
                           "anyOf": [
                             {
@@ -28476,6 +28490,7 @@
                         "registered_at_block",
                         "is_immunity_period",
                         "axon",
+                        "axon_routable",
                         "take"
                       ],
                       "type": "object"
@@ -37996,6 +38011,17 @@
                     ],
                     "description": "The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541)."
                   },
+                  "axon_routable": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report."
+                  },
                   "coldkey": {
                     "anyOf": [
                       {
@@ -38243,6 +38269,17 @@
                     }
                   ],
                   "description": "The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541)."
+                },
+                "axon_routable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report."
                 },
                 "block_number": {
                   "anyOf": [
@@ -53124,6 +53161,17 @@
                   ],
                   "description": "The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541)."
                 },
+                "axon_routable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report."
+                },
                 "coldkey": {
                   "anyOf": [
                     {
@@ -59294,6 +59342,17 @@
                   ],
                   "description": "The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541)."
                 },
+                "axon_routable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report."
+                },
                 "coldkey": {
                   "anyOf": [
                     {
@@ -62678,6 +62737,17 @@
                     }
                   ]
                 },
+                "axon_routable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator."
+                },
                 "coldkey": {
                   "anyOf": [
                     {
@@ -62837,6 +62907,7 @@
                 "registered_at_block",
                 "is_immunity_period",
                 "axon",
+                "axon_routable",
                 "take"
               ],
               "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7565,6 +7565,8 @@ export interface components {
                 subnet_context: {
                     active: boolean;
                     axon: string | null;
+                    /** @description Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator. */
+                    axon_routable: boolean | null;
                     coldkey: string | null;
                     consensus: number | null;
                     dividends: number | null;
@@ -9291,6 +9293,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
@@ -9331,6 +9335,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 block_number?: number | null;
                 captured_at?: string | null;
                 coldkey: string | null;
@@ -11982,6 +11988,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
@@ -13085,6 +13093,8 @@ export interface components {
                 active: boolean;
                 /** @description The neuron's announced serving endpoint (ip:port), emitted only when the on-chain axon IP is non-zero. Null means NOT SERVING, which is the normal state for a validator -- so validator-scoped views read null throughout while miner rows on the same table carry a value. There is no alternate carrier: AxonServed stores only [netuid, hotkey] (#9541). */
                 axon?: string | null;
+                /** @description Whether `axon` points somewhere on the public internet. FALSE means the neuron announced an address nobody can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the same as not announcing, and is why this is a separate field rather than a null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and 246 of those miners earn incentive; on SN33, 247 of 251 announcements are 192.0.2.1 and take 99.82% of the subnet's incentive while the four routable ones earn nothing (#11373). Null when `axon` itself is null, because 'not announcing' has no routability to report. */
+                axon_routable?: boolean | null;
                 coldkey: string | null;
                 consensus?: number | null;
                 dividends?: number | null;
@@ -13703,6 +13713,8 @@ export interface components {
             subnets: {
                 active: boolean;
                 axon: string | null;
+                /** @description Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator. */
+                axon_routable: boolean | null;
                 coldkey: string | null;
                 consensus: number | null;
                 dividends: number | null;
@@ -30456,6 +30468,7 @@ export interface operations {
                      *             "subnet_context": {
                      *               "active": false,
                      *               "axon": "example",
+                     *               "axon_routable": false,
                      *               "coldkey": "example",
                      *               "consensus": 0.5,
                      *               "dividends": 0.5,
@@ -45471,6 +45484,7 @@ export interface operations {
                      *         "neuron": {
                      *           "active": false,
                      *           "axon": "example",
+                     *           "axon_routable": false,
                      *           "coldkey": "example",
                      *           "consensus": 0.5,
                      *           "dividends": 0.5,
@@ -51224,6 +51238,7 @@ export interface operations {
                      *           {
                      *             "active": false,
                      *             "axon": "example",
+                     *             "axon_routable": false,
                      *             "coldkey": "example",
                      *             "consensus": 0.5,
                      *             "dividends": 0.5,

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -93,6 +93,21 @@ export const NeuronSchema = z
           "while miner rows on the same table carry a value. There is no alternate " +
           "carrier: AxonServed stores only [netuid, hotkey] (#9541).",
       ),
+    axon_routable: z
+      .boolean()
+      .nullable()
+      .optional()
+      .describe(
+        "Whether `axon` points somewhere on the public internet. FALSE means the " +
+          "neuron announced an address nobody can reach -- RFC 5737 documentation " +
+          "space, RFC 1918 private space, loopback, or 0.0.0.0/8 -- which is NOT the " +
+          "same as not announcing, and is why this is a separate field rather than a " +
+          "null axon. Measured 2026-08-16: 5.3% of announced axons are unroutable and " +
+          "246 of those miners earn incentive; on SN33, 247 of 251 announcements are " +
+          "192.0.2.1 and take 99.82% of the subnet's incentive while the four routable " +
+          "ones earn nothing (#11373). Null when `axon` itself is null, because " +
+          "'not announcing' has no routability to report.",
+      ),
     // Only present on SubnetValidatorsArtifact rows (a real Set is always
     // passed there); omitted (not false) on metagraph/neuron-detail rows.
     featured: z.boolean().optional(),

--- a/schemas-src/routes/validator-detail.ts
+++ b/schemas-src/routes/validator-detail.ts
@@ -44,6 +44,12 @@ export const ValidatorDetailSubnetSchema = z
     registered_at_block: z.int().min(0).nullable(),
     is_immunity_period: z.boolean(),
     axon: z.string().nullable(),
+    axon_routable: z
+      .boolean()
+      .nullable()
+      .describe(
+        "Whether `axon` points somewhere on the public internet; null when there is no axon. Carried wherever `axon` is, because an unqualified endpoint implies reachability it may not have -- 5.3% of announced axons network-wide sit in RFC 5737, RFC 1918, loopback or 0.0.0.0/8 (#11373). Normally null here: not serving is the usual state for a validator.",
+      ),
     take: z.number().nullable(),
   })
   .strict();

--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -55,6 +55,7 @@
 // answers "something moved", never "this subnet is currently healthy".
 
 import { readStore, type StoreEnv } from "./read-store.ts";
+import { ROUTABLE_AXON_SQL } from "./axon-routable.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
@@ -106,42 +107,6 @@ export const AXON_FLEET_WIDE_FLAGS = 4;
 
 /** Most subnets named in one detail string, so a fleet event stays readable. */
 export const AXON_MAX_LISTED = 8;
-
-/**
- * Address ranges an announced axon can carry that nobody can route to.
- *
- * ONE PATTERN, used to build the SQL predicate and available as a RegExp for
- * tests, so the rule cannot drift between where it is enforced and where it is
- * described. Covers RFC 5737 documentation space, RFC 1918 private space,
- * loopback, and the unspecified `0.0.0.0/8`.
- *
- * MEASURED 2026-08-16, this is not hypothetical: 347 of 6,532 announced axons
- * (5.3%) sit in these ranges, and 246 of those miners earn incentive. SN33 is
- * almost all of it -- 247 of its 251 announcements are `192.0.2.1`, a single
- * RFC 5737 documentation address, and those miners take 99.82% of the subnet's
- * incentive while the four announcing routable addresses earn nothing (#11373).
- *
- * COUNTING THEM AS ANNOUNCING MAKES THIS WATCHDOG BLIND in the one direction it
- * exists to watch: a subnet could lose every real endpoint and read as
- * perfectly healthy while its placeholder count held steady.
- */
-export const UNROUTABLE_AXON_PATTERN =
-  "^(0\\.|10\\.|127\\.|192\\.168\\.|192\\.0\\.2\\.|198\\.51\\.100\\.|203\\.0\\.113\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.)";
-
-/** SQL fragment: the axon is present AND points somewhere routable. */
-export const ROUTABLE_AXON_SQL = `axon IS NOT NULL AND axon <> '' AND split_part(axon, ':', 1) !~ '${UNROUTABLE_AXON_PATTERN}'`;
-
-/** The same rule in JS, for callers holding a row rather than writing SQL. */
-export function isRoutableAxon(axon: unknown): boolean {
-  if (typeof axon !== "string" || axon === "") return false;
-  // `split(":", 1).join("")` rather than indexing: `split` always yields at
-  // least one element, so a `?? ""` guard on `[0]` would be a branch nothing
-  // could reach, and a test written to reach it could only assert the code's
-  // own assumption back at it.
-  const ip = axon.split(":", 1).join("");
-  if (ip === "") return false;
-  return !new RegExp(UNROUTABLE_AXON_PATTERN).test(ip);
-}
 
 /** One subnet-day, as read from `neuron_daily`. */
 export interface AxonDay {

--- a/src/axon-routable.ts
+++ b/src/axon-routable.ts
@@ -1,0 +1,42 @@
+// Whether an announced axon points anywhere on the public internet (#11373).
+//
+// Shared by the serving path (src/metagraph-neurons.ts, which publishes
+// `axon_routable`) and the watchdog (src/axon-announcement-watchdog.ts, which
+// counts only routable announcements). ONE definition: a second copy would be
+// free to drift, and the two answers would disagree about the same row.
+
+/**
+ * Address ranges an announced axon can carry that nobody can route to.
+ *
+ * ONE PATTERN, used to build the SQL predicate and available as a RegExp for
+ * tests, so the rule cannot drift between where it is enforced and where it is
+ * described. Covers RFC 5737 documentation space, RFC 1918 private space,
+ * loopback, and the unspecified `0.0.0.0/8`.
+ *
+ * MEASURED 2026-08-16, this is not hypothetical: 347 of 6,532 announced axons
+ * (5.3%) sit in these ranges, and 246 of those miners earn incentive. SN33 is
+ * almost all of it -- 247 of its 251 announcements are `192.0.2.1`, a single
+ * RFC 5737 documentation address, and those miners take 99.82% of the subnet's
+ * incentive while the four announcing routable addresses earn nothing (#11373).
+ *
+ * COUNTING THEM AS ANNOUNCING MAKES THIS WATCHDOG BLIND in the one direction it
+ * exists to watch: a subnet could lose every real endpoint and read as
+ * perfectly healthy while its placeholder count held steady.
+ */
+export const UNROUTABLE_AXON_PATTERN =
+  "^(0\\.|10\\.|127\\.|192\\.168\\.|192\\.0\\.2\\.|198\\.51\\.100\\.|203\\.0\\.113\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.)";
+
+/** SQL fragment: the axon is present AND points somewhere routable. */
+export const ROUTABLE_AXON_SQL = `axon IS NOT NULL AND axon <> '' AND split_part(axon, ':', 1) !~ '${UNROUTABLE_AXON_PATTERN}'`;
+
+/** The same rule in JS, for callers holding a row rather than writing SQL. */
+export function isRoutableAxon(axon: unknown): boolean {
+  if (typeof axon !== "string" || axon === "") return false;
+  // `split(":", 1).join("")` rather than indexing: `split` always yields at
+  // least one element, so a `?? ""` guard on `[0]` would be a branch nothing
+  // could reach, and a test written to reach it could only assert the code's
+  // own assumption back at it.
+  const ip = axon.split(":", 1).join("");
+  if (ip === "") return false;
+  return !new RegExp(UNROUTABLE_AXON_PATTERN).test(ip);
+}

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -11,6 +11,7 @@ import {
   loadIdentityByColdkeyMap,
 } from "./account-identity.ts";
 import { NeuronSchema } from "../schemas-src/routes/subnet-metagraph.ts";
+import { isRoutableAxon } from "./axon-routable.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import {
   parseFieldsParam,
@@ -470,6 +471,12 @@ export function formatNeuron(
         : nonNegativeInt(row.registered_at_block),
     is_immunity_period: toBooleanFlag(row.is_immunity_period),
     axon: row.axon ?? null,
+    // DERIVED, not stored: routability is a property of the value, so computing
+    // it beside the axon it describes keeps the two consistent and needs no
+    // column. Null when there is no axon -- "not announcing" has no
+    // routability to report, and false would claim it announced something
+    // unreachable (#11373).
+    axon_routable: row.axon == null ? null : isRoutableAxon(row.axon),
     // Global per-hotkey (SubtensorModule::Delegates), not per (netuid, uid) --
     // null means no Delegates entry at capture time (#2548).
     take: row.take == null ? null : round(finiteCellOrNull(row.take)),

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -24,8 +24,6 @@ import {
   evaluateSubnetAxons,
   groupAxonDays,
   isFleetWide,
-  isRoutableAxon,
-  ROUTABLE_AXON_SQL,
   classifyAxonMechanism,
   loadAxonLossMechanisms,
   isoDaysAgo,
@@ -34,6 +32,7 @@ import {
   type AxonDay,
   type AxonFinding,
 } from "../src/axon-announcement-watchdog.ts";
+import { isRoutableAxon, ROUTABLE_AXON_SQL } from "../src/axon-routable.ts";
 
 /** Days at a uniform width, oldest first. */
 const flat = (n: number, withAxon: number, neurons = 256): AxonDay[] =>

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -169,6 +169,69 @@ const MOVERS_CSV_HEADER =
 const GLOBAL_VALIDATOR_CSV_HEADER =
   "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,root_stake_tao,alpha_stake_tao,total_emission_tao,nominator_count,apy_estimate,apy_estimate_eligible_subnet_count,realized_return_1d,realized_return_1w,realized_return_1m,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
 
+describe("axon_routable (#11373)", () => {
+  // `axon IS NOT NULL` is not "reachable". Measured 2026-08-16: 5.3% of
+  // announced axons point at ranges nobody can route to, and 246 of those
+  // miners earn incentive. SN33 announces `192.0.2.1` on 247 of 251 UIDs and
+  // those miners take 99.82% of its incentive.
+
+  test("a routable endpoint is reported routable", () => {
+    const n = formatNeuron({ ...ROW, axon: "152.53.149.254:8091" });
+    assert.equal(n?.axon, "152.53.149.254:8091");
+    assert.equal(n?.axon_routable, true);
+  });
+
+  test("the SN33 placeholder is announced but NOT routable", () => {
+    // The distinction the field exists for: it announced something, and that
+    // something is unreachable. Collapsing this into a null axon would lose it.
+    const n = formatNeuron({ ...ROW, axon: "192.0.2.1:8091" });
+    assert.equal(n?.axon, "192.0.2.1:8091");
+    assert.equal(n?.axon_routable, false);
+  });
+
+  test("private, loopback and unspecified ranges are not routable", () => {
+    for (const axon of [
+      "10.0.0.5:8091",
+      "192.168.1.1:8091",
+      "172.16.0.1:8091",
+      "127.0.0.1:8091",
+      "0.0.0.0:0",
+      "198.51.100.7:8091",
+      "203.0.113.9:8091",
+    ]) {
+      assert.equal(
+        formatNeuron({ ...ROW, axon })?.axon_routable,
+        false,
+        `${axon} must not be routable`,
+      );
+    }
+  });
+
+  test("no axon means NULL routability, never false", () => {
+    // False would claim the neuron announced something unreachable. It
+    // announced nothing, which is a different fact and the normal state for a
+    // validator.
+    const n = formatNeuron({ ...ROW, axon: null });
+    assert.equal(n?.axon, null);
+    assert.equal(n?.axon_routable, null);
+  });
+
+  test("the 172.16-31 boundary is exact in both directions", () => {
+    assert.equal(
+      formatNeuron({ ...ROW, axon: "172.31.255.254:8091" })?.axon_routable,
+      false,
+    );
+    assert.equal(
+      formatNeuron({ ...ROW, axon: "172.32.0.1:8091" })?.axon_routable,
+      true,
+    );
+    assert.equal(
+      formatNeuron({ ...ROW, axon: "172.15.0.1:8091" })?.axon_routable,
+      true,
+    );
+  });
+});
+
 describe("metagraph-neurons builders", () => {
   test("formatNeuron coerces 0/1 INTEGER flags to real booleans", () => {
     const n = formatNeuron(ROW);


### PR DESCRIPTION
Closes #11373

#11375 stopped the watchdog counting placeholders. The API still served them as though they were endpoints: `/subnets/{netuid}/metagraph` returns `192.0.2.1:8091` in exactly the same shape as a real address, and every consumer computing reachability from `axon IS NOT NULL` gets the wrong answer.

## The measurement

347 of 6,532 announced axons (5.3%) point at RFC 5737 documentation space, RFC 1918 private space, loopback, or `0.0.0.0/8` — and **246 of those miners earn incentive**.

Almost all of it is SN33: **247 of its 251 announcements are `192.0.2.1`**, across 18 coldkeys, taking **99.82% of the subnet's incentive**, while the four announcing routable addresses earn nothing.

It is also growing, and it hides a steeper decline:

| | 2026-07-10 | 2026-08-16 |
| --- | --- | --- |
| announced (raw) | 6,754 | 6,528 (−3.3%) |
| unroutable | 250 | 343 (**+37%**) |
| **routable** | 6,504 | **6,185 (−4.9%)** |

## The field

`axon_routable: boolean | null`, derived from the value rather than stored — no migration, and it cannot fall out of sync with the axon it describes.

- `true` / `false` when an axon is announced
- **`null` when there is no axon.** "Not announcing" has no routability to report, and `false` would claim it announced something unreachable. That distinction is the whole reason this is a separate field instead of nulling the axon.

Published on **both** surfaces that carry `axon`: `NeuronSchema` and `ValidatorDetailSubnetSchema`. Anywhere we publish an endpoint, we now say whether it points anywhere — leaving one of them unqualified would just move the problem.

## Caught by the strict schemas

`buildValidatorDetail` reuses `formatNeuron`, so the new key surfaced as an `unrecognized_keys` failure in `tests/zod-schemas.test.ts` against `ValidatorDetailSubnetSchema.strict()`. That is the gate doing its job — the fix was to publish the field there too rather than to strip it, since that row carries `axon` for the same reason.

## One definition

The rule moved to `src/axon-routable.ts`, shared by the serving path and the watchdog. A second copy would be free to drift and the two surfaces would disagree about the same row. The `172.16–31` boundary is pinned in both directions on both sides.

`schemas-src` is the single source, so the MCP and GraphQL mirrors inherit the field rather than hand-copying it.

## Verified

- `tsc --noEmit`, `prettier --check`, `eslint` clean
- full suite **21,558 passing**
- patch coverage by diff intersection: **6/6 lines, 8/8 branches, 100%**
- `validate:contract-drift`, `validate:schemas`, `validate:openapi`, `validate:single-schema-source`, `validate:unreferenced-exports`, `validate:schema-shape-duplicates`, `validate:boundary-casts` pass
- regenerated `openapi.json`, `types.d.ts`, GraphQL schema/types and `packages/contract` committed together

## Unblocks

#11371's coupling facet, which must be computed from `axon_routable` rather than `axon IS NOT NULL` — otherwise it would report near-perfect coupling for SN33, the one subnet where nothing is reachable at all.
