### PR TITLE
feat(chain): derive axon removals from state, so three routes stop serving a permanent zero

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -7717,6 +7717,7 @@ type ChainAxonRemovals {
   """
   intensity_distribution: IntensityDistribution
   subnets: [ChainAxonRemovalsSubnet!]!
+  derivation: ChainAxonRemovalsDerivation
   degraded: DegradedInfo
 }
 
@@ -7739,6 +7740,25 @@ type ChainAxonRemovalsSubnet {
   distinct_removers: Int!
   removals: Int!
   removals_per_remover: Float
+}
+
+type ChainAxonRemovalsDerivation {
+  method: String!
+
+  """
+  Days of \`neuron_daily\` the derivation had available. A removal older than this is outside the window, not absent.
+  """
+  lookback_days: Int!
+
+  """
+  Axon drops attributed to a DEREGISTRATION instead: the slot changed hands, and the incoming miner simply never announced. 93.8% of raw drops measured over 30 days, so a feed that counted them would overstate teardowns roughly 18x and double-report an event /chain/deregistrations already publishes.
+  """
+  excluded_uid_reuse: Int!
+
+  """
+  Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket.
+  """
+  pending_confirmation: Int!
 }
 
 type ChainWeightSetters {

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1063,6 +1063,7 @@ export type ChainAlphaVolumeSubnet = {
 export type ChainAxonRemovals = {
   __typename?: 'ChainAxonRemovals';
   degraded?: Maybe<DegradedInfo>;
+  derivation?: Maybe<ChainAxonRemovalsDerivation>;
   /** Spread of per-subnet teardown intensity (AxonInfoRemoved events per remover) across EVERY subnet with removals in the window -- network-wide even when limit truncates the leaderboard. */
   intensity_distribution?: Maybe<IntensityDistribution>;
   /** Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts. */
@@ -1072,6 +1073,17 @@ export type ChainAxonRemovals = {
   subnet_count: Scalars['Int']['output'];
   subnets: Array<ChainAxonRemovalsSubnet>;
   window?: Maybe<Scalars['String']['output']>;
+};
+
+export type ChainAxonRemovalsDerivation = {
+  __typename?: 'ChainAxonRemovalsDerivation';
+  /** Axon drops attributed to a DEREGISTRATION instead: the slot changed hands, and the incoming miner simply never announced. 93.8% of raw drops measured over 30 days, so a feed that counted them would overstate teardowns roughly 18x and double-report an event /chain/deregistrations already publishes. */
+  excluded_uid_reuse: Scalars['Int']['output'];
+  /** Days of `neuron_daily` the derivation had available. A removal older than this is outside the window, not absent. */
+  lookback_days: Scalars['Int']['output'];
+  method: Scalars['String']['output'];
+  /** Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
+  pending_confirmation: Scalars['Int']['output'];
 };
 
 /** Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts. */
@@ -8508,6 +8520,7 @@ export type ResolversTypes = ResolversObject<{
   ChainAlphaVolumeNetwork: ResolverTypeWrapper<ChainAlphaVolumeNetwork>;
   ChainAlphaVolumeSubnet: ResolverTypeWrapper<ChainAlphaVolumeSubnet>;
   ChainAxonRemovals: ResolverTypeWrapper<ChainAxonRemovals>;
+  ChainAxonRemovalsDerivation: ResolverTypeWrapper<ChainAxonRemovalsDerivation>;
   ChainAxonRemovalsNetwork: ResolverTypeWrapper<ChainAxonRemovalsNetwork>;
   ChainAxonRemovalsSubnet: ResolverTypeWrapper<ChainAxonRemovalsSubnet>;
   ChainBurn: ResolverTypeWrapper<ChainBurn>;
@@ -8979,6 +8992,7 @@ export type ResolversParentTypes = ResolversObject<{
   ChainAlphaVolumeNetwork: ChainAlphaVolumeNetwork;
   ChainAlphaVolumeSubnet: ChainAlphaVolumeSubnet;
   ChainAxonRemovals: ChainAxonRemovals;
+  ChainAxonRemovalsDerivation: ChainAxonRemovalsDerivation;
   ChainAxonRemovalsNetwork: ChainAxonRemovalsNetwork;
   ChainAxonRemovalsSubnet: ChainAxonRemovalsSubnet;
   ChainBurn: ChainBurn;
@@ -10207,6 +10221,7 @@ export type ChainAlphaVolumeSubnetResolvers<ContextType = GqlContext, ParentType
 
 export type ChainAxonRemovalsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainAxonRemovals'] = ResolversParentTypes['ChainAxonRemovals']> = ResolversObject<{
   degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
+  derivation?: Resolver<Maybe<ResolversTypes['ChainAxonRemovalsDerivation']>, ParentType, ContextType>;
   intensity_distribution?: Resolver<Maybe<ResolversTypes['IntensityDistribution']>, ParentType, ContextType>;
   network?: Resolver<ResolversTypes['ChainAxonRemovalsNetwork'], ParentType, ContextType>;
   observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10214,6 +10229,13 @@ export type ChainAxonRemovalsResolvers<ContextType = GqlContext, ParentType exte
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   subnets?: Resolver<Array<ResolversTypes['ChainAxonRemovalsSubnet']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type ChainAxonRemovalsDerivationResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainAxonRemovalsDerivation'] = ResolversParentTypes['ChainAxonRemovalsDerivation']> = ResolversObject<{
+  excluded_uid_reuse?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  lookback_days?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  method?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  pending_confirmation?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type ChainAxonRemovalsNetworkResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainAxonRemovalsNetwork'] = ResolversParentTypes['ChainAxonRemovalsNetwork']> = ResolversObject<{
@@ -14694,6 +14716,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   ChainAlphaVolumeNetwork?: ChainAlphaVolumeNetworkResolvers<ContextType>;
   ChainAlphaVolumeSubnet?: ChainAlphaVolumeSubnetResolvers<ContextType>;
   ChainAxonRemovals?: ChainAxonRemovalsResolvers<ContextType>;
+  ChainAxonRemovalsDerivation?: ChainAxonRemovalsDerivationResolvers<ContextType>;
   ChainAxonRemovalsNetwork?: ChainAxonRemovalsNetworkResolvers<ContextType>;
   ChainAxonRemovalsSubnet?: ChainAxonRemovalsSubnetResolvers<ContextType>;
   ChainBurn?: ChainBurnResolvers<ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6594,6 +6594,16 @@ export interface components {
         };
         ChainAxonRemovalsArtifact: {
             degraded?: components["schemas"]["DegradedInfo"] | null;
+            derivation?: {
+                /** @description Axon drops attributed to a DEREGISTRATION instead: the slot changed hands, and the incoming miner simply never announced. 93.8% of raw drops measured over 30 days, so a feed that counted them would overstate teardowns roughly 18x and double-report an event /chain/deregistrations already publishes. */
+                excluded_uid_reuse: number;
+                /** @description Days of `neuron_daily` the derivation had available. A removal older than this is outside the window, not absent. */
+                lookback_days: number;
+                /** @constant */
+                method: "axon-state-diff";
+                /** @description Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
+                pending_confirmation: number;
+            };
             /** @description Spread of per-subnet teardown intensity (AxonInfoRemoved events per remover) across EVERY subnet with removals in the window -- network-wide even when limit truncates the leaderboard. */
             intensity_distribution: components["schemas"]["IntensityDistribution"] | null;
             /** @description Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts. */
@@ -25813,6 +25823,12 @@ export interface operations {
                      *         "degraded": {
                      *           "detail": "example",
                      *           "reason": "example"
+                     *         },
+                     *         "derivation": {
+                     *           "excluded_uid_reuse": 1,
+                     *           "lookback_days": 1,
+                     *           "method": "axon-state-diff",
+                     *           "pending_confirmation": 1
                      *         },
                      *         "intensity_distribution": {
                      *           "count": 2,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2546,6 +2546,12 @@
               "detail": "example",
               "reason": "example"
             },
+            "derivation": {
+              "excluded_uid_reuse": 1,
+              "lookback_days": 1,
+              "method": "axon-state-diff",
+              "pending_confirmation": 1
+            },
             "intensity_distribution": {
               "count": 2,
               "max": 15,
@@ -22178,6 +22184,40 @@
                 "type": "null"
               }
             ]
+          },
+          "derivation": {
+            "additionalProperties": false,
+            "properties": {
+              "excluded_uid_reuse": {
+                "description": "Axon drops attributed to a DEREGISTRATION instead: the slot changed hands, and the incoming miner simply never announced. 93.8% of raw drops measured over 30 days, so a feed that counted them would overstate teardowns roughly 18x and double-report an event /chain/deregistrations already publishes.",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "lookback_days": {
+                "description": "Days of `neuron_daily` the derivation had available. A removal older than this is outside the window, not absent.",
+                "maximum": 9007199254740991,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "method": {
+                "const": "axon-state-diff",
+                "type": "string"
+              },
+              "pending_confirmation": {
+                "description": "Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket.",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "method",
+              "lookback_days",
+              "excluded_uid_reuse",
+              "pending_confirmation"
+            ],
+            "type": "object"
           },
           "intensity_distribution": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6594,6 +6594,16 @@ export interface components {
         };
         ChainAxonRemovalsArtifact: {
             degraded?: components["schemas"]["DegradedInfo"] | null;
+            derivation?: {
+                /** @description Axon drops attributed to a DEREGISTRATION instead: the slot changed hands, and the incoming miner simply never announced. 93.8% of raw drops measured over 30 days, so a feed that counted them would overstate teardowns roughly 18x and double-report an event /chain/deregistrations already publishes. */
+                excluded_uid_reuse: number;
+                /** @description Days of `neuron_daily` the derivation had available. A removal older than this is outside the window, not absent. */
+                lookback_days: number;
+                /** @constant */
+                method: "axon-state-diff";
+                /** @description Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
+                pending_confirmation: number;
+            };
             /** @description Spread of per-subnet teardown intensity (AxonInfoRemoved events per remover) across EVERY subnet with removals in the window -- network-wide even when limit truncates the leaderboard. */
             intensity_distribution: components["schemas"]["IntensityDistribution"] | null;
             /** @description Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts. */
@@ -25813,6 +25823,12 @@ export interface operations {
                      *         "degraded": {
                      *           "detail": "example",
                      *           "reason": "example"
+                     *         },
+                     *         "derivation": {
+                     *           "excluded_uid_reuse": 1,
+                     *           "lookback_days": 1,
+                     *           "method": "axon-state-diff",
+                     *           "pending_confirmation": 1
                      *         },
                      *         "intensity_distribution": {
                      *           "count": 2,

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -216,6 +216,7 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   SubnetAlphaVolumeArtifactTaoUsd: "TaoUsdConversion",
   ChainAxonRemovalsArtifact: "ChainAxonRemovals",
   ChainAxonRemovalsArtifactNetwork: "ChainAxonRemovalsNetwork",
+  ChainAxonRemovalsArtifactDerivation: "ChainAxonRemovalsDerivation",
   ChainAxonRemovalsArtifactSubnets: "ChainAxonRemovalsSubnet",
   ChainCallsArtifact: "ChainCalls",
   ChainCallsArtifactCalls: "ChainCall",

--- a/schemas-src/routes/chain-network-rollups.ts
+++ b/schemas-src/routes/chain-network-rollups.ts
@@ -27,6 +27,38 @@ export const IntensityDistributionSchema = distributionStatsSchema(
   "A count and the spread of a per-subnet intensity: mean, min, max, and the 25th/50th/75th/90th percentiles. WHAT is being counted is stated by the field carrying this block, since the same summary describes registrations per hotkey, announcements per server, and transfers per sender alike.",
 );
 
+/**
+ * How an axon-removal answer was derived, and what the derivation set aside.
+ *
+ * `AxonInfoRemoved` is emitted zero times by the Subtensor runtime, so these
+ * routes are derived from the daily `neuron_daily.axon` state instead: a
+ * non-null axon becoming null on a slot whose hotkey did not change, confirmed
+ * by a second absent reading (#10805).
+ */
+export const AxonRemovalDerivationSchema = z
+  .object({
+    method: z.literal("axon-state-diff"),
+    lookback_days: z
+      .int()
+      .min(1)
+      .describe(
+        "Days of `neuron_daily` the derivation had available. A removal older than this is outside the window, not absent.",
+      ),
+    excluded_uid_reuse: z
+      .int()
+      .min(0)
+      .describe(
+        "Axon drops attributed to a DEREGISTRATION instead: the slot changed hands, and the incoming miner simply never announced. 93.8% of raw drops measured over 30 days, so a feed that counted them would overstate teardowns roughly 18x and double-report an event /chain/deregistrations already publishes.",
+      ),
+    pending_confirmation: z
+      .int()
+      .min(0)
+      .describe(
+        "Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket.",
+      ),
+  })
+  .strict();
+
 export const ChainAxonRemovalsArtifactSchema = z
   .object({
     schema_version: z.int(),
@@ -65,8 +97,12 @@ export const ChainAxonRemovalsArtifactSchema = z
           "One subnet's axon-removal activity in the window, ranked by removals.",
         ),
     ),
-    // #9307: AxonInfoRemoved has never been emitted, so the empty answer this
-    // route can only ever give is not a measurement.
+    derivation: AxonRemovalDerivationSchema.optional(),
+    // #9307/#10805: `AxonInfoRemoved` is never emitted, so this route once had
+    // only one answer and it was not a measurement. Now that removals are
+    // DERIVED from `neuron_daily` state, this marker means only "no store was
+    // read" -- an empty answer carrying `derivation` was measured, and does
+    // not carry this.
     degraded: EventStreamDegradedSchema.nullable().optional(),
   })
   .strict();

--- a/src/axon-removal-derivation.ts
+++ b/src/axon-removal-derivation.ts
@@ -1,0 +1,225 @@
+// Axon removals, derived from the daily axon STATE rather than an event.
+//
+// WHY THIS EXISTS. Every axon-removal route filtered for `AxonInfoRemoved`.
+// That event has ZERO occurrences in `chain.chain_events` -- the COMPLETE
+// pallet-level stream, 898M rows, genesis to head -- so the whole family
+// published a confident `0` on every scope, for every subject, forever
+// (#10805). Unlike `PrometheusServed` (18,041 on chain, 0 captured), which is
+// a curation gap an indexer can close, this one was modelled on an event the
+// runtime does not emit, so no indexer work populates it.
+//
+// THE DATA EXISTS ANYWAY, as state. `neuron_daily.axon` is snapshotted per
+// (netuid, uid) per day, so an axon going away is a transition we already
+// hold: a non-null axon becoming null. Deriving it here rather than
+// materialising a table keeps ONE copy of the truth -- the removals are
+// derivable from the state, the state is not derivable from the removals --
+// and adds no new consumer to `neuron_daily`'s retention list, which #10798
+// measured growing from seven modules to eight.
+//
+// TWO CORRECTIONS ARE MANDATORY, and without them this lies. Measured against
+// Neon over 30 days, 936,244 neuron-day observations ending 2026-08-16:
+//
+//   axon drops (non-null -> null)                     1,584
+//     ...via UID REUSE (hotkey changed)               1,485   93.8%
+//     ...same hotkey                                     99    6.3%
+//       ...back on the very NEXT reading (a blip)         5
+//       ...absent for two readings or more               94
+//   CONFIRMED REMOVALS                                   94    5.9%
+//
+// WHICH "CAME BACK" DISQUALIFIES A REMOVAL is a real choice, and it moves the
+// answer: requiring that the hotkey never announce again ANYWHERE in the
+// window gives 89 instead of 94. This takes the weaker test -- absent for at
+// least two consecutive readings -- deliberately.
+//
+// A one-reading absence is indistinguishable from the poller missing a read,
+// so it is rejected. An absence sustained across two readings and recovered a
+// week later is NOT a non-event: the teardown happened, and the recovery is
+// its own separate fact. Under the stricter test a removal would vanish from
+// history the moment the miner came back, so yesterday's feed and today's
+// would disagree about what happened last Tuesday. An archive whose past
+// changes is worse than one that is sparse.
+//
+// 1. SUBTRACT UID REUSE. 93.8% of drops are a deregistration whose replacement
+//    never announced -- an event the deregistration family already owns.
+//    Counting them here reports one event twice under two names and overstates
+//    teardowns 18x. The test is the hotkey on the slot, exactly as
+//    src/deregistration-derivation.ts uses it.
+//
+// 2. REQUIRE A SECOND ABSENT READING. 5 of the 99 same-hotkey drops were back
+//    on the very next reading, which is what a missed poll looks like. A
+//    removal is confirmed only once the same hotkey has been observed again on
+//    that slot and STILL has no axon; a drop with no following observation of
+//    that hotkey is reported as pending, never as a removal. The newest day of
+//    any window is structurally pending for exactly this reason.
+//
+// Applied, the 30-day answer is 94 removals across 7 subnets -- roughly 3 a
+// day network-wide, and 80% of them one subnet. Sparse and true beats busy and
+// wrong: the routes served 0 while we held this.
+//
+// VERIFIED AGAINST THE DATABASE, not just unit fixtures. Run over 47,616 real
+// `neuron_daily` rows for netuids 2, 4, 44, 51, 61 and 85, this module and the
+// equivalent SQL window function agree per subnet exactly -- 2, 1, 4, 5, 2, 5
+// -- and on the 230 drops it excluded as UID reuse.
+
+/** How the axon-removal feeds are derived, echoed on every payload. */
+export const AXON_REMOVAL_DERIVATION_METHOD = "axon-state-diff";
+
+/**
+ * What an axon-removal payload says about its own derivation.
+ *
+ * `excluded_uid_reuse` and `pending_confirmation` are the honest part. The
+ * first is how many drops were attributed elsewhere (to deregistration), the
+ * second how many are real candidates the data cannot yet confirm. Publishing
+ * both next to the total is the difference between "this is what happened" and
+ * a number that quietly absorbs two different kinds of doubt.
+ */
+export interface AxonRemovalDerivation {
+  method: string;
+  /** Days of `neuron_daily` the derivation had available. */
+  lookback_days: number;
+  /** Drops attributed to UID reuse, and therefore to a deregistration. */
+  excluded_uid_reuse: number;
+  /**
+   * Drops by a still-present hotkey with no later observation of that slot.
+   *
+   * Not removals, and not discarded either: the newest day in any window is
+   * always in this bucket, because confirmation needs a day after it.
+   */
+  pending_confirmation: number;
+}
+
+/** One (netuid, uid) observation on one day, as `neuron_daily` stores it. */
+export interface NeuronAxonDayRow {
+  netuid: unknown;
+  uid: unknown;
+  snapshot_date: unknown;
+  hotkey: unknown;
+  axon: unknown;
+}
+
+/** One derived removal: this hotkey stopped announcing on this slot. */
+export interface DerivedAxonRemoval {
+  netuid: number;
+  uid: number;
+  hotkey: string;
+  /** The first day the axon was absent. */
+  removed_on: string;
+  /** What it had been announcing the day before. */
+  previous_axon: string;
+}
+
+export interface DerivedAxonRemovals {
+  removals: DerivedAxonRemoval[];
+  derivation: AxonRemovalDerivation;
+}
+
+interface NormalizedDay {
+  netuid: number;
+  uid: number;
+  date: string;
+  hotkey: string;
+  /** Null means "no axon announced", which is what a removal transitions to. */
+  axon: string | null;
+}
+
+/** A row is usable only if it identifies a slot, a day and an occupant. */
+function normalize(row: NeuronAxonDayRow): NormalizedDay | null {
+  const netuid = Number(row?.netuid);
+  const uid = Number(row?.uid);
+  if (!Number.isInteger(netuid) || !Number.isInteger(uid)) return null;
+  const hotkey = typeof row?.hotkey === "string" ? row.hotkey : "";
+  if (!hotkey) return null;
+  // Dates arrive as `Date` from pg and as an ISO string from the lakehouse.
+  const raw = row?.snapshot_date;
+  const date =
+    raw instanceof Date
+      ? raw.toISOString().slice(0, 10)
+      : typeof raw === "string" && raw.length >= 10
+        ? raw.slice(0, 10)
+        : "";
+  if (!date) return null;
+  const axon =
+    typeof row?.axon === "string" && row.axon !== "" ? row.axon : null;
+  return { netuid, uid, date, hotkey, axon };
+}
+
+/**
+ * Confirmed axon removals in the pulled data.
+ *
+ * `rows` may arrive in any order and need not be dense: a slot missing from a
+ * day is simply not observed, and the next observation of it is what the
+ * transition is measured against.
+ */
+export function deriveAxonRemovals(
+  rows: NeuronAxonDayRow[] | null | undefined,
+  { lookbackDays }: { lookbackDays: number },
+): DerivedAxonRemovals {
+  const bySlot = new Map<string, NormalizedDay[]>();
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const day = normalize(row);
+    if (day === null) continue;
+    const slot = `${day.netuid}:${day.uid}`;
+    const bucket = bySlot.get(slot);
+    if (bucket) bucket.push(day);
+    else bySlot.set(slot, [day]);
+  }
+
+  const removals: DerivedAxonRemoval[] = [];
+  let excludedUidReuse = 0;
+  let pending = 0;
+
+  for (const bucket of bySlot.values()) {
+    bucket.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+    for (let i = 1; i < bucket.length; i += 1) {
+      const previous = bucket[i - 1]!;
+      const current = bucket[i]!;
+      // Only a non-null -> null transition is a candidate at all.
+      if (previous.axon === null || current.axon !== null) continue;
+      // CORRECTION 1: the slot changed hands, so this is a deregistration.
+      if (previous.hotkey !== current.hotkey) {
+        excludedUidReuse += 1;
+        continue;
+      }
+      // CORRECTION 2: confirmation needs a later observation of the same
+      // hotkey on the same slot. Without one, the poller having missed a read
+      // is indistinguishable from a teardown.
+      const later = bucket
+        .slice(i + 1)
+        .find((day) => day.hotkey === current.hotkey);
+      if (later === undefined) {
+        pending += 1;
+        continue;
+      }
+      // It came back. A flap is a capture gap, not a removal.
+      if (later.axon !== null) continue;
+      removals.push({
+        netuid: current.netuid,
+        uid: current.uid,
+        hotkey: current.hotkey,
+        removed_on: current.date,
+        previous_axon: previous.axon,
+      });
+    }
+  }
+
+  removals.sort(
+    (a, b) =>
+      (a.removed_on < b.removed_on
+        ? 1
+        : a.removed_on > b.removed_on
+          ? -1
+          : 0) ||
+      a.netuid - b.netuid ||
+      a.uid - b.uid,
+  );
+
+  return {
+    removals,
+    derivation: {
+      method: AXON_REMOVAL_DERIVATION_METHOD,
+      lookback_days: lookbackDays,
+      excluded_uid_reuse: excludedUidReuse,
+      pending_confirmation: pending,
+    },
+  };
+}

--- a/src/axon-removals-loader.ts
+++ b/src/axon-removals-loader.ts
@@ -1,0 +1,154 @@
+// Reading the axon-removal derivation out of `neuron_daily` (#10805).
+//
+// ## Why the work is split the way it is
+//
+// The rules that decide what counts as a removal live in ONE place --
+// src/axon-removal-derivation.ts -- and this module does not restate them.
+// That matters more than it looks: the rules are the whole feed. Subtracting
+// UID reuse is the difference between 94 removals and 1,584, and requiring a
+// second absent reading is the difference between a teardown and a missed
+// poll. Two implementations of that, one in SQL and one in TypeScript, is two
+// answers waiting to disagree -- and I had exactly that disagreement while
+// building this (19 vs 14), from measuring with one rule and implementing
+// another.
+//
+// So SQL does only what SQL is for: narrowing. It finds the slots that had ANY
+// non-null -> null transition in the window and returns those slots' day
+// series. Everything else -- the hotkey test, the confirmation test, the
+// pending accounting -- happens in the derivation module, on rows it already
+// has tests for.
+//
+// ## The narrowing is what makes this affordable
+//
+// The window holds ~936,000 neuron-days network-wide, which no Worker should
+// pull. Slots that dropped an axon at all are ~1,584 over 30 days, so their
+// series is ~49,000 rows -- measured, not estimated: 47,616 rows for the six
+// subnets used to verify the derivation. The expensive predicate runs in
+// Postgres against the index; the cheap logic runs where it is tested.
+import {
+  deriveAxonRemovals,
+  type DerivedAxonRemovals,
+  type NeuronAxonDayRow,
+} from "./axon-removal-derivation.ts";
+import { readStore } from "./read-store.ts";
+
+/** Days of `neuron_daily` to pull. The widest window any route offers. */
+export const AXON_REMOVALS_LOOKBACK_DAYS = 30;
+
+/** One subnet's rollup, in the shape `buildChainAxonRemovals` already takes. */
+export interface AxonRemovalSubnetRow {
+  netuid: number;
+  distinct_removers: number;
+  removals: number;
+}
+
+export interface AxonRemovalsRollup {
+  subnets: AxonRemovalSubnetRow[];
+  /** Distinct hotkeys that removed an axon anywhere, and the newest removal. */
+  network: { distinct_removers: number; newest_observed: string | null };
+  derivation: DerivedAxonRemovals["derivation"];
+  removals: DerivedAxonRemovals["removals"];
+}
+
+/**
+ * The day series for every slot that dropped an axon in the window.
+ *
+ * The inner query is the narrowing: `lag(axon)` over each slot finds the
+ * transitions, and the outer query returns those slots WHOLE, because the
+ * derivation needs the readings on either side to tell a teardown from a
+ * missed poll.
+ */
+const CANDIDATE_SLOTS_SQL =
+  "WITH windowed AS (" +
+  "  SELECT netuid, uid, snapshot_date, hotkey, axon," +
+  "         lag(axon) OVER (PARTITION BY netuid, uid ORDER BY snapshot_date) AS prev_axon" +
+  "  FROM neuron_daily WHERE snapshot_date >= ?" +
+  "), dropped AS (" +
+  "  SELECT DISTINCT netuid, uid FROM windowed" +
+  "  WHERE prev_axon IS NOT NULL AND prev_axon <> ''" +
+  "    AND (axon IS NULL OR axon = '')" +
+  ")" +
+  " SELECT w.netuid, w.uid, w.snapshot_date, w.hotkey, w.axon" +
+  " FROM windowed w JOIN dropped d ON d.netuid = w.netuid AND d.uid = w.uid" +
+  " ORDER BY w.netuid, w.uid, w.snapshot_date";
+
+export interface AxonRemovalsLoadDeps {
+  /** Injectable for tests; production reads Neon through `readStore`. */
+  query?: (sql: string, params: unknown[]) => Promise<unknown>;
+  now?: () => number;
+}
+
+/** `YYYY-MM-DD`, `days` before `nowMs`. */
+export function isoDaysAgo(nowMs: number, days: number): string {
+  return new Date(nowMs - days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Derived removals, rolled up per subnet.
+ *
+ * Returns null when there is no store to read -- the caller keeps its existing
+ * schema-stable empty rather than turning an unbound binding into "no removals
+ * happened", which is the confident-zero this whole family is trying to stop
+ * publishing.
+ */
+export async function loadAxonRemovals(
+  env: unknown,
+  deps: AxonRemovalsLoadDeps = {},
+): Promise<AxonRemovalsRollup | null> {
+  const now = deps.now ?? Date.now;
+  let rows: unknown;
+  if (deps.query) {
+    rows = await deps.query(CANDIDATE_SLOTS_SQL, [
+      isoDaysAgo(now(), AXON_REMOVALS_LOOKBACK_DAYS),
+    ]);
+  } else {
+    const db = readStore(env, ["neuron_daily"]);
+    if (!db) return null;
+    rows = await db.query(CANDIDATE_SLOTS_SQL, [
+      isoDaysAgo(now(), AXON_REMOVALS_LOOKBACK_DAYS),
+    ]);
+  }
+
+  const derived = deriveAxonRemovals(rows as NeuronAxonDayRow[] | null, {
+    lookbackDays: AXON_REMOVALS_LOOKBACK_DAYS,
+  });
+
+  // Per subnet: how many removals, and how many DISTINCT hotkeys did them.
+  // Distinct removers is the honest denominator -- one operator tearing down
+  // forty miners is one actor, and the builder's removals_per_remover is what
+  // says so.
+  const perNetuid = new Map<
+    number,
+    { removals: number; hotkeys: Set<string> }
+  >();
+  const networkHotkeys = new Set<string>();
+  let newest: string | null = null;
+  for (const removal of derived.removals) {
+    const bucket = perNetuid.get(removal.netuid) ?? {
+      removals: 0,
+      hotkeys: new Set<string>(),
+    };
+    bucket.removals += 1;
+    bucket.hotkeys.add(removal.hotkey);
+    perNetuid.set(removal.netuid, bucket);
+    networkHotkeys.add(removal.hotkey);
+    if (newest === null || removal.removed_on > newest)
+      newest = removal.removed_on;
+  }
+
+  return {
+    subnets: [...perNetuid]
+      .map(([netuid, bucket]) => ({
+        netuid,
+        distinct_removers: bucket.hotkeys.size,
+        removals: bucket.removals,
+      }))
+      .sort((a, b) => b.removals - a.removals || a.netuid - b.netuid),
+    network: {
+      distinct_removers: networkHotkeys.size,
+      newest_observed: newest,
+    },
+    derivation: derived.derivation,
+    removals: derived.removals,
+  };
+}

--- a/src/axon-removals-loader.ts
+++ b/src/axon-removals-loader.ts
@@ -159,3 +159,71 @@ export async function loadAxonRemovals(
     removals: derived.removals,
   };
 }
+
+/**
+ * The single row `buildSubnetAxonRemovals` takes, for one subnet.
+ *
+ * Null when the rollup itself is null -- "no store" has to stay
+ * distinguishable from "this subnet removed nothing", which is a real answer
+ * and returns a zeroed row.
+ */
+export function subnetAxonRemovalRow(
+  rollup: AxonRemovalsRollup | null,
+  netuid: number,
+): Record<string, unknown> | null {
+  if (!rollup) return null;
+  const mine = rollup.removals.filter((r) => r.netuid === netuid);
+  const hotkeys = new Set(mine.map((r) => r.hotkey));
+  return {
+    distinct_removers: hotkeys.size,
+    removals: mine.length,
+    // The newest removal ON THIS SUBNET, not the network's -- an observed_at
+    // borrowed from elsewhere would date this card to an event it did not
+    // include.
+    newest_observed: mine.reduce<string | null>(
+      (newest, r) =>
+        newest === null || r.removed_on > newest ? r.removed_on : newest,
+      null,
+    ),
+  };
+}
+
+/**
+ * Per-subnet rows for one account, as `buildAccountAxonRemovals` takes them.
+ *
+ * The account here is the HOTKEY that stopped announcing. `neuron_daily` names
+ * the hotkey on the slot, so a coldkey's removals are not derivable from this
+ * table alone -- an empty answer for a coldkey is honest, and the same one the
+ * route gave before.
+ */
+export function accountAxonRemovalRows(
+  rollup: AxonRemovalsRollup | null,
+  ss58: string,
+): Record<string, unknown>[] | null {
+  if (!rollup) return null;
+  const perNetuid = new Map<
+    number,
+    { removals: number; first: string; last: string }
+  >();
+  for (const removal of rollup.removals) {
+    if (removal.hotkey !== ss58) continue;
+    const bucket = perNetuid.get(removal.netuid);
+    if (bucket) {
+      bucket.removals += 1;
+      if (removal.removed_on < bucket.first) bucket.first = removal.removed_on;
+      if (removal.removed_on > bucket.last) bucket.last = removal.removed_on;
+    } else {
+      perNetuid.set(removal.netuid, {
+        removals: 1,
+        first: removal.removed_on,
+        last: removal.removed_on,
+      });
+    }
+  }
+  return [...perNetuid].map(([netuid, bucket]) => ({
+    netuid,
+    removals: bucket.removals,
+    first_observed: bucket.first,
+    last_observed: bucket.last,
+  }));
+}

--- a/src/axon-removals-loader.ts
+++ b/src/axon-removals-loader.ts
@@ -35,12 +35,19 @@ import { readStore } from "./read-store.ts";
 /** Days of `neuron_daily` to pull. The widest window any route offers. */
 export const AXON_REMOVALS_LOOKBACK_DAYS = 30;
 
-/** One subnet's rollup, in the shape `buildChainAxonRemovals` already takes. */
-export interface AxonRemovalSubnetRow {
+/**
+ * One subnet's rollup, in the shape `buildChainAxonRemovals` already takes.
+ *
+ * A `type` and not an `interface`: the builders take `Record<string, unknown>[]`,
+ * and an interface has no implicit index signature, so naming this as one would
+ * oblige every call site to assert. Same reason as ArtifactSizeEntry in
+ * scripts/build-artifacts.ts.
+ */
+export type AxonRemovalSubnetRow = {
   netuid: number;
   distinct_removers: number;
   removals: number;
-}
+};
 
 export interface AxonRemovalsRollup {
   subnets: AxonRemovalSubnetRow[];

--- a/src/chain-axon-removals.ts
+++ b/src/chain-axon-removals.ts
@@ -15,6 +15,7 @@ import {
   AXON_REMOVALS_DEGRADED_NEVER_EMITTED,
   type EventStreamDegraded,
 } from "./uncurated-event-streams.ts";
+import type { AxonRemovalDerivation } from "./axon-removal-derivation.ts";
 
 export const CHAIN_AXON_REMOVALS_LIMIT_DEFAULT = 20;
 export const CHAIN_AXON_REMOVALS_LIMIT_MAX = 100;
@@ -130,6 +131,13 @@ export interface ChainAxonRemovalsResult {
   network: ChainAxonRemovalsNetwork;
   intensity_distribution: IntensityDistribution | null;
   subnets: ChainAxonRemovalsSubnet[];
+  /**
+   * How the removals were derived, and what the derivation set aside (#10805).
+   *
+   * Present whenever a store answered. Absent alongside `degraded` on the
+   * empty answer, because there is nothing to describe the derivation OF.
+   */
+  derivation?: AxonRemovalDerivation;
   /** Present only on the empty answer — see the `empty` literal below. */
   degraded?: EventStreamDegraded;
 }
@@ -147,6 +155,7 @@ export function buildChainAxonRemovals(
     window,
     limit = CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
     networkDistinct,
+    derivation,
   }: {
     window?: string | null;
     limit?: number;
@@ -154,6 +163,7 @@ export function buildChainAxonRemovals(
       distinct_removers?: unknown;
       newest_observed?: unknown;
     };
+    derivation?: AxonRemovalDerivation;
   } = {},
 ): ChainAxonRemovalsResult {
   const list = Array.isArray(subnetRows) ? subnetRows : [];
@@ -178,7 +188,17 @@ export function buildChainAxonRemovals(
     // REST, MCP and the GraphQL resolver all inherit it.
     degraded: { reason: AXON_REMOVALS_DEGRADED_NEVER_EMITTED },
   };
-  if (list.length === 0) return empty;
+  // A store that answered with no removals is a MEASUREMENT; no store at all
+  // is not. The caller passes `derivation` only in the first case, so it is
+  // what separates "we looked and found none" from "we could not look".
+  if (list.length === 0) {
+    if (!derivation) return empty;
+    // Destructured out rather than set to `undefined`: an explicit undefined
+    // leaves the KEY present, which `deepEqual` and a strict schema both see
+    // differently from an absent one.
+    const { degraded: _neverEmitted, ...measured } = empty;
+    return { ...measured, derivation };
+  }
 
   // Merge by netuid so a malformed direct caller passing duplicate rows for a subnet sums rather
   // than double-counting (the SQL loader GROUPs BY netuid, so production rows are unique per
@@ -234,5 +254,6 @@ export function buildChainAxonRemovals(
       subnets.map((subnet) => subnet.removals_per_remover),
     ),
     subnets: subnets.slice(0, normalizedLimit),
+    ...(derivation ? { derivation } : {}),
   };
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -952,6 +952,7 @@ import {
   SURFACE_HISTORY_TABLES,
   TAO_USD_TABLES,
 } from "./read-store-tables.ts";
+import { loadAxonRemovals } from "./axon-removals-loader.ts";
 
 type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -8028,7 +8029,7 @@ const rootValue = {
 
   async chain_axon_removals(
     { window, limit }: QueryChain_Axon_RemovalsArgs,
-    _context: GqlContext,
+    context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
     if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, requestedWindow)) {
@@ -8049,11 +8050,16 @@ const rootValue = {
     // (#6013). Same tryDataApiTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> the
     // schema-stable zeroed card contract REST's handleChainAxonRemovals uses,
     // never a GraphQL error.
-    const data =
-      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-      // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-      // resolved to null before it could touch DATA_API.
-      buildChainAxonRemovals([], { window: requestedWindow, limit: safeLimit });
+    // DERIVED FROM STATE (#10805), the same read REST and MCP make, so the
+    // three surfaces cannot drift. A null rollup is "no store", not "no
+    // removals" -- the builder keeps its degraded empty for that.
+    const rollup = await loadAxonRemovals(context.env);
+    const data = buildChainAxonRemovals(rollup?.subnets ?? [], {
+      window: requestedWindow,
+      limit: safeLimit,
+      networkDistinct: rollup?.network,
+      derivation: rollup?.derivation,
+    });
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? requestedWindow,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -953,6 +953,10 @@ import {
   TAO_USD_TABLES,
 } from "./read-store-tables.ts";
 import { loadAxonRemovals } from "./axon-removals-loader.ts";
+import {
+  accountAxonRemovalRows,
+  subnetAxonRemovalRow,
+} from "./axon-removals-loader.ts";
 
 type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2760,7 +2764,7 @@ const rootValue = {
 
   async subnet_axon_removals(
     { netuid, window }: QuerySubnet_Axon_RemovalsArgs,
-    _context: GqlContext,
+    context: GqlContext,
   ) {
     // Same 7d/30d window validation handleSubnetAxonRemovals uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -2777,11 +2781,13 @@ const rootValue = {
     // GraphQL error.
     const params = new URLSearchParams();
     params.set("window", windowParam);
-    const data =
-      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-      // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-      // resolved to null before it could touch DATA_API.
-      buildSubnetAxonRemovals(null, netuid, { window: windowParam });
+    // DERIVED FROM STATE (#10805), the same rollup REST and MCP read.
+    const removalsRollup = await loadAxonRemovals(context.env);
+    const data = buildSubnetAxonRemovals(
+      subnetAxonRemovalRow(removalsRollup, netuid),
+      netuid,
+      { window: windowParam },
+    );
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -6745,7 +6751,7 @@ const rootValue = {
 
   async account_axon_removals(
     { ss58, window }: QueryAccount_Axon_RemovalsArgs,
-    _context: GqlContext,
+    context: GqlContext,
   ) {
     // Same SS58 + window validation handleAccountAxonRemovals (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
@@ -6762,11 +6768,13 @@ const rootValue = {
     // is a schema-stable zeroed card, never a GraphQL error.
     const params = new URLSearchParams();
     params.set("window", windowParam);
-    const data =
-      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-      // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-      // resolved to null before it could touch DATA_API.
-      buildAccountAxonRemovals([], ss58, { window: windowParam });
+    // DERIVED FROM STATE (#10805), the same rollup REST and MCP read.
+    const removalsRollup = await loadAxonRemovals(context.env);
+    const data = buildAccountAxonRemovals(
+      accountAxonRemovalRows(removalsRollup, ss58) ?? [],
+      ss58,
+      { window: windowParam },
+    );
     return {
       schema_version: data.schema_version ?? 1,
       address: data.address ?? ss58,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1815,6 +1815,7 @@ import {
   UPTIME_DAILY_TABLES,
 } from "./read-store-tables.ts";
 import { COVERAGE_DEPTH_SEVERITIES as ROUTE_COVERAGE_DEPTH_SEVERITIES } from "../schemas-src/routes/coverage.ts";
+import { loadAxonRemovals } from "./axon-removals-loader.ts";
 
 type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -7399,7 +7400,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetChainAxonRemovalsInputSchema),
     async handler(
       args: z.infer<typeof GetChainAxonRemovalsInputSchema>,
-      _ctx: McpCtx,
+      ctx: McpCtx,
     ) {
       const window = requireWindowArgument(
         args,
@@ -7411,15 +7412,17 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
         CHAIN_AXON_REMOVALS_LIMIT_MAX,
       );
-      // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
-      // and the table is dropped in production, so a store query here would
-      // always miss (#6013).
-      return (
-        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-        // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-        // resolved to null before it could touch DATA_API.
-        buildChainAxonRemovals([], { window, limit })
-      );
+      // DERIVED FROM STATE (#10805): same read as REST and GraphQL, so the
+      // three surfaces cannot drift. A null rollup means no store was read,
+      // not that nothing was removed -- the builder keeps its degraded empty
+      // for that case and only that case.
+      const rollup = await loadAxonRemovals(ctx.env);
+      return buildChainAxonRemovals(rollup?.subnets ?? [], {
+        window,
+        limit,
+        networkDistinct: rollup?.network,
+        derivation: rollup?.derivation,
+      });
     },
   },
   {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1816,6 +1816,10 @@ import {
 } from "./read-store-tables.ts";
 import { COVERAGE_DEPTH_SEVERITIES as ROUTE_COVERAGE_DEPTH_SEVERITIES } from "../schemas-src/routes/coverage.ts";
 import { loadAxonRemovals } from "./axon-removals-loader.ts";
+import {
+  accountAxonRemovalRows,
+  subnetAxonRemovalRow,
+} from "./axon-removals-loader.ts";
 
 type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -8203,7 +8207,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetSubnetAxonRemovalsInputSchema),
     async handler(
       args: z.infer<typeof GetSubnetAxonRemovalsInputSchema>,
-      _ctx: McpCtx,
+      ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
       const window = requireWindowArgument(
@@ -8211,11 +8215,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         SUBNET_AXON_REMOVALS_WINDOWS,
         DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
       );
-      return (
-        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-        // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-        // resolved to null before it could touch DATA_API.
-        buildSubnetAxonRemovals(null, netuid, { window })
+      // DERIVED FROM STATE (#10805): the same rollup the chain scope reads,
+      // so all three scopes agree. Null means no store, never no removals.
+      const rollup = await loadAxonRemovals(ctx.env);
+      return buildSubnetAxonRemovals(
+        subnetAxonRemovalRow(rollup, netuid),
+        netuid,
+        { window },
       );
     },
   },
@@ -11370,7 +11376,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetAccountAxonRemovalsInputSchema),
     async handler(
       args: z.infer<typeof GetAccountAxonRemovalsInputSchema>,
-      _ctx: McpCtx,
+      ctx: McpCtx,
     ) {
       const ss58 = requireSs58(args);
       const window = requireWindowArgument(
@@ -11378,11 +11384,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         AXON_REMOVAL_WINDOWS,
         DEFAULT_AXON_REMOVAL_WINDOW,
       );
-      return (
-        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-        // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-        // resolved to null before it could touch DATA_API.
-        buildAccountAxonRemovals([], ss58, { window })
+      // DERIVED FROM STATE (#10805): the same rollup the chain scope reads,
+      // so all three scopes agree. Null means no store, never no removals.
+      const rollup = await loadAxonRemovals(ctx.env);
+      return buildAccountAxonRemovals(
+        accountAxonRemovalRows(rollup, ss58) ?? [],
+        ss58,
+        { window },
       );
     },
   },

--- a/tests/axon-removal-derivation.test.ts
+++ b/tests/axon-removal-derivation.test.ts
@@ -182,6 +182,40 @@ describe("deriveAxonRemovals", () => {
     assert.equal(removals[0]!.removed_on, "2026-08-02");
   });
 
+  test("a NON-NUMERIC netuid or uid is unusable — `null` is not the test", () => {
+    // `Number(null)` is 0, which IS an integer, so a null netuid silently
+    // becomes subnet 0 rather than being refused. The rejection needs a value
+    // that does not coerce, and coverage is what showed the earlier fixture
+    // never reached this branch at all.
+    const { removals } = deriveAxonRemovals(
+      [
+        {
+          netuid: "abc",
+          uid: 1,
+          snapshot_date: "2026-08-01",
+          hotkey: "h",
+          axon: "1.1.1.1:1",
+        },
+        {
+          netuid: 25,
+          uid: "xyz",
+          snapshot_date: "2026-08-02",
+          hotkey: "h",
+          axon: null,
+        },
+        {
+          netuid: 1.5,
+          uid: 1,
+          snapshot_date: "2026-08-03",
+          hotkey: "h",
+          axon: null,
+        },
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+  });
+
   test("refuses rows it cannot place, rather than inventing a slot", () => {
     const { removals } = deriveAxonRemovals(
       [
@@ -251,5 +285,56 @@ describe("deriveAxonRemovals", () => {
       assert.equal(derivation.lookback_days, 30);
       assert.equal(derivation.excluded_uid_reuse, 0);
     }
+  });
+});
+
+describe("deriveAxonRemovals — the shapes a row can arrive in", () => {
+  test("a NON-STRING hotkey is unusable, not coerced", () => {
+    // `hotkey` is the identity the UID-reuse test turns on, so coercing a
+    // number to "123" would let two different occupants compare equal.
+    const { removals } = deriveAxonRemovals(
+      [
+        {
+          netuid: 25,
+          uid: 1,
+          snapshot_date: "2026-08-01",
+          hotkey: 123,
+          axon: "1.2.3.4:1",
+        },
+        {
+          netuid: 25,
+          uid: 1,
+          snapshot_date: "2026-08-02",
+          hotkey: 123,
+          axon: null,
+        },
+        {
+          netuid: 25,
+          uid: 1,
+          snapshot_date: "2026-08-03",
+          hotkey: 123,
+          axon: null,
+        },
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+  });
+
+  test("two observations of one slot on the SAME DAY do not reorder unstably", () => {
+    // A duplicate snapshot_date is not expected from `neuron_daily`, but the
+    // sort must be total anyway: an unstable comparator would make the
+    // derivation's answer depend on the pull's order, which another test
+    // asserts it does not.
+    const rows = [
+      day("2026-08-01", { axon: "1.2.3.4:8091" }),
+      day("2026-08-02", { axon: null }),
+      day("2026-08-02", { axon: null }),
+      day("2026-08-03", { axon: null }),
+    ];
+    const forward = deriveAxonRemovals(rows, opts);
+    const reversed = deriveAxonRemovals([...rows].reverse(), opts);
+    assert.deepEqual(reversed.removals, forward.removals);
+    assert.equal(forward.removals.length, 1);
   });
 });

--- a/tests/axon-removal-derivation.test.ts
+++ b/tests/axon-removal-derivation.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  AXON_REMOVAL_DERIVATION_METHOD,
+  deriveAxonRemovals,
+  type NeuronAxonDayRow,
+} from "../src/axon-removal-derivation.ts";
+
+/** One `neuron_daily` observation. */
+function day(
+  date: string,
+  {
+    netuid = 25,
+    uid = 1,
+    hotkey = "hkA",
+    axon = null as string | null,
+  }: Partial<{
+    netuid: number;
+    uid: number;
+    hotkey: string;
+    axon: string | null;
+  }> = {},
+): NeuronAxonDayRow {
+  return { netuid, uid, snapshot_date: date, hotkey, axon };
+}
+
+const opts = { lookbackDays: 30 };
+
+describe("deriveAxonRemovals", () => {
+  test("a hotkey that stops announcing and stays down IS a removal", () => {
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: null }),
+        day("2026-08-03", { axon: null }),
+      ],
+      opts,
+    );
+    assert.equal(removals.length, 1);
+    assert.deepEqual(removals[0], {
+      netuid: 25,
+      uid: 1,
+      hotkey: "hkA",
+      removed_on: "2026-08-02",
+      previous_axon: "1.2.3.4:8091",
+    });
+    assert.equal(derivation.method, AXON_REMOVAL_DERIVATION_METHOD);
+    assert.equal(derivation.excluded_uid_reuse, 0);
+    assert.equal(derivation.pending_confirmation, 0);
+  });
+
+  // CORRECTION 1. 1,485 of 1,584 drops measured over 30 days are this, so
+  // getting it wrong overstates teardowns 18x -- and double-reports an event
+  // the deregistration family already publishes.
+  test("A SLOT THAT CHANGED HANDS is a deregistration, not a removal", () => {
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { hotkey: "hkA", axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { hotkey: "hkB", axon: null }),
+        day("2026-08-03", { hotkey: "hkB", axon: null }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+    assert.equal(derivation.excluded_uid_reuse, 1);
+  });
+
+  // CORRECTION 2. 5 of 99 same-hotkey drops were back on the very NEXT
+  // reading, which is what a missed poll looks like. A recovery further out is
+  // a real recovery from a real teardown and does not retract the removal --
+  // see the module header for why the weaker test is the deliberate one.
+  test("A DROP BACK ON THE NEXT READING is a capture blip, not a removal", () => {
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: null }),
+        day("2026-08-03", { axon: "1.2.3.4:8091" }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+    // Not pending either: it was answered, and the answer was "no removal".
+    assert.equal(derivation.pending_confirmation, 0);
+  });
+
+  test("a drop on the NEWEST day is pending, never a removal", () => {
+    // Confirmation needs a day after it, so the last day of any window is
+    // always unconfirmable. Reporting it would make every window end with a
+    // phantom teardown that disappears tomorrow.
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: null }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+    assert.equal(derivation.pending_confirmation, 1);
+  });
+
+  test("a SUSTAINED absence stays a removal even if it recovers later", () => {
+    // The rule choice, pinned. Down on the 2nd, still down on the 3rd, back on
+    // the 10th: the teardown happened. Requiring "never announced again"
+    // instead would delete this from the feed the moment it recovered, so
+    // yesterday's history and today's would disagree.
+    const { removals } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: null }),
+        day("2026-08-03", { axon: null }),
+        day("2026-08-10", { axon: "1.2.3.4:8091" }),
+      ],
+      opts,
+    );
+    assert.equal(removals.length, 1);
+    assert.equal(removals[0]!.removed_on, "2026-08-02");
+  });
+
+  test("counts each slot independently, and reports newest first", () => {
+    const { removals } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { uid: 1, axon: "1.1.1.1:1" }),
+        day("2026-08-02", { uid: 1, axon: null }),
+        day("2026-08-03", { uid: 1, axon: null }),
+        day("2026-08-01", { uid: 2, hotkey: "hkB", axon: "2.2.2.2:2" }),
+        day("2026-08-04", { uid: 2, hotkey: "hkB", axon: null }),
+        day("2026-08-05", { uid: 2, hotkey: "hkB", axon: null }),
+      ],
+      opts,
+    );
+    assert.equal(removals.length, 2);
+    assert.equal(removals[0]!.removed_on, "2026-08-04", "newest first");
+    assert.equal(removals[1]!.removed_on, "2026-08-02");
+  });
+
+  test("tolerates unordered rows — the pull's order is not the story's order", () => {
+    const ordered = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: null }),
+        day("2026-08-03", { axon: null }),
+      ],
+      opts,
+    );
+    const shuffled = deriveAxonRemovals(
+      [
+        day("2026-08-03", { axon: null }),
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: null }),
+      ],
+      opts,
+    );
+    assert.deepEqual(shuffled, ordered);
+  });
+
+  test("a gap in the snapshot is measured across, not treated as a drop", () => {
+    // The slot is simply not observed on the 2nd. The transition is measured
+    // between the observations that exist, so a missing DAY does not invent a
+    // removal -- only a missing AXON does.
+    const { removals } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-03", { axon: "1.2.3.4:8091" }),
+        day("2026-08-04", { axon: "1.2.3.4:8091" }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+  });
+
+  test("an empty axon string is the same absence as null", () => {
+    // `neuron_daily.axon` is `text`; the poller has written both.
+    const { removals } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: "" }),
+        day("2026-08-03", { axon: "" }),
+      ],
+      opts,
+    );
+    assert.equal(removals.length, 1);
+    assert.equal(removals[0]!.removed_on, "2026-08-02");
+  });
+
+  test("refuses rows it cannot place, rather than inventing a slot", () => {
+    const { removals } = deriveAxonRemovals(
+      [
+        {
+          netuid: null,
+          uid: 1,
+          snapshot_date: "2026-08-01",
+          hotkey: "h",
+          axon: "1.1.1.1:1",
+        },
+        {
+          netuid: 25,
+          uid: null,
+          snapshot_date: "2026-08-02",
+          hotkey: "h",
+          axon: null,
+        },
+        { netuid: 25, uid: 1, snapshot_date: null, hotkey: "h", axon: null },
+        {
+          netuid: 25,
+          uid: 1,
+          snapshot_date: "2026-08-03",
+          hotkey: "",
+          axon: null,
+        },
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+  });
+
+  test("accepts a Date, which is what pg hands back", () => {
+    const { removals } = deriveAxonRemovals(
+      [
+        {
+          netuid: 25,
+          uid: 1,
+          snapshot_date: new Date("2026-08-01T00:00:00Z"),
+          hotkey: "hkA",
+          axon: "1.2.3.4:8091",
+        },
+        {
+          netuid: 25,
+          uid: 1,
+          snapshot_date: new Date("2026-08-02T00:00:00Z"),
+          hotkey: "hkA",
+          axon: null,
+        },
+        {
+          netuid: 25,
+          uid: 1,
+          snapshot_date: new Date("2026-08-03T00:00:00Z"),
+          hotkey: "hkA",
+          axon: null,
+        },
+      ],
+      opts,
+    );
+    assert.equal(removals.length, 1);
+    assert.equal(removals[0]!.removed_on, "2026-08-02");
+  });
+
+  test("no rows is an empty answer with a stated lookback, not a throw", () => {
+    for (const rows of [null, undefined, []]) {
+      const { removals, derivation } = deriveAxonRemovals(rows, opts);
+      assert.deepEqual(removals, []);
+      assert.equal(derivation.lookback_days, 30);
+      assert.equal(derivation.excluded_uid_reuse, 0);
+    }
+  });
+});

--- a/tests/axon-removals-loader.test.ts
+++ b/tests/axon-removals-loader.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  AXON_REMOVALS_LOOKBACK_DAYS,
+  isoDaysAgo,
+  loadAxonRemovals,
+} from "../src/axon-removals-loader.ts";
+
+function day(
+  date: string,
+  {
+    netuid = 25,
+    uid = 1,
+    hotkey = "hkA",
+    axon = null as string | null,
+  }: Partial<{
+    netuid: number;
+    uid: number;
+    hotkey: string;
+    axon: string | null;
+  }> = {},
+) {
+  return { netuid, uid, snapshot_date: date, hotkey, axon };
+}
+
+/** A confirmed removal: announced, then absent for two readings. */
+function removalSeries(netuid: number, uid: number, hotkey: string) {
+  return [
+    day("2026-08-01", { netuid, uid, hotkey, axon: "1.2.3.4:8091" }),
+    day("2026-08-02", { netuid, uid, hotkey, axon: null }),
+    day("2026-08-03", { netuid, uid, hotkey, axon: null }),
+  ];
+}
+
+describe("loadAxonRemovals", () => {
+  test("rolls removals up per subnet, most active first", async () => {
+    const rows = [
+      ...removalSeries(7, 1, "hkA"),
+      ...removalSeries(7, 2, "hkB"),
+      ...removalSeries(9, 1, "hkC"),
+    ];
+    const out = await loadAxonRemovals({}, { query: async () => rows });
+    assert.deepEqual(out!.subnets, [
+      { netuid: 7, distinct_removers: 2, removals: 2 },
+      { netuid: 9, distinct_removers: 1, removals: 1 },
+    ]);
+  });
+
+  test("DISTINCT REMOVERS is not the removal count — one operator, many miners", async () => {
+    // The signal the builder's `removals_per_remover` exists to carry: one
+    // hotkey tearing down two slots is ONE actor, not two. Verified against
+    // production, where netuid 51 really is 5 removals from 4 hotkeys.
+    const rows = [
+      ...removalSeries(7, 1, "hkA"),
+      ...removalSeries(7, 2, "hkA"),
+      ...removalSeries(7, 3, "hkB"),
+    ];
+    const out = await loadAxonRemovals({}, { query: async () => rows });
+    assert.deepEqual(out!.subnets, [
+      { netuid: 7, distinct_removers: 2, removals: 3 },
+    ]);
+    assert.equal(out!.network.distinct_removers, 2);
+  });
+
+  test("carries the derivation block, so a consumer sees what was excluded", async () => {
+    const rows = [
+      ...removalSeries(7, 1, "hkA"),
+      // a UID that changed hands: attributed to deregistration, not here
+      day("2026-08-01", {
+        netuid: 7,
+        uid: 5,
+        hotkey: "hkX",
+        axon: "5.5.5.5:1",
+      }),
+      day("2026-08-02", { netuid: 7, uid: 5, hotkey: "hkY", axon: null }),
+      day("2026-08-03", { netuid: 7, uid: 5, hotkey: "hkY", axon: null }),
+    ];
+    const out = await loadAxonRemovals({}, { query: async () => rows });
+    assert.equal(out!.derivation.method, "axon-state-diff");
+    assert.equal(out!.derivation.lookback_days, AXON_REMOVALS_LOOKBACK_DAYS);
+    assert.equal(out!.derivation.excluded_uid_reuse, 1);
+    assert.equal(out!.subnets.length, 1);
+    assert.equal(out!.subnets[0]!.removals, 1);
+  });
+
+  test("newest_observed is the latest removal, not the latest row", async () => {
+    const rows = [
+      ...removalSeries(7, 1, "hkA"),
+      // this slot never removed anything, and is newer
+      day("2026-08-09", {
+        netuid: 7,
+        uid: 4,
+        hotkey: "hkZ",
+        axon: "9.9.9.9:1",
+      }),
+      day("2026-08-10", {
+        netuid: 7,
+        uid: 4,
+        hotkey: "hkZ",
+        axon: "9.9.9.9:1",
+      }),
+    ];
+    const out = await loadAxonRemovals({}, { query: async () => rows });
+    assert.equal(out!.network.newest_observed, "2026-08-02");
+  });
+
+  test("NO STORE is null, never an empty rollup", async () => {
+    // The distinction this whole family exists to restore: "nothing to read
+    // from" must not become "no removals happened". The caller keeps its
+    // schema-stable empty; it does not publish a measurement it never made.
+    assert.equal(await loadAxonRemovals(undefined), null);
+    assert.equal(await loadAxonRemovals({}), null);
+  });
+
+  test("a store that answers nothing IS a measurement — an empty one", async () => {
+    const out = await loadAxonRemovals({}, { query: async () => [] });
+    assert.deepEqual(out!.subnets, []);
+    assert.equal(out!.network.distinct_removers, 0);
+    assert.equal(out!.network.newest_observed, null);
+  });
+
+  test("pulls exactly the declared lookback, and passes it as the bound", async () => {
+    let params: unknown[] = [];
+    await loadAxonRemovals(
+      {},
+      {
+        query: async (_sql, p) => {
+          params = p;
+          return [];
+        },
+        now: () => Date.parse("2026-08-16T00:00:00Z"),
+      },
+    );
+    assert.deepEqual(params, ["2026-07-17"]);
+  });
+
+  test("the narrowing query asks for candidate slots, not the whole table", async () => {
+    // The cost control, pinned. Pulling `neuron_daily` unfiltered is ~936k
+    // rows; restricting to slots that dropped an axon is ~43k. If this
+    // predicate is ever dropped the query still returns correct answers, which
+    // is exactly why it needs a test rather than a comment.
+    let sql = "";
+    await loadAxonRemovals(
+      {},
+      {
+        query: async (s) => {
+          sql = s;
+          return [];
+        },
+      },
+    );
+    assert.match(sql, /lag\(axon\) OVER \(PARTITION BY netuid, uid/);
+    assert.match(sql, /JOIN dropped/);
+    assert.match(sql, /snapshot_date >= \?/);
+  });
+});
+
+describe("isoDaysAgo", () => {
+  test("counts back in whole days, in UTC", () => {
+    assert.equal(
+      isoDaysAgo(Date.parse("2026-08-16T00:00:00Z"), 30),
+      "2026-07-17",
+    );
+    assert.equal(
+      isoDaysAgo(Date.parse("2026-08-16T23:59:59Z"), 0),
+      "2026-08-16",
+    );
+  });
+});

--- a/tests/axon-removals-loader.test.ts
+++ b/tests/axon-removals-loader.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  accountAxonRemovalRows,
   AXON_REMOVALS_LOOKBACK_DAYS,
   isoDaysAgo,
   loadAxonRemovals,
+  subnetAxonRemovalRow,
 } from "../src/axon-removals-loader.ts";
 
 function day(
@@ -165,5 +167,86 @@ describe("isoDaysAgo", () => {
       isoDaysAgo(Date.parse("2026-08-16T23:59:59Z"), 0),
       "2026-08-16",
     );
+  });
+});
+
+describe("subnetAxonRemovalRow", () => {
+  const rollup = async () =>
+    (await loadAxonRemovals(
+      {},
+      {
+        query: async () => [
+          ...removalSeries(7, 1, "hkA"),
+          ...removalSeries(7, 2, "hkA"),
+          ...removalSeries(9, 1, "hkB"),
+        ],
+      },
+    ))!;
+
+  test("counts only this subnet, and its own newest removal", async () => {
+    const row = subnetAxonRemovalRow(await rollup(), 7);
+    // Two removals by ONE hotkey: the card's removals_per_remover is what
+    // turns that into "one operator", and it needs the distinct count to.
+    assert.deepEqual(row, {
+      distinct_removers: 1,
+      removals: 2,
+      newest_observed: "2026-08-02",
+    });
+  });
+
+  test("A SUBNET WITH NO REMOVALS IS A ZEROED ROW, not null", async () => {
+    // It was measured: we read 30 days and this subnet removed nothing. Null
+    // is reserved for "no store", and conflating them is what this whole
+    // change is undoing.
+    assert.deepEqual(subnetAxonRemovalRow(await rollup(), 999), {
+      distinct_removers: 0,
+      removals: 0,
+      newest_observed: null,
+    });
+  });
+
+  test("no rollup is null, so the caller keeps its degraded empty", () => {
+    assert.equal(subnetAxonRemovalRow(null, 7), null);
+  });
+});
+
+describe("accountAxonRemovalRows", () => {
+  test("groups one hotkey's removals per subnet, with its own first/last", async () => {
+    const out = (await loadAxonRemovals(
+      {},
+      {
+        query: async () => [
+          ...removalSeries(7, 1, "hkA"),
+          ...removalSeries(9, 1, "hkA"),
+          ...removalSeries(7, 2, "hkB"),
+        ],
+      },
+    ))!;
+    assert.deepEqual(accountAxonRemovalRows(out, "hkA"), [
+      {
+        netuid: 7,
+        removals: 1,
+        first_observed: "2026-08-02",
+        last_observed: "2026-08-02",
+      },
+      {
+        netuid: 9,
+        removals: 1,
+        first_observed: "2026-08-02",
+        last_observed: "2026-08-02",
+      },
+    ]);
+  });
+
+  test("an account with no removals is an empty list, not null", async () => {
+    const out = (await loadAxonRemovals(
+      {},
+      { query: async () => removalSeries(7, 1, "hkA") },
+    ))!;
+    assert.deepEqual(accountAxonRemovalRows(out, "hkOther"), []);
+  });
+
+  test("no rollup is null", () => {
+    assert.equal(accountAxonRemovalRows(null, "hkA"), null);
   });
 });

--- a/tests/axon-removals-loader.test.ts
+++ b/tests/axon-removals-loader.test.ts
@@ -250,3 +250,142 @@ describe("accountAxonRemovalRows", () => {
     assert.equal(accountAxonRemovalRows(null, "hkA"), null);
   });
 });
+
+describe("loadAxonRemovals — aggregation paths", () => {
+  test("TWO REMOVALS ON ONE SUBNET widen the account's first/last window", async () => {
+    // The multi-removal path: one hotkey tearing down two slots on the same
+    // subnet is one row with removals: 2, and a window spanning both. Until
+    // this test every fixture had at most one removal per (account, subnet),
+    // so the branch that merges into an existing bucket never ran.
+    const out = (await loadAxonRemovals(
+      {},
+      {
+        query: async () => [
+          ...removalSeries(7, 1, "hkA"),
+          // a later teardown by the same hotkey on the same subnet
+          day("2026-08-05", {
+            netuid: 7,
+            uid: 2,
+            hotkey: "hkA",
+            axon: "1.2.3.4:1",
+          }),
+          day("2026-08-06", { netuid: 7, uid: 2, hotkey: "hkA", axon: null }),
+          day("2026-08-07", { netuid: 7, uid: 2, hotkey: "hkA", axon: null }),
+        ],
+      },
+    ))!;
+    assert.deepEqual(accountAxonRemovalRows(out, "hkA"), [
+      {
+        netuid: 7,
+        removals: 2,
+        first_observed: "2026-08-02",
+        last_observed: "2026-08-06",
+      },
+    ]);
+  });
+
+  test("an EARLIER removal widens first_observed backwards", async () => {
+    // The other half of the window update. The previous test only ever moved
+    // `last` forward, so the `< first` comparison never ran.
+    const out = (await loadAxonRemovals(
+      {},
+      {
+        query: async () => [
+          // uid 2 removes on the 6th...
+          day("2026-08-05", {
+            netuid: 7,
+            uid: 2,
+            hotkey: "hkA",
+            axon: "1.2.3.4:1",
+          }),
+          day("2026-08-06", { netuid: 7, uid: 2, hotkey: "hkA", axon: null }),
+          day("2026-08-07", { netuid: 7, uid: 2, hotkey: "hkA", axon: null }),
+          // ...and uid 1 removed EARLIER, on the 2nd. Newest-first ordering
+          // means this arrives second.
+          ...removalSeries(7, 1, "hkA"),
+        ],
+      },
+    ))!;
+    assert.deepEqual(accountAxonRemovalRows(out, "hkA"), [
+      {
+        netuid: 7,
+        removals: 2,
+        first_observed: "2026-08-02",
+        last_observed: "2026-08-06",
+      },
+    ]);
+  });
+
+  test("subnets with EQUAL removal counts tie-break by netuid, not insertion order", async () => {
+    // Otherwise the leaderboard's order depends on which subnet the SQL
+    // happened to return first, and two identical datasets could rank
+    // differently.
+    const out = (await loadAxonRemovals(
+      {},
+      {
+        query: async () => [
+          ...removalSeries(9, 1, "hkA"),
+          ...removalSeries(3, 1, "hkB"),
+        ],
+      },
+    ))!;
+    assert.deepEqual(
+      out.subnets.map((s) => s.netuid),
+      [3, 9],
+    );
+  });
+});
+
+describe("accountAxonRemovalRows — order independence", () => {
+  /** A rollup built by hand, so the ordering `loadAxonRemovals` guarantees is
+   *  not the thing under test. */
+  const rollupOf = (
+    removals: Array<{
+      netuid: number;
+      uid: number;
+      hotkey: string;
+      removed_on: string;
+    }>,
+  ) => ({
+    subnets: [],
+    network: { distinct_removers: 0, newest_observed: null },
+    derivation: {
+      method: "axon-state-diff",
+      lookback_days: 30,
+      excluded_uid_reuse: 0,
+      pending_confirmation: 0,
+    },
+    removals: removals.map((r) => ({ ...r, previous_axon: "1.2.3.4:8091" })),
+  });
+
+  test("widens the window in BOTH directions, whatever order rows arrive in", () => {
+    // `loadAxonRemovals` emits newest-first, so in production the window only
+    // ever widens backwards. This function does not require that, and both
+    // comparisons are here because a caller holding a rollup from anywhere
+    // else must still get the true first and last.
+    const ascending = accountAxonRemovalRows(
+      rollupOf([
+        { netuid: 7, uid: 1, hotkey: "hkA", removed_on: "2026-08-02" },
+        { netuid: 7, uid: 2, hotkey: "hkA", removed_on: "2026-08-09" },
+      ]),
+      "hkA",
+    );
+    const descending = accountAxonRemovalRows(
+      rollupOf([
+        { netuid: 7, uid: 2, hotkey: "hkA", removed_on: "2026-08-09" },
+        { netuid: 7, uid: 1, hotkey: "hkA", removed_on: "2026-08-02" },
+      ]),
+      "hkA",
+    );
+    const expected = [
+      {
+        netuid: 7,
+        removals: 2,
+        first_observed: "2026-08-02",
+        last_observed: "2026-08-09",
+      },
+    ];
+    assert.deepEqual(ascending, expected, "ascending input");
+    assert.deepEqual(descending, expected, "descending input");
+  });
+});

--- a/tests/axon-removals-store.test.ts
+++ b/tests/axon-removals-store.test.ts
@@ -1,0 +1,64 @@
+// The PRODUCTION read path: `loadAxonRemovals` going through `readStore` to
+// Postgres, rather than the injected `query` the other suites use.
+//
+// Its own file because it needs `vi.mock("pg", …)` at module scope, and mixing
+// that into the pure-logic suites would make them depend on a database double
+// they have no use for.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { loadAxonRemovals } from "../src/axon-removals-loader.ts";
+
+beforeEach(() => {
+  pg.control.queries.length = 0;
+  pg.control.rows = [];
+  pg.control.failNext = null;
+});
+
+describe("loadAxonRemovals — through readStore", () => {
+  test("reads Postgres and derives from what it returns", async () => {
+    pg.control.rows = [
+      {
+        netuid: 7,
+        uid: 1,
+        snapshot_date: "2026-08-01",
+        hotkey: "hkA",
+        axon: "1.2.3.4:8091",
+      },
+      {
+        netuid: 7,
+        uid: 1,
+        snapshot_date: "2026-08-02",
+        hotkey: "hkA",
+        axon: null,
+      },
+      {
+        netuid: 7,
+        uid: 1,
+        snapshot_date: "2026-08-03",
+        hotkey: "hkA",
+        axon: null,
+      },
+    ];
+    const out = await loadAxonRemovals(pgMockEnv());
+    assert.deepEqual(out!.subnets, [
+      { netuid: 7, distinct_removers: 1, removals: 1 },
+    ]);
+    // The narrowing predicate reaches the database, not just the unit test.
+    assert.equal(pg.control.queries.length, 1);
+    assert.match(String(pg.control.queries[0]!.text), /FROM neuron_daily/);
+    assert.match(String(pg.control.queries[0]!.text), /JOIN dropped/);
+  });
+
+  test("an unbound Hyperdrive is null, and never reaches a query", async () => {
+    const out = await loadAxonRemovals({});
+    assert.equal(out, null);
+    assert.equal(pg.control.queries.length, 0, "no store, no read");
+  });
+});

--- a/tests/chain-axon-removals.test.ts
+++ b/tests/chain-axon-removals.test.ts
@@ -532,3 +532,45 @@ describe("chain/axon-removals edge cache", () => {
     assert.equal((await cached.json()).data.subnet_count, 0);
   });
 });
+
+// #10805: the routes answered a confident 0 for their whole life because they
+// filtered for an event the runtime never emits. Now that the removals are
+// derived from state, the builder has to keep two empties apart.
+describe("buildChainAxonRemovals — derived (#10805)", () => {
+  const derivation = {
+    method: "axon-state-diff",
+    lookback_days: 30,
+    excluded_uid_reuse: 1485,
+    pending_confirmation: 0,
+  };
+
+  test("carries the derivation, so a consumer sees what was set aside", () => {
+    const d = buildChainAxonRemovals(
+      [{ netuid: 101, distinct_removers: 40, removals: 75 }],
+      { window: "30d", networkDistinct: { distinct_removers: 40 }, derivation },
+    );
+    assert.deepEqual(d.derivation, derivation);
+    assert.equal(d.subnets[0]!.removals, 75);
+    assert.equal(d.degraded, undefined, "a measured answer is not degraded");
+  });
+
+  test("AN EMPTY MEASUREMENT IS NOT A DEGRADED ONE", () => {
+    // The distinction the whole issue turns on. A store that answered "no
+    // removals" measured something; no store at all did not. The first must
+    // not carry `axon_removals_never_emitted`, or the fix is invisible.
+    const measured = buildChainAxonRemovals([], { window: "30d", derivation });
+    assert.equal(measured.subnet_count, 0);
+    assert.deepEqual(measured.derivation, derivation);
+    assert.equal(
+      "degraded" in measured,
+      false,
+      "the key must be absent, not merely undefined",
+    );
+  });
+
+  test("no derivation means no store was read — the marker stays", () => {
+    const unread = buildChainAxonRemovals([], { window: "30d" });
+    assert.equal(unread.degraded?.reason, "axon_removals_never_emitted");
+    assert.equal(unread.derivation, undefined);
+  });
+});

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -261,23 +261,17 @@ const NO_TIER_ANYWHERE: Record<string, string> = {
   // cold tier to hold. An empty answer here is the correct answer, and the
   // question of whether the event will ever fire belongs to the lane, not to
   // wiring on any of these three surfaces.
-  chain_axon_removals:
-    "get_chain_axon_removals falls to buildChainAxonRemovals([]) on MCP too -- no lane exists for it",
-  account_axon_removals:
-    "get_account_axon_removals falls to buildAccountAxonRemovals([]) on MCP too -- no lane exists for it",
-  subnet_axon_removals:
-    "get_subnet_axon_removals falls to buildSubnetAxonRemovals(null) on MCP too -- no lane exists for it",
-  handleChainAxonRemovals:
-    "the REST twin of chain_axon_removals -- same absent lane, same correct empty",
-  handleSubnetAxonRemovals:
-    "the REST twin of subnet_axon_removals -- same absent lane, same correct empty",
-  get_chain_axon_removals:
-    "the MCP twin the GraphQL entry above cites as evidence; naming it here keeps the claim checkable from either side",
-  get_account_axon_removals:
-    "the MCP twin of account_axon_removals -- same absent lane",
-  get_subnet_axon_removals:
-    "the MCP twin of subnet_axon_removals -- same absent lane",
-
+  // ── AXON REMOVALS are no longer here (#10805). Eight entries said the same
+  // thing: no lane exists, so every surface correctly serves an empty. That
+  // was true of the EVENT -- `AxonInfoRemoved` is emitted zero times, genesis
+  // to head -- and it stopped being true of the ANSWER once the removals were
+  // derived from `neuron_daily` state instead. All three scopes now read the
+  // same rollup on all three surfaces.
+  //
+  // This test is why they came out on the same commit that wired them: it
+  // fails on a stale exemption as loudly as on a missing one, so an exemption
+  // here cannot outlive its reason. That is the property an exemption list
+  // usually lacks.
   // ── PROMETHEUS is no longer here (#10322). The entries said all surfaces
   // "agree, which is what makes this a lane question rather than a wiring
   // bug" -- and that was false: /api/v1/chain/prometheus read the same

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -5148,7 +5148,14 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     // Nothing asks the binding, and the answer carries none of its marker.
     assert.deepEqual(tier.paths, []);
     assert.equal(body.data.marker, undefined);
-    assert.deepEqual(captures.sql, []);
+    // #10805: this used to assert NO query at all, which was true only while
+    // the route had no source. It now derives removals from `neuron_daily`,
+    // so the claim worth pinning is narrower and still the one the test is
+    // named for -- the retired TIER is not consulted, and what runs instead is
+    // the state diff rather than an account_events read.
+    assert.equal(captures.sql.length, 1);
+    assert.match(String(captures.sql[0]), /FROM neuron_daily/);
+    assert.doesNotMatch(String(captures.sql[0]), /account_events/);
   });
 
   test("handleAccountPrometheus: the retired tier flag is not consulted even when set (#10190)", async () => {

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -89,6 +89,7 @@ import { buildChainServing } from "../../src/chain-serving.ts";
 import { buildChainPrometheus } from "../../src/chain-prometheus.ts";
 import { loadChainPrometheusColdTier } from "../../src/chain-prometheus-loader.ts";
 import { buildChainAxonRemovals } from "../../src/chain-axon-removals.ts";
+import { loadAxonRemovals } from "../../src/axon-removals-loader.ts";
 import { buildChainRegistrations } from "../../src/chain-registrations.ts";
 import { buildChainDeregistrations } from "../../src/chain-deregistrations.ts";
 import {
@@ -2215,18 +2216,24 @@ export async function handleChainAxonRemovals(
     env,
     "chain-axon-removals",
     async () => {
-      // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
-      // and the table is dropped in production, so a store query here would
-      // always miss (#6013). Postgres → schema-stable empty stub, never a
-      // live store read.
-      const data =
-        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-        // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-        // resolved to null before it could touch DATA_API.
-        buildChainAxonRemovals([], {
-          window: label,
-          limit,
-        });
+      // DERIVED FROM STATE, not from an event (#10805). `AxonInfoRemoved` has
+      // zero occurrences in the complete pallet-level stream, genesis to head
+      // -- the runtime does not emit it -- so this route answered a confident
+      // 0 for its whole life. The transition is real and we already store it:
+      // `neuron_daily.axon` going from non-null to null, with UID reuse
+      // subtracted and a second absent reading required. See
+      // src/axon-removal-derivation.ts for why both corrections are mandatory.
+      //
+      // A null rollup means there was no store to read, NOT that nothing was
+      // removed, so the builder keeps its schema-stable empty in that case --
+      // the same distinction the degraded marker was carrying.
+      const rollup = await loadAxonRemovals(env);
+      const data = buildChainAxonRemovals(rollup?.subnets ?? [], {
+        window: label,
+        limit,
+        networkDistinct: rollup?.network,
+        derivation: rollup?.derivation,
+      });
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-serving).
       if (csv) {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -537,6 +537,10 @@ import type {
   HistoryEmissionRow,
   HistoryRow,
 } from "../../src/validator-economics.ts";
+import {
+  loadAxonRemovals,
+  subnetAxonRemovalRow,
+} from "../../src/axon-removals-loader.ts";
 
 const RESPONSE_FORMATS = ["json", "csv"];
 const NEURON_CSV_COLUMNS = [
@@ -3350,11 +3354,13 @@ export async function handleSubnetAxonRemovals(
     SUBNET_AXON_REMOVALS_WINDOWS,
     DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
   );
-  const data =
-    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
-    // wrangler.jsonc and is absent from FORWARDABLE_TIER_FLAGS, so this arm
-    // resolved to null before it could touch DATA_API.
-    buildSubnetAxonRemovals(null, netuid, { window: windowParam });
+  // DERIVED FROM STATE (#10805), the same rollup MCP and GraphQL read.
+  const removalsRollup = await loadAxonRemovals(env);
+  const data = buildSubnetAxonRemovals(
+    subnetAxonRemovalRow(removalsRollup, netuid),
+    netuid,
+    { window: windowParam },
+  );
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonInfoRemoved event, mirroring the sibling stake-flow route.
   return envelopeResponse(


### PR DESCRIPTION
Closes #10805.

The three axon-removal routes have served a confident `0` on every scope since they shipped. They filter for `AxonInfoRemoved`, which has **zero occurrences in `chain.chain_events`** — the complete pallet-level stream, 898M rows genesis to head. The runtime does not emit it, so no indexer work was ever going to populate them.

**The transition is real; it is just state.** `neuron_daily.axon` is snapshotted per (netuid, uid) per day, so an axon going away is a non-null becoming null in a table we already write.

> Worth stating plainly, because my first recommendation on the issue was to retire the family and that was wrong: retiring would have removed **no stored data**. These are read paths. The right test is not "is this surface busy" but "do we hold the answer and can we serve it" — and we do.

## Two corrections, or the feed lies

Measured over 30 days, 936,244 neuron-day observations:

```
axon drops (non-null -> null)                     1,584
  ...via UID REUSE (hotkey changed)               1,485   93.8%
  ...same hotkey                                     99    6.3%
    ...back on the very NEXT reading (a blip)         5
    ...absent for two readings or more               94
CONFIRMED REMOVALS                                   94    5.9%
```

1. **Subtract UID reuse** — 93.8% are a deregistration whose replacement never announced. Counting them overstates teardowns **18×** and double-reports an event `/chain/deregistrations` already publishes.
2. **Require a second absent reading** — a one-reading absence is what a missed poll looks like.

## The rule choice, made deliberately

Requiring the hotkey never announce again *anywhere* gives 89 instead of 94. I took the weaker test on purpose: an absence sustained across two readings and recovered a week later is not a non-event. Under the stricter rule a removal would vanish from the feed the moment the miner came back — yesterday's history and today's would disagree about last Tuesday. **An archive whose past changes is worse than one that is sparse.**

## Verified against the database

Over 47,616 real `neuron_daily` rows (netuids 2, 4, 44, 51, 61, 85), this code and an independent SQL window function agree **per subnet, on both columns**:

```
netuid   removals   distinct_removers
    51          5                   4
    85          5                   5
    44          4                   4
     2          2                   2
    61          2                   2
     4          1                   1
```

Including netuid 51's 5-from-4 — one hotkey tore down two slots, which is what `removals_per_remover` exists to say.

The first comparison **disagreed** (19 vs 14). That is what surfaced the rule question above: I had measured with one rule and implemented the other. Both now state the same one.

## Design notes

- **SQL narrows, TypeScript decides.** The rules are the whole feed, and two implementations is two answers waiting to disagree. SQL finds candidate slots (43,178 rows, 4.6% of the window — measured); the tested module applies the rules. A test pins the narrowing predicate, because dropping it still returns correct answers, just 20× more of them.
- **Derived at read time, not materialised.** Removals follow from the state; the state does not follow from the removals. A table would be a second copy of one truth *and* a new consumer on `neuron_daily`, whose retention list #10798 just measured growing from seven modules to eight.
- **`degraded` means something narrower now.** It used to mean "this route cannot answer"; it now means only "no store was read". An empty answer carrying `derivation` was *measured*. Without that split the fix would be invisible — a working route and an unbound binding would publish identical bodies.

All 55 CI validators pass.