### PR TITLE
fix(ui): the offline shell never worked in production — cache.add stored a redirect

### DIFF
--- a/apps/ui/public/sw.js
+++ b/apps/ui/public/sw.js
@@ -77,8 +77,50 @@ self.addEventListener("install", (event) => {
   // Deliberately no skipWaiting() -- see the "update" section of
   // use-service-worker.ts for why activation waits on explicit user
   // consent (#8384 requirement 6).
-  event.waitUntil(caches.open(SHELL_CACHE).then((cache) => cache.add("/offline.html")));
+  event.waitUntil(precacheOfflineShell());
 });
+
+/**
+ * Precache /offline.html as a NON-REDIRECTED response.
+ *
+ * `cache.add("/offline.html")` is the obvious spelling and it is the bug
+ * (#9079). Cloudflare Workers Assets strips the `.html` extension, so in
+ * production `/offline.html` answers **307 -> /offline**. `add()` follows the
+ * redirect and succeeds, so nothing looks wrong -- but the response it stores
+ * carries `redirected: true`.
+ *
+ * A navigation request has redirect mode "manual". Answering one from
+ * `respondWith` with a redirected response is a network error, which the
+ * browser renders as its own error page -- exactly the thing this precache
+ * exists to prevent. The e2e failure was `net::ERR_FAILED`, not a 404.
+ *
+ * Measured against production 2026-08-16:
+ *
+ *   cache.add("/offline.html")  -> { status: 200, redirected: true,
+ *                                    url: "https://metagraph.sh/offline" }
+ *   this function              -> { status: 200, redirected: false }
+ *
+ * Re-wrapping the body mints a fresh response with the flag cleared, stored
+ * under the key `handleNavigation` matches on. It also explains why the spec
+ * passed under `npm run dev`: Vite serves `public/offline.html` as a file, with
+ * no extension stripping and so no redirect. This never worked in production.
+ */
+async function precacheOfflineShell() {
+  const cache = await caches.open(SHELL_CACHE);
+  const response = await fetch("/offline.html");
+  if (!response.ok) return;
+  // Body first, then a new Response around it: `redirected` is not settable and
+  // is not carried across construction, which is the whole point.
+  const body = await response.blob();
+  await cache.put(
+    "/offline.html",
+    new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    }),
+  );
+}
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(

--- a/apps/ui/tests/e2e/offline.spec.ts
+++ b/apps/ui/tests/e2e/offline.spec.ts
@@ -33,26 +33,33 @@ if (!existsSync(harPath)) {
   );
 }
 
-// #9079: the WHOLE block is deferred, not deleted. Since #8928 this suite
-// runs against the production Worker instead of the Vite dev server, and BOTH
-// cases fail there -- the never-visited route with net::ERR_FAILED (the very
-// browser network-error page the SW exists to prevent), and the
-// previously-visited route intermittently too. It is not a missing asset:
-// /offline.html, /sw.js and /apis/schemas all serve 200 from the built Worker,
-// and the SW registers. The offline navigation path itself behaves differently
-// under real-Worker serving.
+// #9079 asked which of two things this was: a real production defect, or a
+// `wrangler dev` asset-serving artifact. It was the first, and the block is
+// live again because the cause is fixed rather than because the assertions
+// were loosened.
 //
-// This spec was always dev-server-coupled -- its own header below records that
-// production behaviour was "verified separately" BY HAND and never gated. So
-// #8928 did not break it; it revealed that the production path was never
-// actually covered.
+// Measured against DEPLOYED production (metagraph.sh), 2026-08-16, which is
+// the distinction the issue said had to be made first:
 //
-// Left as fixme rather than "fixed" because the two candidate causes must be
-// distinguished against a DEPLOYED preview first: either the offline fallback
-// is genuinely broken in production (#8384's promise not kept, a user-facing
-// bug), or this is a wrangler-dev asset-serving artifact. Editing the SW or
-// the assertions now would paper over the first case.
-test.describe.fixme("#8384 offline PWA shell", () => {
+//   GET /offline.html                  -> 307, location: /offline
+//   cache.add("/offline.html")         -> { status: 200, redirected: TRUE,
+//                                           url: "https://metagraph.sh/offline" }
+//
+// Cloudflare Workers Assets strips the `.html` extension. `cache.add` follows
+// the redirect and succeeds, so the precache looked healthy -- but it stored a
+// response flagged `redirected`. A navigation request has redirect mode
+// "manual", and answering one from `respondWith` with a redirected response is
+// a network error. That is the `net::ERR_FAILED` this issue opened on: not a
+// missing asset, and not the SW failing to register, but the fallback response
+// itself being unusable for the only kind of request that needs it.
+//
+// It passed under `npm run dev` because Vite serves `public/offline.html` as a
+// file -- no extension stripping, no redirect. The production path had never
+// worked; #8928 running the suite against the real Worker is what exposed it.
+//
+// The fix is in public/sw.js's `precacheOfflineShell`: re-wrap the body so the
+// flag is cleared before `cache.put`. This block gates it from here on.
+test.describe("#8384 offline PWA shell", () => {
   test("a previously-visited route reopens from the service worker's cache while offline, instead of a browser network-error page", async ({
     page,
     context,


### PR DESCRIPTION
Closes #9079, which asked which of two things the failing offline spec was — a real production defect, or a `wrangler dev` artifact — and said the two had to be distinguished against a deployed preview before touching the SW or the assertions.

**It is the defect.** Measured against deployed production (metagraph.sh):

```
GET /offline.html            -> 307, location: /offline
cache.add("/offline.html")   -> { status: 200, redirected: TRUE,
                                  url: "https://metagraph.sh/offline" }
fetch("/offline")            -> { status: 200, redirected: false }
```

Cloudflare Workers Assets strips the `.html` extension. `cache.add` follows the redirect and **resolves**, so the precache looked healthy — but the stored response carries `redirected: true`. A navigation request has redirect mode `"manual"`, and answering one from `respondWith` with a redirected response is a network error, so the browser shows its own error page. That is the `net::ERR_FAILED` the issue opened on: not a missing asset, not a failed registration, but a fallback response unusable for the only request kind that needs it.

It passed under `npm run dev` because Vite serves `public/offline.html` as a file — no stripping, no redirect. The production path had never worked; #8928 moving the suite onto the built Worker exposed it. The spec's header already noted production was "verified separately BY HAND and never gated" — that is what the hand-check missed.

## The fix

Re-wrap the body before `cache.put`. `redirected` is not settable and does not survive construction, so the fresh response is usable, stored under the key `handleNavigation` already matches on.

## Verified both ways, against the production build

```
with the fix     94 passed
fix reverted     93 passed, 1 failed
                 ✘ "a route never visited online falls back to the static
                   offline page instead of a browser error"
                   Error: page.goto: net::ERR_FAILED at .../apis/schemas
```

`test.describe.fixme` → `test.describe`: the cause is fixed, not the assertions loosened. The reverted run also settles the issue's second possibility — the local harness reproduces production exactly, so it was never a `wrangler dev` artifact.