### PR TITLE
refactor(crons): the eight staleness watchdogs move onto one heartbeat

### DIFF
--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -70,8 +70,14 @@ export const PRODUCER_CADENCE_SECS = {
   /** The top-holders flow materialization, rebuilt daily. */
   top_holders_flow: 86_400,
   /**
-   * The top-holders WATCHDOG's own tick -- TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
-   * twice hourly.
+   * The top-holders WATCHDOG's own tick -- twice hourly.
+   *
+   * Since #10849 item 5 the cadence is `everyMinutes` on the
+   * `top-holders-flow-staleness` entry of STALENESS_WATCHDOGS (workers/api.ts),
+   * not a cron expression: the eight staleness watchdogs share one heartbeat.
+   * tests/producer-cadence.test.ts checks this number against that registry the
+   * way it checks the cron-backed lanes against workers/config.ts, so the two
+   * still cannot drift apart.
    *
    * A WATCHDOG IS THE PRODUCER OF ITS OWN VERDICT ROW, and that is the sense
    * this table is keyed in: `laneSilenceCadenceMs` asks "how often does this
@@ -189,7 +195,25 @@ export const WORKER_CRON_LANES: Readonly<
 > = {
   top_holders_flow: "TOP_HOLDERS_FLOW_CRON",
   top_holders_holdings: "TOP_HOLDERS_HOLDINGS_REFRESH_CRON",
-  top_holders_staleness_watchdog: "TOP_HOLDERS_STALENESS_WATCHDOG_CRON",
+  // `top_holders_staleness_watchdog` is deliberately NOT here any more. It no
+  // longer has a cron expression -- since #10849 item 5 it declares
+  // `everyMinutes` in STALENESS_WATCHDOGS -- so naming a constant for it would
+  // name one that does not exist. The test checks it against the registry
+  // instead, which is the same agreement against the source that now decides it.
+} as const;
+
+/**
+ * Lanes whose producer is a REGISTRY entry rather than a cron expression.
+ *
+ * Maps this table's lane key to the `lane_health.lane` name it is registered
+ * under in STALENESS_WATCHDOGS. Same purpose as WORKER_CRON_LANES above: the
+ * declared cadence has to be checked against whatever actually decides it, and
+ * for the staleness family that stopped being a cron.
+ */
+export const WORKER_REGISTRY_LANES: Readonly<
+  Partial<Record<ProducerLane, string>>
+> = {
+  top_holders_staleness_watchdog: "top-holders-flow-staleness",
 } as const;
 
 /**

--- a/src/staleness-watchdog-heartbeat.ts
+++ b/src/staleness-watchdog-heartbeat.ts
@@ -1,0 +1,142 @@
+// One clock for the staleness watchdogs (#10849 item 5).
+//
+// ## What this replaces
+//
+// Eight watchdogs each held a cron expression of its own, and the hourly grid
+// is full. Expanding the step expressions -- `*/5` (raw capture) fires on every
+// multiple of five, `*/15` (health prober) on every multiple of fifteen -- the
+// 60-minute grid has exactly ONE genuinely unclaimed minute. `src/lane-scheduler.ts`
+// recorded the same measurement when it was written ("exactly THREE every-hour
+// minutes were free"), and it has got worse since.
+//
+// The producers already solved this: #10715 gave them one heartbeat and a
+// registry, and #10709 gave the registry a cadence gate so a lane declares HOW
+// OFTEN rather than WHICH MINUTE. This is that pattern for the watchdog family,
+// and it is not a new idea in this file either -- `rpc-usage-staleness` has
+// ridden the health-prune tick since #9228 rather than taking a minute.
+//
+// ## Cadence is preserved exactly, which is the whole point
+//
+// A watchdog that checks less often detects later, and detection latency is the
+// only thing a staleness alarm sells. Measured against the eight crons this
+// replaces, every one runs at 15, 30 or 60 minutes:
+//
+//   neurons-staleness                    6,21,36,51    15m
+//   chain-detail-staleness               14,29,44,59   15m
+//   projection-staleness                 2,32          30m
+//   nominator-positions-staleness        8,38          30m
+//   validator-nominator-counts-staleness 19,49         30m
+//   account-balances-staleness           4,34          30m
+//   top-holders-*-staleness              22,52         30m
+//   hotkey-alpha-staleness               54            60m
+//
+// All three divide into a 15-minute tick, so a quarter-hourly heartbeat plus
+// `lanesDue` reproduces each cadence exactly rather than approximately. That is
+// why the heartbeat is quarter-hourly and not hourly: an hourly clock would
+// quietly turn two 15-minute alarms into 60-minute ones, and the issue asking
+// for this consolidation asks for it on comprehensibility grounds -- which is
+// not a trade worth any detection latency at all.
+//
+// ## One lane's failure must never silence another's alarm
+//
+// This is the property the whole module exists to protect, and it is the lesson
+// #9228 already paid for here: `rpc-usage-staleness` was moved to run BEFORE a
+// sibling's gate precisely because "the gate can early-return this whole tick,
+// and an alarm that a sibling lane's failure can silence is an alarm that
+// reports healthy for exactly the reason it should be shouting."
+//
+// Eight watchdogs behind one trigger makes that failure mode eight times
+// cheaper to hit, so every lane runs inside its own try/catch and a throw is
+// recorded and stepped over. `Promise.all` would have been shorter and is
+// exactly wrong: the first rejection abandons the rest.
+//
+// A THROWN LANE IS NOT MARKED HEALTHY. It writes no verdict, so its
+// `lane_health.checked_at` freezes and the existing lane alarm reports it stale
+// on the normal path. Writing a verdict here to record the failure would
+// refresh that stamp and make a permanently broken watchdog look recently
+// checked -- suppressing the alarm at the moment it should fire.
+//
+// ## Sequential, not concurrent
+//
+// Each lane is a `MAX(...)` against Neon through Hyperdrive. Eight at once is
+// eight pooled connections for no gain -- the tick has fifteen minutes and the
+// work is milliseconds -- and Neon compute is the estate's live cost pressure.
+import { lanesDue, type ScheduledLane } from "./lane-scheduler.ts";
+
+/** A staleness watchdog that declares a cadence instead of taking a minute. */
+export interface StalenessWatchdogLane<E> extends ScheduledLane {
+  /**
+   * `name` must equal the lane's own `lane_health.lane` value, because that row's
+   * `checked_at` is what gates the cadence. These watchdogs stamp `now()` at the
+   * moment they run -- verified per module -- so it is a true last-run stamp.
+   * That is NOT true of `lane_health` generally: lanes stamped with a producer's
+   * pass time freeze while the producer is down, and feeding one of those to the
+   * gate would read a dead lane as permanently overdue.
+   */
+  run: (env: E) => Promise<Record<string, unknown>>;
+}
+
+/** What one lane did on one tick. */
+export interface StalenessWatchdogOutcome {
+  lane: string;
+  ok: boolean;
+  /** The thrown message, when it threw. Absent on success. */
+  error?: string;
+}
+
+export interface StalenessWatchdogTick {
+  /** False if ANY lane that ran threw. An idle tick is ok. */
+  ok: boolean;
+  ran: StalenessWatchdogOutcome[];
+  /** Registered lanes the cadence gate held back, so "ran two of eight" reads
+   * as six not-due rather than as six gone missing. */
+  skipped: number;
+}
+
+export interface StalenessWatchdogTickDeps {
+  /** Lane name to last-run wall clock, from `lastRunFromLaneHealth`. */
+  lastRunMs?: Readonly<Record<string, number | null | undefined>>;
+  now?: () => number;
+}
+
+/**
+ * Run every registered watchdog that is due, in order, isolating each.
+ *
+ * Returns rather than throws: the caller is a cron branch whose return value is
+ * a report, and a throw here would lose the outcomes of every lane that already
+ * succeeded on this tick.
+ */
+export async function runDueStalenessWatchdogs<E>(
+  lanes: ReadonlyArray<StalenessWatchdogLane<E>>,
+  env: E,
+  deps: StalenessWatchdogTickDeps = {},
+): Promise<StalenessWatchdogTick> {
+  const now = deps.now ?? Date.now;
+  const registered = Array.isArray(lanes) ? lanes : [];
+  const due = lanesDue(registered, deps.lastRunMs ?? {}, now());
+
+  const ran: StalenessWatchdogOutcome[] = [];
+  for (const lane of due) {
+    try {
+      await lane.run(env);
+      ran.push({ lane: lane.name, ok: true });
+    } catch (error) {
+      // Recorded and stepped over. The next lane still runs, and this one's
+      // frozen `checked_at` is what raises the alarm -- see the header.
+      ran.push({
+        lane: lane.name,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    // `[].every()` is true, so a tick with nothing due reports ok -- which is
+    // correct, and is the common case on a grid that ticks more often than the
+    // slowest lane wants.
+    ok: ran.every((outcome) => outcome.ok),
+    ran,
+    skipped: registered.length - ran.length,
+  };
+}

--- a/src/staleness-watchdog-heartbeat.ts
+++ b/src/staleness-watchdog-heartbeat.ts
@@ -119,8 +119,10 @@ export async function runDueStalenessWatchdogs<E>(
   deps: StalenessWatchdogTickDeps = {},
 ): Promise<StalenessWatchdogTick> {
   const now = deps.now ?? Date.now;
-  const registered = Array.isArray(lanes) ? lanes : [];
-  const due = lanesDue(registered, deps.lastRunMs ?? {}, now());
+  // No Array.isArray guard: `lanes` is a typed module constant, not a store
+  // read, so the non-array case is one the type system already rules out. A
+  // guard for it would be an unreachable branch dressed as safety.
+  const due = lanesDue(lanes, deps.lastRunMs ?? {}, now());
 
   const ran: StalenessWatchdogOutcome[] = [];
   for (const lane of due) {
@@ -144,6 +146,6 @@ export async function runDueStalenessWatchdogs<E>(
     // slowest lane wants.
     ok: ran.every((outcome) => outcome.ok),
     ran,
-    skipped: registered.length - ran.length,
+    skipped: lanes.length - ran.length,
   };
 }

--- a/src/staleness-watchdog-heartbeat.ts
+++ b/src/staleness-watchdog-heartbeat.ts
@@ -80,6 +80,13 @@ export interface StalenessWatchdogLane<E> extends ScheduledLane {
 export interface StalenessWatchdogOutcome {
   lane: string;
   ok: boolean;
+  /**
+   * What the watchdog itself returned. Carried rather than dropped so the
+   * heartbeat's report says as much as the eight separate cron returns did --
+   * otherwise consolidating the trigger would quietly cost every lane its
+   * verdict detail at the dispatch boundary.
+   */
+  summary?: Record<string, unknown>;
   /** The thrown message, when it threw. Absent on success. */
   error?: string;
 }
@@ -118,8 +125,8 @@ export async function runDueStalenessWatchdogs<E>(
   const ran: StalenessWatchdogOutcome[] = [];
   for (const lane of due) {
     try {
-      await lane.run(env);
-      ran.push({ lane: lane.name, ok: true });
+      const summary = await lane.run(env);
+      ran.push({ lane: lane.name, ok: true, summary });
     } catch (error) {
       // Recorded and stepped over. The next lane still runs, and this one's
       // frozen `checked_at` is what raises the alarm -- see the header.

--- a/tests/account-balances-staleness-watchdog.test.ts
+++ b/tests/account-balances-staleness-watchdog.test.ts
@@ -44,6 +44,7 @@ import {
 } from "../src/account-balances-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;
 const HOUR = 60 * 60_000;
@@ -510,43 +511,10 @@ describe("runAccountBalancesStalenessWatchdog", () => {
 });
 
 describe("the cron string is unique and wired", () => {
-  test("no other cron in workers/config.ts shares the literal string", () => {
-    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
-    // this lane into another branch entirely.
-    const crons = Object.entries(workerConfig)
-      .filter(([key]) => key.endsWith("_CRON"))
-      .map(([, value]) => value);
-    const mine = workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON;
-    assert.equal(
-      crons.filter((cron) => cron === mine).length,
-      1,
-      `${mine} is declared by more than one lane`,
-    );
-  });
-
-  test("wrangler.jsonc declares the trigger", () => {
-    // A cron the Worker dispatches on but wrangler never fires is dead code --
-    // and the failure is silent, since the branch simply never runs.
-    const raw = readFileSync(
-      new URL("../wrangler.jsonc", import.meta.url),
-      "utf8",
-    )
-      .replace(/^\s*\/\/.*$/gm, "")
-      .replace(/,(\s*[}\]])/g, "$1");
-    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
-    assert.ok(
-      parsed.triggers?.crons?.includes(
-        workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
-      ),
-    );
-  });
-
   test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
     const { env, queries } = fakeDb(Date.now());
-    const result = (await handleScheduled(
-      {
-        cron: workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
-      } as unknown as ScheduledController,
+    const result = (await runStalenessLane(
+      "account-balances-staleness",
       env as unknown as Parameters<typeof handleScheduled>[1],
       {} as unknown as ExecutionContext,
     )) as { ok: boolean; alerted: boolean };

--- a/tests/account-balances-staleness-watchdog.test.ts
+++ b/tests/account-balances-staleness-watchdog.test.ts
@@ -20,7 +20,6 @@
 // verbatim, because a rule that gets every synthetic case right and that one
 // wrong is the rule this file already had.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
@@ -43,7 +42,6 @@ import {
   runAccountBalancesStalenessWatchdog,
 } from "../src/account-balances-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
-import * as workerConfig from "../workers/config.ts";
 import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;

--- a/tests/chain-detail-staleness-watchdog.test.ts
+++ b/tests/chain-detail-staleness-watchdog.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../src/chain-detail-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;
 const HEAD = 8_762_600;
@@ -241,30 +242,10 @@ describe("runChainDetailStalenessWatchdog", () => {
 });
 
 describe("the cron wiring", () => {
-  test("both #9208 crons are unique strings across the whole config", () => {
-    const crons = Object.entries(workerConfig)
-      .filter(([name]) => name.endsWith("_CRON"))
-      .map(([, value]) => value);
-    assert.equal(
-      new Set(crons).size,
-      crons.length,
-      "dispatch keys on the LITERAL cron string, so a duplicate routes one " +
-        "lane into another lane's branch",
-    );
-    assert.ok(crons.includes(workerConfig.CHAIN_DETAIL_PRUNE_CRON));
-    assert.ok(
-      crons.includes(workerConfig.CHAIN_DETAIL_STALENESS_WATCHDOG_CRON),
-    );
-    assert.notEqual(
-      workerConfig.CHAIN_DETAIL_PRUNE_CRON,
-      workerConfig.CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
-    );
-  });
-
   test("the watchdog cron reaches the watchdog, and reports its verdict", async () => {
     const { env } = fakeDb(Date.now() - 1_000);
-    const result = (await handleScheduled(
-      { cron: workerConfig.CHAIN_DETAIL_STALENESS_WATCHDOG_CRON } as never,
+    const result = (await runStalenessLane(
+      "chain-detail-staleness",
       env as never,
       {} as never,
     )) as Record<string, unknown>;

--- a/tests/helpers/staleness-lane.ts
+++ b/tests/helpers/staleness-lane.ts
@@ -1,0 +1,35 @@
+// Reaching one staleness watchdog through the registry that now owns it.
+//
+// These lanes used to have a cron each, and their tests dispatched through
+// `handleScheduled({ cron })` to prove the wiring reached them. Since #10849
+// item 5 there is one heartbeat, and dispatching through it would run all eight
+// siblings against an env fixture built for one -- harmless, because the
+// heartbeat isolates every lane, but it would add the siblings' queries to the
+// `queries` arrays these tests assert on.
+//
+// So the per-lane tests exercise the REGISTRY ENTRY, which is the part specific
+// to them, and tests/staleness-watchdog-registry.test.ts covers the part that is
+// shared: that the heartbeat cron is declared, unique, handled, and actually
+// runs the registry.
+import { STALENESS_WATCHDOGS } from "../../workers/api.ts";
+
+/** The registered lane, or a failure naming what is missing. */
+export function stalenessLane(name: string) {
+  const lane = STALENESS_WATCHDOGS.find((entry) => entry.name === name);
+  if (!lane) {
+    throw new Error(
+      `no staleness watchdog registered as "${name}" -- registered: ` +
+        STALENESS_WATCHDOGS.map((entry) => entry.name).join(", "),
+    );
+  }
+  return lane;
+}
+
+/** Run one registered lane the way the heartbeat runs it. */
+export async function runStalenessLane(
+  name: string,
+  env: unknown,
+  ctx?: unknown,
+): Promise<Record<string, unknown>> {
+  return stalenessLane(name).run({ env, ctx } as never);
+}

--- a/tests/hotkey-alpha-staleness-watchdog.test.ts
+++ b/tests/hotkey-alpha-staleness-watchdog.test.ts
@@ -44,6 +44,7 @@ import {
 } from "../src/hotkey-alpha-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;
 const HOUR = 60 * 60_000;
@@ -480,53 +481,10 @@ describe("runHotkeyAlphaStalenessWatchdog", () => {
 });
 
 describe("the cron string is unique and wired", () => {
-  test("no other cron in workers/config.ts shares the literal string", () => {
-    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
-    // this lane into another branch entirely.
-    const crons = Object.entries(workerConfig)
-      .filter(([key]) => key.endsWith("_CRON"))
-      .map(([, value]) => value);
-    const mine = workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON;
-    assert.equal(
-      crons.filter((cron) => cron === mine).length,
-      1,
-      `${mine} is declared by more than one lane`,
-    );
-  });
-
-  test("it stays off the */5 and */15 grids", () => {
-    // Both grids fire on every minute divisible by 5, so a watchdog sharing one
-    // contends with the raw-capture and probe lanes on the same tick.
-    const minute = Number(
-      workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON.split(" ")[0],
-    );
-    assert.equal(Number.isInteger(minute), true);
-    assert.notEqual(minute % 5, 0);
-  });
-
-  test("wrangler.jsonc declares the trigger", () => {
-    // A cron the Worker dispatches on but wrangler never fires is dead code —
-    // and the failure is silent, since the branch simply never runs.
-    const raw = readFileSync(
-      new URL("../wrangler.jsonc", import.meta.url),
-      "utf8",
-    )
-      .replace(/^\s*\/\/.*$/gm, "")
-      .replace(/,(\s*[}\]])/g, "$1");
-    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
-    assert.ok(
-      parsed.triggers?.crons?.includes(
-        workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
-      ),
-    );
-  });
-
   test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
     const { env, queries } = fakeDb(Date.now());
-    const result = (await handleScheduled(
-      {
-        cron: workerConfig.HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
-      } as unknown as ScheduledController,
+    const result = (await runStalenessLane(
+      "hotkey-alpha-staleness",
       env as unknown as Parameters<typeof handleScheduled>[1],
       {} as unknown as ExecutionContext,
     )) as { ok: boolean; alerted: boolean };
@@ -536,30 +494,5 @@ describe("the cron string is unique and wired", () => {
       q.includes("FROM hotkey_alpha"),
     );
     assert.equal(reads.length, 1);
-  });
-
-  test("it does not swallow the neighbouring lane's cron", async () => {
-    // This branch is checked immediately BEFORE the account-balances watchdog,
-    // so a mistake here — a copied constant, a stray `||` — routes that lane
-    // into this one and silences it while both crons keep firing. Dispatch keys
-    // on the literal string and nothing else proves the two stay distinct.
-    const { env, queries } = fakeDb(Date.now());
-    const result = (await handleScheduled(
-      {
-        cron: workerConfig.ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
-      } as unknown as ScheduledController,
-      env as unknown as Parameters<typeof handleScheduled>[1],
-      {} as unknown as ExecutionContext,
-    )) as { ok: boolean };
-    assert.equal(result.ok, true);
-    // The neighbour read ITS table, and this lane's read never happened.
-    assert.equal(
-      queries.filter((q: string) => q.includes("FROM account_balances")).length,
-      1,
-    );
-    assert.equal(
-      queries.filter((q: string) => q.includes("FROM hotkey_alpha")).length,
-      0,
-    );
   });
 });

--- a/tests/hotkey-alpha-staleness-watchdog.test.ts
+++ b/tests/hotkey-alpha-staleness-watchdog.test.ts
@@ -21,7 +21,6 @@
 // place is an alarm that is quietly too low to fire, and nothing about a passing
 // tick would say so.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
@@ -43,7 +42,6 @@ import {
   runHotkeyAlphaStalenessWatchdog,
 } from "../src/hotkey-alpha-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
-import * as workerConfig from "../workers/config.ts";
 import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -35,7 +35,6 @@ import {
 } from "../src/neurons-staleness-watchdog.ts";
 import { FLUSH_INTERVAL_MS } from "../src/neon-write-buffer.ts";
 import { handleScheduled } from "../workers/api.ts";
-import * as workerConfig from "../workers/config.ts";
 import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -36,6 +36,7 @@ import {
 import { FLUSH_INTERVAL_MS } from "../src/neon-write-buffer.ts";
 import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;
 /** A pass that covered the network, so coverage is never the thing under test
@@ -404,13 +405,11 @@ describe("runNeuronsStalenessWatchdog", () => {
   });
 });
 
-describe("handleScheduled NEURONS_STALENESS_WATCHDOG_CRON", () => {
+describe("the neurons lane, reached through the watchdog registry", () => {
   test("dispatches to the watchdog and returns its summary", async () => {
     const { env, queries } = fakeDb(Date.now());
-    const result = (await handleScheduled(
-      {
-        cron: workerConfig.NEURONS_STALENESS_WATCHDOG_CRON,
-      } as unknown as ScheduledController,
+    const result = (await runStalenessLane(
+      "neurons-staleness",
       env as unknown as Parameters<typeof handleScheduled>[1],
       {} as unknown as ExecutionContext,
     )) as { ok: boolean; alerted: boolean };

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -7,7 +7,6 @@
 // 34 hours and produced this issue.
 import assert from "node:assert/strict";
 import { POSITION_SOURCE_ALPHA } from "../src/nominator-positions-neon-write.ts";
-import { readFileSync } from "node:fs";
 import { describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
@@ -31,7 +30,6 @@ import {
   runNominatorPositionsStalenessWatchdog,
 } from "../src/nominator-positions-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
-import * as workerConfig from "../workers/config.ts";
 import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../src/nominator-positions-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;
 
@@ -514,43 +515,10 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
 });
 
 describe("the cron string is unique and wired", () => {
-  test("no other cron in workers/config.ts shares the literal string", () => {
-    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
-    // this lane into another branch entirely.
-    const crons = Object.entries(workerConfig)
-      .filter(([key]) => key.endsWith("_CRON"))
-      .map(([, value]) => value);
-    const mine = workerConfig.NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON;
-    assert.equal(
-      crons.filter((cron) => cron === mine).length,
-      1,
-      `${mine} is declared by more than one lane`,
-    );
-  });
-
-  test("wrangler.jsonc declares the trigger", () => {
-    // A cron the Worker dispatches on but wrangler never fires is dead code --
-    // and the failure is silent, since the branch simply never runs.
-    const raw = readFileSync(
-      new URL("../wrangler.jsonc", import.meta.url),
-      "utf8",
-    )
-      .replace(/^\s*\/\/.*$/gm, "")
-      .replace(/,(\s*[}\]])/g, "$1");
-    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
-    assert.ok(
-      parsed.triggers?.crons?.includes(
-        workerConfig.NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
-      ),
-    );
-  });
-
   test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
     const { env, queries } = fakeDb(Date.now());
-    const result = (await handleScheduled(
-      {
-        cron: workerConfig.NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
-      } as unknown as ScheduledController,
+    const result = (await runStalenessLane(
+      "nominator-positions-staleness",
       env as unknown as Parameters<typeof handleScheduled>[1],
       {} as unknown as ExecutionContext,
     )) as { ok: boolean; alerted: boolean };

--- a/tests/producer-cadence.test.ts
+++ b/tests/producer-cadence.test.ts
@@ -39,6 +39,7 @@ import { VALIDATOR_NOMINATOR_COUNTS_PASS_WINDOW_MS } from "../src/validator-nomi
 import { TOP_HOLDERS_FLOW_STALENESS_THRESHOLD_MS } from "../src/top-holders-staleness-watchdog.ts";
 import {
   WORKER_CRON_LANES,
+  WORKER_REGISTRY_LANES,
   cronIntervalSecs,
 } from "../src/producer-cadence.ts";
 import * as CONFIG from "../workers/config.ts";
@@ -254,8 +255,28 @@ describe("a worker lane's declared cadence matches the cron it runs on", () => {
     assert.deepEqual(Object.keys(WORKER_CRON_LANES).sort(), [
       "top_holders_flow",
       "top_holders_holdings",
-      "top_holders_staleness_watchdog",
     ]);
+  });
+
+  // The staleness watchdog's cadence stopped being a cron in #10849 item 5, so
+  // the agreement is now checked against the registry that replaced it. Losing
+  // this check rather than moving it is how a declared floor goes stale in
+  // prose: the number stays, the thing it was measured against disappears.
+  test("a REGISTRY-backed lane's declared seconds are its everyMinutes", async () => {
+    const { STALENESS_WATCHDOGS } = await import("../workers/api.ts");
+    for (const [lane, laneName] of Object.entries(WORKER_REGISTRY_LANES)) {
+      const entry = STALENESS_WATCHDOGS.find((l) => l.name === laneName);
+      assert.ok(
+        entry,
+        `${lane} names the registry lane "${laneName}", which STALENESS_WATCHDOGS does not declare`,
+      );
+      assert.equal(
+        entry.everyMinutes * 60,
+        PRODUCER_CADENCE_SECS[lane as keyof typeof PRODUCER_CADENCE_SECS],
+        `${lane} declares ${PRODUCER_CADENCE_SECS[lane as keyof typeof PRODUCER_CADENCE_SECS]}s ` +
+          `but "${laneName}" runs every ${entry.everyMinutes}m`,
+      );
+    }
   });
 });
 

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -486,11 +486,8 @@ describe("every tick leaves a durable verdict, not just a notification", () => {
   });
 });
 
-describe("the watchdog cron", () => {
-  // Dispatch keys on the LITERAL cron string, so a duplicate silently steals
-  // the other's tick.
-  test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
-    const { handleScheduled } = await import("../workers/api.ts");
+describe("the watchdog lane, as the heartbeat runs it", () => {
+  test("the registry entry reaches the watchdog and returns its summary", async () => {
     const reads: string[] = [];
     const result = (await runStalenessLane(
       "projection-staleness",
@@ -508,7 +505,7 @@ describe("the watchdog cron", () => {
             };
           },
         },
-      } as unknown as Parameters<typeof handleScheduled>[1],
+      } as unknown,
       {} as unknown as ExecutionContext,
     )) as { ok: boolean; stale: boolean; checked: number };
     assert.equal(result.ok, true);

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -19,11 +19,9 @@ import {
   PROJECTION_LANES,
   PROJECTION_NETWORKS,
 } from "../src/projection-lanes.ts";
-import {
-  PROJECTION_LANES_CRON,
-  PROJECTION_STALENESS_WATCHDOG_CRON,
-} from "../workers/config.ts";
+import { PROJECTION_LANES_CRON } from "../workers/config.ts";
 import { projectionKey } from "../src/chain-network.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const HOUR = 3_600_000;
 
@@ -491,39 +489,11 @@ describe("every tick leaves a durable verdict, not just a notification", () => {
 describe("the watchdog cron", () => {
   // Dispatch keys on the LITERAL cron string, so a duplicate silently steals
   // the other's tick.
-  test("does not collide with the lane cron it watches", async () => {
-    const config = await import("../workers/config.ts");
-    const crons = Object.entries(config)
-      .filter(([name]) => name.endsWith("_CRON"))
-      .map(([, value]) => String(value));
-    const mine = crons.filter((c) => c === PROJECTION_STALENESS_WATCHDOG_CRON);
-    assert.equal(mine.length, 1, "the cron string must be unique in config");
-  });
-
-  test("wrangler.jsonc declares the trigger", async () => {
-    // A cron the Worker dispatches on but wrangler never fires is dead code,
-    // and the failure is silent: the branch simply never runs.
-    const { readFileSync } = await import("node:fs");
-    const raw = readFileSync(
-      new URL("../wrangler.jsonc", import.meta.url),
-      "utf8",
-    )
-      .replace(/^\s*\/\/.*$/gm, "")
-      .replace(/,(\s*[}\]])/g, "$1");
-    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
-    assert.ok(
-      parsed.triggers?.crons?.includes(PROJECTION_STALENESS_WATCHDOG_CRON),
-      `wrangler.jsonc must fire ${PROJECTION_STALENESS_WATCHDOG_CRON}`,
-    );
-  });
-
   test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
     const { handleScheduled } = await import("../workers/api.ts");
     const reads: string[] = [];
-    const result = (await handleScheduled(
-      {
-        cron: PROJECTION_STALENESS_WATCHDOG_CRON,
-      } as unknown as ScheduledController,
+    const result = (await runStalenessLane(
+      "projection-staleness",
       {
         METAGRAPH_ARCHIVE: {
           async get(key: string) {
@@ -551,19 +521,5 @@ describe("the watchdog cron", () => {
       PROJECTION_LANES.length * PROJECTION_NETWORKS.length,
     );
     assert.equal(result.checked, reads.length);
-  });
-
-  test("samples after a lane run has finished, not during one", () => {
-    const [watchMinutes] = PROJECTION_STALENESS_WATCHDOG_CRON.split(" ");
-    const minutes = watchMinutes!.split(",").map(Number);
-    // The lane cron is 11,41; a run takes ~5 minutes. Judging at 2,32 leaves
-    // 21 minutes of slack, so a slow run is never called stale mid-flight.
-    for (const m of minutes) {
-      const sinceLaneStart = (m - 11 + 60) % 30;
-      assert.ok(
-        sinceLaneStart >= 10,
-        `minute ${m} judges only ${sinceLaneStart} min after a lane tick begins`,
-      );
-    }
   });
 });

--- a/tests/staleness-watchdog-heartbeat.test.ts
+++ b/tests/staleness-watchdog-heartbeat.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  runDueStalenessWatchdogs,
+  type StalenessWatchdogLane,
+} from "../src/staleness-watchdog-heartbeat.ts";
+
+/** A lane that records every env it was run with. */
+function lane(
+  name: string,
+  everyMinutes: number,
+  run: (env: string) => Promise<Record<string, unknown>> = async () => ({}),
+): StalenessWatchdogLane<string> {
+  return { name, everyMinutes, run };
+}
+
+const MINUTE = 60_000;
+
+describe("runDueStalenessWatchdogs", () => {
+  test("runs every lane when none has ever run", async () => {
+    const calls: string[] = [];
+    const tick = await runDueStalenessWatchdogs(
+      [
+        lane("a", 15, async () => (calls.push("a"), {})),
+        lane("b", 60, async () => (calls.push("b"), {})),
+      ],
+      "env",
+      { lastRunMs: {}, now: () => 1_000_000 },
+    );
+    assert.deepEqual(calls, ["a", "b"]);
+    assert.equal(tick.ok, true);
+    assert.equal(tick.skipped, 0);
+  });
+
+  // THE REGRESSION TEST. Eight watchdogs gave up their own cron minutes for
+  // this heartbeat, and the only thing they sold in exchange was detection
+  // latency. Simulated over the quarter-hourly grid, each cadence must come out
+  // at exactly the rate its old cron ran at: 15m -> 4/hour, 30m -> 2, 60m -> 1.
+  test("reproduces 15/30/60-minute cadences EXACTLY over an hour", async () => {
+    const ranAt: Record<string, number[]> = { q: [], h: [], hr: [] };
+    const lanes = [
+      lane("q", 15, async () => ({})),
+      lane("h", 30, async () => ({})),
+      lane("hr", 60, async () => ({})),
+    ];
+    const lastRun: Record<string, number> = {};
+    // Ticks at :06, :21, :36, :51 -- the grid the heartbeat claims.
+    const start = 6 * MINUTE;
+    // Five ticks: the first seeds last-run, the next four are the hour measured.
+    for (let i = 0; i < 5; i += 1) {
+      const now = start + i * 15 * MINUTE;
+      const tick = await runDueStalenessWatchdogs(lanes, "env", {
+        lastRunMs: lastRun,
+        now: () => now,
+      });
+      for (const outcome of tick.ran) {
+        lastRun[outcome.lane] = now;
+        if (i > 0) ranAt[outcome.lane]!.push(now);
+      }
+    }
+    assert.equal(ranAt.q!.length, 4, "a 15-minute lane runs 4x an hour");
+    assert.equal(ranAt.h!.length, 2, "a 30-minute lane runs 2x an hour");
+    assert.equal(ranAt.hr!.length, 1, "a 60-minute lane runs 1x an hour");
+  });
+
+  test("a lane that is not due is skipped, and counted as skipped", async () => {
+    const calls: string[] = [];
+    const now = 10 * 60 * MINUTE;
+    const tick = await runDueStalenessWatchdogs(
+      [
+        lane("fresh", 60, async () => (calls.push("fresh"), {})),
+        lane("stale", 15, async () => (calls.push("stale"), {})),
+      ],
+      "env",
+      {
+        // `fresh` ran a minute ago; `stale` ran an hour ago.
+        lastRunMs: { fresh: now - MINUTE, stale: now - 60 * MINUTE },
+        now: () => now,
+      },
+    );
+    assert.deepEqual(calls, ["stale"]);
+    assert.equal(tick.skipped, 1);
+    assert.equal(tick.ran.length, 1);
+  });
+});
+
+// The property the module exists for. Eight alarms behind one trigger makes
+// "one lane's failure silences another's alarm" eight times cheaper to hit, and
+// #9228 already paid for that lesson once in this codebase.
+describe("one lane's failure cannot silence another's alarm", () => {
+  test("a THROWING lane does not stop the lanes after it", async () => {
+    const calls: string[] = [];
+    const tick = await runDueStalenessWatchdogs(
+      [
+        lane("first", 15, async () => (calls.push("first"), {})),
+        lane("boom", 15, async () => {
+          calls.push("boom");
+          throw new Error("neon said no");
+        }),
+        lane("last", 15, async () => (calls.push("last"), {})),
+      ],
+      "env",
+      { lastRunMs: {}, now: () => 1_000_000 },
+    );
+    assert.deepEqual(calls, ["first", "boom", "last"], "all three were run");
+    assert.equal(tick.ok, false, "the tick is not ok");
+    assert.deepEqual(
+      tick.ran.map((r) => [r.lane, r.ok]),
+      [
+        ["first", true],
+        ["boom", false],
+        ["last", true],
+      ],
+      "the failure is attributed to the lane that threw, and only to it",
+    );
+    assert.equal(tick.ran[1]!.error, "neon said no");
+  });
+
+  test("a lane that throws is reported, never marked healthy", async () => {
+    // It writes no verdict, so its lane_health.checked_at freezes and the
+    // existing alarm reports it stale. Recording a verdict here would refresh
+    // that stamp and make a permanently broken watchdog look recently checked.
+    const tick = await runDueStalenessWatchdogs(
+      [
+        lane("boom", 15, async () => {
+          throw new Error("down");
+        }),
+      ],
+      "env",
+      { lastRunMs: {}, now: () => 1_000_000 },
+    );
+    assert.equal(tick.ok, false);
+    assert.equal(tick.ran[0]!.ok, false);
+  });
+
+  test("a non-Error throw is still attributed, not swallowed", async () => {
+    const tick = await runDueStalenessWatchdogs(
+      [
+        lane("odd", 15, async () => {
+          throw "a string";
+        }),
+      ],
+      "env",
+      { lastRunMs: {}, now: () => 1_000_000 },
+    );
+    assert.equal(tick.ran[0]!.error, "a string");
+    assert.equal(tick.ok, false);
+  });
+
+  test("lanes run SEQUENTIALLY, not concurrently", async () => {
+    // Eight MAX() queries at once is eight pooled Neon connections for no gain.
+    // Overlap is what this asserts against: a concurrent implementation would
+    // interleave the enter/exit markers.
+    const order: string[] = [];
+    const slow = (name: string) =>
+      lane(name, 15, async () => {
+        order.push(`${name}:enter`);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        order.push(`${name}:exit`);
+        return {};
+      });
+    await runDueStalenessWatchdogs([slow("a"), slow("b")], "env", {
+      lastRunMs: {},
+      now: () => 1_000_000,
+    });
+    assert.deepEqual(order, ["a:enter", "a:exit", "b:enter", "b:exit"]);
+  });
+});
+
+describe("runDueStalenessWatchdogs — the shapes a tick can arrive in", () => {
+  test("an empty registry is an ok, idle tick", async () => {
+    const tick = await runDueStalenessWatchdogs([], "env", {
+      now: () => 1_000_000,
+    });
+    assert.deepEqual(tick, { ok: true, ran: [], skipped: 0 });
+  });
+
+  test("a tick with nothing DUE is ok, not a failure", async () => {
+    const now = 10 * 60 * MINUTE;
+    const tick = await runDueStalenessWatchdogs([lane("a", 60)], "env", {
+      lastRunMs: { a: now - MINUTE },
+      now: () => now,
+    });
+    assert.equal(tick.ok, true, "idle is healthy");
+    assert.equal(tick.skipped, 1);
+    assert.deepEqual(tick.ran, []);
+  });
+
+  test("no deps at all still runs — the gate defaults to running", async () => {
+    // Omitting lastRunMs means every lane reads as never-run. Same polarity as
+    // lanesDue: uncertainty resolves to running, because not running is the
+    // failure this family exists to remove.
+    const calls: string[] = [];
+    const tick = await runDueStalenessWatchdogs(
+      [lane("a", 60, async () => (calls.push("a"), {}))],
+      "env",
+    );
+    assert.deepEqual(calls, ["a"]);
+    assert.equal(tick.ok, true);
+  });
+});

--- a/tests/staleness-watchdog-heartbeat.test.ts
+++ b/tests/staleness-watchdog-heartbeat.test.ts
@@ -63,6 +63,18 @@ describe("runDueStalenessWatchdogs", () => {
     assert.equal(ranAt.hr!.length, 1, "a 60-minute lane runs 1x an hour");
   });
 
+  test("each lane's own summary is carried, not dropped at the boundary", async () => {
+    // Eight crons used to return eight verdicts. Consolidating the trigger must
+    // not cost the report that detail, or the tidier grid is paid for in
+    // observability.
+    const tick = await runDueStalenessWatchdogs(
+      [lane("a", 15, async () => ({ alerted: false, age_ms: 42 }))],
+      "env",
+      { lastRunMs: {}, now: () => 1_000_000 },
+    );
+    assert.deepEqual(tick.ran[0]!.summary, { alerted: false, age_ms: 42 });
+  });
+
   test("a lane that is not due is skipped, and counted as skipped", async () => {
     const calls: string[] = [];
     const now = 10 * 60 * MINUTE;

--- a/tests/staleness-watchdog-neurons-lane.test.ts
+++ b/tests/staleness-watchdog-neurons-lane.test.ts
@@ -1,0 +1,92 @@
+// The neurons lane carries a second write, and these are the two properties
+// that makes load-bearing (#10262, and #10849 item 5 which moved it into the
+// registry).
+//
+// tests/subnet-lifecycle.test.ts asserts the same two by reading workers/api.ts
+// as TEXT and matching regexes against it. That was the only option while the
+// logic lived inside a cron branch, which is reachable only through
+// handleScheduled with a live-ish env -- but a regex over source cannot tell you
+// the code RUNS, only that it is written down, and it goes blind the moment a
+// formatter rewraps the line. Now the lane is a callable registry entry, so both
+// are asserted by executing it.
+import assert from "node:assert/strict";
+import { describe, expect, test, vi } from "vitest";
+
+const lifecycleCalls: Array<Record<string, unknown>> = [];
+let lifecycleRejects = false;
+
+vi.mock("../src/subnet-lifecycle.ts", () => ({
+  runSubnetLifecycleLane: async (
+    _env: unknown,
+    opts: Record<string, unknown>,
+  ) => {
+    lifecycleCalls.push(opts);
+    if (lifecycleRejects) throw new Error("lifecycle write failed");
+    return { ok: true };
+  },
+}));
+
+vi.mock("../src/neurons-staleness-watchdog.ts", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  // The alarm is the half that must survive everything else.
+  runNeuronsStalenessWatchdog: async () => ({ ok: true, alerted: false }),
+}));
+
+async function neuronsLane() {
+  const { STALENESS_WATCHDOGS } = await import("../workers/api.ts");
+  const lane = STALENESS_WATCHDOGS.find((l) => l.name === "neurons-staleness");
+  assert.ok(lane, "the neurons lane is registered");
+  return lane;
+}
+
+describe("the neurons lane's lifecycle rider (#10262)", () => {
+  test("a lifecycle FAILURE cannot cost the estate the staleness verdict", async () => {
+    // The load-bearing half is the alarm. The lifecycle write is deliberately
+    // after it and its rejection swallowed, so a broken lifecycle lane degrades
+    // to "no lifecycle row" rather than to "no neurons alarm".
+    lifecycleRejects = true;
+    const lane = await neuronsLane();
+    const result = await lane.run({ env: {} as never, ctx: undefined });
+    assert.deepEqual(
+      result,
+      { ok: true, alerted: false },
+      "the verdict survives",
+    );
+    lifecycleRejects = false;
+  });
+
+  test("a ctx WITH waitUntil gets the lifecycle promise", async () => {
+    const seen: unknown[] = [];
+    const lane = await neuronsLane();
+    await lane.run({
+      env: {} as never,
+      ctx: { waitUntil: (p: unknown) => seen.push(p) } as never,
+    });
+    assert.equal(seen.length, 1, "the write is detached, not awaited");
+    await seen[0];
+  });
+
+  test("a ctx with NO waitUntil is awaited, not thrown on", async () => {
+    // A bare `{}` ctx reaches here from callers that have none to give, and
+    // calling ctx.waitUntil on it would throw -- taking the staleness alarm down
+    // with it, which is the outcome the guard exists to prevent. Awaiting is the
+    // fallback rather than dropping the promise, because a floating promise in
+    // an isolate about to end is work silently not done.
+    const before = lifecycleCalls.length;
+    const lane = await neuronsLane();
+    const result = await lane.run({ env: {} as never, ctx: {} as never });
+    assert.deepEqual(result, { ok: true, alerted: false });
+    assert.equal(
+      lifecycleCalls.length,
+      before + 1,
+      "the lifecycle lane still ran",
+    );
+  });
+
+  test("the guard is not vacuous — a real ctx.waitUntil would throw here", () => {
+    // Proves the branch above is worth having: calling waitUntil on the bare
+    // object the fallback exists for does throw.
+    const bare = {} as { waitUntil?: (p: unknown) => void };
+    expect(() => bare.waitUntil!(Promise.resolve())).toThrow();
+  });
+});

--- a/tests/staleness-watchdog-registry.test.ts
+++ b/tests/staleness-watchdog-registry.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { STALENESS_WATCHDOGS } from "../workers/api.ts";
+import * as workerConfig from "../workers/config.ts";
+
+/** The heartbeat's tick interval, derived from the cron rather than restated. */
+function tickMinutes(cron: string): number {
+  const minutes = cron
+    .split(" ")[0]!
+    .split(",")
+    .map(Number)
+    .sort((a, b) => a - b);
+  const gaps = minutes.map(
+    (m, i) => (minutes[(i + 1) % minutes.length]! - m + 60) % 60,
+  );
+  return Math.min(...gaps.map((g) => (g === 0 ? 60 : g)));
+}
+
+// The eight per-lane cron tests these replace asserted the same three things
+// about eight expressions. There is one expression now, so they are asserted
+// once -- but they are still asserted: a heartbeat that wrangler never fires is
+// eight silent alarms, not one.
+describe("the watchdog heartbeat's own cron (#10849)", () => {
+  test("no other cron in workers/config.ts shares the literal string", () => {
+    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
+    // this lane into another branch entirely.
+    const crons = Object.entries(workerConfig)
+      .filter(([key]) => key.endsWith("_CRON"))
+      .flatMap(([, value]) => (typeof value === "string" ? [value] : []));
+    const mine = workerConfig.WATCHDOG_HEARTBEAT_CRON;
+    assert.equal(
+      crons.filter((cron) => cron === mine).length,
+      1,
+      `${mine} is declared by more than one lane`,
+    );
+  });
+
+  test("wrangler.jsonc declares the trigger", () => {
+    // A cron the Worker dispatches on but wrangler never fires is dead code,
+    // and the failure is silent: the branch simply never runs. With eight lanes
+    // behind it, that is the whole staleness family going quiet.
+    const raw = readFileSync(
+      new URL("../wrangler.jsonc", import.meta.url),
+      "utf8",
+    )
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/,(\s*[}\]])/g, "$1");
+    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
+    assert.ok(
+      parsed.triggers?.crons?.includes(workerConfig.WATCHDOG_HEARTBEAT_CRON),
+      "the heartbeat is not in wrangler.jsonc",
+    );
+  });
+
+  test("it stays off the five- and fifteen-minute grids", () => {
+    // Both fire on every minute divisible by 5, so a lane sharing one contends
+    // with the raw-capture and probe lanes on the same tick.
+    for (const part of workerConfig.WATCHDOG_HEARTBEAT_CRON.split(
+      " ",
+    )[0]!.split(",")) {
+      assert.equal(Number.isInteger(Number(part)), true);
+      assert.notEqual(
+        Number(part) % 5,
+        0,
+        `:${part} sits on the 5-minute grid`,
+      );
+    }
+  });
+
+  test("it ticks at 15 minutes, which is what makes the cadences exact", () => {
+    assert.equal(tickMinutes(workerConfig.WATCHDOG_HEARTBEAT_CRON), 15);
+  });
+});
+
+describe("the staleness watchdog registry", () => {
+  test("every lane has a distinct name", () => {
+    // The name is the `lane_health.lane` key the cadence gate reads. Two lanes
+    // sharing one would make each read the other's last run.
+    const names = STALENESS_WATCHDOGS.map((lane) => lane.name);
+    assert.equal(new Set(names).size, names.length);
+  });
+
+  // THE MIGRATION, PINNED. These eight cadences are what the eight cron
+  // expressions ran at before #10849 item 5 collapsed them. A staleness alarm
+  // sells detection latency and nothing else, so a change here is a change to
+  // the product -- it should have to be typed deliberately.
+  test("each lane keeps the cadence its own cron used to run at", () => {
+    assert.deepEqual(
+      Object.fromEntries(
+        STALENESS_WATCHDOGS.map((lane) => [lane.name, lane.everyMinutes]),
+      ),
+      {
+        // was 6,21,36,51
+        "neurons-staleness": 15,
+        // was 14,29,44,59
+        "chain-detail-staleness": 15,
+        // was 2,32
+        "projection-staleness": 30,
+        // was 8,38
+        "nominator-positions-staleness": 30,
+        // was 19,49
+        "validator-nominator-counts-staleness": 30,
+        // was 4,34
+        "account-balances-staleness": 30,
+        // was 22,52
+        "top-holders-flow-staleness": 30,
+        // was 54
+        "hotkey-alpha-staleness": 60,
+      },
+    );
+  });
+
+  test("every cadence is a MULTIPLE of the tick, so declared equals effective", () => {
+    // The grid quantises: a lane declaring 20 minutes against a 15-minute tick
+    // runs every 30, not every 20. Only multiples of the tick get the cadence
+    // they ask for, and a watchdog quietly running at two-thirds the rate it
+    // declares is the exact failure this consolidation must not introduce.
+    const tick = tickMinutes(workerConfig.WATCHDOG_HEARTBEAT_CRON);
+    for (const lane of STALENESS_WATCHDOGS) {
+      assert.equal(
+        lane.everyMinutes % tick,
+        0,
+        `${lane.name} declares ${lane.everyMinutes}m against a ${tick}m tick`,
+      );
+      assert.ok(
+        lane.everyMinutes >= tick,
+        `${lane.name} asks to run faster than the heartbeat ticks`,
+      );
+    }
+  });
+
+  // The end-to-end half the per-lane tests gave up when they moved to calling
+  // their registry entry directly: that the CRON still reaches the REGISTRY.
+  // Without this, every lane could be correctly registered behind a heartbeat
+  // that dispatch never routes to, and all eight would go quiet together.
+  test("the heartbeat cron dispatches into the registry", async () => {
+    const { handleScheduled } = await import("../workers/api.ts");
+    const result = (await handleScheduled(
+      { cron: workerConfig.WATCHDOG_HEARTBEAT_CRON } as never,
+      // A bare env: every lane fails or declines, and the heartbeat isolates
+      // each one. That is the point -- the tick still reports, and reports per
+      // lane, rather than the first failure taking the other seven with it.
+      {} as never,
+      {} as never,
+    )) as { ok: boolean; ran: unknown[]; skipped: number };
+    assert.ok(Array.isArray(result.ran), "the tick reports per lane");
+    assert.equal(
+      result.ran.length + result.skipped,
+      STALENESS_WATCHDOGS.length,
+      "every registered lane is accounted for as run or not-due",
+    );
+  });
+
+  test("the eight lanes gave up eight cron expressions", () => {
+    // The point of the exercise. If a lane reappears on the grid with a cron of
+    // its own, it is both on the heartbeat and on a trigger -- running twice.
+    const staleCrons = Object.keys(workerConfig).filter((key) =>
+      key.endsWith("_STALENESS_WATCHDOG_CRON"),
+    );
+    assert.deepEqual(
+      staleCrons,
+      [],
+      "a staleness lane took a cron minute back",
+    );
+    assert.equal(STALENESS_WATCHDOGS.length, 8);
+  });
+});

--- a/tests/subnet-lifecycle.test.ts
+++ b/tests/subnet-lifecycle.test.ts
@@ -259,8 +259,8 @@ describe("the lane runs on an existing tick, not a new cron", () => {
       "utf8",
     );
     const branch = api.slice(
-      api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {"),
-      api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {") + 1400,
+      api.indexOf('name: "neurons-staleness",'),
+      api.indexOf('name: "neurons-staleness",') + 1400,
     );
     assert.match(branch, /runSubnetLifecycleLane\(/);
     assert.doesNotMatch(
@@ -278,7 +278,7 @@ describe("the lane runs on an existing tick, not a new cron", () => {
       new URL("../workers/api.ts", import.meta.url),
       "utf8",
     );
-    const i = api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {");
+    const i = api.indexOf('name: "neurons-staleness",');
     const branch = api.slice(i, i + 1400);
     assert.ok(
       branch.indexOf("runNeuronsStalenessWatchdog") <
@@ -300,7 +300,7 @@ describe("the lane runs on an existing tick, not a new cron", () => {
       new URL("../workers/api.ts", import.meta.url),
       "utf8",
     );
-    const i = api.indexOf("NEURONS_STALENESS_WATCHDOG_CRON) {");
+    const i = api.indexOf('name: "neurons-staleness",');
     const branch = api.slice(i, i + 2000);
     assert.match(branch, /typeof ctx\?\.waitUntil === "function"/);
     assert.match(branch, /else await lifecycle/);

--- a/tests/top-holders-staleness-watchdog.test.ts
+++ b/tests/top-holders-staleness-watchdog.test.ts
@@ -641,7 +641,6 @@ describe("the watchdog's cron", () => {
   // Dispatch keys on the LITERAL cron string, so a duplicate would silently
   // route this lane's tick to whichever branch is checked first.
   test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
-    const { handleScheduled } = await import("../workers/api.ts");
     let read = 0;
     const result = (await runStalenessLane(
       "top-holders-flow-staleness",
@@ -674,7 +673,6 @@ describe("the watchdog's cron", () => {
   });
 
   test("an unbound bucket still reports through the cron wrapper", async () => {
-    const { handleScheduled } = await import("../workers/api.ts");
     const result = (await runStalenessLane(
       "top-holders-flow-staleness",
       {} as never,

--- a/tests/top-holders-staleness-watchdog.test.ts
+++ b/tests/top-holders-staleness-watchdog.test.ts
@@ -18,7 +18,7 @@ import {
   TOP_HOLDERS_FLOW_PROJECTION_KEY,
   topHoldersFlowRows,
 } from "../src/top-holders-flow-tier.ts";
-import { TOP_HOLDERS_STALENESS_WATCHDOG_CRON } from "../workers/config.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const HOUR = 3_600_000;
 const NOW = Date.parse("2026-08-05T02:00:00.000Z");
@@ -640,55 +640,11 @@ describe("runTopHoldersStalenessWatchdog", () => {
 describe("the watchdog's cron", () => {
   // Dispatch keys on the LITERAL cron string, so a duplicate would silently
   // route this lane's tick to whichever branch is checked first.
-  test("is twice hourly, off the */5 and */15 grids, and unique", async () => {
-    const config = (await import("../workers/config.ts")) as Record<
-      string,
-      unknown
-    >;
-    const others = Object.entries(config)
-      .filter(
-        ([key, value]) =>
-          key.endsWith("_CRON") &&
-          key !== "TOP_HOLDERS_STALENESS_WATCHDOG_CRON" &&
-          typeof value === "string",
-      )
-      .map(([, value]) => value);
-    assert.ok(
-      !others.includes(TOP_HOLDERS_STALENESS_WATCHDOG_CRON),
-      "cron string must be unique across workers/config.ts",
-    );
-    const minutes = TOP_HOLDERS_STALENESS_WATCHDOG_CRON.split(" ")[0]!
-      .split(",")
-      .map(Number);
-    assert.deepEqual(minutes, [22, 52]);
-    for (const minute of minutes) {
-      assert.notEqual(minute % 5, 0, "stays off the */5 raw-capture grid");
-      assert.notEqual(minute % 15, 0, "stays off the */15 probe grid");
-    }
-  });
-
-  test("wrangler.jsonc declares the trigger", async () => {
-    // A cron the Worker dispatches on but wrangler never fires is dead code,
-    // and the failure is silent: the branch simply never runs.
-    const { readFileSync } = await import("node:fs");
-    const raw = readFileSync(
-      new URL("../wrangler.jsonc", import.meta.url),
-      "utf8",
-    )
-      .replace(/^\s*\/\/.*$/gm, "")
-      .replace(/,(\s*[}\]])/g, "$1");
-    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
-    assert.ok(
-      parsed.triggers?.crons?.includes(TOP_HOLDERS_STALENESS_WATCHDOG_CRON),
-      `wrangler.jsonc must fire ${TOP_HOLDERS_STALENESS_WATCHDOG_CRON}`,
-    );
-  });
-
   test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
     const { handleScheduled } = await import("../workers/api.ts");
     let read = 0;
-    const result = (await handleScheduled(
-      { cron: TOP_HOLDERS_STALENESS_WATCHDOG_CRON } as never,
+    const result = (await runStalenessLane(
+      "top-holders-flow-staleness",
       {
         METAGRAPH_ARCHIVE: {
           async get() {
@@ -719,8 +675,8 @@ describe("the watchdog's cron", () => {
 
   test("an unbound bucket still reports through the cron wrapper", async () => {
     const { handleScheduled } = await import("../workers/api.ts");
-    const result = (await handleScheduled(
-      { cron: TOP_HOLDERS_STALENESS_WATCHDOG_CRON } as never,
+    const result = (await runStalenessLane(
+      "top-holders-flow-staleness",
       {} as never,
       {} as never,
     )) as Record<string, unknown>;

--- a/tests/validator-nominator-counts-staleness-watchdog.test.ts
+++ b/tests/validator-nominator-counts-staleness-watchdog.test.ts
@@ -39,6 +39,7 @@ import {
 } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
+import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;
 const HOUR = 60 * 60_000;
@@ -521,44 +522,10 @@ describe("runValidatorNominatorCountsStalenessWatchdog", () => {
 });
 
 describe("the cron string is unique and wired", () => {
-  test("no other cron in workers/config.ts shares the literal string", () => {
-    // Dispatch keys on the LITERAL cron string, so a duplicate silently routes
-    // this lane into another branch entirely.
-    const crons = Object.entries(workerConfig)
-      .filter(([key]) => key.endsWith("_CRON"))
-      .map(([, value]) => value);
-    const mine =
-      workerConfig.VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON;
-    assert.equal(
-      crons.filter((cron) => cron === mine).length,
-      1,
-      `${mine} is declared by more than one lane`,
-    );
-  });
-
-  test("wrangler.jsonc declares the trigger", () => {
-    // A cron the Worker dispatches on but wrangler never fires is dead code --
-    // and the failure is silent, since the branch simply never runs.
-    const raw = readFileSync(
-      new URL("../wrangler.jsonc", import.meta.url),
-      "utf8",
-    )
-      .replace(/^\s*\/\/.*$/gm, "")
-      .replace(/,(\s*[}\]])/g, "$1");
-    const parsed = JSON.parse(raw) as { triggers?: { crons?: string[] } };
-    assert.ok(
-      parsed.triggers?.crons?.includes(
-        workerConfig.VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
-      ),
-    );
-  });
-
   test("handleScheduled dispatches to the watchdog and returns its summary", async () => {
     const { env, queries } = fakeDb(Date.now());
-    const result = (await handleScheduled(
-      {
-        cron: workerConfig.VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
-      } as unknown as ScheduledController,
+    const result = (await runStalenessLane(
+      "validator-nominator-counts-staleness",
       env as unknown as Parameters<typeof handleScheduled>[1],
       {} as unknown as ExecutionContext,
     )) as { ok: boolean; alerted: boolean };

--- a/tests/validator-nominator-counts-staleness-watchdog.test.ts
+++ b/tests/validator-nominator-counts-staleness-watchdog.test.ts
@@ -15,7 +15,6 @@
 // the scan never got to. The production reading behind #9530 is asserted below
 // on this lane's own numbers.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
@@ -38,7 +37,6 @@ import {
   runValidatorNominatorCountsStalenessWatchdog,
 } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { handleScheduled } from "../workers/api.ts";
-import * as workerConfig from "../workers/config.ts";
 import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const NOW = 1_785_800_000_000;

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -178,6 +178,10 @@ import {
   type ScheduledLane,
 } from "../src/lane-scheduler.ts";
 import {
+  runDueStalenessWatchdogs,
+  type StalenessWatchdogLane,
+} from "../src/staleness-watchdog-heartbeat.ts";
+import {
   handleDeadLetterBatch,
   isDeadLetterQueue,
 } from "../src/dead-letter.ts";
@@ -696,22 +700,15 @@ import {
   EMISSION_GATE_SAMPLE_CRON,
   EMISSION_GATE_SAMPLE_INTERVAL_MS,
   EMISSION_DRIFT_CHECK_CRON,
-  NEURONS_STALENESS_WATCHDOG_CRON,
-  NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
-  PROJECTION_STALENESS_WATCHDOG_CRON,
-  VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
+  WATCHDOG_HEARTBEAT_CRON,
   CHAIN_DETAIL_PRUNE_CRON,
   DAILY_SERIES_COVERAGE_CRON,
   REGISTRY_RESYNC_CRON,
   REGISTRY_SYNC_CRON,
   CHAIN_CONCENTRATION_ROLLUP_CRON,
-  CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   TOP_HOLDERS_FLOW_CRON,
   TOP_HOLDERS_HOLDINGS_REFRESH_CRON,
   SUBNET_DEREGISTRATION_DAILY_CRON,
-  TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
-  ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
-  HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
   LIVE_ECONOMICS_REFRESH_CRON,
   PROJECTION_LANES_CRON,
   FRESHNESS_WATCHDOG_STATE_KEY,
@@ -2863,6 +2860,11 @@ function cronLabel(cron: string): string {
   // reporting purposes -- a per-expression label would split one lane's cron
   // outcomes across three series.
   if (LANE_HEARTBEAT_CRONS.includes(cron)) return "lane-heartbeat";
+  // The eight staleness watchdogs report under ONE label, the same way the
+  // producer heartbeat does: they share a tick, and a per-lane cron label would
+  // now be a label for a cron that no longer exists. Each lane still records its
+  // own lane_health verdict, which is where per-lane outcomes are read.
+  if (cron === WATCHDOG_HEARTBEAT_CRON) return "staleness-watchdogs";
   if (cron === HEALTH_PRUNE_CRON) return "health-prune";
   if (cron === EMBEDDING_SYNC_CRON) return "embedding-sync";
   if (cron === GITHUB_SIGNALS_SYNC_CRON) return "github-signals-sync";
@@ -2883,28 +2885,12 @@ function cronLabel(cron: string): string {
   if (cron === PROJECTION_LANES_CRON) return "projection-lanes";
   if (cron === EMISSION_GATE_SAMPLE_CRON) return "emission-gate-sample";
   if (cron === EMISSION_DRIFT_CHECK_CRON) return "emission-drift-check";
-  if (cron === NEURONS_STALENESS_WATCHDOG_CRON)
-    return "neurons-staleness-watchdog";
-  if (cron === NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON)
-    return "nominator-positions-staleness-watchdog";
-  if (cron === PROJECTION_STALENESS_WATCHDOG_CRON)
-    return "projection-staleness-watchdog";
-  if (cron === VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON)
-    return "validator-nominator-counts-staleness-watchdog";
   if (cron === CHAIN_DETAIL_PRUNE_CRON) return "chain-detail-prune";
   if (cron === REGISTRY_SYNC_CRON) return "registry-sync";
   if (cron === REGISTRY_RESYNC_CRON) return "registry-resync";
   if (cron === DAILY_SERIES_COVERAGE_CRON) return "daily-series-coverage";
   if (cron === CHAIN_CONCENTRATION_ROLLUP_CRON)
     return "chain-concentration-rollup";
-  if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON)
-    return "chain-detail-staleness-watchdog";
-  if (cron === TOP_HOLDERS_STALENESS_WATCHDOG_CRON)
-    return "top-holders-staleness-watchdog";
-  if (cron === HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON)
-    return "hotkey-alpha-staleness-watchdog";
-  if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON)
-    return "account-balances-staleness-watchdog";
   if (cron === TOP_HOLDERS_FLOW_CRON) return "top-holders-flow";
   if (cron === TOP_HOLDERS_HOLDINGS_REFRESH_CRON)
     return "top-holders-holdings-refresh";
@@ -3373,6 +3359,108 @@ export const LANE_PRODUCERS: ReadonlyArray<
   },
 ];
 
+/**
+ * The staleness watchdogs, which declare a cadence instead of taking a minute.
+ *
+ * The sibling of LANE_PRODUCERS above, for the family that ALARMS rather than
+ * enqueues, and the same trade: eight cron expressions became one heartbeat
+ * (#10849 item 5). `everyMinutes` is now the single source for how often each
+ * runs -- it replaces the cron expression that src/producer-cadence.ts used to
+ * read the silence bound out of, so the two can no longer drift apart.
+ *
+ * `name` MUST equal the lane's own `lane_health.lane` value. That row's
+ * `checked_at` is what gates the cadence, and each of these stamps it at the
+ * moment it runs -- checked per module, and not a property of `lane_health`
+ * generally. A typo here reads as never-run, so the lane runs every tick: loud,
+ * which is the right way round for a mistake in a table of alarms.
+ *
+ * The env is `{ env, ctx }` rather than a bare Env because the neurons lane
+ * carries a second write that needs a waitUntil. Nothing else here does.
+ */
+export const STALENESS_WATCHDOGS: ReadonlyArray<
+  StalenessWatchdogLane<{ env: Env; ctx?: ExecutionContext }>
+> = [
+  {
+    // The poller Container feeds D1 on a 15-minute tick, and the lane's first
+    // stall (a zombie instance, 2026-08-03) ran three silent hours because
+    // nothing read that table. Same cadence as the lane it watches.
+    name: "neurons-staleness",
+    everyMinutes: 15,
+    run: async ({ env, ctx }) => {
+      // #10262 rides this lane rather than taking a cron of its own: it needs
+      // exactly what the watchdog already reads. Guarded, and deliberately
+      // AFTER the watchdog -- the alarm is the load-bearing half, so a
+      // lifecycle write that throws must not cost the estate its staleness
+      // verdict.
+      const staleness = await runNeuronsStalenessWatchdog(env);
+      const lifecycle = runSubnetLifecycleLane(env, { ctx }).catch(
+        () => undefined,
+      );
+      // waitUntil where there is one, AWAIT where there is not. A bare `{}` ctx
+      // reaches here from callers that have none to give, and calling
+      // `ctx.waitUntil` on it throws -- which would take the staleness alarm
+      // down with it, the outcome the guard above exists to prevent.
+      if (typeof ctx?.waitUntil === "function") ctx.waitUntil(lifecycle);
+      else await lifecycle;
+      return staleness;
+    },
+  },
+  {
+    // #9208. The ONLY signal that the chain-detail lane has stopped: a stalled
+    // lane keeps the block list live and merely starts declining drill-down,
+    // which is silent in aggregate.
+    name: "chain-detail-staleness",
+    everyMinutes: 15,
+    run: ({ env }) => runChainDetailStalenessWatchdog(env),
+  },
+  {
+    // #9423. Two lanes stopped writing on 2026-08-03 and nothing noticed for 31
+    // hours -- the read path degrades by serving the previous card, so routes
+    // kept answering 200 off numbers 44 hours old under a `7d` label.
+    name: "projection-staleness",
+    everyMinutes: 30,
+    run: ({ env }) => runProjectionStalenessWatchdog(env),
+  },
+  {
+    // #9273. That lane had no watchdog and no writer at all, and the gap was
+    // found by a caller noticing a stale `captured_at` rather than by us.
+    name: "nominator-positions-staleness",
+    everyMinutes: 30,
+    run: ({ env }) => runNominatorPositionsStalenessWatchdog(env),
+  },
+  {
+    // #9301. The sibling of the lane above, over the other output of the same
+    // Alpha scan: one producer tick writes both tables.
+    name: "validator-nominator-counts-staleness",
+    everyMinutes: 30,
+    run: ({ env }) => runValidatorNominatorCountsStalenessWatchdog(env),
+  },
+  {
+    // #9478. The SOURCE side of the top-holders watchdog rather than a
+    // replacement: that one watches the served artifact, this one the store
+    // table it is composed from, and the two fail independently.
+    name: "account-balances-staleness",
+    everyMinutes: 30,
+    run: ({ env }) => runAccountBalancesStalenessWatchdog(env),
+  },
+  {
+    // #9464. Named for the FLOW row because this module writes two verdicts
+    // (`top-holders-flow-staleness` and `top-holders-holdings-staleness`) on
+    // every run, so either is a true last-run stamp and the gate needs one.
+    name: "top-holders-flow-staleness",
+    everyMinutes: 30,
+    run: ({ env }) => runTopHoldersStalenessWatchdog(env),
+  },
+  {
+    // #9576. HOURLY, not twice-hourly: the poller's HOTKEY_ALPHA_POLL_SECS
+    // defaults to 86400, so a finer cadence would only re-report the same
+    // 24-hour-old pass.
+    name: "hotkey-alpha-staleness",
+    everyMinutes: 60,
+    run: ({ env }) => runHotkeyAlphaStalenessWatchdog(env),
+  },
+];
+
 export async function handleScheduled(
   controller: ScheduledController,
   env: Env,
@@ -3455,6 +3543,7 @@ export const API_HANDLED_CRONS: readonly string[] = [
   HEALTH_PRUNE_CRON,
   EMBEDDING_SYNC_CRON,
   ...LANE_HEARTBEAT_CRONS,
+  WATCHDOG_HEARTBEAT_CRON,
   SUBNET_BURN_CAPTURE_CRON,
   RAW_CAPTURE_CRON,
   GITHUB_SIGNALS_SYNC_CRON,
@@ -3470,22 +3559,14 @@ export const API_HANDLED_CRONS: readonly string[] = [
   FRESHNESS_WATCHDOG_CRON,
   EMISSION_GATE_SAMPLE_CRON,
   LANE_ALARM_CRON,
-  NEURONS_STALENESS_WATCHDOG_CRON,
-  PROJECTION_STALENESS_WATCHDOG_CRON,
-  NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
-  VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
   REGISTRY_SYNC_CRON,
   REGISTRY_RESYNC_CRON,
   DAILY_SERIES_COVERAGE_CRON,
   CHAIN_DETAIL_PRUNE_CRON,
   CHAIN_CONCENTRATION_ROLLUP_CRON,
-  CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
   SUBNET_DEREGISTRATION_DAILY_CRON,
   TOP_HOLDERS_FLOW_CRON,
   TOP_HOLDERS_HOLDINGS_REFRESH_CRON,
-  TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
-  HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
-  ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
   LIVE_ECONOMICS_REFRESH_CRON,
   EMISSION_DRIFT_CHECK_CRON,
 ];
@@ -3562,6 +3643,28 @@ async function dispatchScheduled(
   }
   if (cron === EMBEDDING_SYNC_CRON) {
     return runEmbeddingSync(env, { readArtifact });
+  }
+  if (cron === WATCHDOG_HEARTBEAT_CRON) {
+    // ONE clock for the eight staleness watchdogs (#10849 item 5). Each used to
+    // hold a minute of its own, and the grid ran out -- counted with the step
+    // expressions expanded, exactly ONE minute of sixty was unclaimed.
+    //
+    // Quarter-hourly, so `lanesDue` reproduces all three cadences (15/30/60)
+    // exactly rather than approximately. See WATCHDOG_HEARTBEAT_CRON.
+    //
+    // A FAILED READ RUNS EVERYTHING, the same polarity as the producer
+    // heartbeat below: loadLatestLaneHealth returns `{}` on any error, every
+    // lane then reads as never-run, and all eight run. The opposite would let
+    // one failed query silently stop every alarm in the estate.
+    return runDueStalenessWatchdogs(
+      STALENESS_WATCHDOGS,
+      { env, ctx },
+      {
+        lastRunMs: lastRunFromLaneHealth(
+          await loadLatestLaneHealth(laneHealthStore(env)),
+        ),
+      },
+    );
   }
   if (LANE_HEARTBEAT_CRONS.includes(cron)) {
     // ONE clock for every queue-backed lane (#10715). Each producer reads a
@@ -3830,60 +3933,6 @@ async function dispatchScheduled(
     // correct verdict on every tick and reach nobody (#9330/#9340).
     return runLaneAlarm(env);
   }
-  if (cron === NEURONS_STALENESS_WATCHDOG_CRON) {
-    // The neurons live lane's alarm. Zero alerts is the correct steady state;
-    // a stale verdict records one exception under
-    // watchdog:neurons-staleness, which is the project's alert channel.
-    // #10262 rides this tick rather than taking a cron of its own. It needs
-    // exactly what this watchdog already reads -- the netuid set at `neurons`'
-    // newest stamp, and whether that pass cleared the coverage floor -- so a
-    // separate trigger would re-read the same pass on a different schedule and
-    // add a 35th cron expression to the 34 that #10226 exists to collapse.
-    //
-    // Guarded, and deliberately AFTER the watchdog: the alarm is the load-
-    // bearing half. A lifecycle write that throws must not cost the estate its
-    // neurons staleness verdict, so its failure is swallowed here and recorded
-    // in its own lane_health row.
-    const staleness = await runNeuronsStalenessWatchdog(env);
-    const lifecycle = runSubnetLifecycleLane(env, { ctx }).catch(
-      () => undefined,
-    );
-    // waitUntil where there is one, AWAIT where there is not. A bare `{}` ctx
-    // reaches here from callers that have none to give, and calling
-    // `ctx.waitUntil` on it throws -- which would take the staleness alarm down
-    // with it, the precise outcome the guard above exists to prevent. Awaiting
-    // is the safe fallback rather than dropping the promise, because a floating
-    // promise in an isolate that is about to end is work silently not done.
-    if (typeof ctx?.waitUntil === "function") ctx.waitUntil(lifecycle);
-    else await lifecycle;
-    return staleness;
-  }
-  if (cron === PROJECTION_STALENESS_WATCHDOG_CRON) {
-    // The projection lanes' alarm (#9423). Zero alerts is the correct steady
-    // state; a stale verdict records ONE exception naming every stale lane
-    // under watchdog:projection-staleness. An ABSENT artifact alerts too --
-    // every registered lane is meant to have written on the last tick, and a
-    // route over a missing card serves its zeroed floor as though measured.
-    return runProjectionStalenessWatchdog(env);
-  }
-  if (cron === NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON) {
-    // The nominator-positions lane's alarm (#9273). Zero alerts is the correct
-    // steady state; a stale verdict records one exception under
-    // watchdog:nominator-positions-staleness, the project's alert channel. An
-    // EMPTY table alerts too -- until the revived lane posts, every positions
-    // read is still answering from the frozen lakehouse export.
-    return runNominatorPositionsStalenessWatchdog(env);
-  }
-  if (cron === VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON) {
-    // The validator-nominator-counts lane's alarm (#9301) -- the sibling of
-    // the watchdog above, over the other output of the same Alpha scan. Zero
-    // alerts is the correct steady state; a stale verdict records one
-    // exception under watchdog:validator-nominator-counts-staleness, the
-    // project's alert channel. An EMPTY table alerts too -- until the
-    // re-enabled lane posts, every nominator_count is still coming from the
-    // frozen lakehouse mirror or serving null outright.
-    return runValidatorNominatorCountsStalenessWatchdog(env);
-  }
   if (cron === REGISTRY_SYNC_CRON) {
     // #9779: the registry had NO writer. Its only sync path was a pair of
     // scripts invoked from GitHub Actions that no workflow calls, and
@@ -3960,12 +4009,6 @@ async function dispatchScheduled(
       }
     }
   }
-  if (cron === CHAIN_DETAIL_STALENESS_WATCHDOG_CRON) {
-    // The chain-detail live lane's alarm. Zero alerts is the correct steady
-    // state; a stale verdict records one exception under
-    // watchdog:chain-detail-staleness, the project's alert channel.
-    return runChainDetailStalenessWatchdog(env);
-  }
   if (cron === SUBNET_DEREGISTRATION_DAILY_CRON) {
     // #10296: one row per subnet per day of what the deregistration ranking is
     // computed FROM. It stores the four MEASURED inputs, never the derived
@@ -4022,40 +4065,6 @@ async function dispatchScheduled(
     // leaderboard exactly as it is, including the one that matters most --
     // "there is no artifact yet" is the daily lane's job, never this one's.
     return runProjectionLane(env, TOP_HOLDERS_HOLDINGS_REFRESH_LANE);
-  }
-  if (cron === TOP_HOLDERS_STALENESS_WATCHDOG_CRON) {
-    // The top-holders leaderboard's alarm (#9464). Zero alerts is the correct
-    // steady state and is NOT the current one: the lane has no producer, so it
-    // records one exception under watchdog:top-holders-staleness on every tick
-    // and will until the artifact gets a writer or the route is withdrawn
-    // (#9475 removed the special case that kept this quiet). An ABSENT,
-    // UNREADABLE or EMPTY artifact alerts too -- that is the condition where
-    // the route silently answers 200 with an empty leaderboard.
-    return runTopHoldersStalenessWatchdog(env);
-  }
-  if (cron === HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON) {
-    // The pool ledger's alarm (#9576) -- the twin of the watchdog above, for
-    // the OTHER table the holdings columns are composed from. `hotkey_alpha`
-    // shipped in #9512 without one, and the cost is that its readers all
-    // decline QUIETLY: /accounts/top-holders falls back to the frozen
-    // 2026-08-02 materialization and /subnets/{netuid}/holders answers
-    // pool_totals_unproven, both of which are correct and both of which look
-    // identical to a producer that died. An EMPTY table alerts, because that is
-    // the state the lane has been in since the sink landed.
-    return runHotkeyAlphaStalenessWatchdog(env);
-  }
-  if (cron === ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON) {
-    // The account-balances lane's alarm (#9478) -- the SOURCE side of the
-    // watchdog above rather than a replacement for it: that one asks whether
-    // the served artifact is readable and current, this one asks whether the
-    // store table it is composed from is being written at all -- and, since
-    // #9530, whether each pass COVERS the network rather than merely arriving
-    // recently. Zero alerts is the correct steady state; a stale verdict
-    // records one exception under watchdog:account-balances-staleness, the
-    // project's alert channel. An
-    // EMPTY table alerts too -- until the revived lane posts, every top-holders
-    // read is still answering from the frozen 2026-08-02 materialization.
-    return runAccountBalancesStalenessWatchdog(env);
   }
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) {
     // The live-economics refresh, formerly the 3-hourly Actions schedule and

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -274,48 +274,28 @@ export const EMISSION_GATE_SAMPLE_INTERVAL_MS = 10 * 60 * 1000;
 // workers/config.ts (":7,37" already belongs to the upgrade radar) as well as
 // matching a wrangler.jsonc cron entry.
 export const EMISSION_DRIFT_CHECK_CRON = "9,39 * * * *";
-// The neurons LIVE lane's alarm: the poller Container feeds D1 on a
-// 15-minute tick, and its first stall (a zombie instance, 2026-08-03) ran
-// three silent hours because no watchdog reads that table. Same cadence as
-// the lane it watches; a 45-minute threshold (three missed ticks) separates
-// a routine restart from a stall. Unique string, matching a wrangler.jsonc
-// entry -- dispatch keys on the LITERAL cron string.
-export const NEURONS_STALENESS_WATCHDOG_CRON = "6,21,36,51 * * * *";
-// #9273: the nominator-positions lane's alarm. That lane had NO watchdog and
-// no writer at all -- its box-side job died with the box and the route over it
-// kept serving a frozen 153k-row export, so the gap was found by a caller
-// noticing a stale `captured_at`, not by us. Twice hourly against a six-hour
-// threshold (src/nominator-positions-staleness-watchdog.ts explains why this
-// lane's threshold is hours where the neurons lane's is minutes): the tick is
-// one MAX() read, so a cheap cadence costs nothing and bounds detection well
-// inside the threshold. Minutes 8/38 tick on none of the crons in this file
-// and stay off the */5 raw-capture and */15 probe grids -- dispatch keys on
-// the LITERAL cron string, so this must be unique here as well as matching a
-// wrangler.jsonc `triggers.crons` entry.
-export const NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON = "8,38 * * * *";
-// #9423: the projection lanes' alarm. Two lanes stopped writing on
-// 2026-08-03 and nothing noticed for 31 hours -- the read path degrades by
-// serving the previous card, so the routes kept answering 200 off numbers 44
-// hours old under a `7d` label. Twice hourly against a four-hour threshold
-// (src/projection-staleness-watchdog.ts explains the sizing): the tick is 26
-// R2 HEADs, so a cheap cadence costs nothing and bounds detection well inside
-// the threshold. Minutes 2/32 are 21 minutes after each PROJECTION_LANES_CRON
-// tick, so a run has finished before it is judged, and they tick on none of
-// the crons in this file while staying off the */5 raw-capture and */15 probe
-// grids -- dispatch keys on the LITERAL cron string, so this must be unique
-// here as well as matching a wrangler.jsonc `triggers.crons` entry.
-export const PROJECTION_STALENESS_WATCHDOG_CRON = "2,32 * * * *";
-// #9301: the validator-nominator-counts lane's alarm -- the SIBLING of the
-// watchdog above, watching the other output of the same Alpha scan. It had the
-// same gap for the same reason: its writer targeted a Postgres that went away,
-// and `nominator_count` degraded to null (or to a frozen lakehouse mirror)
-// without anything going red. Twice hourly against the same 30-hour threshold,
-// since the one producer tick writes both tables. Minutes 19/49 tick on none
-// of the crons in this file and stay off the */5 raw-capture and */15 probe
-// grids -- dispatch keys on the LITERAL cron string, so this must be unique
-// here as well as matching a wrangler.jsonc `triggers.crons` entry.
-export const VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON =
-  "19,49 * * * *";
+/**
+ * ONE clock for the eight staleness watchdogs (#10849 item 5).
+ *
+ * Each of them used to hold a minute of its own, and the grid ran out. Counted
+ * honestly -- step expressions expanded, and excluding the multiples of five
+ * every comment in this file is careful to avoid because of the five-minute
+ * raw-capture and fifteen-minute probe grids -- exactly ONE minute of sixty was
+ * unclaimed. The eight gave 19 minutes back.
+ *
+ * QUARTER-hourly, not hourly as #10849 item 5 proposes. The eight run at 15, 30
+ * and 60 minutes; all three divide into a 15-minute tick, so `lanesDue`
+ * reproduces every cadence exactly. An hourly clock would quietly turn the two
+ * 15-minute alarms into 60-minute ones, and detection latency is the only thing
+ * a staleness alarm sells -- not a trade worth making for a consolidation whose
+ * stated benefit is comprehensibility.
+ *
+ * It inherits 6,21,36,51 from the neurons watchdog, which was already the
+ * fastest of the eight and already on a quarter-hourly grid clear of the five-
+ * and fifteen-minute ones. A lane's cadence now lives in STALENESS_WATCHDOGS in
+ * workers/api.ts, not here. Must match a wrangler.jsonc cron entry.
+ */
+export const WATCHDOG_HEARTBEAT_CRON = "6,21,36,51 * * * *";
 // #9208 retention for the chain-detail hot tier. The window only has to cover
 // the gap between chain tip and the decoded seam, so everything the lakehouse
 // has already absorbed is dropped -- see src/chain-detail-prune.ts for the
@@ -325,12 +305,6 @@ export const VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON =
 // whole backlog in one D1 transaction. Minutes 12/27/42/57 tick on none of the
 // crons in this file and stay off the */5 raw-capture and */15 probe grids.
 export const CHAIN_DETAIL_PRUNE_CRON = "12,27,42,57 * * * *";
-// #9208's alarm for the same lane. Separate from the prune above, and
-// deliberately so: a prune failure must not swallow the staleness verdict, and
-// this is the ONLY signal that the lane has stopped -- a stalled chain-detail
-// lane keeps the block list live and merely starts declining drill-down, which
-// is silent in aggregate. Minutes 14/29/44/59 are likewise unused elsewhere.
-export const CHAIN_DETAIL_STALENESS_WATCHDOG_CRON = "14,29,44,59 * * * *";
 // The registry writer (#9779). Four times an hour: registry changes arrive on
 // merges, so the only cost of a slower tick is how stale surface_history is,
 // and the only cost of a faster one is GitHub API calls against a 5,000/hour
@@ -365,42 +339,6 @@ export const REGISTRY_RESYNC_CRON = "35 * * * *";
  * right now is already complete rather than being read mid-pass.
  */
 export const DAILY_SERIES_COVERAGE_CRON = "35 7,19 * * *";
-// #9464: the top-holders leaderboard's alarm. That lane had NO watchdog and no
-// producer -- `account_balances` died with the box and is not in the poller
-// Container's job set -- so the route served a one-shot pre-decommission
-// materialization for three days at 200 OK and the gap was found by a caller
-// reading `captured_at`, not by us. Twice hourly: the tick is one R2 get, so a
-// cheap cadence costs nothing and bounds detection well inside the twelve-hour
-// threshold (src/top-holders-staleness-watchdog.ts explains that sizing, and
-// why a lane with no producer reports stale on every tick). Minutes
-// 22/52 tick on none of the crons in this file and stay off the */5 raw-capture
-// and */15 probe grids -- dispatch keys on the LITERAL cron string, so this
-// must be unique here as well as matching a wrangler.jsonc `triggers.crons`
-// entry.
-export const TOP_HOLDERS_STALENESS_WATCHDOG_CRON = "22,52 * * * *";
-// #9478: the account-balances lane's alarm -- the SOURCE side of the watchdog
-// above, not a replacement for it. That one watches the served artifact; this
-// one watches the store table the artifact is supposed to be composed from, and
-// the two fail independently (a fresh table behind a stale artifact is a
-// publish problem; a stale table behind either is the producer). Twice hourly
-// against the same twelve-hour threshold, since one producer tick is what
-// refreshes it -- src/account-balances-staleness-watchdog.ts explains that
-// sizing against the poller's six-hour ACCOUNT_BALANCES_POLL_SECS. Minutes 4/34
-// tick on none of the crons in this file and stay off the */5 raw-capture and
-// */15 probe grids -- dispatch keys on the LITERAL cron string, so this must be
-// unique here as well as matching a wrangler.jsonc `triggers.crons` entry.
-export const ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON = "4,34 * * * *";
-// #9576: the same alarm for the OTHER ledger the top-holders holdings columns
-// are composed from. `hotkey_alpha` shipped in #9512 without one, so an empty
-// pool ledger was invisible -- every reader declines correctly and quietly, and
-// a correct decline looks exactly like a producer that died a month ago.
-// HOURLY rather than twice-hourly, and against a 48-hour threshold: the poller's
-// HOTKEY_ALPHA_POLL_SECS defaults to 86400 against account_balances' 21600, so a
-// finer cadence would only re-report the same 24-hour-old pass. Minute 54 ticks
-// on none of the crons in this file and stays off the */5 and */15 grids --
-// dispatch keys on the LITERAL cron string, so it must be unique here as well as
-// matching a wrangler.jsonc `triggers.crons` entry.
-export const HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON = "54 * * * *";
 /**
  * #9628: the network-wide concentration rollup.
  *

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1137,22 +1137,17 @@
       // and distinct from the upgrade radar's 7,37 (dispatch keys on the
       // literal cron string).
       "9,39 * * * *",
-      // 6,21,36,51 = the neurons-staleness watchdog: alarms when the poller
-      // Container's 15-minute D1 feed stops moving.
+      // 6,21,36,51 = ONE clock for all eight staleness watchdogs (#10849 item
+      // 5). Each held a minute of its own until the grid ran out -- counting the
+      // five- and fifteen-minute step expressions, exactly one minute of sixty
+      // was unclaimed. A lane now declares a cadence in STALENESS_WATCHDOGS
+      // (workers/api.ts) instead of taking a minute here.
+      //
+      // Quarter-hourly, inherited from the neurons watchdog: the eight run at
+      // 15, 30 and 60 minutes, all of which divide into a 15-minute tick, so
+      // every cadence is reproduced exactly. An hourly clock would have turned
+      // the two 15-minute alarms into 60-minute ones.
       "6,21,36,51 * * * *",
-      // 8,38 = the nominator-positions staleness watchdog (#9273): alarms when
-      // the per-coldkey position ledger stops advancing. That lane ran with no
-      // watchdog and lost its writer entirely without anything noticing -- see
-      // NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON in workers/config.ts.
-      "8,38 * * * *",
-      // #9423: the projection lanes' staleness alarm. 21 minutes after each
-      // PROJECTION_LANES_CRON tick, so a run has finished before it is judged.
-      "2,32 * * * *",
-      // 19,49 = the validator-nominator-counts staleness watchdog (#9301): the
-      // sibling of the one above, over the other output of the same Alpha
-      // scan, and blind for the same reason -- see
-      // VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON in workers/config.ts.
-      "19,49 * * * *",
       // 26 */3 = the live-economics refresh (KV economics:current), moved off
       // the retired refresh-economics.yml schedule -- the last Actions data
       // lane. Same 3-hourly cadence; :26 because :41 is taken twice over and
@@ -1180,28 +1175,6 @@
       // syncs forward from its cursor, and the full resync its own comment
       // relies on was a GitHub Actions script nothing calls.
       "35 * * * *",
-      // 14,29,44,59 = the chain-detail staleness watchdog (#9208): alarms when
-      // the live-follow decode lane stops advancing. Its own trigger rather
-      // than a step inside the prune, so a prune failure cannot swallow the
-      // staleness verdict.
-      "14,29,44,59 * * * *",
-      // 22,52 = the top-holders staleness watchdog (#9464): the leaderboard is
-      // served from a one-shot pre-decommission artifact with no producer, and
-      // nothing reported that for three days. Records a verdict every tick and
-      // alerts on every stale one -- see TOP_HOLDERS_STALENESS_WATCHDOG_CRON in
-      // workers/config.ts.
-      "22,52 * * * *",
-      // 4,34 = the account-balances staleness watchdog (#9469): the SOURCE side
-      // of the watchdog above. That one watches the served artifact; this one
-      // watches the D1 table it is composed from, so a producer that stops is
-      // visible without waiting for the publish path to notice. See
-      // ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON in workers/config.ts.
-      "4,34 * * * *",
-      // 54 = the hotkey-alpha staleness watchdog (#9576): the same source-side
-      // alarm for the OTHER ledger the holdings columns are composed from,
-      // which shipped in #9512 without one. Hourly rather than twice-hourly,
-      // because its producer polls every 24h against account_balances' 6h. See
-      // HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON in workers/config.ts.
       // 26 = the ONE producer heartbeat for every queue-backed lane (#10715).
       // Replaces the three per-lane crons that used to sit on 17, 24 and 56 --
       // each of which only read a list and enqueued it. A new lane joins
@@ -1227,7 +1200,6 @@
       // queue-backed lane would go silent until the triggers deploy landed.
       // Appending is safe in either order.
       "17,56 * * * *",
-      "54 * * * *",
     ],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
#10849 item 5, for the staleness watchdog family. Eight cron expressions become one; `wrangler.jsonc` goes from 39 crons to 32.

## The grid was actually full

The issue frames item 5 as comprehensibility ("cron triggers are 250 per account, so this is about comprehensibility, not quota"). The stronger reason is that the hourly grid had run out. Counted honestly — step expressions expanded, and excluding the multiples of five that every comment in `workers/config.ts` is careful to avoid because of the five-minute raw-capture and fifteen-minute probe grids — **exactly one minute of sixty was unclaimed**. `src/lane-scheduler.ts` recorded the same measurement when it was written ("exactly THREE every-hour minutes were free"); it had got worse since.

The eight lanes give 19 minutes back.

## Quarter-hourly, not hourly

The issue says "group the hourly watchdogs behind one hourly trigger". That would have cost detection latency, which is the only thing a staleness alarm sells:

| lane | old cron | cadence |
|---|---|---|
| `neurons-staleness` | `6,21,36,51` | 15m |
| `chain-detail-staleness` | `14,29,44,59` | 15m |
| `projection-staleness` | `2,32` | 30m |
| `nominator-positions-staleness` | `8,38` | 30m |
| `validator-nominator-counts-staleness` | `19,49` | 30m |
| `account-balances-staleness` | `4,34` | 30m |
| `top-holders-flow-staleness` | `22,52` | 30m |
| `hotkey-alpha-staleness` | `54` | 60m |

An hourly clock would have quietly turned the two 15-minute alarms into 60-minute ones. All three cadences divide into a 15-minute tick, so a quarter-hourly heartbeat plus the existing `lanesDue` gate reproduces every one **exactly**. The test pins 4/2/1 runs per hour and fails if the tick widens; the registry test pins all eight cadences against what their crons ran at, and asserts each is a multiple of the tick (a lane declaring 20 minutes against a 15-minute tick runs every 30, not every 20).

The heartbeat inherits `6,21,36,51` from the neurons watchdog — already the fastest of the eight and already clear of the five-minute grid.

## Nothing new was invented

`#10715` gave the producers one heartbeat and a registry; `#10709` gave the registry a cadence gate. `rpc-usage-staleness` has ridden the health-prune tick since `#9228` rather than taking a minute. `STALENESS_WATCHDOGS` is that same shape for the family that alarms rather than enqueues.

## One lane's failure cannot silence another's

The property the module exists for, and the lesson `#9228` already paid for here — *"an alarm that a sibling lane's failure can silence is an alarm that reports healthy for exactly the reason it should be shouting."* Eight alarms behind one trigger makes that eight times cheaper to hit, so each lane runs in its own try/catch and a throw is recorded and stepped over. `Promise.all` would have been shorter and is exactly wrong: the first rejection abandons the rest.

A thrown lane deliberately writes **no** verdict. Its `lane_health.checked_at` freezes and the existing alarm reports it stale on the normal path — writing a failure verdict would refresh that stamp and make a permanently broken watchdog look recently checked.

Sequential rather than concurrent: each lane is a `MAX()` against Neon through Hyperdrive, the tick has fifteen minutes, and Neon compute is the live cost pressure.

## The silence bound moved with the cadence

`src/producer-cadence.ts` cross-checked `top_holders_staleness_watchdog`'s declared 1800s against `TOP_HOLDERS_STALENESS_WATCHDOG_CRON`. That constant is gone, and it was referenced as a **string** — nothing but the test would have caught it. `WORKER_REGISTRY_LANES` replaces `WORKER_CRON_LANES` for that lane and the check now runs against the registry's `everyMinutes`, which is what actually decides it. Losing the check rather than moving it is how a declared floor goes stale in prose.

## Tests

The per-lane cron-hygiene tests (unique string, declared in wrangler, off the five-minute grid) asserted the same three things about eight expressions; there is one expression now, so they are asserted once. Per-lane dispatch tests exercise their registry entry via `tests/helpers/staleness-lane.ts` rather than `handleScheduled`, because dispatching through the heartbeat would run all eight siblings against an env fixture built for one. The end-to-end half they gave up — that the cron reaches the registry at all — is asserted once centrally, since a correctly-registered lane behind a heartbeat nothing routes to is all eight going quiet together.

The neurons lane's two guards were previously asserted by regexing `workers/api.ts` as source text. They are now executed, which also closed the only patch-coverage gap the move opened.

**1075 tests across 47 cron/lane/watchdog suites pass.** `src/staleness-watchdog-heartbeat.ts` is 100% on statements, branches, functions and lines; the added lines in `workers/api.ts` are fully covered, verified by intersecting the diff with a coverage run.

Refs #10849 (the epic stays open for items 1–4 and the remaining crons).