### PR TITLE
feat(api): publish whether a subnet's PAID miners are its REACHABLE ones

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11980,6 +11980,16 @@ export interface components {
             schema_version: number;
         };
         SubnetMetagraphArtifact: {
+            axon_earning?: {
+                /** @description How many of `earning_miners` publish an axon that points somewhere ROUTABLE. Stricter than 'announces an axon': an address in a private, loopback or reserved range is announced and unreachable, which is 5.3% of announced axons network-wide. Compare against `earning_miners` to read whether being reachable has anything to do with being paid on this subnet -- on roughly half of the subnets that pay miners at all, this is zero. */
+                announcing_earners: number;
+                /** @description Whether the burn UID was identified and removed from the figures above. Burn earns incentive and is not a miner, so including it dilutes the share. It can only be excluded when the burn hotkey was resolvable from chain state for this request; when false, the figures include burn and should be read as an upper bound on `earning_miners` and a lower bound on the share. */
+                burn_excluded: boolean;
+                /** @description How many neurons earn a non-zero incentive. Incentive is the miner signal (validators are paid dividends), so this is the count of miners this subnet actually pays. Excludes the burn UID when `burn_excluded` is true. */
+                earning_miners: number;
+                /** @description The fraction of this subnet's miner incentive that reaches miners publishing a routable endpoint, 0..1. NULL when no neuron earns incentive -- a subnet paying no miners has no share to report, which is a different answer from 0 ('pays miners, none reachable'). Incentive normalizes to 1.0 within a subnet, so this is a within-subnet proportion and is NOT comparable across subnets as a magnitude. */
+                incentive_share_to_announcers: number | null;
+            };
             block_number?: number | null;
             captured_at?: string | null;
             netuid: number;
@@ -45202,6 +45212,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "axon_earning": {
+                     *           "announcing_earners": 1,
+                     *           "burn_excluded": false,
+                     *           "earning_miners": 1,
+                     *           "incentive_share_to_announcers": 0.5
+                     *         },
                      *         "block_number": 5000000,
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
                      *         "netuid": 7,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10590,6 +10590,12 @@
       "SubnetMetagraphArtifactResponse": {
         "value": {
           "data": {
+            "axon_earning": {
+              "announcing_earners": 1,
+              "burn_excluded": false,
+              "earning_miners": 1,
+              "incentive_share_to_announcers": 0.5
+            },
             "block_number": 5000000,
             "captured_at": "2026-06-01T00:00:00.000Z",
             "netuid": 7,
@@ -53110,6 +53116,47 @@
       "SubnetMetagraphArtifact": {
         "additionalProperties": false,
         "properties": {
+          "axon_earning": {
+            "additionalProperties": false,
+            "properties": {
+              "announcing_earners": {
+                "description": "How many of `earning_miners` publish an axon that points somewhere ROUTABLE. Stricter than 'announces an axon': an address in a private, loopback or reserved range is announced and unreachable, which is 5.3% of announced axons network-wide. Compare against `earning_miners` to read whether being reachable has anything to do with being paid on this subnet -- on roughly half of the subnets that pay miners at all, this is zero.",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "burn_excluded": {
+                "description": "Whether the burn UID was identified and removed from the figures above. Burn earns incentive and is not a miner, so including it dilutes the share. It can only be excluded when the burn hotkey was resolvable from chain state for this request; when false, the figures include burn and should be read as an upper bound on `earning_miners` and a lower bound on the share.",
+                "type": "boolean"
+              },
+              "earning_miners": {
+                "description": "How many neurons earn a non-zero incentive. Incentive is the miner signal (validators are paid dividends), so this is the count of miners this subnet actually pays. Excludes the burn UID when `burn_excluded` is true.",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "incentive_share_to_announcers": {
+                "anyOf": [
+                  {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "The fraction of this subnet's miner incentive that reaches miners publishing a routable endpoint, 0..1. NULL when no neuron earns incentive -- a subnet paying no miners has no share to report, which is a different answer from 0 ('pays miners, none reachable'). Incentive normalizes to 1.0 within a subnet, so this is a within-subnet proportion and is NOT comparable across subnets as a magnitude."
+              }
+            },
+            "required": [
+              "earning_miners",
+              "announcing_earners",
+              "incentive_share_to_announcers",
+              "burn_excluded"
+            ],
+            "type": "object"
+          },
           "block_number": {
             "anyOf": [
               {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11980,6 +11980,16 @@ export interface components {
             schema_version: number;
         };
         SubnetMetagraphArtifact: {
+            axon_earning?: {
+                /** @description How many of `earning_miners` publish an axon that points somewhere ROUTABLE. Stricter than 'announces an axon': an address in a private, loopback or reserved range is announced and unreachable, which is 5.3% of announced axons network-wide. Compare against `earning_miners` to read whether being reachable has anything to do with being paid on this subnet -- on roughly half of the subnets that pay miners at all, this is zero. */
+                announcing_earners: number;
+                /** @description Whether the burn UID was identified and removed from the figures above. Burn earns incentive and is not a miner, so including it dilutes the share. It can only be excluded when the burn hotkey was resolvable from chain state for this request; when false, the figures include burn and should be read as an upper bound on `earning_miners` and a lower bound on the share. */
+                burn_excluded: boolean;
+                /** @description How many neurons earn a non-zero incentive. Incentive is the miner signal (validators are paid dividends), so this is the count of miners this subnet actually pays. Excludes the burn UID when `burn_excluded` is true. */
+                earning_miners: number;
+                /** @description The fraction of this subnet's miner incentive that reaches miners publishing a routable endpoint, 0..1. NULL when no neuron earns incentive -- a subnet paying no miners has no share to report, which is a different answer from 0 ('pays miners, none reachable'). Incentive normalizes to 1.0 within a subnet, so this is a within-subnet proportion and is NOT comparable across subnets as a magnitude. */
+                incentive_share_to_announcers: number | null;
+            };
             block_number?: number | null;
             captured_at?: string | null;
             netuid: number;
@@ -45202,6 +45212,12 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "axon_earning": {
+                     *           "announcing_earners": 1,
+                     *           "burn_excluded": false,
+                     *           "earning_miners": 1,
+                     *           "incentive_share_to_announcers": 0.5
+                     *         },
                      *         "block_number": 5000000,
                      *         "captured_at": "2026-06-01T00:00:00.000Z",
                      *         "netuid": 7,

--- a/schemas-src/mcp-tools/get-subnet-metagraph.ts
+++ b/schemas-src/mcp-tools/get-subnet-metagraph.ts
@@ -3,7 +3,7 @@
 // schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
 // reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { NeuronSchema } from "../routes/subnet-metagraph.ts";
+import { AxonEarningSchema, NeuronSchema } from "../routes/subnet-metagraph.ts";
 import {
   NEURON_SORT_FIELD_NAMES,
   NEURON_SORT_NULLS_LAST_NOTE,
@@ -129,6 +129,12 @@ export const GetSubnetMetagraphOutputSchema = z
       ),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
+    // The route's own schema, not a copy (#11371). Unlike neuron_count above,
+    // this describes the SUBNET and is unaffected by `hotkeys`/`active`/
+    // `min_incentive`/`limit` -- a filtered call still reports the subnet's
+    // earning and announcing figures, which is what makes them comparable
+    // across calls that paged differently.
+    axon_earning: AxonEarningSchema.optional(),
     // Typed from the route's own NeuronSchema (#9797), PARTIAL because this
     // tool advertises `fields`: a caller who projects the row must still
     // satisfy the schema the tool publishes, which is the contract #9884

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -132,6 +132,38 @@ export const NeuronSchema = z
     "One UID's live metagraph state within a subnet (hot/cold keys, scores, stake/emission, axon, take).",
   );
 
+/**
+ * Whether the miners this subnet PAYS are the miners that can be REACHED.
+ *
+ * Describes the whole subnet, never the response: these counts are computed
+ * over every neuron before any `limit`/`sort`/filter narrows `neurons`, so a
+ * paged request reports the subnet's figures rather than the page's.
+ *
+ * ABSENT when the snapshot carried no neurons at all. That is not the same as
+ * "pays nobody" -- it is also what a declined cold tier looks like, and a row
+ * of zeroes would be a measurement of a subnet nothing was read for.
+ */
+export const AxonEarningSchema = z
+  .object({
+    earning_miners: z.int().min(0).meta({
+      description:
+        "How many neurons earn a non-zero incentive. Incentive is the miner signal (validators are paid dividends), so this is the count of miners this subnet actually pays. Excludes the burn UID when `burn_excluded` is true.",
+    }),
+    announcing_earners: z.int().min(0).meta({
+      description:
+        "How many of `earning_miners` publish an axon that points somewhere ROUTABLE. Stricter than 'announces an axon': an address in a private, loopback or reserved range is announced and unreachable, which is 5.3% of announced axons network-wide. Compare against `earning_miners` to read whether being reachable has anything to do with being paid on this subnet -- on roughly half of the subnets that pay miners at all, this is zero.",
+    }),
+    incentive_share_to_announcers: z.number().min(0).max(1).nullable().meta({
+      description:
+        "The fraction of this subnet's miner incentive that reaches miners publishing a routable endpoint, 0..1. NULL when no neuron earns incentive -- a subnet paying no miners has no share to report, which is a different answer from 0 ('pays miners, none reachable'). Incentive normalizes to 1.0 within a subnet, so this is a within-subnet proportion and is NOT comparable across subnets as a magnitude.",
+    }),
+    burn_excluded: z.boolean().meta({
+      description:
+        "Whether the burn UID was identified and removed from the figures above. Burn earns incentive and is not a miner, so including it dilutes the share. It can only be excluded when the burn hotkey was resolvable from chain state for this request; when false, the figures include burn and should be read as an upper bound on `earning_miners` and a lower bound on the share.",
+    }),
+  })
+  .strict();
+
 export const SubnetMetagraphArtifactSchema = z
   .object({
     schema_version: z.int(),
@@ -139,6 +171,9 @@ export const SubnetMetagraphArtifactSchema = z
     neuron_count: z.int().min(0),
     captured_at: z.string().nullable().optional(),
     block_number: z.int().nullable().optional(),
+    // Optional because it is ABSENT on an empty snapshot -- see the schema's
+    // own header for why zeroes would be a claim rather than an answer.
+    axon_earning: AxonEarningSchema.optional(),
     neurons: z.array(NeuronSchema),
   })
   .strict();

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -521,6 +521,66 @@ function snapshotStamp(rows: Row[]): {
   };
 }
 
+/**
+ * Does serving correlate with earning on this subnet? (#11371)
+ *
+ * On roughly half the subnets that pay miners at all, NOT ONE miner earning
+ * incentive publishes a routable endpoint. Measured against `neuron_daily`
+ * 2026-08-16: of 65 subnets with >=3 earning miners, 31 had zero announcing
+ * earners; of the 48 with >=10, 22 did. That is a standing property of the
+ * network, and until now every axon-shaped surface here implied otherwise by
+ * publishing an `axon` column with no context.
+ *
+ * ## Routable, not merely announced
+ *
+ * `axon_routable` and not `axon != null`: #11376 measured 347 of 6,532
+ * announced axons (5.3%) sitting in ranges nobody can route to, 246 of them
+ * earning incentive. "Announces something" and "can be reached" are different
+ * claims, and this registry exists to make the stronger one.
+ *
+ * ## Burn is stated, never silently folded in
+ *
+ * Burn UIDs earn incentive and are not miners, so counting them would dilute
+ * exactly the share this exists to report. `is_burn_uid` is emitted only when
+ * the caller resolved a burn hotkey from chain state, so it is not always
+ * knowable -- and the answer differs depending on whether it was. Rather than
+ * publish two different meanings under one name, `burn_excluded` says which
+ * one this is.
+ */
+export function axonEarningSummary(neurons: readonly Row[]): Row | null {
+  // NO ROWS, NO CLAIM. An empty set is not "this subnet pays nobody" -- it is
+  // also what a DECLINED cold tier looks like, because graphql's
+  // subnet_metagraph falls back to `buildSubnetMetagraph([], netuid)` when the
+  // tier says no. Publishing `earning_miners: 0` there would be a measurement
+  // of a subnet nothing was read for: the confident-zero failure the sibling
+  // `total_neuron_count` comment is also about. Absent says "not answered";
+  // zero would say "answered, and the answer is none".
+  if (neurons.length === 0) return null;
+  // Present only when the caller resolved a burn hotkey; `undefined` on every
+  // row otherwise. Checking one row is enough -- formatNeuron emits it for all
+  // of them or none.
+  const burnKnown = neurons.some((n) => n.is_burn_uid !== undefined);
+  const earners = neurons.filter(
+    (n) =>
+      typeof n.incentive === "number" &&
+      n.incentive > 0 &&
+      !(burnKnown && n.is_burn_uid === true),
+  );
+  const announcing = earners.filter((n) => n.axon_routable === true);
+  const total = earners.reduce((sum, n) => sum + Number(n.incentive), 0);
+  const announced = announcing.reduce((sum, n) => sum + Number(n.incentive), 0);
+  return {
+    earning_miners: earners.length,
+    announcing_earners: announcing.length,
+    // Null, not 0, when nothing earns: a subnet paying no miners has no share
+    // to report, and 0 would read as "pays miners, none reachable" -- the
+    // opposite of an empty set and the exact confusion this surface exists to
+    // remove.
+    incentive_share_to_announcers: total > 0 ? announced / total : null,
+    burn_excluded: burnKnown,
+  };
+}
+
 export function buildSubnetMetagraph(
   rows: Row[],
   netuid: unknown,
@@ -538,12 +598,19 @@ export function buildSubnetMetagraph(
   const neurons = rows
     .map((row) => formatNeuron(row, undefined, immunityPeriod, burnHotkey))
     .filter((n): n is Row => Boolean(n));
+  const axonEarning = axonEarningSummary(neurons);
   return {
     schema_version: 1,
     netuid,
     neuron_count: neurons.length,
     captured_at,
     block_number,
+    // Computed HERE, over every row, and deliberately not in selectNeuronRows.
+    // It describes the subnet, not the response: a `?limit=10` on a 256-neuron
+    // subnet must not report ten earning miners. selectNeuronRows spreads the
+    // payload it narrows, so this rides through unchanged -- which is the
+    // behaviour wanted, and is pinned by a test that narrows and re-reads it.
+    ...(axonEarning ? { axon_earning: axonEarning } : {}),
     neurons,
   };
 }

--- a/tests/metagraph-neurons.test.ts
+++ b/tests/metagraph-neurons.test.ts
@@ -4,6 +4,7 @@ import {
   formatNeuron as formatNeuronRaw,
   computeImmunityWindow,
   buildSubnetMetagraph as buildSubnetMetagraphRaw,
+  selectNeuronRows as selectNeuronRowsRaw,
   buildSubnetValidators as buildSubnetValidatorsRaw,
   buildGlobalValidators as buildGlobalValidatorsRaw,
   buildNeuronDetail as buildNeuronDetailRaw,
@@ -54,6 +55,13 @@ function formatNeuron(
     immunityPeriod,
   ) as unknown as Row;
 }
+function selectNeuronRows(
+  data: Row,
+  selection: Parameters<typeof selectNeuronRowsRaw>[1],
+): Row {
+  return selectNeuronRowsRaw(data, selection);
+}
+
 function buildSubnetMetagraph(
   rows: unknown,
   netuid: unknown,
@@ -2692,5 +2700,111 @@ describe("TAO-priced cross-subnet sums (#9051)", () => {
     );
     assert.equal(data.total_stake_tao, 0); // valued at zero...
     // ...and NOT treated as a missing price.
+  });
+});
+
+// #11371: whether the miners a subnet PAYS are the miners that can be REACHED.
+// On roughly half the subnets that pay miners at all, not one earner publishes
+// a routable endpoint, and every axon-shaped surface here used to imply
+// otherwise.
+describe("axonEarningSummary", () => {
+  const miner = (
+    uid: number,
+    incentive: number | null,
+    axon: string | null,
+  ) => ({ uid, hotkey: `hk${uid}`, incentive, axon });
+
+  test("counts earners, and only the ROUTABLE ones as announcing", () => {
+    // 1.2.3.4 is routable; 10.x and 127.x are announced and unreachable, and
+    // so is 203.0.113.x -- RFC 5737 documentation space, which is exactly the
+    // kind of address that looks announced and reaches nobody. The distinction
+    // is the point: "announces something" is a weaker claim than "can be
+    // reached", and 5.3% of announced axons network-wide fail it.
+    const data = buildSubnetMetagraph(
+      [
+        miner(0, 0.5, "1.2.3.4:8091"),
+        miner(1, 0.3, "10.0.0.1:8091"),
+        miner(2, 0.2, "127.0.0.1:8091"),
+        miner(3, 0, "8.8.8.8:8091"),
+        miner(4, null, "8.8.4.4:8091"),
+      ],
+      7,
+    );
+    assert.deepEqual(data.axon_earning, {
+      earning_miners: 3,
+      announcing_earners: 1,
+      incentive_share_to_announcers: 0.5,
+      burn_excluded: false,
+    });
+  });
+
+  test("a subnet paying no miners reports NULL, not a zero share", () => {
+    // 0 would read as "pays miners, none reachable" -- the opposite of an
+    // empty set, and exactly the confusion this surface exists to remove.
+    const data = buildSubnetMetagraph(
+      [miner(0, 0, "1.2.3.4:8091"), miner(1, null, null)],
+      7,
+    );
+    assert.equal(data.axon_earning.earning_miners, 0);
+    assert.equal(data.axon_earning.incentive_share_to_announcers, null);
+  });
+
+  test("EXCLUDES the burn UID when the caller resolved a burn hotkey", () => {
+    // Burn earns incentive and is not a miner, so counting it dilutes the very
+    // share this reports.
+    const rows = [
+      miner(0, 0.6, null), // the burn sink
+      miner(1, 0.4, "1.2.3.4:8091"),
+    ];
+    const withBurn = buildSubnetMetagraph(rows, 7, { burnHotkey: "hk0" });
+    assert.deepEqual(withBurn.axon_earning, {
+      earning_miners: 1,
+      announcing_earners: 1,
+      incentive_share_to_announcers: 1,
+      burn_excluded: true,
+    });
+  });
+
+  test("says so when burn could NOT be excluded, rather than quietly folding it in", () => {
+    // Same rows, no burn hotkey resolved: the figures now include burn, and
+    // `burn_excluded: false` is what tells a reader which answer they have.
+    const rows = [miner(0, 0.6, null), miner(1, 0.4, "1.2.3.4:8091")];
+    const unknown = buildSubnetMetagraph(rows, 7);
+    assert.equal(unknown.axon_earning.burn_excluded, false);
+    assert.equal(unknown.axon_earning.earning_miners, 2);
+    // The share is dragged down by burn, which is why the flag matters.
+    assert.equal(unknown.axon_earning.incentive_share_to_announcers, 0.4);
+  });
+
+  test("DESCRIBES THE SUBNET, NOT THE PAGE — narrowing must not rewrite it", () => {
+    // The trap: `?limit=1` on a subnet with three earners must not report one
+    // earning miner. selectNeuronRows rewrites neuron_count on purpose and
+    // must leave this alone.
+    const data = buildSubnetMetagraph(
+      [
+        miner(0, 0.5, "1.2.3.4:8091"),
+        miner(1, 0.3, "10.0.0.1:8091"),
+        miner(2, 0.2, "8.8.8.8:8091"),
+      ],
+      7,
+    );
+    const narrowed = selectNeuronRows(data, { limit: 1 });
+    assert.equal(narrowed.neuron_count, 1, "the page did narrow");
+    assert.equal(narrowed.total_neuron_count, 3);
+    assert.deepEqual(
+      narrowed.axon_earning,
+      data.axon_earning,
+      "the subnet's figures are unchanged by paging",
+    );
+    assert.equal(narrowed.axon_earning.earning_miners, 3);
+  });
+
+  test("NO ROWS, NO CLAIM — the block is absent, not a row of zeroes", () => {
+    // `buildSubnetMetagraph([], netuid)` is also graphql's fallback when the
+    // cold tier DECLINES, so zeroes here would publish a measurement of a
+    // subnet nothing was read for. Absent says "not answered"; zero would say
+    // "answered, and the answer is none".
+    const data = buildSubnetMetagraph([], 7);
+    assert.equal("axon_earning" in data, false);
   });
 });


### PR DESCRIPTION
Closes #11371.

On roughly half the subnets that pay miners at all, **not one miner earning incentive publishes an endpoint anyone can reach.** We serve an `axon` column with no context, which reads as a reachability answer and is one for about a quarter of subnets.

Reproduced independently against Neon before building, a snapshot after the issue's own measurement:

| | issue | reproduced |
| --- | ---: | ---: |
| subnets with ≥3 earning miners | 66 | **65** |
| …where NOT ONE earner announces | 32 | **31** |
| …majority of incentive to announcers | 19 | **19** |
| subnets with ≥10 earning miners | 48 | **48** |
| …where NOT ONE earner announces | 22 | **22** |

## What is published

`axon_earning` on the subnet metagraph: `earning_miners`, `announcing_earners`, `incentive_share_to_announcers`, `burn_excluded`.

**Routable, not merely announced.** Uses `axon_routable` from #11376 rather than `axon != null` — that PR measured 347 of 6,532 announced axons (5.3%) in unroutable ranges, 246 of them earning. A test pins it with RFC 5737 documentation space, which caught my own first draft where I'd used `203.0.113.x` as the *routable* example.

**Burn is stated, never folded in silently.** `is_burn_uid` is only emitted when the caller resolved a burn hotkey, so the answer genuinely differs per request; `burn_excluded` says which one you have rather than publishing two meanings under one name. This is the "join the column in" half of the issue's open caveat, taken as far as the data allows.

**Null share, not zero, when nothing earns** — `0` would read as "pays miners, none reachable", the opposite of an empty set.

**Absent entirely on an empty snapshot.** `buildSubnetMetagraph([], netuid)` is also GraphQL's fallback when the cold tier declines, so zeroes there would be a measurement of a subnet nothing was read for. The full suite caught this: a `graphql.test.ts` assertion on the schema-stable empty payload failed, which was the right answer arriving the hard way.

## Computed over the subnet, not the page

In `buildSubnetMetagraph`, from rows already in hand — no new query. `selectNeuronRows` narrows `neurons` and rewrites `neuron_count` on purpose, so computing there would answer "10 earning miners" for a 256-neuron subnet on `?limit=10`. A test narrows and re-reads it.

## Verified against production, two ways

Netuid 8, derived from the live served payload (which already carries `axon_routable`) and independently in Postgres:

```
                       SQL      live payload
earning miners          34               34
announcing routable      1                1
share               0.0185           0.0185
```

The MCP tool reuses the route's `AxonEarningSchema` rather than restating it — which `validate:mcp` demanded the moment its strict envelope saw an unknown key.

All 55 CI validators pass; 1,251 tests across the touched suites.