### PR TITLE
fix(axon): parse the port from the end, so an IPv6 axon is not read as its first hex group

### DIFF
--- a/src/axon-routable.ts
+++ b/src/axon-routable.ts
@@ -26,17 +26,56 @@
 export const UNROUTABLE_AXON_PATTERN =
   "^(0\\.|10\\.|127\\.|192\\.168\\.|192\\.0\\.2\\.|198\\.51\\.100\\.|203\\.0\\.113\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.)";
 
-/** SQL fragment: the axon is present AND points somewhere routable. */
-export const ROUTABLE_AXON_SQL = `axon IS NOT NULL AND axon <> '' AND split_part(axon, ':', 1) !~ '${UNROUTABLE_AXON_PATTERN}'`;
+/**
+ * IPv6 ranges nobody can route to: unspecified `::`, loopback `::1`,
+ * unique-local `fc00::/7`, and link-local `fe80::/10`.
+ *
+ * Separate from the IPv4 pattern because the two are different address
+ * families, not different spellings -- `10.` and `10::` share a prefix and
+ * mean unrelated things.
+ */
+export const UNROUTABLE_AXON_V6_PATTERN =
+  "^(::$|::1$|[fF][cCdD]|[fF][eE][89aAbB])";
 
-/** The same rule in JS, for callers holding a row rather than writing SQL. */
+/** SQL fragment: the axon is present AND points somewhere routable. */
+/** SQL fragment: the axon is present AND points somewhere routable.
+ *
+ * `left(axon, length(axon) - strpos(reverse(axon), ':'))` is "everything before
+ * the LAST colon" -- the same address/port split `splitAxon` does, so an IPv6
+ * announcement is not read as its first hex group. */
+export const AXON_ADDRESS_SQL =
+  "left(axon, length(axon) - strpos(reverse(axon), ':'))";
+export const ROUTABLE_AXON_SQL =
+  `axon IS NOT NULL AND axon <> '' AND ${AXON_ADDRESS_SQL} <> '' AND ` +
+  `CASE WHEN ${AXON_ADDRESS_SQL} LIKE '%:%' ` +
+  `THEN ${AXON_ADDRESS_SQL} !~ '${UNROUTABLE_AXON_V6_PATTERN}' ` +
+  `ELSE ${AXON_ADDRESS_SQL} !~ '${UNROUTABLE_AXON_PATTERN}' END`;
+
+/**
+ * Split an announced axon into address and port.
+ *
+ * THE PORT IS AFTER THE LAST COLON, not the second. IPv4 makes the two look
+ * identical (`1.2.3.4:8091`), which is why the naive split survived review --
+ * but an IPv6 axon is `2607:fb90:...:1036:10000`, where taking component two
+ * yields `fb90` as the port and `2607` as the address. Measured 2026-08-16,
+ * three announcements on SN12/SN51/SN56 are IPv6 and were being parsed that
+ * way; they classified correctly only by accident, because `2607` matches no
+ * IPv4 unroutable prefix. An IPv6 loopback would have read as routable.
+ */
+export function splitAxon(axon: string): { address: string; port: string } {
+  const cut = axon.lastIndexOf(":");
+  if (cut < 0) return { address: axon, port: "" };
+  return { address: axon.slice(0, cut), port: axon.slice(cut + 1) };
+}
+
+/** The same rule as the SQL, in JS, for callers holding a row. */
 export function isRoutableAxon(axon: unknown): boolean {
   if (typeof axon !== "string" || axon === "") return false;
-  // `split(":", 1).join("")` rather than indexing: `split` always yields at
-  // least one element, so a `?? ""` guard on `[0]` would be a branch nothing
-  // could reach, and a test written to reach it could only assert the code's
-  // own assumption back at it.
-  const ip = axon.split(":", 1).join("");
-  if (ip === "") return false;
-  return !new RegExp(UNROUTABLE_AXON_PATTERN).test(ip);
+  const { address } = splitAxon(axon);
+  if (address === "") return false;
+  // An address carrying a colon is IPv6 and gets the IPv6 rules; applying the
+  // IPv4 prefixes to it would compare a hex group against a dotted quad.
+  return address.includes(":")
+    ? !new RegExp(UNROUTABLE_AXON_V6_PATTERN).test(address)
+    : !new RegExp(UNROUTABLE_AXON_PATTERN).test(address);
 }

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -32,7 +32,11 @@ import {
   type AxonDay,
   type AxonFinding,
 } from "../src/axon-announcement-watchdog.ts";
-import { isRoutableAxon, ROUTABLE_AXON_SQL } from "../src/axon-routable.ts";
+import {
+  isRoutableAxon,
+  splitAxon,
+  ROUTABLE_AXON_SQL,
+} from "../src/axon-routable.ts";
 
 /** Days at a uniform width, oldest first. */
 const flat = (n: number, withAxon: number, neurons = 256): AxonDay[] =>
@@ -1088,19 +1092,81 @@ describe("routable axons only (#11373)", () => {
     // The rule is enforced in SQL; a second copy would be free to drift from
     // the one the JS predicate documents and the tests above pin.
     assert.match(ROUTABLE_AXON_SQL, /axon IS NOT NULL/);
-    assert.match(ROUTABLE_AXON_SQL, /split_part\(axon, ':', 1\) !~/);
+    // The address is everything before the LAST colon, so an IPv6 axon is not
+    // read as its first hex group (#11373 follow-up).
+    assert.match(ROUTABLE_AXON_SQL, /strpos\(reverse\(axon\), ':'\)/);
+    assert.doesNotMatch(ROUTABLE_AXON_SQL, /split_part\(axon, ':', 1\)/);
     assert.match(ROUTABLE_AXON_SQL, /192\\\.0\\\.2\\\./);
   });
 
   test("the predicate the JS mirrors is the one the SQL embeds", () => {
     // Same source string on both sides -- if the pattern is retuned, both move.
-    const embedded = ROUTABLE_AXON_SQL.match(/!~ '(.+)'$/)?.[1];
-    assert.ok(embedded, "the SQL carries the pattern inline");
+    // The IPv4 pattern is the one after the ELSE branch.
+    const embedded = ROUTABLE_AXON_SQL.match(/ELSE .+ !~ '(.+?)' END/)?.[1];
+    assert.ok(embedded, "the SQL carries the IPv4 pattern inline");
     assert.equal(
       new RegExp(embedded).test("192.0.2.1"),
       true,
       "the embedded pattern matches what isRoutableAxon rejects",
     );
     assert.equal(new RegExp(embedded).test("152.53.149.254"), false);
+  });
+});
+
+describe("IPv6 axons — the port is after the LAST colon", () => {
+  // Measured 2026-08-16: three announcements are IPv6 (SN12, SN51, SN56), e.g.
+  // `2607:fb90:2832:452:9369:e6b4:10f3:1036:10000`. Splitting on the FIRST
+  // colon read `2607` as the address and `fb90` as the port. They classified
+  // correctly only by accident -- `2607` matches no IPv4 unroutable prefix --
+  // and an IPv6 loopback would have read as routable.
+
+  test("splitAxon takes the port from the end, not position two", () => {
+    assert.deepEqual(splitAxon("1.2.3.4:8091"), {
+      address: "1.2.3.4",
+      port: "8091",
+    });
+    assert.deepEqual(splitAxon("2607:fb90:1036:10000"), {
+      address: "2607:fb90:1036",
+      port: "10000",
+    });
+    assert.deepEqual(splitAxon("nocolon"), { address: "nocolon", port: "" });
+  });
+
+  test("the real production IPv6 announcements are routable", () => {
+    for (const axon of [
+      "2607:fb90:2832:452:9369:e6b4:10f3:1036:10000",
+      "2607:fb92:480:5ab2:61d1:e593:914b:538d:8001",
+      "2605:a141:2310:2189::1:20004",
+    ]) {
+      assert.equal(isRoutableAxon(axon), true, `${axon} is public IPv6`);
+    }
+  });
+
+  test("IPv6 loopback, link-local and unique-local are NOT routable", () => {
+    // The cases the first-colon split got wrong: each would have been read as
+    // its leading hex group and passed the IPv4 prefix test.
+    for (const axon of [
+      "::1:8091", // loopback
+      "fe80::1:8091", // link-local
+      "fc00::1:8091", // unique-local
+      "fd12:3456::1:8091", // unique-local, fd half of fc00::/7
+      "FE80::1:8091", // case-insensitive
+    ]) {
+      assert.equal(isRoutableAxon(axon), false, `${axon} must not be routable`);
+    }
+  });
+
+  test("a documentation IPv6 prefix is still routable — we only claim what we test", () => {
+    // 2001:db8::/32 is RFC 3849 documentation space. It is NOT in the pattern,
+    // and this pins that as a deliberate limit rather than an oversight: no
+    // announcement in the measured window uses it, and claiming coverage we
+    // have not measured would be worse than the gap.
+    assert.equal(isRoutableAxon("2001:db8::1:8091"), true);
+  });
+
+  test("the SQL splits on the last colon and branches by family", () => {
+    assert.match(ROUTABLE_AXON_SQL, /strpos\(reverse\(axon\), ':'\)/);
+    assert.match(ROUTABLE_AXON_SQL, /LIKE '%:%'/);
+    assert.match(ROUTABLE_AXON_SQL, /CASE WHEN/);
   });
 });


### PR DESCRIPTION
Found checking my own work from #11375/#11376. `isRoutableAxon` validated the IP by splitting on the **first** colon. IPv4 makes that indistinguishable from the correct rule, which is why it survived — but the port is after the **last** colon, and three announcements on the network are IPv6.

## The bug

```
2607:fb90:2832:452:9369:e6b4:10f3:1036:10000   SN12
2607:fb92:480:5ab2:61d1:e593:914b:538d:8001    SN51
2605:a141:2310:2189::1:20004                   SN56
```

Splitting on the first colon read `2607` as the address and `fb90` as the port. All three classified as routable, which is the **right answer for the wrong reason** — `2607` matches no IPv4 unroutable prefix, so it passed by accident.

The failure it hides: an IPv6 loopback (`::1`), link-local (`fe80::`) or unique-local (`fc00::/7`) address would be read as its leading hex group, match no IPv4 prefix, and be reported **routable**.

## The fix

`splitAxon` takes everything before the last colon as the address, and the two address families are tested against their own patterns — `10.` and `10::` share a prefix and mean unrelated things, so one combined pattern would be wrong.

SQL follows the same rule via `left(axon, length(axon) - strpos(reverse(axon), ':'))` with a `CASE` on whether the address contains a colon, so the stored predicate and the JS predicate cannot disagree about a row.

## No behaviour change today, and that is the point

Verified against production:

```
announced     6,527
routable NEW  6,185
routable OLD  6,185
IPv6 axons        3
```

Identical, because all three production IPv6 addresses are public either way. This is a correctness fix for a parser that was right by luck — it changes nothing now and stops being wrong when IPv6 adoption grows or one of those hosts moves to a link-local address.

## Deliberate limit, pinned by a test

`2001:db8::/32` (RFC 3849 IPv6 documentation space) is **not** in the pattern, and a test asserts it reads as routable. No announcement in the measured window uses it, and claiming coverage I have not measured would be worse than the gap — the IPv4 side earned its ranges from 347 real observations.

## Verified

- 14 hand-checked cases including the `fc00::/7` and `fe80::/10` boundaries and case-insensitivity
- the generated SQL executed against production Neon
- `tsc --noEmit`, `prettier --check`, `eslint` clean
- full suite **936 files / 21,563 passing**
- patch coverage by diff intersection: **9/9 lines, 6/6 branches, 100%**
- `validate:contract-drift`, `validate:unreferenced-exports`, `validate:boundary-casts` pass

Also refreshes two assertions from #11375 that pinned the old `split_part(axon, ':', 1)` shape.
