### PR TITLE
fix(lanes): two more floors documented as a value the code stopped computing

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -207,7 +207,16 @@ export const ACCOUNT_BALANCES_EXPECTED_ACCOUNTS = 366_700;
  */
 export const ACCOUNT_BALANCES_COVERAGE_FLOOR_RATIO = 0.8;
 
-/** The floor the rule compares against, ~244,800 rows. */
+/**
+ * The floor the rule compares against: 293,360 rows.
+ *
+ * DERIVED -- never restate it from memory. This read "~244,800" until
+ * 2026-08-16, which is 0.8 x 306,000, the floor from before #11197 re-pinned
+ * the expectation to 366,700. It UNDERSTATES the real floor by 48,560, so a
+ * pass landing in that band reads as comfortably above the floor to anyone
+ * reading the comment while the code calls it `partial` -- the opposite
+ * direction to the sibling lanes' error, and the harder one to notice.
+ */
 export const ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS = Math.round(
   ACCOUNT_BALANCES_EXPECTED_ACCOUNTS * ACCOUNT_BALANCES_COVERAGE_FLOOR_RATIO,
 );

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -159,7 +159,17 @@ export const VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS = 21_547;
  */
 export const VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_RATIO = 0.8;
 
-/** The floor the rule compares against, ~89,796 hotkeys. */
+/**
+ * The floor the rule compares against: 17,238 hotkeys.
+ *
+ * DERIVED -- never restate it from memory. This read "~89,796" until
+ * 2026-08-16, which is 0.8 x 112,245, the floor from before #11166 re-pinned
+ * the expectation to 21,547. An operator triaging a `partial` verdict would
+ * read a covered count near 17,000 against a quoted floor of 89,796 and see an
+ * 81% shortfall -- a catastrophically truncated scan -- when the lane is
+ * sitting on its floor. See derived-floor-comments.test.ts, which now fails on
+ * a mismatch instead of leaving it to be found during an incident.
+ */
 export const VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS = Math.round(
   VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS *
     VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_RATIO,

--- a/tests/derived-floor-comments.test.ts
+++ b/tests/derived-floor-comments.test.ts
@@ -1,0 +1,116 @@
+import { describe, test } from "vitest";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS } from "../src/account-balances-staleness-watchdog.ts";
+import { NEURONS_COVERAGE_FLOOR_NETUIDS } from "../src/neurons-staleness-watchdog.ts";
+import { NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS } from "../src/nominator-positions-staleness-watchdog.ts";
+import { VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
+
+// A FLOOR RESTATED IN PROSE GOES STALE ON THE NEXT RE-PIN (#11384).
+//
+// Each of these floors is `Math.round(EXPECTED * RATIO)`, and each carries a
+// JSDoc that quotes the product for a human. Re-pinning the expectation updates
+// the constant and leaves the prose, so the comment goes on describing a floor
+// the code stopped computing. Found three times in one sweep on 2026-08-16:
+//
+//   nominator-positions        quoted ~18,934   computed 17,010
+//   validator-nominator-counts quoted ~89,796   computed 17,238   (5.2x off)
+//   account-balances           quoted ~244,800  computed 293,360  (understated)
+//
+// The 89,796 one is the reason this is a gate rather than a cleanup. Triaging a
+// `partial` verdict means comparing the covered count against the floor, and a
+// reader who takes the floor from the comment sees an 81% shortfall -- a scan
+// that died mid-walk -- on a lane merely sitting on its floor.
+//
+// SCOPED TO THE JSDOC DIRECTLY ABOVE THE CONSTANT, deliberately. These files
+// also carry legitimate historical prose ("At 306,000 the floor was 244,800"),
+// which is correct as history and must not be rewritten. The authoritative
+// restatement is the one attached to the declaration, and all three bugs were
+// there.
+
+const FLOORS = [
+  {
+    file: "src/nominator-positions-staleness-watchdog.ts",
+    name: "NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS",
+    value: NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS,
+  },
+  {
+    file: "src/validator-nominator-counts-staleness-watchdog.ts",
+    name: "VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS",
+    value: VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS,
+  },
+  {
+    file: "src/account-balances-staleness-watchdog.ts",
+    name: "ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS",
+    value: ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS,
+  },
+  {
+    file: "src/neurons-staleness-watchdog.ts",
+    name: "NEURONS_COVERAGE_FLOOR_NETUIDS",
+    value: NEURONS_COVERAGE_FLOOR_NETUIDS,
+  },
+] as const;
+
+/** The `/** ... *\/` block immediately preceding `export const <name>`. */
+function docBlockAbove(source: string, name: string): string {
+  const at = source.indexOf(`export const ${name}`);
+  assert.ok(at > 0, `${name} is not declared where this test expects it`);
+  const before = source.slice(0, at);
+  const open = before.lastIndexOf("/**");
+  const close = before.lastIndexOf("*/");
+  // The block must be the LAST thing before the declaration: an unrelated
+  // earlier block would make this read a comment about something else.
+  assert.ok(
+    open >= 0 && close > open && before.slice(close + 2).trim() === "",
+    `${name} has no JSDoc block directly above it`,
+  );
+  return before.slice(open, close + 2);
+}
+
+/** Every integer in the block, tolerating `,` and `_` group separators. */
+function quotedNumbers(block: string): number[] {
+  return [...block.matchAll(/\b\d[\d,_]*\b/g)].map((m) =>
+    Number(m[0].replace(/[,_]/g, "")),
+  );
+}
+
+describe("a derived floor's own JSDoc must quote what the code computes", () => {
+  for (const floor of FLOORS) {
+    test(`${floor.name} states ${floor.value}`, () => {
+      const source = readFileSync(
+        new URL(`../${floor.file}`, import.meta.url),
+        "utf8",
+      );
+      const block = docBlockAbove(source, floor.name);
+      const numbers = quotedNumbers(block);
+
+      // CONTAINMENT, not equality of every figure. These blocks legitimately
+      // cite the value they REPLACED ("this read ~89,796 until 2026-08-16"),
+      // and that history is worth keeping -- it is how the next reader learns
+      // the failure mode. What must not happen is the block naming a floor and
+      // never naming the current one, which is exactly what all three bugs did.
+      //
+      // Doubles as the positive control: a block with no figures at all cannot
+      // contain the value, so deleting the number fails rather than passing
+      // vacuously.
+      assert.ok(
+        numbers.includes(floor.value),
+        `${floor.file}: the JSDoc above ${floor.name} never states ${floor.value}, ` +
+          `which is what the code computes. It quotes ${JSON.stringify(numbers)}. ` +
+          `Re-pinning the expectation changed the product and left the prose behind.`,
+      );
+    });
+  }
+
+  test("the extractor actually reads numbers out of a block", () => {
+    // Guards the guard: a regex that silently matched nothing would make every
+    // case above pass on an empty list.
+    assert.deepEqual(
+      quotedNumbers("/** floor is 17,010 or 17_010 or 103 */"),
+      [17_010, 17_010, 103],
+      "all three group-separator spellings read back as the same integer",
+    );
+    assert.deepEqual(quotedNumbers("/** prose with no figures at all */"), []);
+  });
+});


### PR DESCRIPTION
## Two more instances of the #11385 defect

Both created by the 2026-08-14 re-pins (#11166, #11197), which updated the expectation constant and left the derived-value JSDoc directly beneath it.

| file | quoted | computed | |
| --- | --- | --- | --- |
| `validator-nominator-counts-staleness-watchdog.ts:162` | ~89,796 | **17,238** | `0.8 × 112,245`, the pre-#11166 floor — **off by 5.2×** |
| `account-balances-staleness-watchdog.ts:210` | ~244,800 | **293,360** | `0.8 × 306,000`, the pre-#11197 floor — understates by 48,560 |

The first is worse than the original. Triaging a `partial` verdict means comparing the covered count against the floor; a reader taking the floor from the comment sees ~17,000 against 89,796 — an **81% shortfall**, reading as a catastrophically truncated scan — on a lane merely sitting on its floor.

The second fails in the opposite, harder-to-notice direction: it **understates** the floor, so a pass landing between 244,800 and 293,360 reads as comfortably healthy to a comment-reader while the code calls it `partial`.

## The gate

`tests/derived-floor-comments.test.ts` — each of the four `Math.round(EXPECTED × RATIO)` floors must state, in the JSDoc attached to its declaration, the value the code computes.

**Containment, not equality of every figure.** These blocks legitimately cite the value they replaced ("this read ~89,796 until 2026-08-16"), and that history is how the next reader learns the failure mode. What must not happen is a block naming a floor and never naming the current one — which is exactly what all three bugs did.

It doubles as its own positive control: a block with no figures cannot contain the value, so deleting the number fails rather than passing vacuously. The extractor is separately unit-tested, because a regex that silently matched nothing would make every case pass on an empty list.

**Proven to fail.** Restoring the original comment produces:

```
src/validator-nominator-counts-staleness-watchdog.ts: the JSDoc above
VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS never states 17238, which is
what the code computes. It quotes [89796].
```

## Deliberately not in scope

`VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS = 21_547` is the next constant to cross its floor — pinned by the **same chain walk on the same day** as the exemplar's 21,263, and `nominator-positions`'s own comment notes the drift "runs the same direction as validator_nominator_counts". That is a re-measure (`scripts/measure-lane-populations.ts` already does it against chain), and #11384's trailing-history approach is the durable answer rather than a fourth re-pin.

## Verification

102 tests pass across the five affected suites; `tsc`, prettier and eslint clean.

Closes #11387