### PR TITLE
fix(watchdog): pure churn records its verdict instead of paging

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -457,7 +457,32 @@ export async function runAxonAnnouncementWatchdog(
   const fleetWide = isFleetWide(findings);
   const detail = axonDetail(findings);
 
-  if (findings.length > 0) {
+  // CHURN RECORDS, IT DOES NOT PAGE (#11386).
+  //
+  // `churn-replaced` means the announcing miners were deregistered and their
+  // UIDs reused by miners that never served. Nobody went dark, and there is
+  // nobody to go looking for. Measured across the network, restricted to
+  // subnets with >=3 miners earning incentive, 32 of 66 (48%) have NOT ONE
+  // earner that announces -- and only ~21% of registered neurons announce a
+  // routable axon at all. A subnet whose announcing set is ground down one
+  // deregistration at a time is describing the network's ordinary state.
+  //
+  // SN25 alone would have paged twice a day for about a week on this shape,
+  // until its baseline decayed below the floor.
+  //
+  // The verdict is still WRITTEN, so it stays on /self-health and in history
+  // with the mechanism and counts inline (#11385). Suppressing the page is not
+  // suppressing the finding -- lane_health is the durable record by design
+  // (#9330/#9340), and PostHog was never it.
+  //
+  // A withdrawal, a fleet-wide flag, an unread mechanism or any MIXED set all
+  // still page: `every` is the bar, so one non-churn finding restores it.
+  const churnOnly =
+    findings.length > 0 &&
+    !fleetWide &&
+    findings.every((f) => f.kind === "churn-replaced");
+
+  if (findings.length > 0 && !churnOnly) {
     // A fleet-wide flag is reported as OUR failure and given its own error
     // code, because it sends a reader somewhere completely different: to the
     // poller, not to a subnet's operators. Collapsing the two would make an
@@ -468,25 +493,20 @@ export async function runAxonAnnouncementWatchdog(
           ? `${findings.length} subnets dropped below their axon baseline on the same day -- ` +
               `that is far more than any observed independent cluster (max 3), so read this as the ` +
               `metagraph capture failing rather than as subnets going dark: ${detail}`
-          : findings.every((f) => f.kind === "churn-replaced")
-            ? `announced axons fell through CHURN, not withdrawal: ${detail} -- the announcing ` +
-              `miners were DEREGISTERED and their UIDs reused by miners that never served. ` +
-              `Nobody went dark; the announcing set is ground down one registration at a time, ` +
-              `and it only reverses if serving starts paying on that subnet (#11369)`
-            : // ONLY ON A MEASURED WITHDRAWAL. This sentence names a cause and
-              // sends a reader to a specific subnet's operators, so it is
-              // gated on having actually counted same-hotkey stops rather
-              // than on being the last branch left.
-              findings.some((f) => f.kind === "announcements-withdrawn")
-              ? `announced axons collapsed: ${detail} -- miners that are still registered and ` +
-                `still earning stopped publishing an axon, so this is a reachability change ` +
-                `nothing else in the fleet reports (#11328)`
-              : // Turnover and unread mechanisms land here. The detail already
-                // says which, and neither is a withdrawal, so this states the
-                // drop and stops -- see the `mechanism-unknown` note on
-                // AxonFinding for why inventing the cause was worse.
-                `announced axons fell below baseline: ${detail} -- this reports the DROP only; ` +
-                `no miner was measured to have stopped announcing`,
+          : // ONLY ON A MEASURED WITHDRAWAL. This sentence names a cause and
+            // sends a reader to a specific subnet's operators, so it is gated
+            // on having actually counted same-hotkey stops rather than on
+            // being the last branch left.
+            findings.some((f) => f.kind === "announcements-withdrawn")
+            ? `announced axons collapsed: ${detail} -- miners that are still registered and ` +
+              `still earning stopped publishing an axon, so this is a reachability change ` +
+              `nothing else in the fleet reports (#11328)`
+            : // Turnover, unread mechanisms, and churn MIXED with either land
+              // here -- pure churn never reaches this call at all. The detail
+              // already says which, and none of them is a withdrawal, so this
+              // states the drop and stops.
+              `announced axons fell below baseline: ${detail} -- this reports the DROP only; ` +
+              `no miner was measured to have stopped announcing`,
       ),
       route: `watchdog:${AXON_ANNOUNCEMENT_LANE}`,
       errorCode: fleetWide
@@ -508,7 +528,11 @@ export async function runAxonAnnouncementWatchdog(
 
   return {
     ok: true,
-    alerted: findings.length > 0,
+    // WHETHER IT PAGED, which is no longer the same as whether it found
+    // something -- pure churn is recorded without an exception.
+    alerted: findings.length > 0 && !churnOnly,
+    flagged: findings.length > 0,
+    churn_only: churnOnly,
     fleet_wide: fleetWide,
     subnets_measured: bySubnet.size,
     findings,

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -877,7 +877,11 @@ describe("the tick reports the mechanism it measured", () => {
     return String(insert.values[3]);
   };
 
-  test("a churn subnet is reported as churn, not as withdrawal", async () => {
+  test("PURE CHURN records its verdict and does NOT page (#11386)", async () => {
+    // SN25's real shape. Churn means the announcing miners were deregistered
+    // and their UIDs reused by miners that never served -- nobody went dark and
+    // there is nobody to go looking for. Paging on it would have sent ~14
+    // Discord alerts over the week SN25's baseline took to decay.
     answer(rowsFor(25, then(flat(8, 80), [14, 256])), [
       { netuid: 25, via_reuse: 67, same_hotkey: 0 },
     ]);
@@ -888,15 +892,62 @@ describe("the tick reports the mechanism it measured", () => {
         captured = ev;
         return true;
       }) as never,
-    })) as { findings: AxonFinding[] };
+    })) as {
+      findings: AxonFinding[];
+      alerted: boolean;
+      flagged: boolean;
+      churn_only: boolean;
+    };
 
     assert.equal(result.findings[0].kind, "churn-replaced");
     assert.equal(result.findings[0].lossesViaReuse, 67);
+    assert.equal(captured, null, "pure churn must not raise an exception");
+    assert.equal(result.alerted, false);
+    // SUPPRESSING THE PAGE IS NOT SUPPRESSING THE FINDING. The durable record
+    // still carries it, with the mechanism spelled out.
+    assert.equal(result.flagged, true);
+    assert.equal(result.churn_only, true);
     assert.match(verdict(), /churn-replaced: 67 of 67/);
+  });
+
+  test("churn MIXED with a withdrawal still pages", async () => {
+    // `every` is the bar, so one non-churn finding restores the page. A real
+    // withdrawal must not be silenced by a churning neighbour on the same day.
+    answer(
+      [
+        ...rowsFor(25, then(flat(8, 80), [14, 256])),
+        ...rowsFor(101, then(flat(8, 223), [125, 256])),
+      ],
+      [
+        { netuid: 25, via_reuse: 67, same_hotkey: 0 },
+        { netuid: 101, via_reuse: 64, same_hotkey: 75 },
+      ],
+    );
+    let captured: Record<string, unknown> | null = null;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    })) as {
+      alerted: boolean;
+      churn_only: boolean;
+      findings: AxonFinding[];
+    };
+
+    // Pin the MIX, or this passes on a single withdrawal finding and says
+    // nothing about churn failing to silence it.
+    assert.equal(result.findings.length, 2);
+    assert.deepEqual([...result.findings].map((f) => f.kind).sort(), [
+      "announcements-withdrawn",
+      "churn-replaced",
+    ]);
+    assert.equal(result.churn_only, false);
+    assert.equal(result.alerted, true);
     assert.match(
       String((captured as unknown as { error: Error }).error.message),
-      /fell through CHURN, not withdrawal/,
-      "the message must not claim anyone went dark",
+      /stopped publishing an axon/,
     );
   });
 


### PR DESCRIPTION
## Why

`churn-replaced` means the announcing miners were deregistered and their UIDs reused by miners that never served. Nobody went dark; there is nobody to go looking for. The lane paged Discord on it twice a day — SN25 alone would have sent ~14 alerts over the week its baseline takes to decay below the floor.

Not a marginal call. Measured across the network, restricted to subnets with ≥3 miners earning incentive:

| | subnets |
| --- | --- |
| with ≥3 earning miners | 66 |
| **where NOT ONE earner announces an axon** | **32 (48%)** |

Announcing is decoupled from earning on roughly half the network, and only ~21% of registered neurons announce a routable axon at all. **Churn is the norm.**

## What still pages

`every` is the bar, so one non-churn finding restores it:

- `announcements-withdrawn` — the #11328 shape, somebody's miners went dark
- fleet-wide — read as our capture failing, not as subnets going dark
- `mechanism-unknown` — an unread cause is not an all-clear (#11381)
- **any mixed set** containing a withdrawal

That last one has its own test, and it pins *both* kinds rather than asserting on a set that could have held a single withdrawal — otherwise it would pass without testing the mix at all.

## Suppressing the page is not suppressing the finding

The verdict is still written, so it stays on `/self-health` and in history with the mechanism and counts inline (#11385). `lane_health` is the durable record by design (#9330/#9340); PostHog was never it.

`alerted` now means **whether it paged**, which is no longer the same as whether it found something. `flagged` and `churn_only` carry the rest.

Also drops the churn wording from the exception ternary — it has no remaining caller.

## Verification

81 tests pass; **100% statement, branch, function and line coverage** on the watchdog.
`tsc`, prettier, eslint, and `validate:{unreferenced-exports,lane-topology,boundary-casts}` clean.

Closes #11386