### PR TITLE
fix(watchdog): an unread mechanism is not a withdrawal — say unknown, not why

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -139,11 +139,26 @@ export interface AxonFinding {
    *   the opposite of what happened.
    * - `subnet-turned-over`: the metagraph itself emptied, so the missing axons
    *   are missing NEURONS and membership is the story.
+   * - `mechanism-unknown`: the per-UID read did not answer. THE STARTING VALUE
+   *   (#11381).
    *
-   * Defaults to `announcements-withdrawn` until the mechanism read runs, which
-   * is the conservative direction: it is the reading that asks for a human.
+   * It used to start at `announcements-withdrawn`, on the reasoning that the
+   * alarming reading is the conservative one. That confuses escalating with
+   * asserting. `loadAxonLossMechanisms` returns `{}` on any failure, so an
+   * unreadable mechanism did not become "we could not tell" -- it became the
+   * sentence "miners that are still registered and still earning stopped
+   * publishing an axon", published as fact. On the two subnets flagged
+   * 2026-08-15 that sentence was INVERTED: 67 and 43 losses via UID reuse, and
+   * zero same-hotkey stops on either.
+   *
+   * An alarm may escalate on uncertainty. It may not invent the finding it is
+   * uncertain about.
    */
-  kind: "announcements-withdrawn" | "churn-replaced" | "subnet-turned-over";
+  kind:
+    | "announcements-withdrawn"
+    | "churn-replaced"
+    | "subnet-turned-over"
+    | "mechanism-unknown";
   /** Axon losses in the window whose UID changed hands. Null until measured. */
   lossesViaReuse: number | null;
   /** Axon losses where the same hotkey stopped announcing. Null until measured. */
@@ -214,7 +229,9 @@ export function evaluateSubnetAxons(
     ratio,
     neurons: latest.neurons,
     neuronBaseline,
-    kind: turnedOver ? "subnet-turned-over" : "announcements-withdrawn",
+    // `mechanism-unknown` until a per-UID read moves it (#11381): this pure
+    // evaluator counts axons and cannot see WHY any went away.
+    kind: turnedOver ? "subnet-turned-over" : "mechanism-unknown",
     // Filled in by the mechanism read, which needs per-UID rows this pure
     // evaluator is deliberately not given. Null means "not measured", never
     // "zero" -- see classifyAxonMechanism.
@@ -253,14 +270,19 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
           ? `, neurons ${f.neurons}/${f.neuronBaseline} -- the subnet turned over`
           : f.kind === "churn-replaced"
             ? `, churn-replaced: ${f.lossesViaReuse ?? 0} of ${(f.lossesViaReuse ?? 0) + (f.lossesSameHotkey ?? 0)} losses were deregistrations`
-            : f.lossesSameHotkey !== null
-              ? `, ${f.lossesSameHotkey} miner(s) stopped announcing` +
-                (f.lossesDistinctIps === null
-                  ? ""
-                  : f.lossesDistinctIps === 1
-                    ? " -- ALL FROM ONE ADDRESS, so this is one host rather than the subnet"
-                    : ` from ${f.lossesDistinctIps} addresses`)
-              : "") +
+            : f.kind === "mechanism-unknown"
+              ? // Says so, rather than printing a bare ratio (#11381). The old
+                // fallback suppressed this suffix too, so a failed read and a
+                // measured withdrawal published the identical string.
+                ", mechanism unmeasured -- the losses are real, why is not known"
+              : f.lossesSameHotkey !== null
+                ? `, ${f.lossesSameHotkey} miner(s) stopped announcing` +
+                  (f.lossesDistinctIps === null
+                    ? ""
+                    : f.lossesDistinctIps === 1
+                      ? " -- ALL FROM ONE ADDRESS, so this is one host rather than the subnet"
+                      : ` from ${f.lossesDistinctIps} addresses`)
+                : "") +
         ")",
     )
     .join("; ");
@@ -280,11 +302,19 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
  * one is somebody's fleet going dark, the other is ordinary registration churn
  * grinding the announcing set down because replacements do not announce.
  *
- * NULL COUNTS LEAVE THE DEFAULT ALONE. An unmeasured mechanism must not be
- * reported as churn, because churn is the reading that does NOT ask anyone to
- * go looking; guessing it would turn an unread number into an all-clear.
+ * NULL COUNTS LEAVE THE FALLBACK ALONE, and since #11381 that fallback is
+ * `mechanism-unknown` rather than a named mechanism. An unmeasured mechanism
+ * must not be reported as churn -- churn is the reading that does NOT ask
+ * anyone to go looking -- and it must not be reported as withdrawal either,
+ * which is the reading that says somebody's miners went dark.
  *
- * A tie resolves to `announcements-withdrawn` for the same reason.
+ * A read that SUCCEEDS and explains nothing (`reuse + same === 0`) takes the
+ * same exit. Different fact, same claim: the losses are real and this did not
+ * account for them.
+ *
+ * A tie between the two still resolves to `announcements-withdrawn`: that is a
+ * measured tie, not an absent measurement, and it is the half of the tie worth
+ * a human's attention.
  */
 export function classifyAxonMechanism(
   counts: { viaReuse: number | null; sameHotkey: number | null },
@@ -448,9 +478,18 @@ export async function runAxonAnnouncementWatchdog(
               `miners were DEREGISTERED and their UIDs reused by miners that never served. ` +
               `Nobody went dark; the announcing set is ground down one registration at a time, ` +
               `and it only reverses if serving starts paying on that subnet (#11369)`
-            : `announced axons collapsed: ${detail} -- miners that are still registered and ` +
-              `still earning stopped publishing an axon, so this is a reachability change ` +
-              `nothing else in the fleet reports (#11328)`,
+            : // EARNED, not defaulted to (#11381). This sentence is the #11328
+              // claim -- somebody's miners went dark -- and it is only allowed
+              // when a per-UID read actually found a same-hotkey stop. It used
+              // to be the last branch left, so an unreadable mechanism and a
+              // turned-over subnet both borrowed it.
+              findings.some((f) => f.kind === "announcements-withdrawn")
+              ? `announced axons collapsed: ${detail} -- miners that are still registered and ` +
+                `still earning stopped publishing an axon, so this is a reachability change ` +
+                `nothing else in the fleet reports (#11328)`
+              : `announced axons fell below baseline: ${detail} -- the mechanism was NOT ` +
+                `established, so this says how many went away and deliberately not why. ` +
+                `Read it as "worth a look", never as miners going dark (#11381)`,
       ),
       route: `watchdog:${AXON_ANNOUNCEMENT_LANE}`,
       errorCode: fleetWide

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -90,7 +90,11 @@ describe("evaluateSubnetAxons — the real incidents", () => {
     const series = then(flat(8, 223), [129, 256]);
     const f = evaluateSubnetAxons(101, series);
     assert.ok(f, "SN101's drop is a finding");
-    assert.equal(f.kind, "announcements-withdrawn");
+    // The evaluator counts axons and cannot see why any went away, so it says
+    // `mechanism-unknown` and the per-UID read moves it (#11381). SN101 IS the
+    // #11328 withdrawal case -- see the mechanism tests below, where a real
+    // same-hotkey count earns that label.
+    assert.equal(f.kind, "mechanism-unknown");
     assert.equal(f.withAxon, 129);
     assert.equal(f.baseline, 223);
     assert.ok(f.ratio < 0.6);
@@ -103,7 +107,7 @@ describe("evaluateSubnetAxons — the real incidents", () => {
     const f = evaluateSubnetAxons(25, series);
     assert.ok(f, "SN25's decline is caught against baseline");
     assert.equal(f.withAxon, 21);
-    assert.equal(f.kind, "announcements-withdrawn");
+    assert.equal(f.kind, "mechanism-unknown");
   });
 
   test("the first 26% step alone is NOT flagged", () => {
@@ -169,7 +173,7 @@ describe("evaluateSubnetAxons — what it refuses to measure", () => {
     ];
     const f = evaluateSubnetAxons(9, series);
     assert.ok(f);
-    assert.equal(f.kind, "announcements-withdrawn");
+    assert.equal(f.kind, "mechanism-unknown");
   });
 });
 
@@ -353,7 +357,7 @@ describe("the defensive fallbacks, each exercised", () => {
     assert.equal(f.neuronBaseline, 0);
     assert.equal(
       f.kind,
-      "announcements-withdrawn",
+      "mechanism-unknown",
       "an unmeasurable neuron baseline cannot assert the subnet turned over",
     );
   });
@@ -911,15 +915,84 @@ describe("the tick reports the mechanism it measured", () => {
     );
   });
 
-  test("an unmeasured mechanism leaves the default and the plain detail", async () => {
-    // The mechanism read returns nothing: the finding stands, unlabelled.
+  test("an unmeasured mechanism says SO — it does not borrow the withdrawal claim", async () => {
+    // #11381: this used to assert `announcements-withdrawn`, which is the bug.
+    // `loadAxonLossMechanisms` returns {} on any failure, so an unreadable
+    // mechanism published "miners that are still registered and still earning
+    // stopped publishing an axon" as fact. On the two subnets flagged
+    // 2026-08-15 that was inverted -- 67 and 43 losses via UID reuse, zero
+    // same-hotkey stops.
     answer(rowsFor(25, then(flat(8, 80), [14, 256])), []);
     const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
       now: () => Date.parse("2026-08-16T00:00:00Z"),
       recordException: (async () => true) as never,
     })) as { findings: AxonFinding[] };
-    assert.equal(result.findings[0].kind, "announcements-withdrawn");
+    assert.equal(result.findings[0].kind, "mechanism-unknown");
     assert.equal(result.findings[0].lossesViaReuse, null);
+    // And the detail names the gap rather than printing a bare ratio, which is
+    // what made a failed read indistinguishable from a measured withdrawal.
+    assert.match(verdict(), /mechanism unmeasured/);
+  });
+
+  test("the WITHDRAWAL claim is earned by a measured same-hotkey stop, never defaulted to", async () => {
+    // The #11328 sentence -- "miners that are still registered and still
+    // earning stopped publishing an axon" -- used to be the last branch left,
+    // so an unreadable mechanism inherited it. It is gated on a measured
+    // withdrawal now (#11381).
+    answer(rowsFor(25, then(flat(8, 80), [14, 256])), [
+      { netuid: 25, via_reuse: 1, same_hotkey: 40 },
+    ]);
+    let captured: Record<string, unknown> | null = null;
+    await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    });
+    assert.match(
+      String((captured as unknown as { error: Error }).error.message),
+      /still registered and still earning stopped publishing an axon/,
+    );
+  });
+
+  test("an UNMEASURED mechanism gets a message that refuses to say why", async () => {
+    // The exact inversion #11381 reports: on 2026-08-15 production published
+    // the withdrawal sentence for two subnets whose losses were 100% UID
+    // reuse. The message must now say how many went away and decline to say
+    // why.
+    answer(rowsFor(25, then(flat(8, 80), [14, 256])), []);
+    let captured: Record<string, unknown> | null = null;
+    await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    });
+    const message = String(
+      (captured as unknown as { error: Error }).error.message,
+    );
+    assert.match(message, /the mechanism was NOT established/);
+    assert.doesNotMatch(
+      message,
+      /stopped publishing an axon/,
+      "an alarm may escalate on uncertainty; it may not invent the finding",
+    );
+  });
+
+  test("a mechanism read that explains NOTHING takes the same exit", async () => {
+    // Different fact, same claim: the read succeeded, reported 0 and 0, and
+    // therefore accounted for none of the losses. Reporting a mechanism here
+    // would be inventing one.
+    answer(rowsFor(25, then(flat(8, 80), [14, 256])), [
+      { netuid: 25, via_reuse: 0, same_hotkey: 0 },
+    ]);
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async () => true) as never,
+    })) as { findings: AxonFinding[] };
+    assert.equal(result.findings[0].kind, "mechanism-unknown");
   });
 
   test("turnover is never reclassified as churn", async () => {


### PR DESCRIPTION
Closes #11381.

`loadAxonLossMechanisms` returns `{}` on any failure — right for the read. But the finding's starting `kind` was `announcements-withdrawn`, so an unreadable mechanism degraded not to "we could not tell" but to a confident, specific claim:

> announced axons collapsed: SN25 14/80 axons (18%) — miners that are still registered and still earning stopped publishing an axon…

On the two subnets flagged at `2026-08-15T19:36:02Z` that sentence was **inverted**:

| subnet | via_reuse | same_hotkey |
| --- | ---: | ---: |
| 25 | 67 | **0** |
| 102 | 43 | **0** |

Zero miners went dark. Every loss was a deregistration whose replacement never served. The same fallback suppressed the detail suffix too, so a failed read and a measured withdrawal published the identical string.

**An alarm may escalate on uncertainty. It may not invent the finding it is uncertain about.**

## Changes

- `mechanism-unknown` is a fourth kind and the **starting value**; only a successful per-UID read moves it. A read that succeeds and explains nothing (`reuse + same === 0`) takes the same exit.
- The detail names the gap instead of printing a bare ratio.
- The #11328 withdrawal wording is gated on `findings.some(kind === "announcements-withdrawn")` rather than on being the last branch left, so neither an unread mechanism nor a turned-over subnet borrows it. What's left gets its own message: how many went away, deliberately not why.
- A measured **tie** still resolves to withdrawal — that's a measured tie, not an absent measurement.

## Pinned

Two tests assert the message both ways, including `assert.doesNotMatch(/stopped publishing an axon/)` on the unknown path. Five existing assertions encoded the old default and were updated rather than worked around — the one named *"an unmeasured mechanism leaves the default and the plain detail"* was the bug written down as a test.

Mutation-verified: restoring the old starting value fails 7 tests; restoring the ungated message fails 1.

All 55 CI validators pass. Latent robustness — the enrichment query is healthy in production.