### PR TITLE
feat(axon): a removal is a loss of REACHABILITY, not of a populated field

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -7759,6 +7759,11 @@ type ChainAxonRemovalsDerivation {
   Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket.
   """
   pending_confirmation: Int!
+
+  """
+  Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160.
+  """
+  moved_unroutable: Int!
 }
 
 type ChainWeightSetters {

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1082,6 +1082,8 @@ export type ChainAxonRemovalsDerivation = {
   /** Days of `neuron_daily` the derivation had available. A removal older than this is outside the window, not absent. */
   lookback_days: Scalars['Int']['output'];
   method: Scalars['String']['output'];
+  /** Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160. */
+  moved_unroutable: Scalars['Int']['output'];
   /** Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
   pending_confirmation: Scalars['Int']['output'];
 };
@@ -10235,6 +10237,7 @@ export type ChainAxonRemovalsDerivationResolvers<ContextType = GqlContext, Paren
   excluded_uid_reuse?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   lookback_days?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   method?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  moved_unroutable?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   pending_confirmation?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6601,6 +6601,8 @@ export interface components {
                 lookback_days: number;
                 /** @constant */
                 method: "axon-state-diff";
+                /** @description Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160. */
+                moved_unroutable: number;
                 /** @description Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
                 pending_confirmation: number;
             };
@@ -25918,6 +25920,7 @@ export interface operations {
                      *           "excluded_uid_reuse": 1,
                      *           "lookback_days": 1,
                      *           "method": "axon-state-diff",
+                     *           "moved_unroutable": 1,
                      *           "pending_confirmation": 1
                      *         },
                      *         "intensity_distribution": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2595,6 +2595,7 @@
               "excluded_uid_reuse": 1,
               "lookback_days": 1,
               "method": "axon-state-diff",
+              "moved_unroutable": 1,
               "pending_confirmation": 1
             },
             "intensity_distribution": {
@@ -22418,6 +22419,12 @@
                 "const": "axon-state-diff",
                 "type": "string"
               },
+              "moved_unroutable": {
+                "description": "Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160.",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
               "pending_confirmation": {
                 "description": "Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket.",
                 "maximum": 9007199254740991,
@@ -22429,7 +22436,8 @@
               "method",
               "lookback_days",
               "excluded_uid_reuse",
-              "pending_confirmation"
+              "pending_confirmation",
+              "moved_unroutable"
             ],
             "type": "object"
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6601,6 +6601,8 @@ export interface components {
                 lookback_days: number;
                 /** @constant */
                 method: "axon-state-diff";
+                /** @description Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160. */
+                moved_unroutable: number;
                 /** @description Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
                 pending_confirmation: number;
             };
@@ -25918,6 +25920,7 @@ export interface operations {
                      *           "excluded_uid_reuse": 1,
                      *           "lookback_days": 1,
                      *           "method": "axon-state-diff",
+                     *           "moved_unroutable": 1,
                      *           "pending_confirmation": 1
                      *         },
                      *         "intensity_distribution": {

--- a/schemas-src/routes/chain-network-rollups.ts
+++ b/schemas-src/routes/chain-network-rollups.ts
@@ -31,9 +31,10 @@ export const IntensityDistributionSchema = distributionStatsSchema(
  * How an axon-removal answer was derived, and what the derivation set aside.
  *
  * `AxonInfoRemoved` is emitted zero times by the Subtensor runtime, so these
- * routes are derived from the daily `neuron_daily.axon` state instead: a
- * non-null axon becoming null on a slot whose hotkey did not change, confirmed
- * by a second absent reading (#10805).
+ * routes are derived from the daily `neuron_daily.axon` state instead: an axon
+ * that stops being REACHABLE on a slot whose hotkey did not change, confirmed
+ * by a second reading (#10805, widened from presence to reachability in
+ * #11398).
  */
 export const AxonRemovalDerivationSchema = z
   .object({
@@ -55,6 +56,12 @@ export const AxonRemovalDerivationSchema = z
       .min(0)
       .describe(
         "Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket.",
+      ),
+    moved_unroutable: z
+      .int()
+      .min(0)
+      .describe(
+        "Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160.",
       ),
   })
   .strict();

--- a/src/axon-removal-derivation.ts
+++ b/src/axon-removal-derivation.ts
@@ -61,6 +61,8 @@
 // equivalent SQL window function agree per subnet exactly -- 2, 1, 4, 5, 2, 5
 // -- and on the 230 drops it excluded as UID reuse.
 
+import { isRoutableAxon } from "./axon-routable.ts";
+
 /** How the axon-removal feeds are derived, echoed on every payload. */
 export const AXON_REMOVAL_DERIVATION_METHOD = "axon-state-diff";
 
@@ -86,6 +88,14 @@ export interface AxonRemovalDerivation {
    * always in this bucket, because confirmation needs a day after it.
    */
   pending_confirmation: number;
+  /**
+   * Of the confirmed removals, how many still announce something unreachable.
+   *
+   * Stated on the payload because it is the majority and a reader paging the
+   * list would otherwise have to count them: 166 of 271 same-hotkey losses
+   * over 38 days were moves, not departures (#11398).
+   */
+  moved_unroutable: number;
 }
 
 /** One (netuid, uid) observation on one day, as `neuron_daily` stores it. */
@@ -97,15 +107,29 @@ export interface NeuronAxonDayRow {
   axon: unknown;
 }
 
-/** One derived removal: this hotkey stopped announcing on this slot. */
+/** How a slot stopped being reachable, with the same hotkey still in it. */
+export type AxonRemovalKind = "stopped-announcing" | "moved-unroutable";
+
+/** One derived removal: this hotkey stopped being reachable on this slot. */
 export interface DerivedAxonRemoval {
   netuid: number;
   uid: number;
   hotkey: string;
-  /** The first day the axon was absent. */
+  /** The first day the axon was unreachable. */
   removed_on: string;
   /** What it had been announcing the day before. */
   previous_axon: string;
+  /**
+   * `stopped-announcing` cleared the field; `moved-unroutable` still publishes
+   * an address, at somewhere nothing can reach.
+   *
+   * Both are removals of REACHABILITY and both belong in the feed, but they
+   * ask different things of a reader: one miner went away, the other is
+   * running and misconfigured. Collapsing them would hide the second entirely.
+   */
+  kind: AxonRemovalKind;
+  /** The unreachable address on a move; null when the field was cleared. */
+  current_axon: string | null;
 }
 
 export interface DerivedAxonRemovals {
@@ -118,8 +142,25 @@ interface NormalizedDay {
   uid: number;
   date: string;
   hotkey: string;
-  /** Null means "no axon announced", which is what a removal transitions to. */
+  /**
+   * Null means "nothing REACHABLE announced" -- which is what a removal
+   * transitions to.
+   *
+   * Reachability, not presence (#11398). An axon in RFC 5737 documentation
+   * space or RFC 1918 private space is announced and cannot be reached by
+   * anyone, so a miner that moves to one has stopped serving exactly as much
+   * as one that cleared the field. Testing presence alone missed 166 of 271
+   * same-hotkey losses over 38 days, and all but one of SN126's 160 -- the
+   * largest same-hotkey source on the network, which read as a single event.
+   */
   axon: string | null;
+  /**
+   * What is announced, reachable or not.
+   *
+   * Non-null while `axon` is null is precisely the move case, and it is what
+   * separates `moved-unroutable` from `stopped-announcing` below.
+   */
+  announced: string | null;
 }
 
 /** A row is usable only if it identifies a slot, a day and an occupant. */
@@ -138,9 +179,14 @@ function normalize(row: NeuronAxonDayRow): NormalizedDay | null {
         ? raw.slice(0, 10)
         : "";
   if (!date) return null;
-  const axon =
+  const announced =
     typeof row?.axon === "string" && row.axon !== "" ? row.axon : null;
-  return { netuid, uid, date, hotkey, axon };
+  // `isRoutableAxon` is the same predicate the serving path publishes as
+  // `axon_routable` and the axon-announcement alarm counts by, so all three
+  // agree on what "reachable" means rather than each deciding for itself.
+  const axon =
+    announced !== null && isRoutableAxon(announced) ? announced : null;
+  return { netuid, uid, date, hotkey, axon, announced };
 }
 
 /**
@@ -198,6 +244,11 @@ export function deriveAxonRemovals(
         hotkey: current.hotkey,
         removed_on: current.date,
         previous_axon: previous.axon,
+        kind:
+          current.announced === null
+            ? "stopped-announcing"
+            : "moved-unroutable",
+        current_axon: current.announced,
       });
     }
   }
@@ -220,6 +271,9 @@ export function deriveAxonRemovals(
       lookback_days: lookbackDays,
       excluded_uid_reuse: excludedUidReuse,
       pending_confirmation: pending,
+      moved_unroutable: removals.filter(
+        (removal) => removal.kind === "moved-unroutable",
+      ).length,
     },
   };
 }

--- a/tests/axon-removal-derivation.test.ts
+++ b/tests/axon-removal-derivation.test.ts
@@ -43,10 +43,13 @@ describe("deriveAxonRemovals", () => {
       hotkey: "hkA",
       removed_on: "2026-08-02",
       previous_axon: "1.2.3.4:8091",
+      kind: "stopped-announcing",
+      current_axon: null,
     });
     assert.equal(derivation.method, AXON_REMOVAL_DERIVATION_METHOD);
     assert.equal(derivation.excluded_uid_reuse, 0);
     assert.equal(derivation.pending_confirmation, 0);
+    assert.equal(derivation.moved_unroutable, 0);
   });
 
   // CORRECTION 1. 1,485 of 1,584 drops measured over 30 days are this, so
@@ -336,5 +339,107 @@ describe("deriveAxonRemovals — the shapes a row can arrive in", () => {
     const reversed = deriveAxonRemovals([...rows].reverse(), opts);
     assert.deepEqual(reversed.removals, forward.removals);
     assert.equal(forward.removals.length, 1);
+  });
+});
+
+describe("deriveAxonRemovals — reachability, not presence (#11398)", () => {
+  // THE GAP THIS CLOSES. Testing `axon` non-null -> null asks whether a field
+  // is populated. A miner that moves to RFC 5737 documentation space is still
+  // populated and reachable by nobody. Measured over the 38 days neuron_daily
+  // retains: 166 of 271 same-hotkey losses are moves, and SN126 -- the largest
+  // same-hotkey source on the network -- read as ONE event instead of 160.
+
+  test("a move into documentation space IS a removal, and says so", () => {
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: "192.0.2.1:8091" }),
+        day("2026-08-03", { axon: "192.0.2.1:8091" }),
+      ],
+      opts,
+    );
+    assert.equal(removals.length, 1);
+    assert.equal(removals[0].kind, "moved-unroutable");
+    assert.equal(removals[0].previous_axon, "1.2.3.4:8091");
+    // The address it moved TO, so a reader can see it is misconfigured rather
+    // than gone -- a running miner nobody can reach.
+    assert.equal(removals[0].current_axon, "192.0.2.1:8091");
+    assert.equal(derivation.moved_unroutable, 1);
+  });
+
+  test("private and loopback space count too", () => {
+    for (const unreachable of [
+      "10.0.0.5:8091",
+      "127.0.0.1:8091",
+      "192.168.1.9:8091",
+    ]) {
+      const { removals } = deriveAxonRemovals(
+        [
+          day("2026-08-01", { axon: "1.2.3.4:8091" }),
+          day("2026-08-02", { axon: unreachable }),
+          day("2026-08-03", { axon: unreachable }),
+        ],
+        opts,
+      );
+      assert.equal(removals.length, 1, unreachable);
+      assert.equal(removals[0].kind, "moved-unroutable", unreachable);
+    }
+  });
+
+  test("moving between two REACHABLE addresses is not a removal", () => {
+    // Re-homing a live miner is ordinary operations, and the feed must not
+    // report it -- otherwise every host migration on the network lands here.
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: "5.6.7.8:8091" }),
+        day("2026-08-03", { axon: "5.6.7.8:8091" }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+    assert.equal(derivation.moved_unroutable, 0);
+  });
+
+  test("coming BACK to a reachable address is a flap, not a removal", () => {
+    // The same debounce that protects a missed poll protects this: a slot that
+    // is reachable again on the next reading was never torn down.
+    const { removals } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: "192.0.2.1:8091" }),
+        day("2026-08-03", { axon: "1.2.3.4:8091" }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+  });
+
+  test("a move whose slot changes hands is STILL uid reuse, not a removal", () => {
+    // Correction 1 runs before the mechanism split, so widening what counts as
+    // "lost" cannot smuggle a deregistration back into the feed.
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: "192.0.2.1:8091", hotkey: "hkB" }),
+        day("2026-08-03", { axon: "192.0.2.1:8091", hotkey: "hkB" }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+    assert.equal(derivation.excluded_uid_reuse, 1);
+    assert.equal(derivation.moved_unroutable, 0);
+  });
+
+  test("an unconfirmed move is PENDING, not published", () => {
+    const { removals, derivation } = deriveAxonRemovals(
+      [
+        day("2026-08-01", { axon: "1.2.3.4:8091" }),
+        day("2026-08-02", { axon: "192.0.2.1:8091" }),
+      ],
+      opts,
+    );
+    assert.deepEqual(removals, []);
+    assert.equal(derivation.pending_confirmation, 1);
   });
 });

--- a/tests/axon-removals-loader.test.ts
+++ b/tests/axon-removals-loader.test.ts
@@ -354,8 +354,16 @@ describe("accountAxonRemovalRows — order independence", () => {
       lookback_days: 30,
       excluded_uid_reuse: 0,
       pending_confirmation: 0,
+      moved_unroutable: 0,
     },
-    removals: removals.map((r) => ({ ...r, previous_axon: "1.2.3.4:8091" })),
+    removals: removals.map((r) => ({
+      ...r,
+      previous_axon: "1.2.3.4:8091",
+      // These fixtures are all field-cleared removals; the move case has its
+      // own coverage in axon-removal-derivation.test.ts (#11398).
+      kind: "stopped-announcing" as const,
+      current_axon: null,
+    })),
   });
 
   test("widens the window in BOTH directions, whatever order rows arrive in", () => {

--- a/tests/chain-axon-removals.test.ts
+++ b/tests/chain-axon-removals.test.ts
@@ -542,6 +542,7 @@ describe("buildChainAxonRemovals — derived (#10805)", () => {
     lookback_days: 30,
     excluded_uid_reuse: 1485,
     pending_confirmation: 0,
+    moved_unroutable: 0,
   };
 
   test("carries the derivation, so a consumer sees what was set aside", () => {


### PR DESCRIPTION
Builds on #11391, which got the hard parts right — subtracting UID reuse, and requiring a second reading so a missed poll is not a teardown. This widens its predicate; it does not disagree with it.

## The gap

Its rule is `axon` non-null → null, which asks whether a field is **populated**. A miner that moves to RFC 5737 documentation space is populated and reachable by nobody.

Measured over the 38 days `neuron_daily` retains, same hotkey:

| | count |
| --- | ---: |
| current rule (`axon` → null) | 106 |
| reachable → unreachable | 271 |
| **invisible to the current rule** | **166** |

With **#11391's own confirmation rule applied**, per subnet — the largest source on the network is the one it cannot see:

| subnet | kind | confirmed |
| --- | --- | ---: |
| **126** | **moved-unroutable** | **128** ← the feed showed ONE |
| 101 | stopped-announcing | 75 |
| 85 / 51 / 108 | stopped-announcing | 5 each |

SN126's miners never stopped announcing. They moved to addresses nothing can reach, and the feed reported a single event across 38 days.

## Why it belongs in this feed rather than beside it

A running-but-unreachable miner and a departed one are the same fact for anyone asking *"can I reach the miners here"* — both stopped serving. They differ in what a reader should **do**: one operator has gone, the other is misconfigured and probably does not know. That is a `kind`, not a separate route.

## What changed

`NormalizedDay.axon` now means **reachable**, via the `isRoutableAxon` predicate the metagraph already publishes as `axon_routable` (#11376) and the axon-announcement alarm already counts by (#11392). All three surfaces now agree on what "reachable" means instead of each deciding for itself.

Each removal gains `kind` (`stopped-announcing` | `moved-unroutable`) and `current_axon` — the unreachable address, so a reader sees a misconfiguration rather than a departure. The derivation block gains `moved_unroutable`, because it is the majority and paging the list to count it is not reasonable.

## Every existing correction still runs, and runs FIRST

Widening what counts as "lost" must not smuggle anything back in. Each of these has a test:

- a move whose slot **changed hands** is still UID reuse, not a removal
- an **unconfirmed** move is still `pending_confirmation`, not published
- moving between two **reachable** addresses is still a non-event
- a slot **reachable again** on the next reading is still a flap

## Verification

The per-subnet table above was produced by replicating #11391's confirmation rule in SQL against production Neon, so the 128 is what the shipped derivation will emit, not what an idealised one would.

**21,678 tests pass across 943 files. Every CI validator passes**, with `openapi.json`, the GraphQL SDL and the generated client regenerated and committed.

Closes #11398