### PR TITLE
fix(watchdog): a move to an unroutable address is not "stopped announcing"

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -137,6 +137,12 @@ export interface AxonFinding {
    *   2026-08-16, this is 100% of SN25's and SN102's losses -- zero same-hotkey
    *   stops between them -- so labelling those `announcements-withdrawn` states
    *   the opposite of what happened.
+   * - `moved-unroutable`: the same miners are STILL ANNOUNCING, at an address
+   *   nobody can reach. Measured 2026-08-16 over 38 days, 166 of the 271
+   *   same-hotkey losses network-wide are this, not withdrawal -- and SN126,
+   *   the single largest source (160 in 14 days, larger than the #11328 case),
+   *   is almost entirely this shape. Calling it "stopped publishing an axon"
+   *   is false: they never stopped.
    * - `subnet-turned-over`: the metagraph itself emptied, so the missing axons
    *   are missing NEURONS and membership is the story.
    * - `mechanism-unknown`: the drop is real but nothing here explains it. Either
@@ -156,12 +162,20 @@ export interface AxonFinding {
   kind:
     | "announcements-withdrawn"
     | "churn-replaced"
+    | "moved-unroutable"
     | "subnet-turned-over"
     | "mechanism-unknown";
   /** Axon losses in the window whose UID changed hands. Null until measured. */
   lossesViaReuse: number | null;
   /** Axon losses where the same hotkey stopped announcing. Null until measured. */
   lossesSameHotkey: number | null;
+  /**
+   * Of those, the ones STILL ANNOUNCING -- at an unroutable address.
+   *
+   * A subset of `lossesSameHotkey`, so `sameHotkey - movedUnroutable` is the
+   * count that genuinely went dark. Null until measured.
+   */
+  lossesMovedUnroutable: number | null;
   /**
    * Distinct IPs the withdrawn axons were announcing from. Null until measured.
    *
@@ -234,6 +248,7 @@ export function evaluateSubnetAxons(
     // "zero" -- see classifyAxonMechanism.
     lossesViaReuse: null,
     lossesSameHotkey: null,
+    lossesMovedUnroutable: null,
     lossesDistinctIps: null,
   };
 }
@@ -267,17 +282,19 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
           ? `, neurons ${f.neurons}/${f.neuronBaseline} -- the subnet turned over`
           : f.kind === "mechanism-unknown"
             ? ", mechanism UNREAD -- the drop is real, the cause is not established"
-            : f.kind === "churn-replaced"
-              ? `, churn-replaced: ${f.lossesViaReuse ?? 0} of ${(f.lossesViaReuse ?? 0) + (f.lossesSameHotkey ?? 0)} losses were deregistrations`
-              : // `announcements-withdrawn` is only reachable through a
-                // successful mechanism read, so the count is a number here --
-                // an unread one is `mechanism-unknown` above.
-                `, ${f.lossesSameHotkey} miner(s) stopped announcing` +
-                (f.lossesDistinctIps === null
-                  ? ""
-                  : f.lossesDistinctIps === 1
-                    ? " -- ALL FROM ONE ADDRESS, so this is one host rather than the subnet"
-                    : ` from ${f.lossesDistinctIps} addresses`)) +
+            : f.kind === "moved-unroutable"
+              ? `, ${f.lossesMovedUnroutable} of ${f.lossesSameHotkey} still announce -- they MOVED to an unroutable address rather than going dark`
+              : f.kind === "churn-replaced"
+                ? `, churn-replaced: ${f.lossesViaReuse ?? 0} of ${(f.lossesViaReuse ?? 0) + (f.lossesSameHotkey ?? 0)} losses were deregistrations`
+                : // `announcements-withdrawn` is only reachable through a
+                  // successful mechanism read, so the count is a number here --
+                  // an unread one is `mechanism-unknown` above.
+                  `, ${f.lossesSameHotkey} miner(s) stopped announcing` +
+                  (f.lossesDistinctIps === null
+                    ? ""
+                    : f.lossesDistinctIps === 1
+                      ? " -- ALL FROM ONE ADDRESS, so this is one host rather than the subnet"
+                      : ` from ${f.lossesDistinctIps} addresses`)) +
         ")",
     )
     .join("; ");
@@ -312,14 +329,28 @@ export function axonDetail(findings: readonly AxonFinding[]): string {
  * evidence for both is still evidence that some miners went dark.
  */
 export function classifyAxonMechanism(
-  counts: { viaReuse: number | null; sameHotkey: number | null },
+  counts: {
+    viaReuse: number | null;
+    sameHotkey: number | null;
+    movedUnroutable?: number | null;
+  },
   fallback: AxonFinding["kind"],
 ): AxonFinding["kind"] {
   const reuse = counts?.viaReuse;
   const same = counts?.sameHotkey;
   if (typeof reuse !== "number" || typeof same !== "number") return fallback;
   if (reuse + same === 0) return fallback;
-  return reuse > same ? "churn-replaced" : "announcements-withdrawn";
+  if (reuse > same) return "churn-replaced";
+  // SAME-HOTKEY IS TWO MECHANISMS, NOT ONE. A miner that moved to an
+  // unroutable address still announces, so "stopped publishing an axon" is
+  // false for it -- and network-wide the moves OUTNUMBER the stops 166 to 105.
+  // Only a measured majority of genuine stops earns the withdrawal wording;
+  // an unmeasured `movedUnroutable` is 0, which leaves today's answer.
+  const moved = counts?.movedUnroutable;
+  if (typeof moved === "number" && Number.isFinite(moved) && moved > same / 2) {
+    return "moved-unroutable";
+  }
+  return "announcements-withdrawn";
 }
 
 /**
@@ -343,18 +374,28 @@ export async function loadAxonLossMechanisms(
 ): Promise<
   Record<
     number,
-    { viaReuse: number; sameHotkey: number; distinctIps: number | null }
+    {
+      viaReuse: number;
+      sameHotkey: number;
+      movedUnroutable: number;
+      distinctIps: number | null;
+    }
   >
 > {
   const out: Record<
     number,
-    { viaReuse: number; sameHotkey: number; distinctIps: number | null }
+    {
+      viaReuse: number;
+      sameHotkey: number;
+      movedUnroutable: number;
+      distinctIps: number | null;
+    }
   > = {};
   const ids = (netuids ?? []).filter((n) => Number.isSafeInteger(n) && n >= 0);
   if (!db?.query || ids.length === 0) return out;
   try {
     const rows = (await db.query(
-      "WITH seq AS (SELECT netuid, uid, snapshot_date, hotkey, " +
+      "WITH seq AS (SELECT netuid, uid, snapshot_date, hotkey, axon, " +
         `(${ROUTABLE_AXON_SQL}) AS has_axon, ` +
         `LAG(${ROUTABLE_AXON_SQL}) OVER w AS prev_has, ` +
         "LAG(hotkey) OVER w AS prev_hotkey, LAG(axon) OVER w AS prev_axon " +
@@ -364,6 +405,8 @@ export async function loadAxonLossMechanisms(
         "SELECT netuid, " +
         "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey IS DISTINCT FROM prev_hotkey) AS via_reuse, " +
         "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS same_hotkey, " +
+        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey " +
+        "AND axon IS NOT NULL AND axon <> '') AS moved_unroutable, " +
         "COUNT(DISTINCT split_part(prev_axon, ':', 1)) FILTER " +
         "(WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS distinct_ips " +
         "FROM seq GROUP BY netuid",
@@ -373,12 +416,20 @@ export async function loadAxonLossMechanisms(
       const netuid = Number(row?.netuid);
       const viaReuse = Number(row?.via_reuse ?? 0);
       const sameHotkey = Number(row?.same_hotkey ?? 0);
+      const moved = Number(row?.moved_unroutable ?? 0);
       const ips = Number(row?.distinct_ips);
       if (!Number.isFinite(netuid)) continue;
       if (!Number.isFinite(viaReuse) || !Number.isFinite(sameHotkey)) continue;
       out[netuid] = {
         viaReuse,
         sameHotkey,
+        // Clamped into the same-hotkey total it is a subset of: a driver that
+        // hands back something unreadable must not make "moved" exceed the
+        // losses it partitions, which would render as a negative "stopped".
+        movedUnroutable:
+          Number.isFinite(moved) && moved >= 0
+            ? Math.min(moved, sameHotkey)
+            : 0,
         // Null rather than 0 when unreadable: "no addresses" and "we did not
         // count the addresses" are different, and only one of them is a fact.
         distinctIps: Number.isFinite(ips) ? ips : null,
@@ -446,6 +497,7 @@ export async function runAxonAnnouncementWatchdog(
     if (!counts) continue;
     finding.lossesViaReuse = counts.viaReuse;
     finding.lossesSameHotkey = counts.sameHotkey;
+    finding.lossesMovedUnroutable = counts.movedUnroutable;
     finding.lossesDistinctIps = counts.distinctIps;
     // Turnover is decided by the neuron count and is not up for revision here:
     // a subnet that emptied is not "churn" at any ratio.
@@ -501,12 +553,16 @@ export async function runAxonAnnouncementWatchdog(
             ? `announced axons collapsed: ${detail} -- miners that are still registered and ` +
               `still earning stopped publishing an axon, so this is a reachability change ` +
               `nothing else in the fleet reports (#11328)`
-            : // Turnover, unread mechanisms, and churn MIXED with either land
-              // here -- pure churn never reaches this call at all. The detail
-              // already says which, and none of them is a withdrawal, so this
-              // states the drop and stops.
-              `announced axons fell below baseline: ${detail} -- this reports the DROP only; ` +
-              `no miner was measured to have stopped announcing`,
+            : findings.some((f) => f.kind === "moved-unroutable")
+              ? `routable axons fell WITHOUT anyone going dark: ${detail} -- the same miners ` +
+                `are still announcing, at addresses in documentation or private ranges that ` +
+                `nothing can reach. Reachability changed; publishing did not (#11392)`
+              : // Turnover, unread mechanisms, and churn MIXED with either land
+                // here -- pure churn never reaches this call at all. The detail
+                // already says which, and none of them is a withdrawal, so this
+                // states the drop and stops.
+                `announced axons fell below baseline: ${detail} -- this reports the DROP only; ` +
+                `no miner was measured to have stopped announcing`,
       ),
       route: `watchdog:${AXON_ANNOUNCEMENT_LANE}`,
       errorCode: fleetWide

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -190,6 +190,7 @@ describe("the fleet-wide guard", () => {
     kind: "mechanism-unknown",
     lossesViaReuse: null,
     lossesSameHotkey: null,
+    lossesMovedUnroutable: null,
     lossesDistinctIps: null,
   });
 
@@ -668,6 +669,7 @@ describe("mechanism — WHAT happened, not just how much (#11369)", () => {
       kind: "churn-replaced",
       lossesViaReuse: 67,
       lossesSameHotkey: 0,
+      lossesMovedUnroutable: 0,
       lossesDistinctIps: null,
     };
     const detail = axonDetail([churn]);
@@ -690,6 +692,7 @@ describe("mechanism — WHAT happened, not just how much (#11369)", () => {
       kind: "announcements-withdrawn",
       lossesViaReuse: 64,
       lossesSameHotkey: 75,
+      lossesMovedUnroutable: 0,
       lossesDistinctIps: null,
     };
     assert.match(axonDetail([withdrawn]), /75 miner\(s\) stopped announcing/);
@@ -717,10 +720,16 @@ describe("loadAxonLossMechanisms", () => {
       [25, 101],
       "2026-08-08",
     );
-    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0, distinctIps: 0 });
+    assert.deepEqual(out[25], {
+      viaReuse: 67,
+      sameHotkey: 0,
+      movedUnroutable: 0,
+      distinctIps: 0,
+    });
     assert.deepEqual(out[101], {
       viaReuse: 64,
       sameHotkey: 75,
+      movedUnroutable: 0,
       distinctIps: 1,
     });
   });
@@ -730,11 +739,46 @@ describe("loadAxonLossMechanisms", () => {
     pg.control.answers.push({
       match: /FROM seq/,
       rows: [
-        { netuid: 25, via_reuse: "67", same_hotkey: "0", distinct_ips: "0" },
+        {
+          netuid: 25,
+          via_reuse: "67",
+          same_hotkey: "9",
+          moved_unroutable: "4",
+          distinct_ips: "0",
+        },
       ],
     });
     const out = await loadAxonLossMechanisms(pgLaneDb(), [25], "2026-08-08");
-    assert.deepEqual(out[25], { viaReuse: 67, sameHotkey: 0, distinctIps: 0 });
+    assert.deepEqual(out[25], {
+      viaReuse: 67,
+      sameHotkey: 9,
+      movedUnroutable: 4,
+      distinctIps: 0,
+    });
+  });
+
+  test("moved is CLAMPED into the same-hotkey total it partitions", async () => {
+    // `stopped` is rendered as sameHotkey - moved, so a moved count exceeding
+    // its own superset would publish a negative number of miners going dark.
+    pg.control.answers.push({
+      match: /FROM seq/,
+      rows: [
+        { netuid: 25, via_reuse: 0, same_hotkey: 5, moved_unroutable: 99 },
+      ],
+    });
+    const out = await loadAxonLossMechanisms(pgLaneDb(), [25], "2026-08-08");
+    assert.equal(out[25]!.movedUnroutable, 5);
+  });
+
+  test("an unreadable moved count is 0, which keeps the pre-split answer", async () => {
+    pg.control.answers.push({
+      match: /FROM seq/,
+      rows: [
+        { netuid: 25, via_reuse: 0, same_hotkey: 5, moved_unroutable: "junk" },
+      ],
+    });
+    const out = await loadAxonLossMechanisms(pgLaneDb(), [25], "2026-08-08");
+    assert.equal(out[25]!.movedUnroutable, 0);
   });
 
   test("no netuids asks nothing at all", async () => {
@@ -781,6 +825,7 @@ describe("mechanism — the defensive edges", () => {
       kind: "churn-replaced",
       lossesViaReuse: null,
       lossesSameHotkey: null,
+      lossesMovedUnroutable: null,
       lossesDistinctIps: null,
     };
     assert.match(axonDetail([half]), /churn-replaced: 0 of 0 losses/);
@@ -910,6 +955,53 @@ describe("the tick reports the mechanism it measured", () => {
     assert.match(verdict(), /churn-replaced: 67 of 67/);
   });
 
+  test("SN126's REAL shape: moved to an unroutable address, not gone dark", async () => {
+    // Measured 2026-08-16 over 38 days. SN126 is the largest same-hotkey source
+    // on the network -- 160 losses in 14 days, larger than the #11328 case --
+    // and its miners never stopped announcing. They moved to addresses nothing
+    // can reach. Network-wide the moves OUTNUMBER the stops, 166 to 105, so
+    // calling this "stopped publishing an axon" is false for the majority.
+    answer(rowsFor(126, then(flat(8, 80), [14, 256])), [
+      { netuid: 126, via_reuse: 2, same_hotkey: 60, moved_unroutable: 58 },
+    ]);
+    let captured: Record<string, unknown> | null = null;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    })) as { findings: AxonFinding[]; alerted: boolean };
+
+    assert.equal(result.findings[0].kind, "moved-unroutable");
+    assert.equal(result.findings[0].lossesMovedUnroutable, 58);
+    // It still pages -- reachability really did change, and nothing else says so.
+    assert.equal(result.alerted, true);
+    const message = String(
+      (captured as unknown as { error: Error }).error.message,
+    );
+    assert.match(message, /still announcing/);
+    assert.doesNotMatch(
+      message,
+      /stopped publishing an axon/,
+      "they did not stop; the withdrawal wording must not cover a move",
+    );
+    assert.match(verdict(), /58 of 60 still announce/);
+  });
+
+  test("a MINORITY of moves stays withdrawal", async () => {
+    // The split is decided by which mechanism dominates, so a subnet where
+    // most miners genuinely went dark keeps the #11328 wording.
+    answer(rowsFor(101, then(flat(8, 223), [125, 256])), [
+      { netuid: 101, via_reuse: 10, same_hotkey: 75, moved_unroutable: 5 },
+    ]);
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async () => true) as never,
+    })) as { findings: AxonFinding[] };
+    assert.equal(result.findings[0].kind, "announcements-withdrawn");
+  });
+
   test("churn MIXED with a withdrawal still pages", async () => {
     // `every` is the bar, so one non-churn finding restores the page. A real
     // withdrawal must not be silenced by a churning neighbour on the same day.
@@ -1034,6 +1126,7 @@ describe("IP concentration — one host, or the subnet", () => {
     kind: "announcements-withdrawn",
     lossesViaReuse: 64,
     lossesSameHotkey: 75,
+    lossesMovedUnroutable: 0,
     lossesDistinctIps: ips,
   });
 
@@ -1066,6 +1159,7 @@ describe("IP concentration — one host, or the subnet", () => {
       kind: "churn-replaced",
       lossesViaReuse: 67,
       lossesSameHotkey: 0,
+      lossesMovedUnroutable: 0,
     };
     const detail = axonDetail([churn]);
     assert.match(detail, /churn-replaced: 67 of 67/);


### PR DESCRIPTION
## The over-claim

`announcements-withdrawn` is two mechanisms wearing one name, and the wrong one is the majority. Same-hotkey losses of a routable axon, network-wide, over the full 38 days `neuron_daily` retains:

| | count |
| --- | ---: |
| **moved to an unroutable address, still announcing** | **166** |
| truly stopped announcing (`axon IS NULL`) | 105 |

For all 166 the alarm said *"miners that are still registered and still earning stopped publishing an axon."* They never stopped — they publish an address in RFC 5737 documentation space or RFC 1918 private space that nothing can reach.

## SN126, which nothing had looked at

| subnet | same-hotkey losses | days | window |
| --- | ---: | ---: | --- |
| **126** | **160** | 14 | 07-13 → 08-11 |
| 101 | 76 | 2 | 07-19 → 08-11 |
| nine others | 35 total | | |

SN126 is the **largest source on the network** — larger than the SN101 event #11328 exists for — and it is almost entirely moves. Run the same query with `axon IS NOT NULL` instead of the routable test and SN126 has **one** loss, not 160.

The watchdog never saw it: the event ended 08-11, the lane shipped 08-15, and a 7-day trailing baseline only catches what is still happening. This is the flip side of `axon_routable` (#11376) — redefining "announcing" as "routable" made a whole class of event visible, and the classifier had not caught up.

## The change

A fourth kind, `moved-unroutable`, taken when a **measured majority** of same-hotkey losses still announce. `lossesMovedUnroutable` is a subset of `lossesSameHotkey`, so `sameHotkey - moved` is the count that genuinely went dark.

It **still pages** — reachability really did change and nothing else in the fleet reports it — with wording that does not claim anyone stopped. A minority of moves keeps the #11328 wording, and there is a test for that boundary.

Two safety properties, both tested:
- An **unmeasured** moved count reads as `0`, leaving today's answer rather than inventing a move (same direction as #11381).
- The count is **clamped** into the total it partitions, so an unreadable driver value cannot render a negative "stopped".

## Bearing on #10805

This is the third mechanism a derived axon-removals family must separate. A naive `prev_has AND NOT has_axon` derivation reports **2,186** removals over 38 days; **1,915 are deregistrations**, **166 more are moves**, and the honest count of miners that actually stopped announcing is **105** across 10 subnets.

## Verification

85 tests pass; **100% statement, branch, function and line coverage** on the watchdog. `tsc`, prettier, eslint and `validate:{unreferenced-exports,lane-topology,boundary-casts,double-assertions}` clean.

Closes #11392