### PR TITLE
fix(probe): archive_support measured block hashes, so two pruned nodes were called archives

### DIFF
--- a/src/head-poller.ts
+++ b/src/head-poller.ts
@@ -78,9 +78,10 @@ export async function fetchHeadNumber(
  * That is what makes reading it legal for this module, which must never
  * pretend to decode what only the indexer can.
  */
-export const SYSTEM_EVENTS_STORAGE_KEY = bytesToHex(
-  storageMapPrefix("System", "Events"),
-);
+import { SYSTEM_EVENTS_STORAGE_KEY } from "./twox-storage-key.ts";
+// Re-exported because this module's callers and tests have always addressed
+// the key through it; the single declaration lives in twox-storage-key.ts.
+export { SYSTEM_EVENTS_STORAGE_KEY };
 
 /**
  * Storage key for `Aura.Authorities`: twox128("Aura") ++ twox128("Authorities").

--- a/src/health-probe-core.ts
+++ b/src/health-probe-core.ts
@@ -9,6 +9,16 @@
 // the historical build so artifacts stay byte-stable after the extraction
 // (writeJson sorts keys via stableStringify, so only VALUES must match).
 import { ipv6EmbeddedIpv4 } from "./ip-safety.ts";
+import { SYSTEM_EVENTS_STORAGE_KEY } from "./twox-storage-key.ts";
+
+// DECLARED BEFORE the probe list, which reads it at module init: the archive
+// probe asks for STATE at this block, so a `const` below the array would be in
+// its temporal dead zone.
+// Finney (Bittensor mainnet) genesis hash — verified live against
+// bittensor-finney.api.onfinality.io. Endpoints whose block-0 hash differs are
+// classified `wrong-chain`. Override per-network via probeSubtensorHttp options.
+export const FINNEY_GENESIS_HASH =
+  "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03";
 
 export const SUBTENSOR_PROBE_CALLS = [
   {
@@ -20,8 +30,27 @@ export const SUBTENSOR_PROBE_CALLS = [
   { key: "rpc_methods", method: "rpc_methods", params: [] as unknown[] },
   {
     key: "archive_probe",
-    method: "chain_getBlockHash",
-    params: [1] as unknown[],
+    // `state_getStorage` AT GENESIS, and emphatically not `chain_getBlockHash`.
+    //
+    // An archive node is one that retains historical STATE. A pruned node
+    // discards state but keeps every block HASH, so `chain_getBlockHash(1)` --
+    // what this probed until now -- succeeds on both and measured nothing.
+    // Verified against production 2026-08-16: `lite.chain.opentensor.ai` and
+    // `entrypoint-finney.opentensor.ai` both answer `chain_getBlockHash(1)`
+    // with a hash and both answer `state_getStorage` at any historical block
+    // with `UnknownBlock: State already discarded`, while
+    // `archive.chain.opentensor.ai` and onfinality serve the state. The old
+    // probe called all four archives.
+    //
+    // THAT WAS NOT COSMETIC once something selected on it: the raw-capture lane
+    // picks archive hosts to read `state_getStorage` from, so a pruned host
+    // scored as an archive is a host that fails EVERY block it is handed.
+    //
+    // Genesis rather than a recent height because the params must be static and
+    // a moving height is not: the genesis hash is a constant this file already
+    // owns, and state at block 0 is exactly what a pruned node cannot serve.
+    method: "state_getStorage",
+    params: [SYSTEM_EVENTS_STORAGE_KEY, FINNEY_GENESIS_HASH] as unknown[],
   },
   // Genesis (block 0) hash — uniquely identifies the network. Lets us reject an
   // RPC endpoint that answers but is on the WRONG chain (cosmos.directory checks
@@ -29,12 +58,6 @@ export const SUBTENSOR_PROBE_CALLS = [
   // different genesis and is excluded before it can pollute the proxy pool.
   { key: "genesis", method: "chain_getBlockHash", params: [0] as unknown[] },
 ];
-
-// Finney (Bittensor mainnet) genesis hash — verified live against
-// bittensor-finney.api.onfinality.io. Endpoints whose block-0 hash differs are
-// classified `wrong-chain`. Override per-network via probeSubtensorHttp options.
-export const FINNEY_GENESIS_HASH =
-  "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03";
 
 function normalizeHash(value: unknown): string | null {
   return typeof value === "string" ? value.trim().toLowerCase() : null;
@@ -956,15 +979,27 @@ export function summarizeRpcProbe(probe: RpcProbeResult): RpcProbeResult {
   const latestBlock = parseBlockNumber(header?.raw_header);
   return {
     ...probe,
-    archive_support: Boolean(
-      archiveProbe?.ok && archiveProbe.raw_hex_result_present,
-    ),
+    // `ok` ALONE, deliberately: `ok` is `response.ok && !body.error`, so it is
+    // false exactly when the node answered `UnknownBlock: State already
+    // discarded` and true when it served the slot.
+    //
+    // NOT `raw_hex_result_present`, which is what the old criterion added and
+    // is wrong for this question: `System.Events` at GENESIS is legitimately
+    // EMPTY, so a real archive answers `{"result": null}` with no error.
+    // Requiring a hex payload would score every archive as pruned -- the
+    // opposite of the bug this replaces, and just as silent.
+    archive_support: Boolean(archiveProbe?.ok),
     latest_block: latestBlock,
     methods_supported: {
       chain_getHeader: Boolean(methodResults.chain_getHeader?.ok),
       system_health: Boolean(methodResults.system_health?.ok),
       rpc_methods: Boolean(methodResults.rpc_methods?.ok),
-      chain_getBlockHash: Boolean(methodResults.archive_probe?.ok),
+      // KEYED ON THE `genesis` PROBE, which is the call that actually issues
+      // `chain_getBlockHash` now. It used to read `archive_probe` because that
+      // probe WAS a chain_getBlockHash; once the archive probe became a
+      // `state_getStorage`, this field would have reported state-retention
+      // under a method name that no longer matched it.
+      chain_getBlockHash: Boolean(methodResults.genesis?.ok),
     },
     rpc_method_count: methods?.rpc_method_count ?? null,
   };

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -34,12 +34,12 @@
 import { chainRpc } from "./chain-rpc.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 
-/** twox128("System") ++ twox128("Events") — the runtime storage key holding
- * the event list for a block. Stable across runtime upgrades (the KEY is a
- * hash of the pallet/item names; only the VALUE's encoding tracks metadata,
- * which is exactly why capturing the value verbatim is safe here). */
-export const SYSTEM_EVENTS_STORAGE_KEY =
-  "0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7";
+// The key is DERIVED once in twox-storage-key.ts; re-exported here because this
+// module's own callers and tests have always addressed it through this module.
+import { SYSTEM_EVENTS_STORAGE_KEY } from "./twox-storage-key.ts";
+// Re-exported because this module's callers and tests have always addressed
+// the key through it; the single declaration lives in twox-storage-key.ts.
+export { SYSTEM_EVENTS_STORAGE_KEY };
 
 export interface RawBlockCapture {
   block_number: number;

--- a/src/twox-storage-key.ts
+++ b/src/twox-storage-key.ts
@@ -244,3 +244,23 @@ export function twox64ConcatU32StorageKey(
 export function bytesToHex(bytes: Uint8Array): string {
   return "0x" + toHex(bytes);
 }
+
+/**
+ * `System.Events` — twox128("System") ++ twox128("Events").
+ *
+ * DECLARED ONCE, HERE, beside the derivation and the vectors that prove it.
+ * This key had two homes: `head-poller.ts` derived it (arguing, correctly, that
+ * derivation means it "cannot drift from the rest of the repo and cannot be
+ * mistyped into something that silently reads the wrong slot") while
+ * `raw-chain-capture.ts` hardcoded the same 32 bytes as a hex literal -- the
+ * exact thing that comment warns against, sitting one module away from it.
+ * They happened to agree; nothing made them.
+ *
+ * Metadata-independent by construction: both halves hash literal names, so the
+ * key is identical on every Substrate runtime and survives a runtime upgrade.
+ * Only the VALUE's encoding tracks metadata, which is why reading this slot is
+ * legal for modules that must never pretend to decode it.
+ */
+export const SYSTEM_EVENTS_STORAGE_KEY = bytesToHex(
+  storageMapPrefix("System", "Events"),
+);

--- a/tests/health-probe-core.test.ts
+++ b/tests/health-probe-core.test.ts
@@ -382,7 +382,15 @@ describe("summarizeRpcProbe", () => {
         chain_getHeader: { ok: true, raw_header: { number: "0x10" } },
         system_health: { ok: true },
         rpc_methods: { ok: true, rpc_method_count: 42 },
-        archive_probe: { ok: true, raw_hex_result_present: true },
+        // No `raw_hex_result_present`: the archive probe is a state read at
+        // genesis, where `System.Events` is legitimately EMPTY, so a real
+        // archive answers `{"result": null}` with no error. `ok` is the whole
+        // criterion.
+        archive_probe: { ok: true },
+        // `chain_getBlockHash` support is reported from the probe that actually
+        // issues it -- the genesis call -- not from the archive probe, which no
+        // longer uses that method.
+        genesis: { ok: true },
       },
     } as unknown as RpcProbeResult);
     assert.equal(summary.archive_support, true);
@@ -842,13 +850,48 @@ describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
     assert.equal(probe.method_results!.chain_getHeader.ok, true);
   });
 
-  test("archive NOT detected when block-hash result is not a hex string", async () => {
+  test("A PRUNED NODE IS NOT AN ARCHIVE, even though it serves every block hash", async () => {
+    // The bug this replaces. `chain_getBlockHash` succeeds on a pruned node --
+    // hashes are retained, only STATE is discarded -- so probing it called
+    // every endpoint an archive. Verified against production 2026-08-16:
+    // lite.chain.opentensor.ai and entrypoint-finney answered
+    // chain_getBlockHash(1) with a hash and `UnknownBlock: State already
+    // discarded` for state at any historical block.
+    //
+    // It stopped being cosmetic when the raw-capture lane began selecting
+    // archive hosts to read `state_getStorage` from: a pruned host scored as an
+    // archive fails EVERY block handed to it.
     const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
       isUnsafeUrl: async () => false,
       fetchImpl: async (_url, init) => {
         const req = JSON.parse(init!.body as string);
+        if (req.method === "state_getStorage") {
+          return fakeResponse({
+            status: 200,
+            // A JSON-RPC error body, which is how a pruned node refuses a
+            // historical state read -- HTTP 200 with `error` set, never a
+            // transport failure.
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: req.id,
+              error: {
+                code: 4003,
+                message: "Client error: UnknownBlock: State already discarded",
+              },
+            }),
+          });
+        }
         if (req.method === "chain_getBlockHash") {
-          return fakeResponse({ status: 200, body: rpcBody(req.id, null) });
+          // The genesis call must answer with the REAL genesis, or the probe
+          // reads as wrong-chain and this test would assert `live` against a
+          // classification it never reached.
+          return fakeResponse({
+            status: 200,
+            body: rpcBody(
+              req.id,
+              req.params[0] === 0 ? FINNEY_GENESIS_HASH : "0xdead",
+            ),
+          });
         }
         return fakeResponse({
           status: 200,
@@ -857,7 +900,38 @@ describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
       },
     });
     assert.equal(probe.archive_support, false);
+    // ...and the node genuinely does serve chain_getBlockHash, which is the
+    // point: that field says nothing about archive depth.
     assert.equal(probe.methods_supported!.chain_getBlockHash, true);
+    // THE SAFETY PROPERTY. A pruned node is a perfectly healthy RPC endpoint --
+    // it just cannot answer historical state. Classifying it dead would evict
+    // lite/entrypoint from the proxy pool over a probe that was only ever meant
+    // to grade archive DEPTH, turning a capability signal into an outage.
+    assert.equal(classifyRpcProbe(probe), "live");
+  });
+
+  test("AN ARCHIVE IS DETECTED even when the slot it reads is empty", async () => {
+    // `System.Events` at genesis is legitimately empty, so a real archive
+    // answers `{"result": null}` with NO error. Requiring a hex payload -- the
+    // old criterion -- would score every archive as pruned, which is the same
+    // bug pointing the other way.
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_url, init) => {
+        const req = JSON.parse(init!.body as string);
+        if (req.method === "state_getStorage") {
+          return fakeResponse({ status: 200, body: rpcBody(req.id, null) });
+        }
+        if (req.method === "chain_getBlockHash") {
+          return fakeResponse({ status: 200, body: rpcBody(req.id, "0xdead") });
+        }
+        return fakeResponse({
+          status: 200,
+          body: rpcBody(req.id, { number: "0x1" }),
+        });
+      },
+    });
+    assert.equal(probe.archive_support, true);
   });
 
   test("transport error: fail-fast after first failed RPC call", async () => {


### PR DESCRIPTION
Found while verifying #11396 in production. That PR gave the raw-capture lane
pool-based endpoint selection keyed on `archive_support` — and the flag turned
out to be measuring the wrong thing entirely.

## The bug

An archive node is one that retains historical **state**. This probed
`chain_getBlockHash(1)` and called anything that answered it an archive. But a
pruned node discards state and keeps every block **hash**, so the probe
succeeded on both and measured nothing.

Verified against production 2026-08-16:

| endpoint | `chain_getBlockHash(1)` | `state_getStorage` @ 8,847,290 |
| --- | --- | --- |
| `archive.chain.opentensor.ai` | hash | serves it |
| onfinality | hash | serves it |
| `lite.chain.opentensor.ai` | hash | `UnknownBlock: State already discarded` |
| `entrypoint-finney.opentensor.ai` | hash | `UnknownBlock: State already discarded` |

All four were reported `archive_support: true`.

I had earlier concluded the opposite — that `chain_getBlockHash(1)` did
discriminate, because `lite` and `entrypoint` failed it once. That reading was
wrong: the failure was transient and is not reproducible. Only the state read
separates them.

## Why it matters now rather than in the abstract

The capture lane reads `state_getStorage` at heights up to a day back. Selecting
on this flag rotated it onto two hosts that fail **every** block handed to them.
No gap resulted — the same-height failover in `captureTick` retries the other
endpoints — but half the rotation was dead weight, which is the likeliest reason
the post-deploy gain was ~1 block/min rather than the multiple the widened budget
predicted.

## The fix

**The probe** reads `state_getStorage` at **genesis**: params must be static and
a moving height is not, the genesis hash is a constant this file already owns,
and state at block 0 is precisely what a pruned node cannot serve.

**The criterion** drops `raw_hex_result_present` and keeps `ok` alone. `ok` is
`response.ok && !body.error`, so it is false exactly when the node answered
`UnknownBlock`. `System.Events` at genesis is legitimately EMPTY, so a real
archive replies `{"result": null}` with no error — requiring a hex payload would
have scored every archive as pruned, the same bug pointing the other way.

**`methods_supported.chain_getBlockHash`** now keys on the `genesis` probe, which
is the call that still issues that method.

## A pruned node stays live

`classifyRpcProbe` reads `chain_getHeader` + `system_health` and never the
archive probe, so `lite`/`entrypoint` remain healthy and pool-eligible — just not
archive-capable. Pinned by a test, because turning a capability signal into an
eviction would be a worse bug than the one being fixed.

## De-duplicated on the way through

`SYSTEM_EVENTS_STORAGE_KEY` had two homes: derived in `head-poller.ts`, and
hardcoded as a hex literal in `raw-chain-capture.ts` — one module away from the
comment explaining that deriving it is what stops it being "mistyped into
something that silently reads the wrong slot". They agreed; nothing made them.
Now declared once in `twox-storage-key.ts`, beside the derivation and the vectors
that prove it.

## Verification

- 14 validators green, including `unreferenced-exports`, `type-duplicates`,
  `single-schema-source`, `boundary-casts`, `startup-budget`, `contract-drift`
- 738 tests across the probe, capture, health-serving and api-coverage suites
- tsc / eslint / prettier clean
