### PR TITLE
fix(watchdog): the axon alarm named a mechanism it had failed to measure

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -139,11 +139,25 @@ export interface AxonFinding {
    *   the opposite of what happened.
    * - `subnet-turned-over`: the metagraph itself emptied, so the missing axons
    *   are missing NEURONS and membership is the story.
+   * - `mechanism-unknown`: the drop is real but nothing here explains it. Either
+   *   the per-UID read failed, or it ran and found no transition of either
+   *   shape.
    *
-   * Defaults to `announcements-withdrawn` until the mechanism read runs, which
-   * is the conservative direction: it is the reading that asks for a human.
+   * STARTS AT `mechanism-unknown`, and only a successful read moves it. The
+   * earlier default was `announcements-withdrawn` on the grounds that it is the
+   * reading that asks for a human -- but that is an ASSERTION, not a caution:
+   * it names a mechanism, and `loadAxonLossMechanisms` returns `{}` on any
+   * failure, so a broken read published "miners that are still registered and
+   * still earning stopped publishing an axon" having measured nothing. On the
+   * two subnets flagged 2026-08-16 that claim is exactly inverted (SN25 67/0
+   * and SN102 43/0 deregistrations). An alarm may escalate on uncertainty; it
+   * may not invent the finding it is uncertain about.
    */
-  kind: "announcements-withdrawn" | "churn-replaced" | "subnet-turned-over";
+  kind:
+    | "announcements-withdrawn"
+    | "churn-replaced"
+    | "subnet-turned-over"
+    | "mechanism-unknown";
   /** Axon losses in the window whose UID changed hands. Null until measured. */
   lossesViaReuse: number | null;
   /** Axon losses where the same hotkey stopped announcing. Null until measured. */
@@ -214,7 +228,7 @@ export function evaluateSubnetAxons(
     ratio,
     neurons: latest.neurons,
     neuronBaseline,
-    kind: turnedOver ? "subnet-turned-over" : "announcements-withdrawn",
+    kind: turnedOver ? "subnet-turned-over" : "mechanism-unknown",
     // Filled in by the mechanism read, which needs per-UID rows this pure
     // evaluator is deliberately not given. Null means "not measured", never
     // "zero" -- see classifyAxonMechanism.
@@ -251,16 +265,19 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
         `SN${f.netuid} ${f.withAxon}/${f.baseline} axons (${Math.round(f.ratio * 100)}%` +
         (f.kind === "subnet-turned-over"
           ? `, neurons ${f.neurons}/${f.neuronBaseline} -- the subnet turned over`
-          : f.kind === "churn-replaced"
-            ? `, churn-replaced: ${f.lossesViaReuse ?? 0} of ${(f.lossesViaReuse ?? 0) + (f.lossesSameHotkey ?? 0)} losses were deregistrations`
-            : f.lossesSameHotkey !== null
-              ? `, ${f.lossesSameHotkey} miner(s) stopped announcing` +
+          : f.kind === "mechanism-unknown"
+            ? ", mechanism UNREAD -- the drop is real, the cause is not established"
+            : f.kind === "churn-replaced"
+              ? `, churn-replaced: ${f.lossesViaReuse ?? 0} of ${(f.lossesViaReuse ?? 0) + (f.lossesSameHotkey ?? 0)} losses were deregistrations`
+              : // `announcements-withdrawn` is only reachable through a
+                // successful mechanism read, so the count is a number here --
+                // an unread one is `mechanism-unknown` above.
+                `, ${f.lossesSameHotkey} miner(s) stopped announcing` +
                 (f.lossesDistinctIps === null
                   ? ""
                   : f.lossesDistinctIps === 1
                     ? " -- ALL FROM ONE ADDRESS, so this is one host rather than the subnet"
-                    : ` from ${f.lossesDistinctIps} addresses`)
-              : "") +
+                    : ` from ${f.lossesDistinctIps} addresses`)) +
         ")",
     )
     .join("; ");
@@ -280,11 +297,19 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
  * one is somebody's fleet going dark, the other is ordinary registration churn
  * grinding the announcing set down because replacements do not announce.
  *
- * NULL COUNTS LEAVE THE DEFAULT ALONE. An unmeasured mechanism must not be
- * reported as churn, because churn is the reading that does NOT ask anyone to
- * go looking; guessing it would turn an unread number into an all-clear.
+ * NULL COUNTS LEAVE THE DEFAULT ALONE, and that default is now
+ * `mechanism-unknown`. An unmeasured mechanism must not be reported as churn,
+ * because churn is the reading that does NOT ask anyone to go looking; guessing
+ * it would turn an unread number into an all-clear. It must not be reported as
+ * withdrawal either -- that names a cause, and naming the wrong one sends a
+ * reader to the wrong subnet's operators.
  *
- * A tie resolves to `announcements-withdrawn` for the same reason.
+ * `reuse + same === 0` takes the same exit: the read SUCCEEDED and explained
+ * nothing, which is a different fact from a failed read but the same claim --
+ * we cannot say why the count fell.
+ *
+ * A tie resolves to `announcements-withdrawn`, which stays deliberate: equal
+ * evidence for both is still evidence that some miners went dark.
  */
 export function classifyAxonMechanism(
   counts: { viaReuse: number | null; sameHotkey: number | null },
@@ -448,9 +473,20 @@ export async function runAxonAnnouncementWatchdog(
               `miners were DEREGISTERED and their UIDs reused by miners that never served. ` +
               `Nobody went dark; the announcing set is ground down one registration at a time, ` +
               `and it only reverses if serving starts paying on that subnet (#11369)`
-            : `announced axons collapsed: ${detail} -- miners that are still registered and ` +
-              `still earning stopped publishing an axon, so this is a reachability change ` +
-              `nothing else in the fleet reports (#11328)`,
+            : // ONLY ON A MEASURED WITHDRAWAL. This sentence names a cause and
+              // sends a reader to a specific subnet's operators, so it is
+              // gated on having actually counted same-hotkey stops rather
+              // than on being the last branch left.
+              findings.some((f) => f.kind === "announcements-withdrawn")
+              ? `announced axons collapsed: ${detail} -- miners that are still registered and ` +
+                `still earning stopped publishing an axon, so this is a reachability change ` +
+                `nothing else in the fleet reports (#11328)`
+              : // Turnover and unread mechanisms land here. The detail already
+                // says which, and neither is a withdrawal, so this states the
+                // drop and stops -- see the `mechanism-unknown` note on
+                // AxonFinding for why inventing the cause was worse.
+                `announced axons fell below baseline: ${detail} -- this reports the DROP only; ` +
+                `no miner was measured to have stopped announcing`,
       ),
       route: `watchdog:${AXON_ANNOUNCEMENT_LANE}`,
       errorCode: fleetWide

--- a/src/axon-routable.ts
+++ b/src/axon-routable.ts
@@ -37,7 +37,6 @@ export const UNROUTABLE_AXON_PATTERN =
 export const UNROUTABLE_AXON_V6_PATTERN =
   "^(::$|::1$|[fF][cCdD]|[fF][eE][89aAbB])";
 
-/** SQL fragment: the axon is present AND points somewhere routable. */
 /** SQL fragment: the axon is present AND points somewhere routable.
  *
  * `left(axon, length(axon) - strpos(reverse(axon), ':'))` is "everything before

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -90,7 +90,10 @@ describe("evaluateSubnetAxons — the real incidents", () => {
     const series = then(flat(8, 223), [129, 256]);
     const f = evaluateSubnetAxons(101, series);
     assert.ok(f, "SN101's drop is a finding");
-    assert.equal(f.kind, "announcements-withdrawn");
+    // The pure evaluator is given no per-UID rows, so it cannot name a
+    // mechanism -- only the enrichment can, and SN101 is the one subnet that
+    // really is withdrawal (64/75 same-hotkey, measured 2026-08-16).
+    assert.equal(f.kind, "mechanism-unknown");
     assert.equal(f.withAxon, 129);
     assert.equal(f.baseline, 223);
     assert.ok(f.ratio < 0.6);
@@ -103,7 +106,7 @@ describe("evaluateSubnetAxons — the real incidents", () => {
     const f = evaluateSubnetAxons(25, series);
     assert.ok(f, "SN25's decline is caught against baseline");
     assert.equal(f.withAxon, 21);
-    assert.equal(f.kind, "announcements-withdrawn");
+    assert.equal(f.kind, "mechanism-unknown");
   });
 
   test("the first 26% step alone is NOT flagged", () => {
@@ -169,7 +172,7 @@ describe("evaluateSubnetAxons — what it refuses to measure", () => {
     ];
     const f = evaluateSubnetAxons(9, series);
     assert.ok(f);
-    assert.equal(f.kind, "announcements-withdrawn");
+    assert.equal(f.kind, "mechanism-unknown");
   });
 });
 
@@ -182,7 +185,9 @@ describe("the fleet-wide guard", () => {
     ratio: 0.01,
     neurons: 256,
     neuronBaseline: 256,
-    kind: "announcements-withdrawn",
+    // Null counts and `announcements-withdrawn` cannot co-occur any more --
+    // that kind is only reachable through a successful mechanism read.
+    kind: "mechanism-unknown",
     lossesViaReuse: null,
     lossesSameHotkey: null,
     lossesDistinctIps: null,
@@ -353,7 +358,7 @@ describe("the defensive fallbacks, each exercised", () => {
     assert.equal(f.neuronBaseline, 0);
     assert.equal(
       f.kind,
-      "announcements-withdrawn",
+      "mechanism-unknown",
       "an unmeasurable neuron baseline cannot assert the subnet turned over",
     );
   });
@@ -611,28 +616,32 @@ describe("mechanism — WHAT happened, not just how much (#11369)", () => {
     );
   });
 
-  test("UNMEASURED keeps the default rather than guessing churn", () => {
+  test("UNMEASURED keeps the default rather than guessing EITHER reading", () => {
     // Churn is the reading that does NOT send anyone looking, so inferring it
     // from an absent measurement would turn an unread number into an all-clear.
+    // Withdrawal is no safer: it NAMES a cause, and the caller's default is
+    // `mechanism-unknown` precisely so a failed read cannot publish one.
     for (const counts of [
       { viaReuse: null, sameHotkey: 3 },
       { viaReuse: 3, sameHotkey: null },
       { viaReuse: null, sameHotkey: null },
     ]) {
       assert.equal(
-        classifyAxonMechanism(counts, "announcements-withdrawn"),
-        "announcements-withdrawn",
+        classifyAxonMechanism(counts, "mechanism-unknown"),
+        "mechanism-unknown",
       );
     }
   });
 
-  test("no losses at all keeps the default", () => {
+  test("a read that explains nothing is unknown, not withdrawal", () => {
+    // Distinct from the failure above: this read SUCCEEDED and found no
+    // transition of either shape. Same claim -- we cannot say why it fell.
     assert.equal(
       classifyAxonMechanism(
         { viaReuse: 0, sameHotkey: 0 },
-        "announcements-withdrawn",
+        "mechanism-unknown",
       ),
-      "announcements-withdrawn",
+      "mechanism-unknown",
     );
   });
 
@@ -911,15 +920,36 @@ describe("the tick reports the mechanism it measured", () => {
     );
   });
 
-  test("an unmeasured mechanism leaves the default and the plain detail", async () => {
-    // The mechanism read returns nothing: the finding stands, unlabelled.
+  test("an UNREAD mechanism reports the drop and names no cause", async () => {
+    // THE REGRESSION THIS PINS. `loadAxonLossMechanisms` returns `{}` on any
+    // failure, and the old default was `announcements-withdrawn` -- so a broken
+    // read published "miners that are still registered and still earning
+    // stopped publishing an axon" having measured nothing at all. On SN25 that
+    // sentence is inverted: 67 of 67 losses were deregistrations.
     answer(rowsFor(25, then(flat(8, 80), [14, 256])), []);
+    let captured: Record<string, unknown> | null = null;
     const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
       now: () => Date.parse("2026-08-16T00:00:00Z"),
-      recordException: (async () => true) as never,
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
     })) as { findings: AxonFinding[] };
-    assert.equal(result.findings[0].kind, "announcements-withdrawn");
+
+    assert.equal(result.findings[0].kind, "mechanism-unknown");
     assert.equal(result.findings[0].lossesViaReuse, null);
+    // The alarm still fires -- an unread cause is not an all-clear.
+    assert.equal(result.findings.length, 1);
+    const message = String(
+      (captured as unknown as { error: Error }).error.message,
+    );
+    assert.match(message, /reports the DROP only/);
+    assert.doesNotMatch(
+      message,
+      /stopped publishing an axon|fell through CHURN/,
+      "an unmeasured mechanism must not name one",
+    );
+    assert.match(verdict(), /mechanism UNREAD/);
   });
 
   test("turnover is never reclassified as churn", async () => {


### PR DESCRIPTION
## The defect

`loadAxonLossMechanisms` returns `{}` on any failure — correct for the read. The finding's default `kind` was not: `announcements-withdrawn`, so an unreadable mechanism degraded to a *specific claim* rather than to "unknown".

On the two subnets flagged today that claim is inverted. Over the watchdog's own 8-day window, per UID:

| subnet | via_reuse | same_hotkey |
| --- | --- | --- |
| 25 | 67 | **0** |
| 102 | 43 | **0** |

Zero miners went dark on either.

The same fallback suppressed the detail suffix (`lossesSameHotkey` stays null), so production published the bare `SN25 14/80 axons (18%)` at `2026-08-15T19:36:02Z` with no way to tell a failed read from a measured withdrawal.

## The change

- `mechanism-unknown` is the starting kind; only a successful read moves it.
- `reuse + same === 0` takes the same exit — the read succeeded and explained nothing, a different fact but the same claim.
- The `#11328` withdrawal wording is gated on `some(kind === "announcements-withdrawn")` rather than on being the last branch left. Turnover no longer borrows it.
- `axonDetail` says `mechanism UNREAD -- the drop is real, the cause is not established`.
- The alarm still fires. An unread cause is not an all-clear.

One branch was removed rather than tested: `announcements-withdrawn` is now only reachable through a successful read, so `lossesSameHotkey !== null` in `axonDetail` is unreachable.

## Verification

- The enrichment query run directly against Neon returns 67/0 and 43/0 — healthy, so this is latent robustness, not a live outage.
- 80 tests pass; the previously-passing test that *pinned the bug* ("an unmeasured mechanism leaves the default") is rewritten as a regression pin asserting the message does **not** name a mechanism.
- 100% statement and branch coverage on both changed files.
- `tsc`, prettier, eslint, and `validate:{unreferenced-exports,no-hand-written-mjs,boundary-casts,lane-topology,double-assertions}` all pass.

Closes #11381