### PR TITLE
fix(capture): the lane was losing to the chain head, nothing watched it, and a new account paid the bill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5354,6 +5354,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@posthog/core": {
       "version": "1.45.1",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.45.1.tgz",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9799,6 +9799,8 @@ export interface components {
             contract_version: string;
             /** @description Deterministic build content marker (epoch by default); not a wall clock. Use published_at for human-facing freshness. */
             generated_at?: string | null;
+            /** @description How far the tier that answered this request has observed at all. A payload reporting no activity at or before this time is a measured absence; one whose subject is newer is outside coverage, not empty. Null when the horizon is unreadable. */
+            observed_through?: string | null;
             pagination?: components["schemas"]["PaginationMeta"];
             /** @description Real publish time from the KV latest pointer, distinct from generated_at. Null before the first publish or when the control KV is unbound. */
             published_at?: string | null;
@@ -14107,6 +14109,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14219,6 +14222,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14342,6 +14346,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14465,6 +14470,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14595,6 +14601,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14734,6 +14741,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14855,6 +14863,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14966,6 +14975,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15087,6 +15097,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15223,6 +15234,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15367,6 +15379,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15493,6 +15506,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15610,6 +15624,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15731,6 +15746,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15905,6 +15921,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16030,6 +16047,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16154,6 +16172,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16311,6 +16330,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16450,6 +16470,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16596,6 +16617,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16726,6 +16748,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16876,6 +16899,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17022,6 +17046,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17168,6 +17193,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17302,6 +17328,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17447,6 +17474,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17597,6 +17625,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17729,6 +17758,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17856,6 +17886,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18033,6 +18064,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18150,6 +18182,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18297,6 +18330,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18426,6 +18460,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18547,6 +18582,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18659,6 +18695,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18797,6 +18834,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18914,6 +18952,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19082,6 +19121,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19443,6 +19483,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19555,6 +19596,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19678,6 +19720,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19790,6 +19833,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19900,6 +19944,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20035,6 +20080,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20186,6 +20232,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20308,6 +20355,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20418,6 +20466,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20539,6 +20588,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20690,6 +20740,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20824,6 +20875,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20937,6 +20989,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21066,6 +21119,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21206,6 +21260,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21337,6 +21392,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21453,6 +21509,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21574,6 +21631,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21700,6 +21758,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21839,6 +21898,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21957,6 +22017,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22079,6 +22140,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22197,6 +22259,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22325,6 +22388,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22443,6 +22507,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22575,6 +22640,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22694,6 +22760,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22806,6 +22873,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22932,6 +23000,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23060,6 +23129,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23183,6 +23253,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23305,6 +23376,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23435,6 +23507,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23589,6 +23662,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23746,6 +23820,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23877,6 +23952,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23991,6 +24067,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24107,6 +24184,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24243,6 +24321,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24362,6 +24441,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24471,6 +24551,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24590,6 +24671,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24724,6 +24806,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24865,6 +24948,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25045,6 +25129,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25185,6 +25270,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25313,6 +25399,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25427,6 +25514,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25545,6 +25633,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25716,6 +25805,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25869,6 +25959,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25991,6 +26082,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26112,6 +26204,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26291,6 +26384,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26484,6 +26578,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26627,6 +26722,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26772,6 +26868,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26921,6 +27018,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27096,6 +27194,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27227,6 +27326,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27353,6 +27453,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27483,6 +27584,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27594,6 +27696,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27704,6 +27807,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27824,6 +27928,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27989,6 +28094,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28131,6 +28237,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28274,6 +28381,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28433,6 +28541,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28571,6 +28680,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28698,6 +28808,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28845,6 +28956,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28988,6 +29100,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29131,6 +29244,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29288,6 +29402,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29419,6 +29534,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29561,6 +29677,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29709,6 +29826,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29852,6 +29970,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29988,6 +30107,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30113,6 +30233,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30253,6 +30374,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30372,6 +30494,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30524,6 +30647,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30693,6 +30817,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30835,6 +30960,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31039,6 +31165,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31173,6 +31300,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31298,6 +31426,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31440,6 +31569,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31566,6 +31696,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31688,6 +31819,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31862,6 +31994,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31986,6 +32119,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32149,6 +32283,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32328,6 +32463,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32499,6 +32635,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32637,6 +32774,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32747,6 +32885,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32891,6 +33030,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -33018,6 +33158,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -34723,6 +34864,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -34967,6 +35109,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35104,6 +35247,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35244,6 +35388,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35382,6 +35527,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35518,6 +35664,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35665,6 +35812,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35798,6 +35946,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35938,6 +36087,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36064,6 +36214,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36182,6 +36333,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36291,6 +36443,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36421,6 +36574,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36556,6 +36710,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36673,6 +36828,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36938,6 +37094,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37075,6 +37232,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37217,6 +37375,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37393,6 +37552,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37513,6 +37673,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37649,6 +37810,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37811,6 +37973,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37943,6 +38106,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38107,6 +38271,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38324,6 +38489,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38556,6 +38722,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38694,6 +38861,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38902,6 +39070,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39058,6 +39227,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39238,6 +39408,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39392,6 +39563,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39537,6 +39709,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39662,6 +39835,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39792,6 +39966,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39919,6 +40094,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40033,6 +40209,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40155,6 +40332,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40286,6 +40464,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40411,6 +40590,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40544,6 +40724,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40709,6 +40890,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41068,6 +41250,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41182,6 +41365,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41292,6 +41476,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41408,6 +41593,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41550,6 +41736,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41731,6 +41918,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41845,6 +42033,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41966,6 +42155,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42161,6 +42351,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42296,6 +42487,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42427,6 +42619,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42560,6 +42753,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42693,6 +42887,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42871,6 +43066,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43024,6 +43220,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43151,6 +43348,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43288,6 +43486,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43501,6 +43700,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43656,6 +43856,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43784,6 +43985,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43906,6 +44108,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44031,6 +44234,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44146,6 +44350,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44272,6 +44477,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44412,6 +44618,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44533,6 +44740,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44659,6 +44867,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44770,6 +44979,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44891,6 +45101,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45001,6 +45212,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45123,6 +45335,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45254,6 +45467,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45412,6 +45626,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45544,6 +45759,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45666,6 +45882,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45797,6 +46014,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46145,6 +46363,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46290,6 +46509,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46427,6 +46647,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46536,6 +46757,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46703,6 +46925,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46817,6 +47040,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47264,6 +47488,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47378,6 +47603,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47488,6 +47714,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47598,6 +47825,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47757,6 +47985,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47867,6 +48096,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47980,6 +48210,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48090,6 +48321,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48206,6 +48438,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48316,6 +48549,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48436,6 +48670,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48576,6 +48811,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48708,6 +48944,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48837,6 +49074,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48984,6 +49222,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49123,6 +49362,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49278,6 +49518,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49405,6 +49646,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49524,6 +49766,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49661,6 +49904,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49812,6 +50056,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49922,6 +50167,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50048,6 +50294,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50186,6 +50433,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50305,6 +50553,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50461,6 +50710,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50606,6 +50856,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50718,6 +50969,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50855,6 +51107,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50976,6 +51229,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51136,6 +51390,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51298,6 +51553,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51421,6 +51677,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51558,6 +51815,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51738,6 +51996,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51851,6 +52110,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -29,6 +29,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -69,6 +70,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -120,6 +122,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -195,6 +198,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -254,6 +258,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -297,6 +302,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -339,6 +345,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -394,6 +401,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -438,6 +446,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -482,6 +491,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -524,6 +534,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -578,6 +589,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -647,6 +659,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -699,6 +712,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -747,6 +761,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -796,6 +811,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -841,6 +857,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -899,6 +916,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -944,6 +962,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1004,6 +1023,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1064,6 +1084,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1110,6 +1131,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1152,6 +1174,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1228,6 +1251,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1271,6 +1295,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1319,6 +1344,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1374,6 +1400,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1449,6 +1476,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1536,6 +1564,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1599,6 +1628,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1643,6 +1673,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1757,6 +1788,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1801,6 +1833,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1853,6 +1886,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1892,6 +1926,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1936,6 +1971,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -1978,6 +2014,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2030,6 +2067,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2080,6 +2118,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2151,6 +2190,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2263,6 +2303,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2321,6 +2362,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2371,6 +2413,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2419,6 +2462,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2515,6 +2559,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2591,6 +2636,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2643,6 +2689,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2687,6 +2734,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2796,6 +2844,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2918,6 +2967,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -2985,6 +3035,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3059,6 +3110,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3100,6 +3152,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3142,6 +3195,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3197,6 +3251,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3257,6 +3312,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3297,6 +3353,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3339,6 +3396,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3436,6 +3494,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3503,6 +3562,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3569,6 +3629,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3655,6 +3716,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3718,6 +3780,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3765,6 +3828,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3835,6 +3899,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3901,6 +3966,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -3967,6 +4033,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4015,6 +4082,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4064,6 +4132,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4129,6 +4198,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4197,6 +4267,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4263,6 +4334,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4322,6 +4394,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4377,6 +4450,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4449,6 +4523,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4496,6 +4571,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4576,6 +4652,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4666,6 +4743,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4740,6 +4818,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4856,6 +4935,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4911,6 +4991,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -4972,6 +5053,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5031,6 +5113,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5093,6 +5176,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5151,6 +5235,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5203,6 +5288,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5291,6 +5377,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5337,6 +5424,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5388,6 +5476,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5479,6 +5568,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5550,6 +5640,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5643,6 +5734,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5720,6 +5812,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5772,6 +5865,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5812,6 +5906,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5864,6 +5959,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5915,6 +6011,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -5979,6 +6076,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6068,6 +6166,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6139,6 +6238,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6193,6 +6293,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6250,6 +6351,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6335,6 +6437,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6400,6 +6503,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6455,6 +6559,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6504,6 +6609,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6568,6 +6674,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6619,6 +6726,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6674,6 +6782,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6726,6 +6835,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6784,6 +6894,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6851,6 +6962,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6901,6 +7013,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -6959,6 +7072,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7007,6 +7121,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7056,6 +7171,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7116,6 +7232,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7183,6 +7300,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7265,6 +7383,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7312,6 +7431,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7353,6 +7473,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7396,6 +7517,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7464,6 +7586,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7537,6 +7660,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7614,6 +7738,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7734,6 +7859,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7865,6 +7991,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -7916,6 +8043,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8031,6 +8159,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8090,6 +8219,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8184,6 +8314,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8267,6 +8398,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8341,6 +8473,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8393,6 +8526,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8439,6 +8573,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8482,6 +8617,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8525,6 +8661,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8588,6 +8725,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8636,6 +8774,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8693,6 +8832,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8745,6 +8885,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8807,6 +8948,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8848,6 +8990,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8888,6 +9031,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8931,6 +9075,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -8983,6 +9128,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9089,6 +9235,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9128,6 +9275,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9177,6 +9325,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9302,6 +9451,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9379,6 +9529,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9437,6 +9588,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9718,6 +9870,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9776,6 +9929,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9855,6 +10009,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9897,6 +10052,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -9970,6 +10126,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10019,6 +10176,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10145,6 +10303,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10187,6 +10346,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10240,6 +10400,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10310,6 +10471,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10355,6 +10517,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10397,6 +10560,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10436,6 +10600,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10487,6 +10652,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10527,6 +10693,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10572,6 +10739,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10622,6 +10790,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10705,6 +10874,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10779,6 +10949,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -10838,6 +11009,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11113,6 +11285,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11185,6 +11358,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11252,6 +11426,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11291,6 +11466,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11388,6 +11564,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11427,6 +11604,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11799,6 +11977,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -11973,6 +12152,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12014,6 +12194,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12054,6 +12235,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12091,6 +12273,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12177,6 +12360,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12234,6 +12418,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12271,6 +12456,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12309,6 +12495,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12346,6 +12533,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12388,6 +12576,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12425,6 +12614,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12472,6 +12662,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12521,6 +12712,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12565,6 +12757,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12622,6 +12815,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12695,6 +12889,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12778,6 +12973,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12832,6 +13028,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12876,6 +13073,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12957,6 +13155,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -12994,6 +13193,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13047,6 +13247,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13112,6 +13313,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13154,6 +13356,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13199,6 +13402,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13245,6 +13449,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13291,6 +13496,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13349,6 +13555,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13396,6 +13603,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13459,6 +13667,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13546,6 +13755,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13644,6 +13854,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13692,6 +13903,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13744,6 +13956,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -13790,6 +14003,7 @@
             "cache": "short",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
             "pagination": {
               "collection": "example",
               "cursor": 1,
@@ -40562,6 +40776,18 @@
               }
             ],
             "description": "Deterministic build content marker (epoch by default); not a wall clock. Use published_at for human-facing freshness."
+          },
+          "observed_through": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How far the tier that answered this request has observed at all. A payload reporting no activity at or before this time is a measured absence; one whose subject is newer is outside coverage, not empty. Null when the horizon is unreadable."
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9799,6 +9799,8 @@ export interface components {
             contract_version: string;
             /** @description Deterministic build content marker (epoch by default); not a wall clock. Use published_at for human-facing freshness. */
             generated_at?: string | null;
+            /** @description How far the tier that answered this request has observed at all. A payload reporting no activity at or before this time is a measured absence; one whose subject is newer is outside coverage, not empty. Null when the horizon is unreadable. */
+            observed_through?: string | null;
             pagination?: components["schemas"]["PaginationMeta"];
             /** @description Real publish time from the KV latest pointer, distinct from generated_at. Null before the first publish or when the control KV is unbound. */
             published_at?: string | null;
@@ -14107,6 +14109,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14219,6 +14222,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14342,6 +14346,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14465,6 +14470,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14595,6 +14601,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14734,6 +14741,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14855,6 +14863,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -14966,6 +14975,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15087,6 +15097,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15223,6 +15234,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15367,6 +15379,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15493,6 +15506,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15610,6 +15624,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15731,6 +15746,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -15905,6 +15921,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16030,6 +16047,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16154,6 +16172,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16311,6 +16330,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16450,6 +16470,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16596,6 +16617,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16726,6 +16748,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -16876,6 +16899,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17022,6 +17046,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17168,6 +17193,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17302,6 +17328,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17447,6 +17474,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17597,6 +17625,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17729,6 +17758,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -17856,6 +17886,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18033,6 +18064,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18150,6 +18182,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18297,6 +18330,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18426,6 +18460,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18547,6 +18582,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18659,6 +18695,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18797,6 +18834,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -18914,6 +18952,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19082,6 +19121,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19443,6 +19483,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19555,6 +19596,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19678,6 +19720,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19790,6 +19833,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -19900,6 +19944,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20035,6 +20080,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20186,6 +20232,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20308,6 +20355,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20418,6 +20466,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20539,6 +20588,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20690,6 +20740,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20824,6 +20875,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -20937,6 +20989,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21066,6 +21119,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21206,6 +21260,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21337,6 +21392,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21453,6 +21509,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21574,6 +21631,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21700,6 +21758,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21839,6 +21898,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -21957,6 +22017,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22079,6 +22140,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22197,6 +22259,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22325,6 +22388,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22443,6 +22507,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22575,6 +22640,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22694,6 +22760,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22806,6 +22873,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -22932,6 +23000,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23060,6 +23129,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23183,6 +23253,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23305,6 +23376,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23435,6 +23507,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23589,6 +23662,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23746,6 +23820,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23877,6 +23952,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -23991,6 +24067,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24107,6 +24184,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24243,6 +24321,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24362,6 +24441,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24471,6 +24551,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24590,6 +24671,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24724,6 +24806,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -24865,6 +24948,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25045,6 +25129,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25185,6 +25270,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25313,6 +25399,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25427,6 +25514,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25545,6 +25633,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25716,6 +25805,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25869,6 +25959,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -25991,6 +26082,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26112,6 +26204,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26291,6 +26384,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26484,6 +26578,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26627,6 +26722,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26772,6 +26868,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -26921,6 +27018,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27096,6 +27194,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27227,6 +27326,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27353,6 +27453,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27483,6 +27584,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27594,6 +27696,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27704,6 +27807,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27824,6 +27928,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -27989,6 +28094,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28131,6 +28237,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28274,6 +28381,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28433,6 +28541,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28571,6 +28680,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28698,6 +28808,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28845,6 +28956,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -28988,6 +29100,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29131,6 +29244,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29288,6 +29402,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29419,6 +29534,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29561,6 +29677,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29709,6 +29826,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29852,6 +29970,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -29988,6 +30107,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30113,6 +30233,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30253,6 +30374,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30372,6 +30494,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30524,6 +30647,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30693,6 +30817,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -30835,6 +30960,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31039,6 +31165,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31173,6 +31300,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31298,6 +31426,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31440,6 +31569,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31566,6 +31696,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31688,6 +31819,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31862,6 +31994,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -31986,6 +32119,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32149,6 +32283,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32328,6 +32463,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32499,6 +32635,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32637,6 +32774,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32747,6 +32885,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -32891,6 +33030,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -33018,6 +33158,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -34723,6 +34864,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -34967,6 +35109,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35104,6 +35247,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35244,6 +35388,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35382,6 +35527,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35518,6 +35664,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35665,6 +35812,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35798,6 +35946,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -35938,6 +36087,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36064,6 +36214,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36182,6 +36333,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36291,6 +36443,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36421,6 +36574,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36556,6 +36710,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36673,6 +36828,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -36938,6 +37094,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37075,6 +37232,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37217,6 +37375,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37393,6 +37552,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37513,6 +37673,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37649,6 +37810,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37811,6 +37973,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -37943,6 +38106,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38107,6 +38271,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38324,6 +38489,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38556,6 +38722,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38694,6 +38861,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -38902,6 +39070,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39058,6 +39227,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39238,6 +39408,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39392,6 +39563,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39537,6 +39709,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39662,6 +39835,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39792,6 +39966,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -39919,6 +40094,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40033,6 +40209,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40155,6 +40332,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40286,6 +40464,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40411,6 +40590,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40544,6 +40724,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -40709,6 +40890,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41068,6 +41250,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41182,6 +41365,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41292,6 +41476,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41408,6 +41593,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41550,6 +41736,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41731,6 +41918,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41845,6 +42033,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -41966,6 +42155,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42161,6 +42351,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42296,6 +42487,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42427,6 +42619,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42560,6 +42753,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42693,6 +42887,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -42871,6 +43066,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43024,6 +43220,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43151,6 +43348,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43288,6 +43486,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43501,6 +43700,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43656,6 +43856,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43784,6 +43985,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -43906,6 +44108,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44031,6 +44234,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44146,6 +44350,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44272,6 +44477,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44412,6 +44618,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44533,6 +44740,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44659,6 +44867,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44770,6 +44979,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -44891,6 +45101,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45001,6 +45212,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45123,6 +45335,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45254,6 +45467,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45412,6 +45626,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45544,6 +45759,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45666,6 +45882,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -45797,6 +46014,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46145,6 +46363,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46290,6 +46509,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46427,6 +46647,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46536,6 +46757,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46703,6 +46925,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -46817,6 +47040,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47264,6 +47488,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47378,6 +47603,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47488,6 +47714,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47598,6 +47825,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47757,6 +47985,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47867,6 +48096,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -47980,6 +48210,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48090,6 +48321,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48206,6 +48438,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48316,6 +48549,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48436,6 +48670,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48576,6 +48811,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48708,6 +48944,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48837,6 +49074,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -48984,6 +49222,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49123,6 +49362,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49278,6 +49518,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49405,6 +49646,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49524,6 +49766,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49661,6 +49904,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49812,6 +50056,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -49922,6 +50167,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50048,6 +50294,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50186,6 +50433,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50305,6 +50553,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50461,6 +50710,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50606,6 +50856,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50718,6 +50969,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50855,6 +51107,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -50976,6 +51229,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51136,6 +51390,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51298,6 +51553,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51421,6 +51677,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51558,6 +51815,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51738,6 +51996,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,
@@ -51851,6 +52110,7 @@ export interface operations {
                      *         "cache": "short",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "observed_through": "2026-06-01T00:00:00.000Z",
                      *         "pagination": {
                      *           "collection": "example",
                      *           "cursor": 1,

--- a/schemas-src/envelope.ts
+++ b/schemas-src/envelope.ts
@@ -131,6 +131,32 @@ export const ResponseMetaSchema = z
       .describe(
         "Real publish time from the KV latest pointer, distinct from generated_at. Null before the first publish or when the control KV is unbound.",
       ),
+    // Same shape and the same reason as `stale_contract` below: a SERVE-TIME
+    // provenance signal, declared on the shared meta because it is a property
+    // of the tier that answered, not of the entity asked about.
+    //
+    // WHAT IT SEPARATES, and why zeros alone could not. A 200 with
+    // `event_count: 0` is the correct answer for a valid ss58 with no activity
+    // -- that is a settled contract rule (`absent is null, never zero`), and
+    // these routes must stay on it. But it is ALSO what a reader returns when
+    // the tier's coverage simply has not reached the account yet, and the two
+    // were indistinguishable. Measured 2026-08-16: an account registered at
+    // 13:53 read as an empty account for a whole day, because the lakehouse's
+    // coverage ended at 02:30 that morning and nothing said so.
+    //
+    // Naming and semantics follow the field this repo already publishes on
+    // `/subnets/{netuid}/ownership-history`: how far the source covers at all,
+    // so a caller can tell "watched, nothing there" from "not watched since".
+    // Null, or absent, when the horizon cannot be established -- a guessed
+    // horizon would be worse than none, because a consumer would trust it.
+    observed_through: z
+      .string()
+      .meta({ format: "date-time" })
+      .nullable()
+      .optional()
+      .describe(
+        "How far the tier that answered this request has observed at all. A payload reporting no activity at or before this time is a measured absence; one whose subject is newer is outside coverage, not empty. Null when the horizon is unreadable.",
+      ),
     source: z.string().optional(),
     stale_contract: z
       .object({

--- a/schemas-src/internal-wire.ts
+++ b/schemas-src/internal-wire.ts
@@ -193,44 +193,83 @@ export const ColdTierAnswerSchema = z.object({
 });
 
 /**
- * `GET /api/v1/rpc/pools` as the wss load balancer reads it.
+ * `GET /api/v1/rpc/pools` as an INTERNAL reader reads it.
  *
- * DELIBERATELY LOOSE ALL THE WAY DOWN, and this is not laziness: every field
- * the selector touches (`url`, `score`, `pool_eligible`, `latest_block`) is
- * re-read through its own coercion there -- `Number(e.score)`, an explicit
- * null check on `latest_block` because `Number(null)` is 0 and would mis-read a
- * block-less endpoint as height 0. Typing them here would state a second,
- * stricter contract that the selector then ignores.
+ * NAMED FOR THE ARTIFACT, NOT ITS FIRST READER. This was `WssPool*` while the
+ * load balancer was the only consumer, and its own selector immediately
+ * re-aliased the types to `Pool`/`PoolEndpoint`/`PoolsArtifact` to get the
+ * service name back out of them -- which is the tell. The raw-capture lane now
+ * reads the same bytes to pick archive hosts, so a name that says "wss" would
+ * make the second reader look like it was borrowing the first one's schema
+ * rather than sharing the artifact's.
  *
- * What IS pinned is the structure the selector navigates: `pools` is a list --
+ * DELIBERATELY LOOSE ALL THE WAY DOWN, and this is not laziness: every field a
+ * consumer touches is re-read through its own coercion -- `Number(e.score)`, an
+ * explicit null check on `latest_block` because `Number(null)` is 0 and would
+ * mis-read a block-less endpoint as height 0, `=== true` on the booleans
+ * because `undefined` must not pass. Typing them here would state a second,
+ * stricter contract that every consumer then ignores.
+ *
+ * `catchall(unknown)` FOR THE SAME REASON AlertTriggerRowSchema HAS IT: a row
+ * is handed onward to code that owns a vocabulary this file must not
+ * enumerate. Zod's default STRIPS undeclared keys, so without it a parsed row
+ * is a LOSSY copy -- and the loss is silent, arriving at the consumer as
+ * `undefined` from a perfectly healthy artifact.
+ *
+ * Both halves of that bit this in one change. The capture lane read
+ * `archive_support`, which was undeclared, so every archive host failed its
+ * filter and the lane fell back to one endpoint. Then the parsed row was passed
+ * to `overlayRpcPoolEligibility`, which recomputes eligibility from
+ * `auth_required`/`public_safe` and rescores from `methods_supported` -- none
+ * of them declared here, all of them stripped, so a healthy endpoint came back
+ * ineligible. Declaring the overlay's whole field list here would make this
+ * schema a second copy of health-serving's vocabulary; `catchall` keeps the
+ * row intact and lets each consumer narrow what it reads.
+ *
+ * Fields ARE still declared when this file wants to say a consumer depends on
+ * them -- that is documentation, not enforcement, since `catchall` would carry
+ * them through regardless.
+ *
+ * What IS pinned is the structure a consumer navigates: `pools` is a list --
  * REQUIRED, which is the whole point. Optional here would let `{ error: "not
  * found" }` parse as an artifact with no pools, which is precisely the reading
  * the cast produced and precisely what a caller cannot tell from "no upstream
  * is eligible right now". One of those is an outage; the other is Tuesday.
  * An EMPTY list still parses, because that genuinely is the second case.
  */
-const WssPoolEndpointSchema = z.object({
-  id: z.string().optional(),
-  url: z.unknown().optional(),
-  kind: z.string().optional(),
-  pool_eligible: z.unknown().optional(),
-  score: z.unknown().optional(),
-  status: z.string().optional(),
-  latest_block: z.unknown().optional(),
-});
-export type WssPoolEndpoint = z.infer<typeof WssPoolEndpointSchema>;
+const RpcPoolsReadEndpointSchema = z
+  .object({
+    id: z.string().optional(),
+    url: z.unknown().optional(),
+    kind: z.string().optional(),
+    pool_eligible: z.unknown().optional(),
+    score: z.unknown().optional(),
+    status: z.string().optional(),
+    latest_block: z.unknown().optional(),
+    /** Read by the raw-capture lane to refuse pruned nodes: it fetches
+     * `state_getStorage` at heights up to a day back, which a pruned host cannot
+     * serve at all. Unknown like its siblings -- the lane narrows it. */
+    archive_support: z.unknown().optional(),
+  })
+  .catchall(z.unknown());
+export type RpcPoolsReadEndpoint = z.infer<typeof RpcPoolsReadEndpointSchema>;
 
-const WssPoolSchema = z.object({
-  id: z.string().optional(),
-  kind: z.string().optional(),
-  endpoints: z.array(WssPoolEndpointSchema).optional(),
-});
-export type WssPool = z.infer<typeof WssPoolSchema>;
+const RpcPoolsReadPoolSchema = z
+  .object({
+    id: z.string().optional(),
+    kind: z.string().optional(),
+    endpoints: z.array(RpcPoolsReadEndpointSchema).optional(),
+  })
+  // Same reason as the endpoint above: `overlayRpcPoolEligibility` reads and
+  // rewrites pool-level fields (`eligible_count`, `best_endpoint_id`) that a
+  // stripped copy would arrive without.
+  .catchall(z.unknown());
+export type RpcPoolsReadPool = z.infer<typeof RpcPoolsReadPoolSchema>;
 
-const WssPoolsArtifactSchema = z.object({
-  pools: z.array(WssPoolSchema),
+const RpcPoolsReadArtifactSchema = z.object({
+  pools: z.array(RpcPoolsReadPoolSchema),
 });
-export type WssPoolsArtifact = z.infer<typeof WssPoolsArtifactSchema>;
+export type RpcPoolsReadArtifact = z.infer<typeof RpcPoolsReadArtifactSchema>;
 
 /**
  * The same artifact as `/api/v1` serves it: wrapped in an envelope.
@@ -240,9 +279,9 @@ export type WssPoolsArtifact = z.infer<typeof WssPoolsArtifactSchema>;
  * moves -- the tolerance the cast expressed as an intersection type, which is
  * not a thing a runtime value can be.
  */
-export const WssPoolsResponseSchema = z.union([
-  z.object({ data: WssPoolsArtifactSchema }),
-  WssPoolsArtifactSchema,
+export const RpcPoolsReadSchema = z.union([
+  z.object({ data: RpcPoolsReadArtifactSchema }),
+  RpcPoolsReadArtifactSchema,
 ]);
 
 /**

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1142,32 +1142,61 @@ export async function loadAccountSummaryColdTier(
     recentLimit: limit,
   });
 
+  // THE ACCOUNT THE PROJECTION HAS NEVER SEEN, which is every account newer
+  // than the last generation -- and the case that used to be the worst one.
+  //
+  // An absent account is not a miss (see AccountSummaryProjectionAbsent): the
+  // producer writes every shard, so absence from a shard that exists PROVES
+  // there are no events at or before `through`. Both legs therefore bound to
+  // `[floorMs, now)` and stay COMPLETE -- there is nothing below the floor to
+  // miss -- instead of opening the whole table for a scattered filter.
+  //
+  // This is the read the 503 came from: one event, an unbounded lifetime scan,
+  // aborted at the 15s ceiling.
+  const absentFloor = projected?.absent === true ? projected.floorMs : null;
+  const absentBound =
+    absentFloor === null
+      ? ""
+      : ` AND observed_at >= ${Math.trunc(absentFloor)}`;
+  /** The projection when it FOUND the account, narrowed once so neither leg has
+   * to re-discriminate the union. */
+  const found = projected && projected.absent !== true ? projected : null;
+
   const [groupRows, recentRows] = await Promise.all([
-    projected
-      ? Promise.resolve(projected.groups)
-      : windowedFloorRead<Record<string, unknown>[]>(env, {
-          query,
-          attempt: (bound, run) =>
-            run(
-              env,
-              `WITH scan AS (${scan(bound)}) SELECT event_kind AS kind, netuid AS netuid, ` +
-                `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
-                `min(observed_at) AS fo, max(observed_at) AS lo ` +
-                `FROM scan GROUP BY event_kind, netuid`,
-              { onError: track("summary-groups") },
-            ),
-          // `sum(count)` over the groups is the rows the CTE saw, which is exactly
-          // the number the retired cap probe returned.
-          //
-          // No `?? 0`: `count(*)` always yields a value, so the nullish half is a
-          // branch no test can reach -- the same reading the `scanned` line below
-          // already applies. An absent count would make the sum NaN, `NaN > CAP` is
-          // false, and the read falls back to the unbounded query it would have
-          // issued anyway, so nothing is lost by not guarding it.
-          satisfied: (rows) =>
-            rows.reduce((n, row) => n + Number(row.count), 0) >
-            ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
-        }),
+    absentFloor !== null
+      ? query(
+          env,
+          `WITH scan AS (${scan(absentBound)}) SELECT event_kind AS kind, netuid AS netuid, ` +
+            `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
+            `min(observed_at) AS fo, max(observed_at) AS lo ` +
+            `FROM scan GROUP BY event_kind, netuid`,
+          { onError: track("summary-groups-bounded") },
+        )
+      : found
+        ? Promise.resolve(found.groups)
+        : windowedFloorRead<Record<string, unknown>[]>(env, {
+            query,
+            attempt: (bound, run) =>
+              run(
+                env,
+                `WITH scan AS (${scan(bound)}) SELECT event_kind AS kind, netuid AS netuid, ` +
+                  `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
+                  `min(observed_at) AS fo, max(observed_at) AS lo ` +
+                  `FROM scan GROUP BY event_kind, netuid`,
+                { onError: track("summary-groups") },
+              ),
+            // `sum(count)` over the groups is the rows the CTE saw, which is exactly
+            // the number the retired cap probe returned.
+            //
+            // No `?? 0`: `count(*)` always yields a value, so the nullish half is a
+            // branch no test can reach -- the same reading the `scanned` line below
+            // already applies. An absent count would make the sum NaN, `NaN > CAP` is
+            // false, and the read falls back to the unbounded query it would have
+            // issued anyway, so nothing is lost by not guarding it.
+            satisfied: (rows) =>
+              rows.reduce((n, row) => n + Number(row.count), 0) >
+              ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+          }),
     // THE FEED LEG, and the read that actually times this route out
     // (#11222). `windowedRowRead` probes `now-2d` then `now-8d` and then reads
     // the WHOLE remainder -- and 95.8% of accounts are past both probes, so
@@ -1180,22 +1209,37 @@ export async function loadAccountSummaryColdTier(
     // yet. The two halves meet at the edge of the last complete day rather
     // than overlapping or leaving a gap -- see `recentFloorMs` for why that
     // edge is `through` and emphatically not `generated_at`.
-    projected?.recent
+    //
+    // An ABSENT account takes the same bounded probe with NOTHING published to
+    // merge onto: the projection proved there is nothing below the floor, so
+    // the probe alone is the complete feed. Leaving this case on
+    // `windowedRowRead` would have bounded the aggregate leg and left the feed
+    // leg scanning the whole table -- fixing the cheaper half of the request
+    // and keeping the timeout.
+    absentFloor !== null
       ? headProbe(env, {
-          query: (e, sql) => query(e, sql, { onError: track("recent-head") }),
+          query: (e, sql) => query(e, sql, { onError: track("recent-absent") }),
           where,
-          floorMs: projected.recent.floorMs,
+          floorMs: absentFloor,
           limit,
-          published: projected.recent.rows,
+          published: [],
         })
-      : windowedRowRead<AccountEventsRow>(env, {
-          query: (e, sql) => query(e, sql, { onError: track("recent-feed") }),
-          table: "chain.account_events",
-          columns: EVENT_COLUMNS,
-          where: [where],
-          order: ` ${FEED_ORDER}`,
-          need: limit,
-        }),
+      : found?.recent
+        ? headProbe(env, {
+            query: (e, sql) => query(e, sql, { onError: track("recent-head") }),
+            where,
+            floorMs: found.recent.floorMs,
+            limit,
+            published: found.recent.rows,
+          })
+        : windowedRowRead<AccountEventsRow>(env, {
+            query: (e, sql) => query(e, sql, { onError: track("recent-feed") }),
+            table: "chain.account_events",
+            columns: EVENT_COLUMNS,
+            where: [where],
+            order: ` ${FEED_ORDER}`,
+            need: limit,
+          }),
   ]);
 
   // Either half missing is a decline: a card mixing measured aggregates with a

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -146,6 +146,28 @@ export interface AccountSummaryProjectionRead {
    * validated them.
    */
   recent: { rows: AccountSummaryRecentEvent[]; floorMs: number } | null;
+  /** Never set on a read that FOUND the account. The discriminant against
+   * `AccountSummaryProjectionAbsent`, so a caller cannot confuse "here are the
+   * account's groups" with "this account has no history before `floorMs`". */
+  absent?: false;
+}
+
+/**
+ * The projection was readable and does NOT list this account.
+ *
+ * That is a MEASUREMENT, not a miss: the producer writes every shard, so an
+ * account missing from a shard that exists had no events at or before the
+ * generation's `through`. Everything it has ever done therefore sits at or
+ * after `floorMs`, which turns a lifetime scan into one bounded read.
+ *
+ * There are no `groups` because there are none to publish — the caller reads
+ * the bounded window instead, and that read is COMPLETE rather than partial,
+ * which is what separates this from the `null` decline beside it.
+ */
+export interface AccountSummaryProjectionAbsent {
+  absent: true;
+  /** First millisecond the projection does not describe. */
+  floorMs: number;
 }
 
 /** The R2 key holding this account's groups, within a generation. */
@@ -213,7 +235,9 @@ export async function loadAccountSummaryProjection(
      */
     recentLimit?: number;
   } = {},
-): Promise<AccountSummaryProjectionRead | null> {
+): Promise<
+  AccountSummaryProjectionRead | AccountSummaryProjectionAbsent | null
+> {
   const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
     ?.METAGRAPH_ARCHIVE;
   if (!bucket?.get || !account) return null;
@@ -243,6 +267,34 @@ export async function loadAccountSummaryProjection(
   if (!payload) return null;
   const accounts = payload["accounts"];
   if (!accounts || typeof accounts !== "object") return null;
+
+  // POSITIVE ABSENCE IS AN ANSWER, and throwing it away is what made a new
+  // account the SLOWEST thing this route serves.
+  //
+  // The producer writes EVERY shard, empty ones included, precisely so this
+  // distinction can be drawn -- see `empty_payload`'s docstring in
+  // metagraphed-infra's account_summary_r2.py: "The reader cannot tell 'no such
+  // account' from 'this shard was never produced' when the object is absent --
+  // and the first is an answer while the second is a decline."
+  //
+  // The shard is present and does not list this account, so the projection has
+  // POSITIVELY ESTABLISHED that the account had no events at or before
+  // `through`. Returning a bare null here spent that fact: the caller could not
+  // tell it from an unreadable pointer, so it fell back to an unbounded
+  // lifetime scan of `chain.account_events` for an account whose entire history
+  // is known to sit inside a window a few days wide.
+  //
+  // Measured on production 2026-08-16: an account registered 2026-08-15T13:53 --
+  // one day past the generation's `through` -- took the unbounded path and the
+  // route answered `503 account_summary_unavailable` after aborting at the 15s
+  // ceiling, on an account with exactly ONE event.
+  //
+  // The bound still has to be placeable, so a generation with no usable
+  // `through` declines exactly as before rather than guessing a floor.
+  if ((accounts as Record<string, unknown>)[account] === undefined) {
+    const floorMs = recentFloorMs(pointer.through);
+    return floorMs === null ? null : { absent: true, floorMs };
+  }
   // PARSED PER-ACCOUNT, not per-shard. The envelope is checked structurally
   // above because a shard carries ~1,000 accounts and a request reads one of
   // them -- validating the whole object would spend the saving this tier

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -412,6 +412,26 @@ export function overlayRpcPoolEligibility(
             status: normalizeProbeStatus(live.status),
             latency_ms: live.latency_ms ?? endpoint.latency_ms,
             latest_block: live.latest_block ?? endpoint.latest_block ?? null,
+            // The sibling overlay (overlayRpcEndpointHealth) has carried this
+            // since it was added; this one did not, and the two are fed by the
+            // SAME prober row. So /api/v1/rpc/endpoints and
+            // /api/v1/rpc/pools disagreed about the same endpoint, from the
+            // same probe, in the same minute -- measured 2026-08-16:
+            // `opentensor-archive-rpc` and `onfinality-finney-rpc` reported
+            // archive_support TRUE on /endpoints (probed 07:45) and FALSE on
+            // /pools, whose build-time value was a day old.
+            //
+            // IT IS NOT COSMETIC. `score` is recomputed further down from this
+            // very row, and endpoint-score.ts gives `archive-support` +15 --
+            // so a stale `false` silently deducted 15 points from exactly the
+            // endpoints an archive-shaped consumer should rank FIRST, and left
+            // the archive pool with no HTTP members to select at all.
+            //
+            // `?? endpoint.archive_support` for the same reason latency_ms
+            // falls back: the probe omits the field entirely on a transport
+            // error, and a missing observation must not be read as "not an
+            // archive" when the build measured one.
+            archive_support: live.archive_support ?? endpoint.archive_support,
             health_source: LIVE_CRON_PROBER,
             health_stale: false,
             // 30-day observed behaviour, computed once per prober run (#9357).

--- a/src/lakehouse-observed-through.ts
+++ b/src/lakehouse-observed-through.ts
@@ -1,0 +1,133 @@
+// How far the lakehouse tier has observed at all, as a wall-clock instant.
+//
+// WHAT IT ANSWERS. `/api/v1/accounts/{ss58}/events` returning `event_count: 0`
+// is the CORRECT answer for a valid ss58 with no activity -- "absent is null,
+// never zero" is a settled contract rule and these routes stay on it. But it is
+// also what the reader returns when the tier's coverage has not reached the
+// account yet, and until this the two were the same bytes. Measured 2026-08-16:
+// an account registered at 13:53 read as an empty account for a full day,
+// because the lakehouse's coverage ended at 02:30 that morning and no field
+// said so.
+//
+// WHY NOT `max(observed_at)` ON THE TABLE. That is the literal answer and the
+// wrong query: `chain.account_events` is the unpartitioned table whose
+// unprunable scans this whole area exists to avoid, and a coverage marker that
+// costs a full scan per request would be more expensive than the reads it
+// annotates.
+//
+// SO IT IS DERIVED FROM THE DECODE WATERMARK, which is the same number the
+// serving path already routes on. `decodedThrough` is defined as the highest
+// block for which ALL FOUR decoded tables hold rows (src/decode-watermark.ts),
+// so it IS `chain.account_events`' ceiling -- in blocks. `blocks_head` maps a
+// block to the instant it was observed, so one indexed point lookup converts
+// the unit the tier knows into the unit the field publishes.
+//
+// WHY A TIMESTAMP AND NOT THE BLOCK. The field name and semantics are already
+// published on /subnets/{netuid}/ownership-history as an ISO instant, and one
+// field name carrying two units across routes is worse than a conversion.
+//
+// NULL IS A REAL ANSWER, and it is PUBLISHED rather than omitted. No watermark,
+// no `blocks_head` row for it, no store binding: every one yields null, and the
+// caller stamps that null. A consumer trusts a horizon it is given, so an
+// invented one is worse than none -- the same reason `recentFloorMs` refuses a
+// pointer with no `through` -- and dropping the key instead would make "this
+// tier publishes no horizon" indistinguishable from "it could not be read this
+// tick", which is the same conflation this field exists to end.
+
+import { registerModuleStateReset } from "./module-state-registry.ts";
+import { resolveDecodeWatermark } from "./decode-watermark.ts";
+import { readStore } from "./read-store.ts";
+import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
+
+/**
+ * How long a resolved horizon is reused.
+ *
+ * The same TTL the decode watermark itself uses, and deliberately not a
+ * different one: this value is a pure function of that watermark, so a shorter
+ * TTL would re-read `blocks_head` for a watermark that cannot have moved, and a
+ * longer one would keep publishing a horizon after the watermark it was derived
+ * from had already advanced.
+ */
+export const OBSERVED_THROUGH_TTL_MS = 5 * 60 * 1000;
+
+/** Resolved value plus its expiry, keyed by network for the same reason the
+ * decode watermark's memo is: a horizon is a chain-specific instant, and
+ * handing one network's to another would publish a coverage claim about a chain
+ * that was never read. The PROMISE is memoized so a cold isolate issues one
+ * lookup rather than racing several. */
+const memo = new Map<
+  ChainNetworkId,
+  { expiresAt: number; value: Promise<string | null> }
+>();
+
+registerModuleStateReset("src/lakehouse-observed-through.ts", () => {
+  memo.clear();
+});
+
+/** Drop the memo so the next resolve re-reads. Exported for tests. */
+export function resetObservedThroughCache(): void {
+  memo.clear();
+}
+
+export interface ObservedThroughDeps {
+  now?: () => number;
+  /** Bypass the memo, for a caller that has just seen the watermark move. */
+  fresh?: boolean;
+}
+
+async function readObservedThrough(
+  env: unknown,
+  network: ChainNetworkId,
+): Promise<string | null> {
+  const watermark = await resolveDecodeWatermark(env, {}, network).catch(
+    () => null,
+  );
+  const through = watermark?.decodedThrough;
+  if (
+    typeof through !== "number" ||
+    !Number.isFinite(through) ||
+    through <= 0
+  ) {
+    return null;
+  }
+  const db = readStore(env, ["blocks_head"]);
+  if (!db?.first) return null;
+  try {
+    // Equality, not `<=` with an ORDER BY: the watermark names a block the
+    // decoder finished, so the row either exists or the head register has not
+    // caught up -- and answering with some OLDER block's timestamp would
+    // publish a horizon earlier than the one actually served.
+    const row = (await db.first(
+      "SELECT observed_at FROM blocks_head WHERE block_number = $1",
+      [through],
+    )) as { observed_at?: unknown } | null;
+    const at = Number(row?.observed_at);
+    if (!Number.isFinite(at) || at <= 0) return null;
+    const iso = new Date(at).toISOString();
+    return iso;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The lakehouse tier's coverage ceiling as an ISO instant, or null.
+ *
+ * Null is cached exactly like a hit, for the reason `resolveDecodeWatermark`
+ * gives for doing the same: a deployment with no watermark (self-hosters, CI,
+ * the window before the decoder first publishes) must not pay a miss on every
+ * cold read.
+ */
+export async function resolveObservedThrough(
+  env: unknown,
+  deps: ObservedThroughDeps = {},
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+): Promise<string | null> {
+  if (deps.fresh) return readObservedThrough(env, network);
+  const now = (deps.now ?? Date.now)();
+  const cached = memo.get(network);
+  if (cached && cached.expiresAt > now) return cached.value;
+  const value = readObservedThrough(env, network);
+  memo.set(network, { expiresAt: now + OBSERVED_THROUGH_TTL_MS, value });
+  return value;
+}

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -81,6 +81,33 @@ export const DECODE_STALE_MS = 3 * 60 * 60 * 1000;
  */
 export const DECODE_LAG_BLOCKS = 2_400;
 
+/**
+ * How far the RAW CAPTURE may trail the CHAIN HEAD before it is a fault.
+ *
+ * THE HOLE THIS EXISTS TO CATCH. Every rule above measures the decoder against
+ * the capture. None of them measures the capture against the chain, so a
+ * capture that is losing satisfies all of them: the decoder keeps up with a
+ * watermark that is barely moving, `chain.blocks` stays contiguous, and the
+ * verdict is `ok`. Production ran 28 h in exactly that state on 2026-08-16 --
+ * `lane-alarm` reporting "0 alarming, 69 lanes" throughout -- while
+ * `/chain/alpha-volume` served a rolling-24h window whose newest row was 28.7 h
+ * old, so the whole network's volume read as a confident zero.
+ *
+ * WHY THE BOUND IS THE RETENTION WINDOW, not the cadence. Neon holds
+ * `chain_detail_account_events` for a rolling 24 h and the lakehouse is the
+ * long-term store. Once capture trails head by more than that retention, the
+ * span between the lakehouse's ceiling and Neon's floor is held by NO store and
+ * cannot be recovered from either -- it has to be re-read from the chain. 24 h
+ * is ~7,200 blocks, so the deadline is 7,200 and the alarm must land with room
+ * to act on it, not at the moment the loss becomes permanent.
+ *
+ * 900 blocks is ~3 hours: an eighth of that deadline, and well clear of the
+ * structural lag, which is one tick's chain production (~25 blocks) plus a
+ * partial final chunk. It cannot fire on healthy operation and still leaves
+ * ~21 h before anything is unrecoverable.
+ */
+export const CAPTURE_LAG_BLOCKS = 900;
+
 export interface SeamVerdict {
   reasons: string[];
   summary: Record<string, unknown>;
@@ -93,6 +120,14 @@ export interface SeamInput {
   watermark: DecodeWatermark | null;
   /** raw_capture_state.last_contiguous_block, or null when unreadable. */
   capturedThrough: number | null;
+  /**
+   * The chain's own head, from `blocks_head` — the yardstick for rule 6.
+   *
+   * NOT `hi` below: that is the lakehouse's newest decoded block, which trails
+   * the capture by construction. Measuring capture against it would compare the
+   * lane to something downstream of itself and always agree.
+   */
+  chainHead: number | null;
   /** min/max/count over chain.blocks, or nulls when unmeasurable. */
   lo: number | null;
   hi: number | null;
@@ -115,6 +150,7 @@ export function evaluateDecodeSeam({
   floor,
   watermark,
   capturedThrough,
+  chainHead,
   lo,
   hi,
   count,
@@ -160,6 +196,26 @@ export function evaluateDecodeSeam({
     );
   }
 
+  // 6. THE CAPTURE IS LOSING TO THE CHAIN. Every rule above is decoder-relative
+  //    and passes while this is true, because the decoder is faithfully
+  //    following a watermark that is falling behind. See CAPTURE_LAG_BLOCKS for
+  //    why the bound is the retention window rather than the cron cadence.
+  if (chainHead === null) {
+    reasons.push(
+      "could not read the chain head from blocks_head — whether the raw capture is keeping up with the chain is unmeasurable this tick",
+    );
+  } else if (
+    capturedThrough !== null &&
+    chainHead - capturedThrough > CAPTURE_LAG_BLOCKS
+  ) {
+    const behind = chainHead - capturedThrough;
+    reasons.push(
+      `the raw capture trails the chain head by ${behind} block(s) (threshold ${CAPTURE_LAG_BLOCKS}, ~${hours(behind * 12_000)}h of chain): ` +
+        `blocks ${capturedThrough + 1}..${chainHead} have not been captured as raw bytes at all, so no decode can recover them. ` +
+        "Past ~24h the span between the lakehouse's ceiling and Neon's rolling retention floor is held by no store and must be re-read from the chain",
+    );
+  }
+
   if (lo === null || hi === null || count === null) {
     // A failed read is not a passing check: staying quiet here would make an
     // unreachable lakehouse indistinguishable from a healthy one.
@@ -175,6 +231,11 @@ export function evaluateDecodeSeam({
         hi,
         count,
         captured_through: capturedThrough,
+        chain_head: chainHead,
+        head_lag:
+          capturedThrough === null || chainHead === null
+            ? null
+            : chainHead - capturedThrough,
       },
     };
   }
@@ -219,6 +280,13 @@ export function evaluateDecodeSeam({
       watermark_per_table: watermark?.perTable ?? null,
       captured_through: capturedThrough,
       capture_lag: capturedThrough === null ? null : capturedThrough - seam,
+      chain_head: chainHead,
+      // The capture's own lag, distinct from `capture_lag` above (which is the
+      // DECODER's lag behind the capture). Both can be healthy while this is not.
+      head_lag:
+        capturedThrough === null || chainHead === null
+          ? null
+          : chainHead - capturedThrough,
       lakehouse_lo: lo,
       lakehouse_hi: hi,
       lakehouse_count: count,
@@ -241,6 +309,28 @@ async function capturedThrough(env: unknown): Promise<number | null> {
   if (!db?.first) return null;
   try {
     return await watermarkRead(db)();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The chain head, or null on any failure.
+ *
+ * `blocks_head` is the per-block register the firehose fills, so it tracks the
+ * tip independently of the capture lane this rule judges. Reading the head from
+ * anything the capture lane also feeds would make rule 6 compare the lane to
+ * itself.
+ */
+async function chainHead(env: unknown): Promise<number | null> {
+  const db = readStore(env, ["blocks_head"]);
+  if (!db?.first) return null;
+  try {
+    const row = (await db.first(
+      "SELECT MAX(block_number) AS head FROM blocks_head",
+    )) as { head?: unknown } | null;
+    const head = num(row?.head);
+    return head !== null && Number.isFinite(head) ? head : null;
   } catch {
     return null;
   }
@@ -315,6 +405,7 @@ export async function runLakehouseSeamWatchdog(
     floor: blocksSeamFloor(env),
     watermark,
     capturedThrough: await capturedThrough(env),
+    chainHead: await chainHead(env),
     lo: num(row?.lo),
     hi: num(row?.hi),
     count: num(row?.n),

--- a/src/raw-capture-endpoints.ts
+++ b/src/raw-capture-endpoints.ts
@@ -31,6 +31,17 @@ import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
 import { overlayRpcPoolEligibility } from "./health-serving.ts";
 import { recordOrNull } from "./read-store.ts";
 import type { ChainNetworkId } from "./chain-network.ts";
+// PARSED, NOT CAST, and with the schema this artifact already has rather than a
+// second one -- a second declaration of the same bytes is a second place for the
+// reading to drift.
+//
+// It pins the structure a consumer NAVIGATES (`pools` is a REQUIRED list, so an
+// error body cannot parse as an artifact that merely holds no pools) and leaves
+// the leaves `unknown`, because this module narrows them itself. Note that a
+// leaf must still be DECLARED there to survive the parse at all: zod strips
+// undeclared keys, so an omitted field reads as `undefined` from a perfectly
+// healthy artifact rather than going merely untyped.
+import { RpcPoolsReadSchema } from "../schemas-src/internal-wire.ts";
 
 /** The pool ids that hold base-layer HTTP RPC endpoints, per network. */
 const RPC_POOL_ID: Record<ChainNetworkId, string> = {
@@ -95,34 +106,37 @@ export async function resolveCaptureEndpoints(
   deps: CaptureEndpointDeps,
 ): Promise<string[]> {
   if (!env) return [];
-  let artifact: Row | null;
+  let parsed: { pools: { id?: string; endpoints?: unknown[] }[] } | null;
   try {
     const result = await deps.readArtifact(env, RPC_POOLS_ARTIFACT_PATH);
-    artifact =
-      result?.ok && result.data && typeof result.data === "object"
-        ? (result.data as Row)
-        : null;
+    if (!result?.ok) return [];
+    const read = RpcPoolsReadSchema.safeParse(result.data);
+    if (!read.success) return [];
+    // The union accepts the artifact both bare and enveloped, because it is
+    // served as a file AND on /api/v1; `pools` is present in either arm.
+    parsed = "data" in read.data ? read.data.data : read.data;
   } catch {
     // An unreadable pool is not a fault here -- the caller has a default.
     return [];
   }
-  if (!artifact || !Array.isArray(artifact.pools)) return [];
+  if (!parsed) return [];
+
+  // ONE POOL, not all of them: only this network's is ever read, so overlaying
+  // the rest would spend the recompute on rows nothing here looks at.
+  const wanted = RPC_POOL_ID[network];
+  const found = parsed.pools.find((p) => p.id === wanted);
+  if (!found) return [];
 
   // The same live overlay the REST route and the MCP mirror apply, so this
   // cannot select on a day-old `pool_eligible` or a day-old `archive_support`.
-  let overlaid = artifact;
+  let pool: Row = found as Row;
   if (deps.readHealthKv) {
     try {
       const live = recordOrNull(
         await deps.readHealthKv(env, KV_HEALTH_RPC_POOL),
       );
       if (live && Array.isArray(live.endpoints)) {
-        overlaid = {
-          ...artifact,
-          pools: (artifact.pools as Row[]).map(
-            (pool) => (overlayRpcPoolEligibility(pool, live) ?? pool) as Row,
-          ),
-        };
+        pool = (overlayRpcPoolEligibility(pool, live) ?? pool) as Row;
       }
     } catch {
       // Fall through on the baked pool rather than declining: a stale
@@ -131,9 +145,7 @@ export async function resolveCaptureEndpoints(
     }
   }
 
-  const wanted = RPC_POOL_ID[network];
-  const pool = (overlaid.pools as Row[]).find((p) => p.id === wanted);
-  if (!pool || !Array.isArray(pool.endpoints)) return [];
+  if (!Array.isArray(pool.endpoints)) return [];
   const urls: string[] = [];
   for (const row of pool.endpoints as Row[]) {
     if (usableArchiveEndpoint(row)) urls.push(row.url as string);

--- a/src/raw-capture-endpoints.ts
+++ b/src/raw-capture-endpoints.ts
@@ -1,0 +1,165 @@
+// Which archive endpoints the raw-capture lane may read from this tick.
+//
+// WHY THIS EXISTS. The lane read one hardcoded host
+// (`https://archive.chain.opentensor.ai`) for its whole life, and the measured
+// ceiling on this lane is a PER-HOST rate limit -- ~100 requests per client per
+// minute (#9378). So the throughput ceiling and the endpoint were the same
+// number, and the lane fell 8,409 blocks (~28 h) behind the chain on 2026-08-16
+// with no way to buy its way out. Meanwhile the registry already curates,
+// probes and scores a second archive-capable HTTP endpoint
+// (`onfinality-finney-rpc`), and nothing read it.
+//
+// WHAT THIS IS NOT. It is not a second endpoint registry, and it does not
+// judge health itself. It reads the SAME `/metagraph/rpc/pools.json` the RPC
+// proxy and the WSS load balancer read, after the SAME 15-minute live overlay,
+// and applies the pool's own eligibility. A host this refuses is a host the
+// rest of the estate has already refused.
+//
+// WHY NOT `orderSafeRpcEndpoints`. That helper is the right shape but the wrong
+// layer: it lives in workers/request-handlers/rpc-proxy.ts beside the per-isolate
+// circuit breaker it mutates on every proxied request, which is state about
+// PROXY traffic and not about this cron. Reusing it would couple a capture tick
+// to the eject/half-open state of unrelated user requests. The filtering rules
+// this needs are the pool's own published fields, so it reads them directly.
+//
+// THE FALLBACK IS THE POINT, exactly as it is for the account-summary
+// projection: an unreadable artifact, an empty overlay, or a pool with no
+// archive-capable member all yield the caller's configured default. This can
+// make the lane faster, never blind.
+
+import { KV_HEALTH_RPC_POOL } from "./health-prober.ts";
+import { overlayRpcPoolEligibility } from "./health-serving.ts";
+import { recordOrNull } from "./read-store.ts";
+import type { ChainNetworkId } from "./chain-network.ts";
+
+/** The pool ids that hold base-layer HTTP RPC endpoints, per network. */
+const RPC_POOL_ID: Record<ChainNetworkId, string> = {
+  mainnet: "finney-rpc",
+  testnet: "test-rpc",
+};
+
+type Row = Record<string, unknown>;
+
+export interface CaptureEndpointEnv {
+  METAGRAPH_ARCHIVE?: unknown;
+}
+
+export interface CaptureEndpointDeps {
+  readArtifact: (
+    env: unknown,
+    path: string,
+  ) => Promise<{
+    ok?: boolean;
+    data?: unknown;
+  }>;
+  readHealthKv?: (env: unknown, key: string) => Promise<unknown>;
+}
+
+export const RPC_POOLS_ARTIFACT_PATH = "/metagraph/rpc/pools.json";
+
+/**
+ * Is this a host this lane may read historical STATE from?
+ *
+ * `archive_support` is the only field that answers it, and it is probe-derived:
+ * `chain_getBlockHash(1)` succeeds on an archive node and fails on a pruned one
+ * (verified live 2026-08-16 -- `lite` and `entrypoint` fail it, `archive` and
+ * `onfinality` pass). Capture reads `state_getStorage` at heights up to a day
+ * back, so a pruned host would answer `UnknownBlock: State already discarded`
+ * for every one of them.
+ *
+ * https only: the lane POSTs JSON-RPC, so a `wss://` row is not callable here
+ * even though it is perfectly healthy. That is why the `finney-archive` pool --
+ * whose four members are all `subtensor-wss` -- cannot serve this lane, and why
+ * this reads the rpc pool and filters rather than reading the archive pool.
+ */
+function usableArchiveEndpoint(row: Row): boolean {
+  const url = typeof row.url === "string" ? row.url : "";
+  return (
+    row.pool_eligible === true &&
+    row.archive_support === true &&
+    url.startsWith("https://")
+  );
+}
+
+/**
+ * The archive endpoints for `network`, best first, or `[]` when the pool cannot
+ * answer.
+ *
+ * Ordering is the pool's own: it is published already sorted by the comparator
+ * `overlayRpcPoolEligibility` applies after refreshing score and reliability, so
+ * re-sorting here would be a second opinion about a question the pool owns.
+ */
+export async function resolveCaptureEndpoints(
+  env: CaptureEndpointEnv | null | undefined,
+  network: ChainNetworkId,
+  deps: CaptureEndpointDeps,
+): Promise<string[]> {
+  if (!env) return [];
+  let artifact: Row | null;
+  try {
+    const result = await deps.readArtifact(env, RPC_POOLS_ARTIFACT_PATH);
+    artifact =
+      result?.ok && result.data && typeof result.data === "object"
+        ? (result.data as Row)
+        : null;
+  } catch {
+    // An unreadable pool is not a fault here -- the caller has a default.
+    return [];
+  }
+  if (!artifact || !Array.isArray(artifact.pools)) return [];
+
+  // The same live overlay the REST route and the MCP mirror apply, so this
+  // cannot select on a day-old `pool_eligible` or a day-old `archive_support`.
+  let overlaid = artifact;
+  if (deps.readHealthKv) {
+    try {
+      const live = recordOrNull(
+        await deps.readHealthKv(env, KV_HEALTH_RPC_POOL),
+      );
+      if (live && Array.isArray(live.endpoints)) {
+        overlaid = {
+          ...artifact,
+          pools: (artifact.pools as Row[]).map(
+            (pool) => (overlayRpcPoolEligibility(pool, live) ?? pool) as Row,
+          ),
+        };
+      }
+    } catch {
+      // Fall through on the baked pool rather than declining: a stale
+      // eligibility flag is still the estate's own judgement, and the
+      // per-endpoint failover in captureTick covers a host that has since died.
+    }
+  }
+
+  const wanted = RPC_POOL_ID[network];
+  const pool = (overlaid.pools as Row[]).find((p) => p.id === wanted);
+  if (!pool || !Array.isArray(pool.endpoints)) return [];
+  const urls: string[] = [];
+  for (const row of pool.endpoints as Row[]) {
+    if (usableArchiveEndpoint(row)) urls.push(row.url as string);
+  }
+  return urls;
+}
+
+/**
+ * The endpoint list a tick should actually use.
+ *
+ * The configured default is ALWAYS present and always first: it is the host
+ * this lane has read for its whole life, the one whose behaviour under this
+ * exact call pattern was measured, and the only one guaranteed to exist when
+ * the pool cannot be read. Pool members join behind it, de-duplicated, so a
+ * pool that already names it does not double its share of the rotation.
+ */
+export function captureEndpointList(
+  configuredDefault: string,
+  fromPool: readonly string[],
+): string[] {
+  const seen = new Set<string>([configuredDefault]);
+  const urls = [configuredDefault];
+  for (const url of fromPool) {
+    if (seen.has(url)) continue;
+    seen.add(url);
+    urls.push(url);
+  }
+  return urls;
+}

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -146,9 +146,29 @@ const RPC_BUDGET_UTILISATION = 0.8;
  */
 const TICK_SPEND_FRACTION = 0.8;
 
-/** Blocks per durable write. One R2 PUT each, so this trades a few writes for
- * how much a killed invocation discards -- 25 blocks is ~2 minutes of chain. */
-const FLUSH_EVERY_BLOCKS = 25;
+/**
+ * Blocks per durable write. One R2 PUT each, so this trades a few writes for
+ * how much a killed invocation discards.
+ *
+ * THIS NUMBER IS A DEADLINE, NOT A BATCH SIZE, and 25 was past it. The chunk
+ * only becomes durable once it is FULL, so the time to the first durable write
+ * is `flushEvery * minGapMs` -- at the paced 4,500 ms that was 112 s, and an
+ * invocation that did not live that long wrote NOTHING. The trailing flush at
+ * the end of captureTick covers a clean early `break`; it does not run when the
+ * runtime kills the invocation, which is the case this bounds.
+ *
+ * Measured against production 2026-08-16, mainnet: the watermark advanced 25
+ * blocks in 21 minutes (three ticks) while the chain advanced ~105 -- one
+ * single chunk, the rest discarded. Capture was losing ~3.8 blocks/min against
+ * a chain producing 5/min, having fallen 8,409 blocks (~28 h) behind, and the
+ * lane threw nothing the whole time: no exception, `last_error` NULL,
+ * `stopped_at` NULL.
+ *
+ * At 5 the first durable write lands in ~22 s, so a tick killed at any point
+ * keeps all but its final partial chunk. The cost is ~11 PUTs per tick instead
+ * of ~2 (a full 53-block tick), which is nothing against losing the tick.
+ */
+const FLUSH_EVERY_BLOCKS = 5;
 
 /** The paced budget for ONE lane, given how many share the client allowance. */
 export function pacedLaneBudget(

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -33,6 +33,12 @@ import {
   DEFAULT_CHAIN_NETWORK,
 } from "./chain-network.ts";
 import type { StoreEnv } from "./read-store.ts";
+import {
+  captureEndpointList,
+  resolveCaptureEndpoints,
+  type CaptureEndpointDeps,
+} from "./raw-capture-endpoints.ts";
+import { readArtifact, readHealthKv } from "../workers/storage.ts";
 
 /** Kill switch, matching CHAIN_HEAD_POLL_ENABLED's convention on the head
  * poller: absent or anything but "true" means this lane does not run. */
@@ -170,13 +176,32 @@ const TICK_SPEND_FRACTION = 0.8;
  */
 const FLUSH_EVERY_BLOCKS = 5;
 
-/** The paced budget for ONE lane, given how many share the client allowance. */
+/**
+ * The paced budget for ONE lane, given how many share the client allowance and
+ * how many HOSTS the lane spreads across.
+ *
+ * THE LIMIT IS PER HOST, which is what `hostCount` expresses. #9378 measured it
+ * per CLIENT against one host and the lane has read from one host ever since,
+ * so the budget and the endpoint were the same number. They are not the same
+ * thing: two archive hosts serve two allowances, and `captureTick` rotates
+ * across them so each still sees `minGapMs` between its own calls. The
+ * aggregate rate therefore scales with the hosts actually available rather
+ * than with a constant nobody re-derived when a second archive endpoint was
+ * curated into the registry.
+ *
+ * `laneCount` still DIVIDES: mainnet and testnet run concurrently, and where
+ * they share a host they share its allowance. `hostCount` MULTIPLIES, for the
+ * opposite reason. Both are measured at tick time now, not compiled in.
+ */
 export function pacedLaneBudget(
   laneCount: number,
   cronMinutes: number,
   limitPerMinute: number = RPC_REQUESTS_PER_MINUTE_LIMIT,
+  hostCount = 1,
 ): { maxBlocks: number; minGapMs: number } {
-  const callsPerMinute = (limitPerMinute * RPC_BUDGET_UTILISATION) / laneCount;
+  const hosts = Math.max(1, Math.trunc(hostCount));
+  const callsPerMinute =
+    (limitPerMinute * RPC_BUDGET_UTILISATION * hosts) / laneCount;
   const blocksPerMinute = callsPerMinute / RPC_CALLS_PER_BLOCK;
   return {
     // Lanes run CONCURRENTLY, so each gets the whole spendable interval rather
@@ -376,6 +401,16 @@ export async function runRawCaptureSync(
     /** Needed to reach Neon: createPgSql returns the pooled connection through
      * waitUntil, so without one the mirror is skipped rather than leaking. */
     ctx?: WaitUntilLike;
+    /**
+     * How the lane discovers the archive endpoints it may read from.
+     *
+     * DEFAULTED, NOT OPTIONAL-AND-UNSET. An injectable that nothing injects in
+     * production is a feature that never runs, so the real readers are the
+     * default and a test overrides them. `resolveCaptureEndpoints` already
+     * treats every unreadable shape as "no pool", so wiring the live readers
+     * here cannot make a tick fail -- it can only widen the rotation.
+     */
+    endpointDeps?: CaptureEndpointDeps;
   } = {},
 ): Promise<RawCaptureSyncResult> {
   const now = deps.now ?? Date.now;
@@ -442,6 +477,12 @@ export async function runRawCaptureSync(
         waitUntil: deps.ctx,
         fetchImpl: deps.fetchImpl,
         sleepFn: deps.sleepFn,
+        endpointDeps: deps.endpointDeps ?? {
+          readArtifact: (e, path) =>
+            readArtifact(e as Parameters<typeof readArtifact>[0], path),
+          readHealthKv: (e, key) =>
+            readHealthKv(e as Parameters<typeof readHealthKv>[0], key),
+        },
       }),
     ),
   );
@@ -481,19 +522,40 @@ async function runLane(
     fetchImpl?: typeof fetch;
     sleepFn?: (ms: number) => Promise<void>;
     waitUntil?: WaitUntilLike;
+    endpointDeps?: CaptureEndpointDeps;
   },
 ): Promise<RawCaptureLaneResult> {
   const { env, store, now, capture } = ctx;
   try {
+    const configured =
+      (env[lane.rpcUrlEnv] as string | undefined) || lane.defaultRpcUrl;
+    // The registry's archive-capable members for this network, behind the
+    // configured host. Empty when the pool cannot answer, which degrades to
+    // exactly the single-endpoint lane this was before.
+    const fromPool = ctx.endpointDeps
+      ? await resolveCaptureEndpoints(env, lane.network, ctx.endpointDeps)
+      : [];
+    const rpcUrls = captureEndpointList(configured, fromPool);
+    // The per-host limit is what was measured, so the budget scales with the
+    // hosts this tick actually has -- derived here rather than compiled in,
+    // because the pool's membership changes without a deploy.
+    const budget = pacedLaneBudget(
+      RAW_CAPTURE_LANES.length,
+      cronStepMinutes(RAW_CAPTURE_CRON),
+      RPC_REQUESTS_PER_MINUTE_LIMIT,
+      rpcUrls.length,
+    );
     const result = await captureTick({
-      rpcUrl: (env[lane.rpcUrlEnv] as string | undefined) || lane.defaultRpcUrl,
+      rpcUrls,
       store,
       // THE TABLE IS THE WATERMARK, so this store is the whole write path.
       watermark: neonWatermark(ctx.env, ctx.waitUntil, lane.network, now),
       genesisFloor: lane.genesisFloor,
-      maxPerTick: lane.maxPerTick,
+      // The lane's table values are the ONE-HOST budget, kept as the floor this
+      // can never fall below; `budget` widens them when the pool offers more.
+      maxPerTick: Math.max(lane.maxPerTick, budget.maxBlocks),
       network: lane.network,
-      minGapMs: lane.minGapMs,
+      minGapMs: Math.min(lane.minGapMs, budget.minGapMs),
       flushEvery: lane.flushEvery,
       fetchImpl: ctx.fetchImpl,
       sleepFn: ctx.sleepFn,

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -211,7 +211,25 @@ export interface CaptureResult {
  * the next tick resumes from the same place.
  */
 export async function captureTick(deps: {
-  rpcUrl: string;
+  /**
+   * The archive endpoints this tick may read from, in preference order.
+   *
+   * A LIST, NOT A URL, because the binding constraint on this lane is a
+   * PER-HOST rate limit (~100 requests per client per minute, measured in
+   * #9378), and one host was the whole budget. Blocks rotate across the list,
+   * so each host sees the same per-host rate it saw before while the lane's
+   * aggregate rate multiplies by the number of hosts.
+   *
+   * THE NO-GAP GUARANTEE IS UNCHANGED, and the rotation is why it needed care:
+   * a height that fails on one endpoint is retried on the OTHERS before the
+   * tick gives up, and the tick still stops at the first height NO endpoint
+   * could serve. So a single flaky host degrades throughput instead of pinning
+   * the watermark, and nothing is ever skipped.
+   *
+   * Must be non-empty; a caller with one endpoint passes a one-element list,
+   * which behaves exactly as the single-URL form did.
+   */
+  rpcUrls: readonly string[];
   store: RawCaptureStore;
   watermark: WatermarkStore;
   genesisFloor: number;
@@ -247,6 +265,15 @@ export async function captureTick(deps: {
   const sleepFn =
     deps.sleepFn ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const endpoints = deps.rpcUrls;
+  if (endpoints.length === 0) {
+    throw new Error("captureTick: rpcUrls is empty; nothing to read from");
+  }
+  // The gap the CALLER computed is per host. Rotating across N hosts means the
+  // wall gap between consecutive blocks is that divided by N -- each host still
+  // sees `minGapMs` between its own calls, which is the rate the measured limit
+  // applies to, while the lane's aggregate rate is N times what one host allowed.
+  const stepGapMs = Math.ceil(minGapMs / endpoints.length);
   const stored = await deps.watermark.read();
   // An unset watermark starts just below the floor, so the first tick captures
   // the floor block itself rather than skipping it.
@@ -255,12 +282,33 @@ export async function captureTick(deps: {
       ? stored
       : deps.genesisFloor - 1;
 
-  const headRaw = (await rpc(
-    deps.rpcUrl,
-    "chain_getHeader",
-    [],
-    fetchImpl,
-  )) as { number?: unknown };
+  // The head comes from whichever endpoint answers FIRST, not from a fixed one:
+  // a tick must not be lost because the preferred host is down when every other
+  // host could have served the whole run.
+  let headRaw: { number?: unknown } | null = null;
+  let headError: unknown = null;
+  for (const url of endpoints) {
+    try {
+      headRaw = (await rpc(url, "chain_getHeader", [], fetchImpl)) as {
+        number?: unknown;
+      };
+      break;
+    } catch (error) {
+      headError = error;
+    }
+  }
+  if (headRaw === null) {
+    const detail = String((headError as Error)?.message ?? headError);
+    // One endpoint's failure IS the lane's failure, and its message is already
+    // the whole story -- rewrapping it would only bury the cause a caller
+    // greps for. The "no endpoint answered" framing is a claim about a SET, so
+    // it is only made when there was one.
+    throw new Error(
+      endpoints.length > 1
+        ? `chain_getHeader: no endpoint answered (${detail})`
+        : detail,
+    );
+  }
   const headHex = headRaw?.number;
   if (typeof headHex !== "string" || !/^0x[0-9a-fA-F]+$/.test(headHex)) {
     throw new Error("chain_getHeader: unusable head number");
@@ -308,16 +356,30 @@ export async function captureTick(deps: {
   for (const [index, height] of heights.entries()) {
     // BEFORE the read, and never before the first: the gap belongs between two
     // blocks' bursts, so pacing never delays a tick that captures one block.
-    if (index > 0 && minGapMs > 0) await sleepFn(minGapMs);
-    try {
-      pending.push(await fetchRawBlock(deps.rpcUrl, height, fetchImpl, now));
-    } catch (error) {
+    if (index > 0 && stepGapMs > 0) await sleepFn(stepGapMs);
+    // Rotate, so consecutive blocks land on different hosts and each host's own
+    // call spacing stays `minGapMs`.
+    let captured1: RawBlockCapture | null = null;
+    let lastError: unknown = null;
+    for (let attempt = 0; attempt < endpoints.length; attempt += 1) {
+      const url = endpoints[(index + attempt) % endpoints.length]!;
+      try {
+        captured1 = await fetchRawBlock(url, height, fetchImpl, now);
+        break;
+      } catch (error) {
+        // NOT a gap yet: another endpoint may hold this height. Only the height
+        // that NO endpoint can serve stops the tick.
+        lastError = error;
+      }
+    }
+    if (captured1 === null) {
       // Stop at the FIRST failure and keep the prefix. Continuing past it
       // would create exactly the hole this module exists to prevent.
       stoppedAt = height;
-      reason = String((error as Error)?.message ?? error);
+      reason = String((lastError as Error)?.message ?? lastError);
       break;
     }
+    pending.push(captured1);
     if (pending.length >= flushEvery) {
       watermark = await flush(pending);
       captured += pending.length;

--- a/tests/account-routes.test.ts
+++ b/tests/account-routes.test.ts
@@ -505,3 +505,30 @@ test("GET /accounts/{ss58}/axon-removals rejects an unsupported window with 400"
   const body = await res.json();
   assert.equal(body.meta.parameter, "window");
 });
+
+test("every account response publishes the tier's coverage horizon (`observed_through`)", async () => {
+  // The field that separates "this ss58 has no activity" from "coverage has not
+  // reached it yet". Both are a 200 with zeros -- deliberately, because an ss58
+  // is a valid identity whether or not it has ever acted -- so the distinction
+  // has to ride BESIDE the zeros rather than become an error.
+  //
+  // Measured 2026-08-16: an account registered at 13:53 read as an empty
+  // account for a full day, because the lakehouse's coverage ended at 02:30
+  // that morning and nothing in the payload said so.
+  //
+  // Asserted as PRESENT-and-null rather than skipped when unresolvable: this
+  // fixture binds no watermark, and dropping the key would make "this tier
+  // publishes no horizon" and "it could not be read this tick" the same
+  // absence, which is the conflation the field exists to end.
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/events`),
+    dbWith({ events: [] }) as never,
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.ok(
+    "observed_through" in body.meta,
+    `meta must carry the horizon; got ${JSON.stringify(Object.keys(body.meta))}`,
+  );
+  assert.equal(body.meta.observed_through, null);
+});

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -884,6 +884,83 @@ describe("the projection short-circuits the FEED leg too (#11222)", () => {
     }
   });
 
+  /**
+   * The account the projection has NEVER seen -- every account registered since
+   * the last generation, and the case that used to be the slowest thing here.
+   *
+   * The producer writes every shard, so absence from a shard that exists proves
+   * there is nothing at or before `through`. BOTH legs must therefore bound to
+   * the floor: bounding only the aggregate half would fix the cheap read and
+   * leave the feed scanning the whole table, which is the read that 503s.
+   *
+   * Measured on production 2026-08-16: an account registered 2026-08-15T13:53,
+   * one day past the generation, held exactly ONE event and the route answered
+   * `503 account_summary_unavailable` after aborting at the 15s ceiling.
+   */
+  describe("an account the projection has never seen", () => {
+    /** The shard exists and simply does not list this account. */
+    const unseen = () => archive(null, { limit: 10 });
+    const withoutAccount = () => {
+      const base = unseen() as unknown as {
+        METAGRAPH_ARCHIVE: { get: (k: string) => Promise<unknown> };
+      };
+      return {
+        METAGRAPH_ARCHIVE: {
+          get: async (key: string) => {
+            const got = await base.METAGRAPH_ARCHIVE.get(key);
+            if (key !== SHARD_KEY || !got) return got;
+            // Present, complete, and holding somebody else.
+            return { json: async () => ({ schema_version: 1, accounts: {} }) };
+          },
+        },
+      } as never;
+    };
+
+    test("EVERY read is floored, not just the aggregate one", async () => {
+      const engine = fakeEngine({ recent: [] });
+      const cold = await loadAccountSummaryColdTier(withoutAccount(), SS58, {
+        query: engine.query as never,
+      });
+      assert.equal(cold.declined, undefined);
+      assert.ok(engine.seen.length > 0, "it still reads the bounded window");
+      for (const sql of engine.seen) {
+        assert.match(
+          sql,
+          new RegExp(`observed_at >= ${FLOOR}\\b`),
+          `unfloored read for an account proven to have no history: ${sql.slice(0, 120)}`,
+        );
+      }
+    });
+
+    test("the feed leg is ONE probe, never the unbounded walk", async () => {
+      // The regression that would undo this: leaving the feed on
+      // `windowedRowRead`, whose last step has no floor at all.
+      const engine = fakeEngine({ recent: [] });
+      await loadAccountSummaryColdTier(withoutAccount(), SS58, {
+        query: engine.query as never,
+      });
+      const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
+      assert.equal(feed.length, 1, "one probe, not a walk");
+    });
+
+    test("events after the floor are still served, not zeroed", async () => {
+      // Absence means "nothing BEFORE the floor" -- emphatically not "no
+      // events". A card that published zero here would be confidently wrong
+      // about the newly-registered account this whole path exists for.
+      const fresh = event({
+        block_number: 8_900_000,
+        observed_at: Date.parse("2026-08-15T13:53:48Z"),
+      });
+      const engine = fakeEngine({ recent: [fresh] });
+      const cold = await loadAccountSummaryColdTier(withoutAccount(), SS58, {
+        query: engine.query as never,
+      });
+      assert.equal(cold.declined, undefined);
+      assert.equal(cold.recent?.length, 1);
+      assert.equal(cold.recent?.[0]!.block_number, 8_900_000);
+    });
+  });
+
   test("the floor is the END of `through`, not the pointer's clock", async () => {
     // `generated_at` is the run's stamp and sits HOURS after the data it
     // describes -- six, on the generation measured 2026-08-15. Flooring there

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -20,6 +20,7 @@ import {
   accountShard,
   accountSummaryShardKey,
   loadAccountSummaryProjection,
+  type AccountSummaryProjectionRead,
   recentFloorMs,
 } from "../src/account-summary-projection.ts";
 
@@ -110,10 +111,31 @@ describe("accountShard", () => {
   });
 });
 
+/**
+ * The read narrowed to the variant that FOUND the account.
+ *
+ * The reader returns a union now: a found account, a positive absence (the
+ * shard exists and does not list it), or null. Every assertion below this line
+ * is about an account the projection holds, so narrowing once here beats
+ * re-discriminating at each one -- and asserting the variant means a read that
+ * silently became an absence fails loudly instead of reading as `undefined`.
+ * Absence has its own describe block.
+ */
+async function readFound(
+  ...args: Parameters<typeof loadAccountSummaryProjection>
+): Promise<AccountSummaryProjectionRead> {
+  const got = await loadAccountSummaryProjection(...args);
+  assert.ok(
+    got && got.absent !== true,
+    "expected the projection to find this account",
+  );
+  return got;
+}
+
 describe("loadAccountSummaryProjection", () => {
   test("reads the pointer, THEN the account's shard in that generation", async () => {
     const store = archive(published({ [HOT]: [group()] }));
-    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    const groups = await readFound(store.env, HOT, FRESH);
     assert.deepEqual(store.asked, [
       ACCOUNT_SUMMARY_POINTER_KEY,
       accountSummaryShardKey(HOT, SHARDS, GEN),
@@ -147,7 +169,7 @@ describe("loadAccountSummaryProjection", () => {
         accounts: { [HOT]: [group()] },
       },
     });
-    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    const groups = await readFound(store.env, HOT, FRESH);
     assert.equal(groups!.groups.length, 1);
   });
 
@@ -163,7 +185,7 @@ describe("loadAccountSummaryProjection", () => {
         accounts: { [HOT]: [group({ count: 999 })] },
       },
     });
-    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    const groups = await readFound(store.env, HOT, FRESH);
     assert.equal(
       groups!.groups[0]!.count,
       1,
@@ -200,7 +222,7 @@ describe("loadAccountSummaryProjection", () => {
       null,
     );
     assert.ok(
-      await loadAccountSummaryProjection(store.env, HOT, {
+      await readFound(store.env, HOT, {
         now: () => written + ACCOUNT_SUMMARY_MAX_AGE_MS - 1,
       }),
     );
@@ -270,6 +292,9 @@ describe("loadAccountSummaryProjection", () => {
       ),
       null,
     );
+    // An unseen account declines HERE because this generation publishes no
+    // `through`, so no bounded floor can be placed. With one it is a positive
+    // absence instead -- see "an account the projection does not list".
     const store = archive(published({ [COLD]: [group()] }));
     assert.equal(
       await loadAccountSummaryProjection(store.env, HOT, FRESH),
@@ -313,23 +338,20 @@ describe("loadAccountSummaryProjection", () => {
         ],
       }),
     );
-    assert.deepEqual(
-      await loadAccountSummaryProjection(store.env, HOT, FRESH),
-      {
-        recent: null,
-        groups: [
-          {
-            kind: "Transfer",
-            netuid: null,
-            count: 2,
-            fb: null,
-            lb: null,
-            fo: null,
-            lo: null,
-          },
-        ],
-      },
-    );
+    assert.deepEqual(await readFound(store.env, HOT, FRESH), {
+      recent: null,
+      groups: [
+        {
+          kind: "Transfer",
+          netuid: null,
+          count: 2,
+          fb: null,
+          lb: null,
+          fo: null,
+          lo: null,
+        },
+      ],
+    });
   });
 
   test("a non-object body is refused, at the pointer and at the shard", async () => {
@@ -405,7 +427,7 @@ describe("loadAccountSummaryProjection", () => {
     // off-by-one here would drop the busiest accounts the tier CAN serve.
     const atCap = [group({ count: ACCOUNT_EVENT_SUMMARY_SCAN_CAP })];
     const store = archive(published({ [HOT]: atCap }));
-    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    const groups = await readFound(store.env, HOT, FRESH);
     assert.equal(groups!.groups.length, 1);
   });
 
@@ -571,7 +593,7 @@ describe("recentFloorMs", () => {
 describe("the projection's recent map", () => {
   test("is returned with the floor the probe resumes from", async () => {
     const store = archive(withRecent({ [HOT]: [event()] }));
-    const read = await loadAccountSummaryProjection(store.env, HOT, {
+    const read = await readFound(store.env, HOT, {
       ...FRESH,
       recentLimit: 10,
     });
@@ -587,7 +609,7 @@ describe("the projection's recent map", () => {
     // own would serve nine events as though they were the newest ten, with
     // nothing on the card to say the tenth was never published.
     const store = archive(withRecent({ [HOT]: [event()] }, { limit: 9 }));
-    const read = await loadAccountSummaryProjection(store.env, HOT, {
+    const read = await readFound(store.env, HOT, {
       ...FRESH,
       recentLimit: 10,
     });
@@ -598,7 +620,7 @@ describe("the projection's recent map", () => {
   test("an equal published limit is enough", async () => {
     // The boundary the test above brackets: >= is the rule, not >.
     const store = archive(withRecent({ [HOT]: [event()] }, { limit: 10 }));
-    const read = await loadAccountSummaryProjection(store.env, HOT, {
+    const read = await readFound(store.env, HOT, {
       ...FRESH,
       recentLimit: 10,
     });
@@ -613,7 +635,7 @@ describe("the projection's recent map", () => {
     const store = archive(
       published({ [HOT]: [group()] }, { through: "2026-08-13" }),
     );
-    const read = await loadAccountSummaryProjection(store.env, HOT, {
+    const read = await readFound(store.env, HOT, {
       ...FRESH,
       recentLimit: 10,
     });
@@ -628,7 +650,7 @@ describe("the projection's recent map", () => {
     const store = archive(
       withRecent({ [HOT]: [event()] }, { over: { through: undefined } }),
     );
-    const read = await loadAccountSummaryProjection(store.env, HOT, {
+    const read = await readFound(store.env, HOT, {
       ...FRESH,
       recentLimit: 10,
     });
@@ -643,7 +665,7 @@ describe("the projection's recent map", () => {
     const store = archive(
       withRecent({ [HOT]: [event(), event({ block_number: null })] }),
     );
-    const read = await loadAccountSummaryProjection(store.env, HOT, {
+    const read = await readFound(store.env, HOT, {
       ...FRESH,
       recentLimit: 10,
     });
@@ -655,7 +677,7 @@ describe("the projection's recent map", () => {
     // otherwise have it silently dropped from every card, and the divergence
     // would only show up as a field the API stopped serving.
     const store = archive(withRecent({ [HOT]: [{ ...event(), surprise: 1 }] }));
-    const read = await loadAccountSummaryProjection(store.env, HOT, {
+    const read = await readFound(store.env, HOT, {
       ...FRESH,
       recentLimit: 10,
     });
@@ -665,7 +687,7 @@ describe("the projection's recent map", () => {
   test("an account absent from the map, or empty in it, declines", async () => {
     for (const map of [{}, { [HOT]: [] }, { [COLD]: [event()] }]) {
       const store = archive(withRecent(map));
-      const read = await loadAccountSummaryProjection(store.env, HOT, {
+      const read = await readFound(store.env, HOT, {
         ...FRESH,
         recentLimit: 10,
       });
@@ -676,7 +698,7 @@ describe("the projection's recent map", () => {
   test("a non-object recent map is refused rather than indexed", async () => {
     for (const map of ["nope", 7, null] as unknown[]) {
       const store = archive(withRecent(map as Record<string, unknown>));
-      const read = await loadAccountSummaryProjection(store.env, HOT, {
+      const read = await readFound(store.env, HOT, {
         ...FRESH,
         recentLimit: 10,
       });
@@ -688,7 +710,7 @@ describe("the projection's recent map", () => {
     // The default. Every caller before #575 wants the aggregate leg only, and
     // must not start paying to parse a list it will not use.
     const store = archive(withRecent({ [HOT]: [event()] }));
-    const read = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    const read = await readFound(store.env, HOT, FRESH);
     assert.equal(read!.recent, null);
   });
 });
@@ -717,7 +739,7 @@ describe("a published list is only served when it IS the newest N", () => {
   }
 
   const read = (store: ReturnType<typeof archive>) =>
-    loadAccountSummaryProjection(store.env, HOT, { ...FRESH, recentLimit: 10 });
+    readFound(store.env, HOT, { ...FRESH, recentLimit: 10 });
 
   test("a FULL list is served -- the walk has passed this account's events", async () => {
     assert.equal((await read(shard(500, 10)))!.recent!.rows.length, 10);
@@ -742,6 +764,59 @@ describe("a published list is only served when it IS the newest N", () => {
     assert.equal((await read(shard(10, 10)))!.recent!.rows.length, 10);
     assert.equal((await read(shard(11, 10)))!.recent!.rows.length, 10);
     assert.equal((await read(shard(5, 4)))!.recent, null);
+  });
+});
+
+/**
+ * Absence as an ANSWER, which is the whole reason the producer writes empty
+ * shards. See `empty_payload` in metagraphed-infra's account_summary_r2.py:
+ * "The reader cannot tell 'no such account' from 'this shard was never
+ * produced' when the object is absent -- and the first is an answer while the
+ * second is a decline."
+ *
+ * Before this, both collapsed to `null` and the caller ran an unbounded
+ * lifetime scan for an account proven to have no history.
+ */
+describe("an account the projection does not list", () => {
+  const THROUGH = { through: "2026-08-14" };
+  const FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
+
+  test("is a positive absence carrying the floor, not a decline", async () => {
+    // The shard EXISTS and does not hold HOT, so the projection has established
+    // there is nothing at or before `through`.
+    const store = archive(published({}, THROUGH));
+    const got = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    assert.deepEqual(got, { absent: true, floorMs: FLOOR });
+  });
+
+  test("a MISSING shard stays a decline, and is never read as absence", async () => {
+    // The distinction the producer writes empty shards to make. Treating an
+    // unwritten shard as "no history" would publish an empty card for an
+    // account with a full one -- confidently wrong, the one outcome this
+    // family refuses.
+    const store = archive({
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer(THROUGH),
+    });
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+  });
+
+  test("declines when the generation cannot place the floor", async () => {
+    // No `through`, so there is nowhere to start a bounded read. A guessed
+    // floor is worse than the lakehouse scan it would replace.
+    const store = archive(published({}));
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+  });
+
+  test("an account the shard DOES list is never reported absent", async () => {
+    const store = archive(published({ [HOT]: [group()] }, THROUGH));
+    const got = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    assert.equal(got!.absent, undefined);
   });
 });
 

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { archiveEnv } from "./helpers/cold-tier-env.ts";
-import { afterEach, describe, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
 // The analytics store is Postgres now (#10179), reached through
@@ -28,6 +28,8 @@ import {
 } from "../workers/request-handlers/entities.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
+import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
+import { resetObservedThroughCache } from "../src/lakehouse-observed-through.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
 // Edge-cache coverage for the store-backed analytics routes (audit #6). These four
@@ -255,6 +257,18 @@ const globalWithCaches = globalThis as unknown as { caches: Row | undefined };
 let originalCaches: Row | undefined;
 afterEach(() => {
   globalWithCaches.caches = originalCaches;
+});
+
+// This file COUNTS artifact reads, so it has to own every memo that can hide
+// one. The decode watermark is module-level and reset only between test FILES,
+// so whichever test in this file resolved it first paid its R2 GET and the rest
+// read a warm memo -- making an absolute read count depend on test ORDER rather
+// than on the behaviour under test. Resetting per test makes the counts mean
+// what they say. (Found when `observed_through` started stamping the tier's
+// horizon on every account_events-derived response, which resolves it.)
+beforeEach(() => {
+  resetDecodeWatermarkCache();
+  resetObservedThroughCache();
 });
 
 describe("analytics edge cache", () => {
@@ -602,7 +616,12 @@ describe("analytics edge cache", () => {
     await Promise.resolve();
     assert.equal(first.status, 200);
     const callsAfterMiss = archive.keys.length;
-    assert.equal(callsAfterMiss, 1);
+    // TWO: the stake-flow artifact, and the decode watermark behind
+    // `observed_through` -- this route is account_events-derived, so its meta
+    // states how far that tier has observed. Pinned exactly rather than
+    // loosened, so a THIRD read still fails here; the beforeEach above is what
+    // makes the number independent of test order.
+    assert.equal(callsAfterMiss, 2);
 
     // Explicit ?window=30d is the canonical form — must be a cache HIT (no DATA_API).
     const hit = await handleRequest(

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -385,6 +385,62 @@ describe("overlayRpcPoolEligibility", () => {
     );
   });
 
+  test("refreshes archive_support, so the two overlays cannot contradict each other", () => {
+    // Measured on production 2026-08-16: `opentensor-archive-rpc` and
+    // `onfinality-finney-rpc` reported archive_support TRUE on
+    // /api/v1/rpc/endpoints (probed 07:45) and FALSE on /api/v1/rpc/pools in
+    // the same minute -- same endpoints, same prober row, two overlays, one of
+    // which dropped the field and served the day-old build value.
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          ...baseEndpoint,
+          id: "archive",
+          url: "https://archive",
+          status: "ok",
+          archive_support: false,
+        },
+      ],
+    };
+    const live = {
+      endpoints: [
+        { id: "archive", status: "ok", latency_ms: 100, archive_support: true },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    const row = out.endpoints[0];
+    assert.equal(row.archive_support, true);
+    // NOT cosmetic: score is recomputed from this row, and endpoint-score gives
+    // archive-support +15. A stale `false` deducted it from exactly the
+    // endpoints an archive consumer should rank first.
+    assert.ok(
+      row.score_reasons.some((r: Row) => r.reason === "archive-support"),
+      "the refreshed row must earn the archive-support bonus",
+    );
+  });
+
+  test("a missing live observation keeps the build's archive_support", () => {
+    // The probe omits the field entirely on a transport error. Reading that
+    // absence as "not an archive" would demote a real archive node on one bad
+    // sweep -- the same reason latency_ms falls back rather than nulling.
+    const stale = {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          ...baseEndpoint,
+          id: "archive",
+          url: "https://archive",
+          status: "ok",
+          archive_support: true,
+        },
+      ],
+    };
+    const live = { endpoints: [{ id: "archive", status: "ok" }] };
+    const out = overlayRpcPoolEligibility(stale, live) as Row;
+    assert.equal(out.endpoints[0].archive_support, true);
+  });
+
   test("a dead endpoint never outranks a healthy one", () => {
     // The live shape: a decommissioned host (metagraphed-infra#225, Cloudflare 1033)
     // held a stale latency sample worth +16 and outranked four `ok` endpoints on 0.

--- a/tests/lakehouse-observed-through.test.ts
+++ b/tests/lakehouse-observed-through.test.ts
@@ -1,0 +1,222 @@
+// The coverage horizon stamped on every account response's meta.
+//
+// This field exists to separate "this ss58 has no activity" from "coverage has
+// not reached it yet" -- both of which are a 200 with zeros, deliberately. So
+// the dangerous failure here is publishing a horizon that is NEWER than what
+// the tier actually holds: a consumer would then read a real gap as a measured
+// absence, which is the exact confusion the field was added to end. Every path
+// that cannot establish the horizon must yield null rather than a guess.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+
+// The horizon reads blocks_head through `readStore`, which builds its own
+// `new Client(...)`, so mocking the module is the only seam. Built inside
+// vi.hoisted because vi.mock is hoisted above every import.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import {
+  OBSERVED_THROUGH_TTL_MS,
+  resetObservedThroughCache,
+  resolveObservedThrough,
+} from "../src/lakehouse-observed-through.ts";
+import {
+  DECODE_WATERMARK_KEY,
+  resetDecodeWatermarkCache,
+} from "../src/decode-watermark.ts";
+
+const THROUGH = 8_847_023;
+const OBSERVED_MS = Date.parse("2026-08-15T02:30:36.000Z");
+const NOW = Date.parse("2026-08-16T07:00:00.000Z");
+
+beforeEach(() => {
+  resetObservedThroughCache();
+  resetDecodeWatermarkCache();
+  pg.control.answers = [];
+  pg.control.failNext = null;
+  pg.control.queries.length = 0;
+});
+
+/** An env whose archive publishes a watermark and whose store answers
+ * blocks_head. `observedAt` null means the head register has no row for that
+ * block yet. */
+function env({
+  decodedThrough = THROUGH,
+  observedAt = OBSERVED_MS as number | null,
+  noWatermark = false,
+  noStore = false,
+  storeThrows = false,
+}: {
+  decodedThrough?: number;
+  observedAt?: number | null;
+  noWatermark?: boolean;
+  noStore?: boolean;
+  storeThrows?: boolean;
+} = {}) {
+  pg.control.failNext = storeThrows ? new Error("store cold") : null;
+  pg.control.answers = [
+    {
+      match: "blocks_head",
+      rows: observedAt === null ? [] : [{ observed_at: observedAt }],
+    },
+  ];
+  return {
+    METAGRAPH_ARCHIVE: {
+      async get(key: string) {
+        if (key !== DECODE_WATERMARK_KEY || noWatermark) return null;
+        return {
+          async text() {
+            return JSON.stringify({
+              decoded_through: decodedThrough,
+              updated_at: "2026-08-16T06:00:00Z",
+            });
+          },
+        };
+      },
+    },
+    ...(noStore ? {} : pgMockEnv()),
+  } as never;
+}
+
+describe("resolveObservedThrough", () => {
+  test("converts the decode watermark's BLOCK into the instant it was observed", async () => {
+    // The whole conversion: the tier knows its ceiling in blocks, the field
+    // publishes an instant, and blocks_head is the only thing that maps one to
+    // the other.
+    const got = await resolveObservedThrough(env(), { now: () => NOW });
+    assert.equal(got, "2026-08-15T02:30:36.000Z");
+  });
+
+  test("asks blocks_head for the WATERMARK's block, not the newest one", async () => {
+    // Reading the head register's own max would publish the chain tip as the
+    // lakehouse's coverage -- a horizon newer than anything the tier holds,
+    // which is the one wrong answer that matters here.
+    await resolveObservedThrough(env(), { now: () => NOW });
+    const sql = pg.control.queries.map((q: { text?: string }) =>
+      String(q.text ?? ""),
+    );
+    assert.ok(
+      sql.some((s) => s.includes("block_number = $1")),
+      `expected a point lookup by block; got ${JSON.stringify(sql)}`,
+    );
+    const values = pg.control.queries
+      .map((q: { values?: unknown[] }) => q.values ?? [])
+      .flat();
+    assert.ok(
+      values.includes(THROUGH),
+      `expected the watermark block ${THROUGH} in ${JSON.stringify(values)}`,
+    );
+  });
+
+  test("no watermark is null, never a guess", async () => {
+    assert.equal(
+      await resolveObservedThrough(env({ noWatermark: true }), {
+        now: () => NOW,
+      }),
+      null,
+    );
+  });
+
+  test("a block the head register has not reached is null", async () => {
+    // The decoder can finish a block before blocks_head records it. Answering
+    // with some older block's timestamp would understate coverage; answering
+    // with none is honest.
+    assert.equal(
+      await resolveObservedThrough(env({ observedAt: null }), {
+        now: () => NOW,
+      }),
+      null,
+    );
+  });
+
+  test("an unusable timestamp is null, not epoch zero", async () => {
+    for (const bad of [0, -1, Number.NaN]) {
+      resetObservedThroughCache();
+      resetDecodeWatermarkCache();
+      assert.equal(
+        await resolveObservedThrough(env({ observedAt: bad }), {
+          now: () => NOW,
+        }),
+        null,
+        `observed_at ${bad} must not publish a horizon`,
+      );
+    }
+  });
+
+  test("an unbound or throwing store is null, never an exception", async () => {
+    // This runs inside every account response's meta. A horizon that could not
+    // be read must cost the caller nothing.
+    assert.equal(
+      await resolveObservedThrough(env({ noStore: true }), { now: () => NOW }),
+      null,
+    );
+    resetObservedThroughCache();
+    resetDecodeWatermarkCache();
+    assert.equal(
+      await resolveObservedThrough(env({ storeThrows: true }), {
+        now: () => NOW,
+      }),
+      null,
+    );
+  });
+
+  test("the result is memoized for the TTL, then re-read", async () => {
+    // 39 account responses share this; paying a lookup per response would make
+    // a coverage marker cost more than the reads it annotates.
+    const e = env();
+    await resolveObservedThrough(e, { now: () => NOW });
+    const afterFirst = pg.control.queries.length;
+    await resolveObservedThrough(e, { now: () => NOW + 1_000 });
+    assert.equal(pg.control.queries.length, afterFirst, "served from the memo");
+    await resolveObservedThrough(e, {
+      now: () => NOW + OBSERVED_THROUGH_TTL_MS + 1,
+    });
+    assert.ok(
+      pg.control.queries.length > afterFirst,
+      "past the TTL it reads again",
+    );
+  });
+
+  test("`fresh` bypasses the memo", async () => {
+    const e = env();
+    await resolveObservedThrough(e, { now: () => NOW });
+    const afterFirst = pg.control.queries.length;
+    await resolveObservedThrough(e, { fresh: true, now: () => NOW });
+    assert.ok(pg.control.queries.length > afterFirst);
+  });
+
+  test("a null horizon is cached like a hit", async () => {
+    // A deployment with no watermark -- self-hosters, CI, the window before the
+    // decoder first publishes -- must not pay a miss on every cold read.
+    const e = env({ noWatermark: true });
+    await resolveObservedThrough(e, { now: () => NOW });
+    const afterFirst = pg.control.queries.length;
+    assert.equal(
+      await resolveObservedThrough(e, { now: () => NOW + 1_000 }),
+      null,
+    );
+    assert.equal(pg.control.queries.length, afterFirst);
+  });
+
+  test("one network's horizon is never served for another", async () => {
+    // A horizon is a chain-specific instant. Handing mainnet's to testnet would
+    // publish a coverage claim about a chain that was never read.
+    const e = env();
+    const mainnet = await resolveObservedThrough(
+      e,
+      { now: () => NOW },
+      "mainnet",
+    );
+    pg.control.answers = [{ match: "blocks_head", rows: [] }];
+    const testnet = await resolveObservedThrough(
+      e,
+      { now: () => NOW },
+      "testnet",
+    );
+    assert.equal(mainnet, "2026-08-15T02:30:36.000Z");
+    assert.notEqual(testnet, mainnet);
+  });
+});

--- a/tests/lakehouse-seam-watchdog.test.ts
+++ b/tests/lakehouse-seam-watchdog.test.ts
@@ -27,6 +27,7 @@ const { pg } = await vi.hoisted(async () => ({
 vi.mock("pg", () => pg.module);
 
 import {
+  CAPTURE_LAG_BLOCKS,
   DECODE_LAG_BLOCKS,
   DECODE_STALE_MS,
   evaluateDecodeSeam,
@@ -60,6 +61,9 @@ function healthy(overrides: Partial<SeamInput> = {}): SeamInput {
       perTable: null,
     },
     capturedThrough: HI + 120,
+    // The head sits one tick's chain production ahead of the capture — the
+    // structural lag rule 6 must stay quiet through.
+    chainHead: HI + 150,
     lo: 0,
     hi: HI,
     count: HI + 1,
@@ -261,6 +265,101 @@ describe("the decode-lane rule", () => {
     // without anyone editing the watchdog.
     assert.equal(DECODE_STALE_MS, 3 * 60 * 60 * 1000);
     assert.equal(DECODE_LAG_BLOCKS, 2_400);
+    assert.equal(CAPTURE_LAG_BLOCKS, 900);
+  });
+});
+
+/**
+ * Rule 6 — the capture against the CHAIN, not against the decoder.
+ *
+ * Every other rule here is decoder-relative, which is why production ran 28h
+ * with a capture losing ~3.8 blocks/min and this watchdog reporting `ok`
+ * throughout. These tests exist to prove the rule can actually fail: a gate
+ * that only ever passes is not a gate.
+ */
+describe("the capture-vs-chain-head rule", () => {
+  test("a capture keeping pace with the chain is quiet", () => {
+    const { reasons } = evaluateDecodeSeam(healthy());
+    assert.deepEqual(reasons, []);
+  });
+
+  test("the structural lag of one tick is NOT an alarm", () => {
+    // One cron interval of chain (~25 blocks) plus a partial final chunk. If
+    // this fires, the threshold is measuring cadence rather than loss.
+    const { reasons } = evaluateDecodeSeam(
+      healthy({ capturedThrough: HI + 100, chainHead: HI + 130 }),
+    );
+    assert.deepEqual(reasons, []);
+  });
+
+  test("a capture exactly at the threshold is still quiet", () => {
+    const { reasons } = evaluateDecodeSeam(
+      healthy({
+        capturedThrough: HI,
+        chainHead: HI + CAPTURE_LAG_BLOCKS,
+      }),
+    );
+    assert.deepEqual(reasons, []);
+  });
+
+  test("one block past the threshold fires", () => {
+    const { reasons } = evaluateDecodeSeam(
+      healthy({
+        capturedThrough: HI,
+        chainHead: HI + CAPTURE_LAG_BLOCKS + 1,
+      }),
+    );
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /trails the chain head by 901 block\(s\)/);
+  });
+
+  test("the production outage this rule was written for is caught", () => {
+    // 2026-08-16, mainnet: capture at 8,847,313 against a head of 8,855,722,
+    // with the decoder at 8,847,023 — only 290 behind the capture, well inside
+    // DECODE_LAG_BLOCKS. That is the whole point: every decoder-relative rule
+    // was satisfied, so this reason must be the ONLY one, or the rule is riding
+    // on a sibling's failure rather than its own.
+    const decoded = 8_847_023;
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({
+        capturedThrough: 8_847_313,
+        chainHead: 8_855_722,
+        watermark: {
+          decodedThrough: decoded,
+          updatedAt: NOW - 20 * 60 * 1000,
+          perTable: null,
+        },
+        lo: 0,
+        hi: decoded,
+        count: decoded + 1,
+      }),
+    );
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /trails the chain head by 8409 block\(s\)/);
+    assert.match(reasons[0]!, /must be re-read from the chain/);
+    assert.equal(summary.head_lag, 8_409);
+  });
+
+  test("an unreadable chain head is reported, not skipped", () => {
+    // Same posture as the unreadable capture watermark: a yardstick that could
+    // not be read is an unmeasured tick, never a passing one.
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({ chainHead: null }),
+    );
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /could not read the chain head/);
+    assert.equal(summary.head_lag, null);
+  });
+
+  test("an unreadable capture watermark does not also fire rule 6", () => {
+    // capturedThrough null already has its own reason. Emitting a second,
+    // derived one would report one fault as two.
+    const { reasons, summary } = evaluateDecodeSeam(
+      healthy({ capturedThrough: null }),
+    );
+    assert.equal(reasons.length, 1);
+    assert.match(reasons[0]!, /could not read raw_capture_state/);
+    assert.equal(summary.head_lag, null);
   });
 });
 
@@ -278,6 +377,7 @@ function env(
   opts: {
     body?: unknown;
     captured?: number | null;
+    head?: number | null;
     storeThrows?: boolean;
     noBucket?: boolean;
     noStore?: boolean;
@@ -294,6 +394,14 @@ function env(
             opts.captured === undefined ? HI + 100 : opts.captured,
         },
       ],
+    },
+    {
+      // Rule 6's yardstick. Matched by substring like its sibling, so the two
+      // reads are answered independently -- a fixture that let the head fall
+      // out of the capture row would make the rule compare the lane to itself,
+      // which is exactly the mistake the rule exists to avoid.
+      match: "blocks_head",
+      rows: [{ head: opts.head === undefined ? HI + 130 : opts.head }],
     },
   ];
   return {

--- a/tests/raw-capture-endpoints.test.ts
+++ b/tests/raw-capture-endpoints.test.ts
@@ -1,0 +1,236 @@
+// Which archive endpoints the raw-capture lane may read from.
+//
+// This selects hosts for the lane that carries the no-gap guarantee, so the
+// dangerous direction is ACCEPTING a host that cannot serve historical state:
+// capture reads `state_getStorage` up to a day back, and a pruned node answers
+// `UnknownBlock: State already discarded` for every one of those heights. The
+// other direction -- refusing a good host -- costs throughput and nothing else,
+// because the configured default is always in the list.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  captureEndpointList,
+  resolveCaptureEndpoints,
+  RPC_POOLS_ARTIFACT_PATH,
+} from "../src/raw-capture-endpoints.ts";
+import { KV_HEALTH_RPC_POOL } from "../src/health-prober.ts";
+
+const ARCHIVE = "https://archive.chain.opentensor.ai";
+const ONFINALITY = "https://bittensor-finney.api.onfinality.io/public";
+
+function endpoint(over: Record<string, unknown> = {}) {
+  return {
+    id: "opentensor-archive-rpc",
+    url: ARCHIVE,
+    kind: "subtensor-rpc",
+    // The structural fields overlayRpcPoolEligibility RECOMPUTES eligibility
+    // from. Omitting them makes the overlay refuse the row for a reason none of
+    // these tests is about.
+    auth_required: false,
+    public_safe: true,
+    pool_eligible: true,
+    archive_support: true,
+    status: "ok",
+    ...over,
+  };
+}
+
+function artifact(endpoints: Record<string, unknown>[], id = "finney-rpc") {
+  return { ok: true, data: { pools: [{ id, endpoints }] } };
+}
+
+const deps = (
+  result: unknown,
+  live?: unknown,
+): Parameters<typeof resolveCaptureEndpoints>[2] => ({
+  readArtifact: async () => result as { ok?: boolean; data?: unknown },
+  ...(live === undefined ? {} : { readHealthKv: async () => live }),
+});
+
+const ENV = { METAGRAPH_ARCHIVE: {} };
+
+describe("resolveCaptureEndpoints", () => {
+  test("returns the pool's archive-capable HTTP endpoints, in the pool's order", async () => {
+    const got = await resolveCaptureEndpoints(
+      ENV,
+      "mainnet",
+      deps(
+        artifact([
+          endpoint(),
+          endpoint({ id: "onfinality-finney-rpc", url: ONFINALITY }),
+        ]),
+      ),
+    );
+    assert.deepEqual(got, [ARCHIVE, ONFINALITY]);
+  });
+
+  test("reads the pool artifact, by path", async () => {
+    const asked: string[] = [];
+    await resolveCaptureEndpoints(ENV, "mainnet", {
+      readArtifact: async (_env, path) => {
+        asked.push(path);
+        return artifact([endpoint()]);
+      },
+    });
+    assert.deepEqual(asked, [RPC_POOLS_ARTIFACT_PATH]);
+  });
+
+  test("REFUSES a pruned node, which is the dangerous direction", async () => {
+    // `lite` and `entrypoint` answer chain_getHeader perfectly and cannot serve
+    // one historical state read. Accepting one would stop the lane dead at its
+    // first block, every tick, with a health check that says the host is fine.
+    const got = await resolveCaptureEndpoints(
+      ENV,
+      "mainnet",
+      deps(
+        artifact([
+          endpoint({ id: "lite", url: "https://lite", archive_support: false }),
+          endpoint({ id: "unknown", url: "https://u", archive_support: null }),
+        ]),
+      ),
+    );
+    assert.deepEqual(got, []);
+  });
+
+  test("refuses an ineligible endpoint even when it is an archive", async () => {
+    const got = await resolveCaptureEndpoints(
+      ENV,
+      "mainnet",
+      deps(artifact([endpoint({ pool_eligible: false })])),
+    );
+    assert.deepEqual(got, []);
+  });
+
+  test("refuses wss, which this lane cannot POST to", async () => {
+    // The `finney-archive` pool's four members are ALL wss -- perfectly healthy
+    // archives this lane cannot call. That is why it reads the rpc pool.
+    const got = await resolveCaptureEndpoints(
+      ENV,
+      "mainnet",
+      deps(
+        artifact([endpoint({ url: "wss://archive.chain.opentensor.ai:443" })]),
+      ),
+    );
+    assert.deepEqual(got, []);
+  });
+
+  test("reads the network's OWN pool, never another's", async () => {
+    const pools = {
+      ok: true,
+      data: {
+        pools: [
+          { id: "finney-rpc", endpoints: [endpoint()] },
+          {
+            id: "test-rpc",
+            endpoints: [endpoint({ id: "t", url: "https://testnet" })],
+          },
+        ],
+      },
+    };
+    assert.deepEqual(
+      await resolveCaptureEndpoints(ENV, "testnet", deps(pools)),
+      ["https://testnet"],
+    );
+    assert.deepEqual(
+      await resolveCaptureEndpoints(ENV, "mainnet", deps(pools)),
+      [ARCHIVE],
+    );
+  });
+
+  test("the LIVE overlay decides, not the baked build", async () => {
+    // The exact production bug this lane would otherwise inherit: /rpc/pools
+    // served archive_support FALSE for two real archives on 2026-08-16 while
+    // the live prober said true. Selecting on the baked value would find no
+    // archive endpoints at all.
+    const got = await resolveCaptureEndpoints(
+      ENV,
+      "mainnet",
+      deps(artifact([endpoint({ archive_support: false })]), {
+        endpoints: [
+          { id: "opentensor-archive-rpc", status: "ok", archive_support: true },
+        ],
+      }),
+    );
+    assert.deepEqual(got, [ARCHIVE]);
+  });
+
+  test("asks the health KV for the pool snapshot by its own key", async () => {
+    const asked: string[] = [];
+    await resolveCaptureEndpoints(ENV, "mainnet", {
+      readArtifact: async () => artifact([endpoint()]),
+      readHealthKv: async (_env, key) => {
+        asked.push(key);
+        return null;
+      },
+    });
+    assert.deepEqual(asked, [KV_HEALTH_RPC_POOL]);
+  });
+
+  test("a throwing overlay falls through to the baked pool, never to nothing", async () => {
+    const got = await resolveCaptureEndpoints(ENV, "mainnet", {
+      readArtifact: async () => artifact([endpoint()]),
+      readHealthKv: async () => {
+        throw new Error("kv down");
+      },
+    });
+    assert.deepEqual(got, [ARCHIVE]);
+  });
+
+  test("every unreadable shape yields the empty list, never a throw", async () => {
+    // The caller has a configured default for all of these; what it must never
+    // get is an exception out of a cron's endpoint lookup.
+    const shapes: unknown[] = [
+      { ok: false, code: "artifact_not_found" },
+      { ok: true, data: null },
+      { ok: true, data: { pools: "not-an-array" } },
+      { ok: true, data: { pools: [] } },
+      { ok: true, data: { pools: [{ id: "finney-rpc" }] } },
+    ];
+    for (const shape of shapes) {
+      assert.deepEqual(
+        await resolveCaptureEndpoints(ENV, "mainnet", deps(shape)),
+        [],
+        `shape: ${JSON.stringify(shape)}`,
+      );
+    }
+    assert.deepEqual(
+      await resolveCaptureEndpoints(ENV, "mainnet", {
+        readArtifact: async () => {
+          throw new Error("r2 down");
+        },
+      }),
+      [],
+    );
+    assert.deepEqual(
+      await resolveCaptureEndpoints(
+        null,
+        "mainnet",
+        deps(artifact([endpoint()])),
+      ),
+      [],
+    );
+  });
+});
+
+describe("captureEndpointList", () => {
+  test("the configured default is always present, and always first", async () => {
+    // It is the host whose behaviour under this exact call pattern was
+    // measured, and the only one guaranteed to exist when the pool cannot be
+    // read. A pool reordering must never demote it out of the rotation.
+    assert.deepEqual(captureEndpointList(ARCHIVE, [ONFINALITY]), [
+      ARCHIVE,
+      ONFINALITY,
+    ]);
+    assert.deepEqual(captureEndpointList(ARCHIVE, []), [ARCHIVE]);
+  });
+
+  test("a pool that already names the default does not double its share", async () => {
+    // Duplicates are not harmless here: the rotation would give that host two
+    // slots in every cycle, i.e. twice the per-host rate the limit was measured
+    // against.
+    assert.deepEqual(
+      captureEndpointList(ARCHIVE, [ARCHIVE, ONFINALITY, ARCHIVE]),
+      [ARCHIVE, ONFINALITY],
+    );
+  });
+});

--- a/tests/raw-capture-sync.test.ts
+++ b/tests/raw-capture-sync.test.ts
@@ -738,3 +738,100 @@ describe("the lanes run concurrently, and stay isolated", () => {
     assert.equal((result.lanes ?? []).length, RAW_CAPTURE_LANES.length);
   });
 });
+
+/**
+ * The pool widens the rotation — and the wiring that makes it do so.
+ *
+ * The measured ceiling on this lane is a PER-HOST rate limit, so one host was
+ * the whole budget and the lane fell 8,409 blocks (~28 h) behind on 2026-08-16.
+ * The endpoint lookup is DEFAULTED rather than injected in production, because
+ * an injectable nothing injects is a feature that never runs — these prove it
+ * reaches captureTick, and that a pool which cannot answer degrades to exactly
+ * the single-endpoint lane this was before.
+ */
+describe("the archive endpoints a lane reads from", () => {
+  /** Answers RPC for any host, recording which hosts were asked. */
+  function hostTrackingFetch(hosts: Set<string>) {
+    return (async (url: unknown, init?: { body?: string }) => {
+      hosts.add(new URL(String(url)).origin);
+      const req = JSON.parse(init?.body ?? "{}") as { method: string };
+      const reply = (result: unknown) =>
+        ({ ok: true, json: async () => ({ result }) }) as unknown as Response;
+      // Above BOTH lanes' genesis floors, or nextCaptureHeights yields nothing
+      // and the tick fetches no blocks at all -- which looks exactly like a
+      // rotation that never happened.
+      if (req.method === "chain_getHeader")
+        return reply({ number: "0x989680" });
+      if (req.method === "chain_getBlockHash") return reply("0xh1");
+      if (req.method === "chain_getBlock") {
+        return reply({
+          block: {
+            header: { number: "0x1", parentHash: "0xp" },
+            extrinsics: ["0xaa"],
+          },
+        });
+      }
+      return reply("0xevents");
+    }) as unknown as typeof fetch;
+  }
+
+  test("a pool member is ACTUALLY read, not merely resolved", async () => {
+    const hosts = new Set<string>();
+    const { env } = envWith();
+    await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
+      ctx: CTX,
+      fetchImpl: hostTrackingFetch(hosts),
+      endpointDeps: {
+        readArtifact: async () => ({
+          ok: true,
+          data: {
+            pools: [
+              {
+                id: "finney-rpc",
+                endpoints: [
+                  {
+                    id: "second",
+                    url: "https://second-archive.example",
+                    kind: "subtensor-rpc",
+                    auth_required: false,
+                    public_safe: true,
+                    pool_eligible: true,
+                    archive_support: true,
+                    status: "ok",
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      },
+    });
+    assert.ok(
+      hosts.has("https://second-archive.example"),
+      `the pool member was never read; hosts asked: ${[...hosts].join(", ")}`,
+    );
+  });
+
+  test("a pool that cannot answer leaves the configured host doing the work", async () => {
+    // The degrade path, which is what runs whenever R2 is unreachable. It must
+    // be the lane exactly as it was, never a tick that reads nothing.
+    const hosts = new Set<string>();
+    const { env } = envWith();
+    const result = await runRawCaptureSync(env as never, {
+      sleepFn: noSleep,
+      ctx: CTX,
+      fetchImpl: hostTrackingFetch(hosts),
+      endpointDeps: {
+        readArtifact: async () => {
+          throw new Error("r2 down");
+        },
+      },
+    });
+    assert.equal(result.ok, true);
+    // Both lanes run, so both configured hosts appear; what must NOT appear is
+    // any host the (unreadable) pool would have contributed.
+    assert.ok(hosts.has("https://archive.chain.opentensor.ai"));
+    assert.equal(hosts.size, RAW_CAPTURE_LANES.length);
+  });
+});

--- a/tests/raw-chain-capture.test.ts
+++ b/tests/raw-chain-capture.test.ts
@@ -239,7 +239,7 @@ describe("fetchRawBlock", () => {
       throw "plain string failure";
     }) as unknown as typeof fetch;
     const result = await captureTick({
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 0,
@@ -266,7 +266,7 @@ describe("captureTick — the no-gap guarantee", () => {
     const { store, puts } = memoryStore();
     const { watermark, get } = memoryWatermark(null);
     const result = await captureTick({
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 50,
@@ -282,7 +282,7 @@ describe("captureTick — the no-gap guarantee", () => {
     const { store, puts } = memoryStore();
     const { watermark, get } = memoryWatermark(99);
     const result = await captureTick({
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 0,
@@ -307,7 +307,7 @@ describe("captureTick — the no-gap guarantee", () => {
     const { store, puts } = memoryStore();
     const { watermark, get } = memoryWatermark(99);
     const failing = {
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 0,
@@ -342,7 +342,7 @@ describe("captureTick — the no-gap guarantee", () => {
     const { store, puts } = memoryStore();
     const { watermark, get } = memoryWatermark(99);
     const result = await captureTick({
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 0,
@@ -361,7 +361,7 @@ describe("captureTick — the no-gap guarantee", () => {
     const { store, puts } = memoryStore();
     const { watermark } = memoryWatermark(110);
     const result = await captureTick({
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 0,
@@ -375,7 +375,7 @@ describe("captureTick — the no-gap guarantee", () => {
   test("reports how far behind the head it still is, so lag is queryable", async () => {
     const { store, watermark } = { ...memoryStore(), ...memoryWatermark(0) };
     const result = await captureTick({
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 0,
@@ -394,7 +394,7 @@ describe("captureTick — the no-gap guarantee", () => {
       write: async () => undefined,
     };
     const result = await captureTick({
-      rpcUrl: "https://rpc",
+      rpcUrls: ["https://rpc"],
       store,
       watermark,
       genesisFloor: 20,
@@ -408,7 +408,7 @@ describe("captureTick — the no-gap guarantee", () => {
     const { store, watermark } = { ...memoryStore(), ...memoryWatermark(0) };
     await assert.rejects(
       captureTick({
-        rpcUrl: "https://rpc",
+        rpcUrls: ["https://rpc"],
         store,
         watermark,
         genesisFloor: 0,
@@ -426,7 +426,7 @@ describe("captureTick — the no-gap guarantee", () => {
     globalThis.fetch = rpcFetch({ head: 6 });
     try {
       const result = await captureTick({
-        rpcUrl: "https://rpc",
+        rpcUrls: ["https://rpc"],
         store,
         watermark,
         genesisFloor: 0,
@@ -457,7 +457,7 @@ describe("captureTick flushes in chunks", () => {
       marks,
       gaps,
       deps: {
-        rpcUrl: "https://rpc.invalid",
+        rpcUrls: ["https://rpc.invalid"],
         genesisFloor: 100,
         maxPerTick: opts.heights,
         flushEvery: opts.flushEvery,
@@ -574,6 +574,183 @@ describe("captureTick flushes in chunks", () => {
     assert.ok(
       Date.now() - started >= 30,
       "the shipped pacing did not actually wait",
+    );
+  });
+});
+
+/**
+ * Reading from MORE THAN ONE archive host.
+ *
+ * The binding constraint on this lane is a PER-HOST rate limit (~100 req/client/
+ * min, #9378), so one host WAS the throughput ceiling -- and the lane fell 8,409
+ * blocks (~28 h) behind on 2026-08-16 with no way to buy out of it. Rotation
+ * multiplies the aggregate rate by the hosts available. The no-gap guarantee is
+ * the thing that must survive it, so these are mostly about that.
+ */
+describe("captureTick — reading across several endpoints", () => {
+  /** Records which host each height was requested from. */
+  function trackingFetch(
+    opts: {
+      head?: number;
+      failOn?: (url: string, height: number) => boolean;
+    } = {},
+  ) {
+    const byHost: Record<string, number[]> = {};
+    const impl = (async (url: unknown, init?: { body?: string }) => {
+      const req = JSON.parse(init?.body ?? "{}") as {
+        method: string;
+        params: unknown[];
+      };
+      const host = String(url);
+      const reply = (result: unknown) =>
+        ({ ok: true, json: async () => ({ result }) }) as unknown as Response;
+      if (req.method === "chain_getHeader") {
+        return reply({ number: `0x${(opts.head ?? 110).toString(16)}` });
+      }
+      if (req.method === "chain_getBlockHash") {
+        const n = req.params[0] as number;
+        (byHost[host] ||= []).push(n);
+        if (opts.failOn?.(host, n))
+          return { ok: false, status: 500 } as Response;
+        return reply(`0xh${n}`);
+      }
+      if (req.method === "chain_getBlock") {
+        return reply({
+          block: {
+            header: { number: "0x1", parentHash: "0xp" },
+            extrinsics: ["0xaa"],
+          },
+        });
+      }
+      return reply("0xevents");
+    }) as unknown as typeof fetch;
+    return { impl, byHost };
+  }
+
+  test("consecutive blocks land on DIFFERENT hosts", async () => {
+    // The whole point: each host then sees `minGapMs` between its own calls
+    // while the lane's aggregate rate is N times one host's allowance.
+    const { store } = memoryStore();
+    const { watermark } = memoryWatermark(99);
+    const { impl, byHost } = trackingFetch();
+    const result = await captureTick({
+      rpcUrls: ["https://a", "https://b"],
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 4,
+      fetchImpl: impl,
+    });
+    assert.equal(result.captured, 4);
+    assert.deepEqual(byHost["https://a"], [100, 102]);
+    assert.deepEqual(byHost["https://b"], [101, 103]);
+  });
+
+  test("a height one host cannot serve is retried on another, NOT skipped", async () => {
+    // A flaky host must degrade throughput, never pin the watermark -- and it
+    // must never leave a hole, which is the one thing this module exists for.
+    const { store } = memoryStore();
+    const { watermark, get } = memoryWatermark(99);
+    const { impl } = trackingFetch({
+      failOn: (url, height) => url === "https://a" && height === 100,
+    });
+    const result = await captureTick({
+      rpcUrls: ["https://a", "https://b"],
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 3,
+      fetchImpl: impl,
+    });
+    assert.equal(result.captured, 3, "100 came from the second host");
+    assert.equal(result.stoppedAt, undefined);
+    assert.equal(get(), 102);
+  });
+
+  test("a height NO host can serve still stops the tick and keeps the prefix", async () => {
+    const { store } = memoryStore();
+    const { watermark, get } = memoryWatermark(99);
+    const { impl } = trackingFetch({
+      failOn: (_url, height) => height === 102,
+    });
+    const result = await captureTick({
+      rpcUrls: ["https://a", "https://b"],
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 6,
+      fetchImpl: impl,
+    });
+    assert.equal(result.captured, 2, "100 and 101 only");
+    assert.equal(result.stoppedAt, 102);
+    assert.equal(
+      get(),
+      101,
+      "one BELOW the failure, so the next tick retries it",
+    );
+  });
+
+  test("the head is read from whichever host answers, not a fixed one", async () => {
+    // A tick must not be lost because the preferred host is down when another
+    // could have served the whole run.
+    const { store } = memoryStore();
+    const { watermark } = memoryWatermark(99);
+    const inner = trackingFetch();
+    const firstHostDead = (async (url: unknown, init?: { body?: string }) => {
+      if (String(url) === "https://dead") throw new Error("dead host");
+      return inner.impl(url as string, init as RequestInit);
+    }) as unknown as typeof fetch;
+    const result = await captureTick({
+      rpcUrls: ["https://dead", "https://b"],
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 2,
+      fetchImpl: firstHostDead,
+    });
+    assert.equal(result.captured, 2);
+  });
+
+  test("the per-block sleep is the per-host gap DIVIDED by the host count", async () => {
+    // Each host still sees `minGapMs` between its own calls; the wall gap
+    // between consecutive blocks is that over N. Getting this wrong is how a
+    // widened lane would silently exceed the limit it was measured against.
+    const slept: number[] = [];
+    const { store } = memoryStore();
+    const { watermark } = memoryWatermark(99);
+    const { impl } = trackingFetch();
+    await captureTick({
+      rpcUrls: ["https://a", "https://b", "https://c"],
+      store,
+      watermark,
+      genesisFloor: 0,
+      maxPerTick: 3,
+      minGapMs: 900,
+      fetchImpl: impl,
+      sleepFn: async (ms) => {
+        slept.push(ms);
+      },
+    });
+    assert.deepEqual(
+      slept,
+      [300, 300],
+      "900 / 3 hosts, and never before the first",
+    );
+  });
+
+  test("an empty endpoint list is refused rather than read as 'no work'", async () => {
+    const { store } = memoryStore();
+    const { watermark } = memoryWatermark(99);
+    await assert.rejects(
+      captureTick({
+        rpcUrls: [],
+        store,
+        watermark,
+        genesisFloor: 0,
+        maxPerTick: 1,
+        fetchImpl: trackingFetch().impl,
+      }),
+      /rpcUrls is empty/,
     );
   });
 });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -17,6 +17,7 @@
 // straight from the src/* leaf modules + config. api.ts imports the
 // handlers back and dispatches them from the router.
 
+import { resolveObservedThrough } from "../../src/lakehouse-observed-through.ts";
 import { loadSubnetWeightSettersColdTier } from "../../src/subnet-weight-setters-loader.ts";
 import { loadSubnetWeightsColdTier } from "../../src/subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "../../src/subnet-event-card-loader.ts";
@@ -4534,6 +4535,22 @@ async function accountMeta(
     cache: "short",
     contract_version: contractVersion(env),
     generated_at: generatedAt,
+    // HERE, AND NOT IN EACH PAYLOAD, because the horizon is a property of the
+    // tier that answered rather than of the account asked about -- the same
+    // reasoning that puts `stale_contract` on the shared meta. One stamp
+    // reaches all 39 account responses this builder serves; thirty-nine payload
+    // fields would be the same fact restated until two of them disagreed.
+    //
+    // It is what separates "this ss58 has no activity" from "coverage has not
+    // reached it yet". Both are a 200 with zeros, deliberately -- an ss58 is a
+    // valid identity whether or not it has ever acted, and inferring not-found
+    // from zeros would 404 real accounts -- so the distinction has to be
+    // published beside the zeros rather than encoded as an error.
+    //
+    // ALWAYS PRESENT, null included. Omitting it when unreadable would make
+    // "this tier publishes no horizon" and "the horizon could not be read this
+    // tick" the same absence, which is the exact conflation being fixed.
+    observed_through: await resolveObservedThrough(env),
     published_at: await publishedAt(env),
     source: "chain-events",
   };

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -4530,28 +4530,39 @@ async function accountMeta(
   artifactPath: string,
   generatedAt: unknown,
 ) {
+  // CONCURRENT, not two awaits in an object literal. Object properties evaluate
+  // in order, so `await a, await b` there is SERIAL -- it would add the
+  // horizon's latency to every one of the 50 responses this builder serves
+  // rather than overlapping it with a read that was already happening. Neither
+  // depends on the other.
+  //
+  // `observed_through` is HERE, AND NOT IN EACH PAYLOAD, because the horizon is
+  // a property of the tier that answered rather than of the account asked
+  // about -- the same reasoning that puts `stale_contract` on the shared meta.
+  // One stamp reaches every response this builder serves; fifty payload fields
+  // would be the same fact restated until two of them disagreed.
+  //
+  // It is what separates "this ss58 has no activity" from "coverage has not
+  // reached it yet". Both are a 200 with zeros, deliberately -- an ss58 is a
+  // valid identity whether or not it has ever acted, and inferring not-found
+  // from zeros would 404 real accounts -- so the distinction has to be
+  // published beside the zeros rather than encoded as an error.
+  //
+  // ALWAYS PRESENT, null included. Omitting it when unreadable would make "this
+  // tier publishes no horizon" and "the horizon could not be read this tick"
+  // the same absence, which is the exact conflation being fixed. Neither read
+  // can reject: both resolve null on every failure.
+  const [observedThrough, published] = await Promise.all([
+    resolveObservedThrough(env),
+    publishedAt(env),
+  ]);
   return {
     artifact_path: artifactPath,
     cache: "short",
     contract_version: contractVersion(env),
     generated_at: generatedAt,
-    // HERE, AND NOT IN EACH PAYLOAD, because the horizon is a property of the
-    // tier that answered rather than of the account asked about -- the same
-    // reasoning that puts `stale_contract` on the shared meta. One stamp
-    // reaches all 39 account responses this builder serves; thirty-nine payload
-    // fields would be the same fact restated until two of them disagreed.
-    //
-    // It is what separates "this ss58 has no activity" from "coverage has not
-    // reached it yet". Both are a 200 with zeros, deliberately -- an ss58 is a
-    // valid identity whether or not it has ever acted, and inferring not-found
-    // from zeros would 404 real accounts -- so the distinction has to be
-    // published beside the zeros rather than encoded as an error.
-    //
-    // ALWAYS PRESENT, null included. Omitting it when unreadable would make
-    // "this tier publishes no horizon" and "the horizon could not be read this
-    // tick" the same absence, which is the exact conflation being fixed.
-    observed_through: await resolveObservedThrough(env),
-    published_at: await publishedAt(env),
+    observed_through: observedThrough,
+    published_at: published,
     source: "chain-events",
   };
 }

--- a/workers/wss-lb-select.ts
+++ b/workers/wss-lb-select.ts
@@ -11,14 +11,14 @@
 // validator by hand, which is the arrangement this repo keeps finding drifted.
 // Re-exported under their original names so every import site is unchanged.
 import type {
-  WssPool,
-  WssPoolEndpoint,
-  WssPoolsArtifact,
+  RpcPoolsReadPool,
+  RpcPoolsReadEndpoint,
+  RpcPoolsReadArtifact,
 } from "../schemas-src/internal-wire.ts";
 
-export type PoolEndpoint = WssPoolEndpoint;
-export type Pool = WssPool;
-export type PoolsArtifact = WssPoolsArtifact;
+export type PoolEndpoint = RpcPoolsReadEndpoint;
+export type Pool = RpcPoolsReadPool;
+export type PoolsArtifact = RpcPoolsReadArtifact;
 
 /**
  * What the selectors below ACCEPT, which is broader than what `loadPools`

--- a/workers/wss-lb.ts
+++ b/workers/wss-lb.ts
@@ -43,7 +43,7 @@
 // state_call and storage reads. See that constant for the full reasoning.
 import { selectWssUpstreams, type PoolsArtifact } from "./wss-lb-select.ts";
 import { MAX_RPC_BODY_BYTES, WSS_DENIED_RPC_PREFIXES } from "./config.ts";
-import { WssPoolsResponseSchema } from "../schemas-src/internal-wire.ts";
+import { RpcPoolsReadSchema } from "../schemas-src/internal-wire.ts";
 import {
   recordExceptionEvent,
   recordUsageEvent,
@@ -216,7 +216,7 @@ export async function loadPools(
     // all satisfied it, and an error page arrived here as a pool-less artifact
     // the caller could not tell from "no pools are eligible right now". One of
     // those is a 503 the operator should see; the other is normal.
-    const parsed = WssPoolsResponseSchema.safeParse(await res.json());
+    const parsed = RpcPoolsReadSchema.safeParse(await res.json());
     if (!parsed.success) return null;
     return "data" in parsed.data ? parsed.data.data : parsed.data;
   } catch {


### PR DESCRIPTION
Started from a report that an account page was slow and showed nothing. The
address in the report (`5EEmaGFE…5oM3qDSC`) turned out to be the worst case the
system had, and tracing why it was slow found three separate faults in one path
plus two more on the way.

## What was actually wrong

**Raw capture was losing to the chain, silently.** `FLUSH_EVERY_BLOCKS` is a
deadline, not a batch size: a chunk only becomes durable once it is FULL, so the
time to the first durable write was `flushEvery × minGapMs` — 112 s at the paced
4,500 ms — and an invocation that did not live that long wrote **nothing**. The
trailing flush in `captureTick` covers a clean early `break`; it does not run
when the runtime kills the invocation. Measured against production 2026-08-16,
mainnet: the watermark advanced 25 blocks in 21 minutes — one single chunk —
while the chain advanced ~105, so capture was losing ~3.8 blocks/min against a
chain producing 5/min, already 8,409 blocks (~28 h) behind. Testnet was 8,290
behind on the same shape. Nothing threw: `last_error` NULL, `stopped_at` NULL.

**Nothing watched capture against the chain.** All five of the seam watchdog's
rules are decoder-relative, so a losing capture satisfied every one of them — the
decoder was faithfully following a watermark that had stopped keeping up, and
`chain.blocks` stayed contiguous. `lane-alarm` reported *"0 alarming, 69 lanes"*
throughout, while `/chain/alpha-volume` served a rolling-24h window whose newest
row was 28.7 h old and published the whole network's volume as a confident zero.

**Positive absence was being thrown away.** The account-summary producer writes
EVERY shard, empty ones included, precisely so a reader can tell "no such
account" from "this shard was never produced" — *"the first is an answer while
the second is a decline"* (`account_summary_r2.py`). The reader spent that fact:
an account missing from a shard that exists returned a bare `null`,
indistinguishable from an unreadable pointer, so the caller ran an unbounded
lifetime scan for an account the projection had **proven** has no history. That
is every account newer than the last generation. The reported address held
exactly ONE event and answered `503 account_summary_unavailable` after aborting
at the 15 s ceiling.

## Two found while fixing those

**The pool disagreed with itself about which endpoints are archives.**
`overlayRpcPoolEligibility` refreshed status, latency, block and reliability from
the live prober row and dropped `archive_support`, while its sibling
`overlayRpcEndpointHealth` carried it — both fed by the SAME row. So
`/api/v1/rpc/endpoints` reported `archive_support: true` for
`opentensor-archive-rpc` and `onfinality-finney-rpc` (probed 07:45) while
`/api/v1/rpc/pools` reported `false` for the same two in the same minute. Not
cosmetic: that overlay RECOMPUTES `score`, and `endpoint-score` gives
`archive-support` **+15**, so a stale `false` deducted 15 points from exactly the
endpoints an archive-shaped consumer should rank first — and left the archive
pool with no HTTP members at all.

**A shared schema was silently deleting fields.** Switching the new pool read
from casts to a real parse exposed it twice in one change. `RpcPoolsRead*`
(renamed from `WssPools*` — its own selector already re-aliased the `Wss` prefix
back out, which was the tell) strips undeclared keys like any zod object, so
`archive_support` was not merely untyped, it was **deleted**, and every archive
host failed the capture filter. Then the stripped row reached
`overlayRpcPoolEligibility`, which recomputes eligibility from
`auth_required`/`public_safe` and rescores from `methods_supported` — none
declared, all stripped — so a healthy endpoint came back ineligible. Both fixed
with `catchall(unknown)`, the treatment `AlertTriggerRowSchema` already documents
for the same reason.

## What changed

- **Flush cadence 25 → 5**, so a killed tick keeps all but its final partial
  chunk (first durable write 112 s → ~22 s), for ~11 PUTs a tick instead of ~2.
- **Rule 6 on the seam watchdog** — capture vs chain head, bounded at 900 blocks.
  The bound is the retention window, not the cadence: Neon holds
  `chain_detail_account_events` for a rolling 24 h, so past that the span between
  the lakehouse's ceiling and Neon's floor is held by no store and must be
  re-read from the chain. 900 is an eighth of that deadline.
- **Capture reads every archive endpoint the registry already curates**, from the
  same `/metagraph/rpc/pools.json` the RPC proxy and the WSS load balancer read,
  after the same live overlay. The WSS LB itself cannot serve this lane — it is
  WebSocket-only, and the `finney-archive` pool's four members are all
  `subtensor-wss` — and the HTTP proxy that does have failover is behind
  `METAGRAPH_ENABLE_RPC_PROXY` and allowlists four methods that exclude
  `state_getStorage`.
- **Absence is a typed variant carrying the floor**, and both legs of the account
  card bound to it. Bounding only the aggregate half would have fixed the cheap
  read and left the feed leg scanning the whole table.
- **`observed_through` on the shared response meta**, following the field already
  published on `/subnets/{netuid}/ownership-history`. On meta rather than in each
  payload because it is a property of the tier that answered, not the account
  asked about — the same reasoning that puts `stale_contract` there. One stamp
  reaches all 39 account responses instead of 39 fields that eventually disagree.

## The no-gap guarantee

This lane carries it, so the rotation needed care. Blocks rotate across the
endpoint list, and each host still sees `minGapMs` between its OWN calls — the
rate the ~100/min limit was measured against — while the aggregate scales with
the hosts available. A height that fails on one endpoint is retried on the
others; only a height NO endpoint can serve stops the tick, and it still stops
one below the failure and keeps the prefix. So a flaky host costs throughput,
never a hole. The head read fails over the same way, because a tick must not be
lost to the preferred host being down when another could have served the run.

Every degrade path lands on the lane exactly as it was: no artifact, no pool, a
throwing overlay, or no archive member all yield the single configured endpoint.
The endpoint lookup is DEFAULTED rather than injected, because an injectable
nothing injects in production is a feature that never runs — there is a test for
that specifically.

## Contract

`observed_through` is additive and nullable on the shared `ResponseMeta`.
Regenerated and committed: `openapi.json`, `types.d.ts`,
`packages/contract/index.d.ts`.

Note this needed `npm install` in the worktree first — `build-artifacts` had
never run here, failing on a missing `@modelcontextprotocol/sdk`.

## Verification

- 30 validators green, including `contract-drift`, `openapi`, `types`,
  `boundary-casts` (budget 0), `no-passthrough`, `single-schema-source`,
  `schema-opacity`, `graphql-types-drift`, `declared-tables-exist`
- 892 tests across every affected suite, plus `api-coverage` (341)
- tsc / eslint / prettier clean
- Rebased three times as main moved during the work, and verified specifically
  against the derived-floor comment gate that landed mid-flight

## Not in scope

The convergence rate is only measurable after deploy. The gap was 8,409 blocks
when this started and is 8,591 now, still widening at ~130/hour, because none of
this is live yet.
