### PR TITLE
fix(lanes): the durable verdict said less than the alert it outlives

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -87,6 +87,7 @@
 // on the case above.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { laneVerdictDetail } from "./lane-verdict-detail.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -410,7 +411,11 @@ export async function runAccountBalancesStalenessWatchdog(
       lane: "account-balances-staleness",
       verdict: verdict.stale ? "stale" : "ok",
       age_ms: verdict.age_ms,
-      detail: verdict.reason ?? null,
+      detail: laneVerdictDetail(verdict.reason, {
+        covered: verdict.covered_rows,
+        total: verdict.total_rows,
+        floor: verdict.coverage_floor_rows,
+      }),
       checked_at: now(),
     });
     // `ok` describes whether the TICK ran, not whether the lane is fresh.

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -27,6 +27,7 @@
 // healthy check is still legible.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { laneVerdictDetail } from "./lane-verdict-detail.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore, safeIntOrNull } from "./read-store.ts";
@@ -193,7 +194,9 @@ export async function runChainDetailStalenessWatchdog(
       lane: "chain-detail-staleness",
       verdict: verdict.stale ? "stale" : "ok",
       age_ms: verdict.age_ms,
-      detail: verdict.reason ?? null,
+      detail: laneVerdictDetail(verdict.reason, {
+        head_block: verdict.head_block,
+      }),
       checked_at: now(),
     });
     // `ok` describes whether the TICK ran, not whether the lane is fresh.

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -61,6 +61,7 @@
 // lanes' names on one fault and send whoever reads it to the wrong producer.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { laneVerdictDetail } from "./lane-verdict-detail.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -344,7 +345,11 @@ export async function runHotkeyAlphaStalenessWatchdog(
       lane: "hotkey-alpha-staleness",
       verdict: verdict.stale ? "stale" : "ok",
       age_ms: verdict.age_ms,
-      detail: verdict.reason ?? null,
+      detail: laneVerdictDetail(verdict.reason, {
+        covered: verdict.covered_rows,
+        total: verdict.total_rows,
+        floor: verdict.coverage_floor_rows,
+      }),
       checked_at: now(),
     });
     // `ok` describes whether the TICK ran, not whether the lane is fresh.

--- a/src/lane-verdict-detail.ts
+++ b/src/lane-verdict-detail.ts
@@ -1,0 +1,51 @@
+// The counts a staleness verdict was decided ON, in the record that outlives it
+// (#11384).
+//
+// ## The gap this closes
+//
+// Every staleness lane builds a rich exception message and then writes
+// `detail: verdict.reason ?? null` to `lane_health` -- the bare word `partial`
+// or `stale`. So the DURABLE record carries strictly less than the transient
+// notification, on a surface whose own comment argues it is the record
+// precisely because "a dropped $exception is indistinguishable from a lane that
+// was fine".
+//
+// Measured 2026-08-16: `nominator-positions-staleness` published `partial` for
+// five consecutive ticks. Triaging it needed the covered count, the total and
+// the floor -- all three already computed, all three one field away, none of
+// them published. The answer turned out to be a 22-coldkey miss against a floor
+// of 17,010, but nothing on `/self-health` could distinguish that from a scan
+// that died halfway.
+//
+// ## Why a formatter rather than columns
+//
+// The five coverage lanes count different things -- rows, netuids, coldkeys --
+// and two more lanes have no coverage leg at all. A column per fact would be
+// mostly null and would need a migration per lane. The verdict is already
+// serialised for humans; what it lacked was the numbers, not a schema.
+//
+// ## Facts are OMITTED, never guessed
+//
+// A non-finite fact is dropped rather than rendered as `0` or `null`. Zero
+// covered rows and "we could not count the rows" are different claims and only
+// one of them is a fact -- the same rule `loadAxonLossMechanisms` follows for
+// an unmeasured mechanism (#11381).
+
+/**
+ * `reason (key=value, ...)`, or the bare reason when nothing is measurable.
+ *
+ * Returns null for a healthy lane, matching the `detail` column's existing
+ * meaning -- an `ok` verdict has no reason and gains no facts.
+ */
+export function laneVerdictDetail(
+  reason: string | null | undefined,
+  facts: Readonly<Record<string, number | null | undefined>> = {},
+): string | null {
+  if (typeof reason !== "string" || reason === "") return null;
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(facts ?? {})) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    parts.push(`${key}=${value}`);
+  }
+  return parts.length === 0 ? reason : `${reason} (${parts.join(", ")})`;
+}

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -43,6 +43,7 @@
 // so ~2.9M store rows read a day.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { laneVerdictDetail } from "./lane-verdict-detail.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import {
   FLUSH_INTERVAL_MS,
@@ -361,7 +362,11 @@ export async function runNeuronsStalenessWatchdog(
       lane: "neurons-staleness",
       verdict: verdict.stale ? "stale" : "ok",
       age_ms: verdict.age_ms,
-      detail: verdict.reason ?? null,
+      detail: laneVerdictDetail(verdict.reason, {
+        covered: verdict.covered_netuids,
+        total: verdict.total_netuids,
+        floor: verdict.coverage_floor_netuids,
+      }),
       checked_at: now(),
     });
     // `ok` describes whether the TICK ran, not whether the lane is fresh.

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -53,6 +53,7 @@
 // ~6M store rows read a day.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { laneVerdictDetail } from "./lane-verdict-detail.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
@@ -175,7 +176,14 @@ export const NOMINATOR_POSITIONS_EXPECTED_COLDKEYS = 21_263;
 /**
  * How much of that a single pass must cover before it counts as complete.
  *
- * EIGHTY PERCENT (~18,934 coldkeys), the ratio the three sibling lanes use.
+ * EIGHTY PERCENT (17,010 coldkeys), the ratio the three sibling lanes use.
+ *
+ * THAT NUMBER IS DERIVED, SO DO NOT RESTATE IT FROM MEMORY. It read "~18,934"
+ * here until 2026-08-16 -- 0.8 x 23,668, the expectation from a PREVIOUS
+ * re-pin. Against 18,934 the live coverage of 16,988 reads as a 10% shortfall,
+ * which looks exactly like a scan that died mid-walk and sends a reader hunting
+ * for one. Against the real floor it is 22 coldkeys, 0.13%, and the answer is
+ * to re-measure the expectation. That misreading cost a full triage cycle.
  *
  * The drift here runs the same direction as validator_nominator_counts and NOT
  * the same as account_balances, because this counts coldkeys holding a position
@@ -189,7 +197,15 @@ export const NOMINATOR_POSITIONS_EXPECTED_COLDKEYS = 21_263;
  */
 export const NOMINATOR_POSITIONS_COVERAGE_FLOOR_RATIO = 0.8;
 
-/** The floor the rule compares against, ~18,934 coldkeys. */
+/**
+ * The floor the rule compares against: 17,010 coldkeys.
+ *
+ * Live coverage was 16,988 on 2026-08-16, so this lane is ~22 coldkeys under
+ * and reports `partial` every tick. That is the re-measure case this module's
+ * own guidance describes, not a truncated pass -- #11384 tracks replacing the
+ * pinned expectation with a floor derived from the lane's own trailing history,
+ * once the counts this PR publishes have accumulated enough of one.
+ */
 export const NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS = Math.round(
   NOMINATOR_POSITIONS_EXPECTED_COLDKEYS *
     NOMINATOR_POSITIONS_COVERAGE_FLOOR_RATIO,
@@ -434,7 +450,11 @@ export async function runNominatorPositionsStalenessWatchdog(
       lane: "nominator-positions-staleness",
       verdict: verdict.stale ? "stale" : "ok",
       age_ms: verdict.age_ms,
-      detail: verdict.reason ?? null,
+      detail: laneVerdictDetail(verdict.reason, {
+        covered: verdict.covered_coldkeys,
+        total: verdict.total_coldkeys,
+        floor: verdict.coverage_floor_coldkeys,
+      }),
       checked_at: now(),
     });
     // `ok` describes whether the TICK ran, not whether the lane is fresh.

--- a/src/rpc-usage-staleness-watchdog.ts
+++ b/src/rpc-usage-staleness-watchdog.ts
@@ -23,6 +23,7 @@
 // one of those looks identical from the reading end -- a healthy route over
 // data that has stopped advancing.
 import { laneHealthStore } from "./lane-health-store.ts";
+import { laneVerdictDetail } from "./lane-verdict-detail.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import {
@@ -177,7 +178,7 @@ export async function runRpcUsageStalenessWatchdog(
     lane: "rpc-usage-staleness",
     verdict: verdict.stale ? "stale" : "ok",
     age_ms: verdict.age_ms,
-    detail: verdict.reason ?? null,
+    detail: laneVerdictDetail(verdict.reason),
     checked_at: now(),
   });
   // `ok` describes whether the TICK ran, not whether the lane is fresh.

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -44,6 +44,7 @@
 // ~5.4M store rows read a day.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { laneVerdictDetail } from "./lane-verdict-detail.ts";
 import { passWindowMs } from "./producer-cadence.ts";
 import { countOrZero, numberOrNull, readStore } from "./read-store.ts";
 import type { ValidatorNominatorCounts } from "../generated/db/types.ts";
@@ -367,7 +368,11 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
       lane: "validator-nominator-counts-staleness",
       verdict: verdict.stale ? "stale" : "ok",
       age_ms: verdict.age_ms,
-      detail: verdict.reason ?? null,
+      detail: laneVerdictDetail(verdict.reason, {
+        covered: verdict.covered_rows,
+        total: verdict.total_rows,
+        floor: verdict.coverage_floor_rows,
+      }),
       checked_at: now(),
     });
     // `ok` describes whether the TICK ran, not whether the lane is fresh.

--- a/tests/lane-verdict-detail.test.ts
+++ b/tests/lane-verdict-detail.test.ts
@@ -1,0 +1,73 @@
+import { describe, test } from "vitest";
+import assert from "node:assert/strict";
+
+import { laneVerdictDetail } from "../src/lane-verdict-detail.ts";
+
+describe("laneVerdictDetail — the counts the verdict was decided on (#11384)", () => {
+  test("a healthy lane has no detail", () => {
+    // `ok` verdicts pass `reason: null`, and the column's existing meaning for
+    // that is null rather than an empty string.
+    assert.equal(laneVerdictDetail(null), null);
+    assert.equal(laneVerdictDetail(undefined), null);
+    assert.equal(laneVerdictDetail(""), null);
+  });
+
+  test("THE REAL CASE: partial carries covered, total and floor", () => {
+    // Measured on production 2026-08-16. The published detail was the bare word
+    // `partial`, and triage needed exactly these three numbers to tell a
+    // 22-coldkey drift from a scan that died halfway.
+    assert.equal(
+      laneVerdictDetail("partial", {
+        covered: 16_988,
+        total: 19_873,
+        floor: 17_010,
+      }),
+      "partial (covered=16988, total=19873, floor=17010)",
+    );
+  });
+
+  test("no facts leaves the reason exactly as it was", () => {
+    // The age-only lanes have no coverage leg, so they must round-trip
+    // unchanged -- this is what makes converting them zero-risk.
+    assert.equal(laneVerdictDetail("stale"), "stale");
+    assert.equal(laneVerdictDetail("no_rows", {}), "no_rows");
+  });
+
+  test("UNMEASURABLE facts are dropped, never rendered as zero", () => {
+    // "nothing covered" and "we could not count what was covered" are
+    // different claims and only one is a fact.
+    assert.equal(
+      laneVerdictDetail("partial", {
+        covered: null,
+        total: undefined,
+        floor: Number.NaN,
+      }),
+      "partial",
+    );
+    assert.equal(
+      laneVerdictDetail("partial", { covered: Number.POSITIVE_INFINITY }),
+      "partial",
+    );
+  });
+
+  test("a measured zero SURVIVES, because zero is a fact", () => {
+    assert.equal(
+      laneVerdictDetail("partial", { covered: 0, floor: 17_010 }),
+      "partial (covered=0, floor=17010)",
+    );
+  });
+
+  test("partially-measurable facts keep the ones that read", () => {
+    assert.equal(
+      laneVerdictDetail("partial", { covered: 12, total: null, floor: 40 }),
+      "partial (covered=12, floor=40)",
+    );
+  });
+
+  test("a null facts object is tolerated", () => {
+    assert.equal(
+      laneVerdictDetail("stale", null as unknown as Record<string, number>),
+      "stale",
+    );
+  });
+});

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -300,7 +300,7 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
   });
 
   test("a recent but half-scanned keyspace alerts, naming both counts", async () => {
-    const { env } = fakeDb(NOW - HOUR, 11_800, 24_121);
+    const { env, queries, binds } = fakeDb(NOW - HOUR, 11_800, 24_121);
     const recorded: { error?: Error; route?: string; errorCode?: string }[] =
       [];
     const result = await runNominatorPositionsStalenessWatchdog(env, {
@@ -313,6 +313,18 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
     assert.equal(result.alerted, true);
     assert.equal(result.reason, "partial");
     assert.equal(result.covered_coldkeys, 11_800);
+    // THE DURABLE RECORD CARRIES THE COUNTS (#11384). It published the bare
+    // word `partial` until 2026-08-16, so `/self-health` could not distinguish
+    // a 22-coldkey drift from a scan that died halfway -- while the exception
+    // built ten lines below had all three numbers.
+    const laneWrite = queries.findIndex((q) =>
+      q.includes("INSERT INTO lane_health"),
+    );
+    assert.ok(laneWrite >= 0, "the tick records a verdict");
+    assert.equal(
+      binds[laneWrite]![3],
+      `partial (covered=11800, total=24121, floor=${NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS})`,
+    );
     assert.equal(recorded.length, 1);
     assert.equal(recorded[0]!.errorCode, "stale_lane");
     const message = String(recorded[0]!.error?.message);


### PR DESCRIPTION
## The gap

Every staleness lane builds a rich exception message, then writes `detail: verdict.reason ?? null` to `lane_health` — the bare word `partial`. The durable record carries strictly less than the transient notification, on the surface whose own comment argues it is *the* record because "a dropped `$exception` is indistinguishable from a lane that was fine".

Measured on production 2026-08-16: `nominator-positions-staleness` published `partial` for five consecutive ticks. Triage needed `covered`, `total` and `floor` — all computed, all one field away, none published.

**Seven lanes shared the line:** `account-balances`, `chain-detail`, `hotkey-alpha`, `neurons`, `rpc-usage`, `validator-nominator-counts`, `nominator-positions`.

## The change

`laneVerdictDetail(reason, facts)` renders `partial (covered=16988, total=19873, floor=17010)`.

- A non-finite fact is **dropped, not rendered as 0** — "nothing covered" and "we could not count what was covered" are different claims and only one is a fact. Same rule `loadAxonLossMechanisms` follows for an unmeasured mechanism (#11381).
- A measured **zero survives**, because zero is a fact.
- The two age-only lanes pass no facts and round-trip byte-identical, which is what makes converting them zero-risk — they go through the helper so a lane copied from either starts correct.

## The comment that misdirected triage

The floor is `round(21_263 × 0.8) = 17_010`. Two comments still quoted **"~18,934"** — `0.8 × 23,668`, the expectation from a *previous* re-pin. Against 18,934 the live coverage of 16,988 reads as a **10% shortfall** and looks exactly like a scan that died mid-walk. Against the real floor it is **22 coldkeys, 0.13%**, and the answer is to re-measure. That cost a full triage cycle before anyone did the arithmetic.

## Deliberately not in scope

The pinned `EXPECTED_COLDKEYS` is left alone. It has now gone stale twice (the file cites #11167), so #11384 replaces it with a floor derived from the lane's own trailing history — and **these counts are where that history has to come from**: `nominator_positions` upserts, so only one full pass is ever retained. Re-pinning today would just re-arm the same alarm in a few weeks.

## Verification

- The new end-to-end assertion was **proven to fail** on the old behaviour: `Expected: "partial (covered=11800, total=24121, floor=17010)"` / `Received: "partial"` — which also confirms the 17,010 arithmetic against the running code.
- 307 tests pass across all ten affected suites; 100% statement and branch coverage on the new module.
- `tsc`, prettier, eslint, and `validate:{unreferenced-exports,no-hand-written-mjs,boundary-casts,lane-topology,double-assertions,module-state-resets}` pass.

Closes #11384