### PR TITLE
fix(capture): the RPC limit is per client, so rotating across hosts spends it faster rather than raising it

### DIFF
--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -39,6 +39,8 @@ import {
   type CaptureEndpointDeps,
 } from "./raw-capture-endpoints.ts";
 import { readArtifact, readHealthKv } from "../workers/storage.ts";
+import { recordLaneVerdict } from "./lane-health.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
 
 /** Kill switch, matching CHAIN_HEAD_POLL_ENABLED's convention on the head
  * poller: absent or anything but "true" means this lane does not run. */
@@ -189,19 +191,31 @@ const FLUSH_EVERY_BLOCKS = 5;
  * than with a constant nobody re-derived when a second archive endpoint was
  * curated into the registry.
  *
- * `laneCount` still DIVIDES: mainnet and testnet run concurrently, and where
- * they share a host they share its allowance. `hostCount` MULTIPLIES, for the
- * opposite reason. Both are measured at tick time now, not compiled in.
+ * `laneCount` DIVIDES: mainnet and testnet run concurrently and share one
+ * client allowance.
+ *
+ * `hostCount` DOES NOT MULTIPLY, and briefly did. Adding endpoints looks like
+ * it should buy proportional throughput, and it does not: #9378 measured this
+ * limit as PER CLIENT, not per host -- "probing test.chain.opentensor.ai
+ * straight afterwards stopped after 4 blocks, because the first probe had
+ * already spent the budget." Reading more hosts spends ONE allowance faster,
+ * so a multiplier here does not raise the ceiling, it front-loads the minute
+ * and buys a 429 partway through the tick.
+ *
+ * There is deliberately NO host parameter, and a test pins the budget against
+ * the endpoint count so one cannot be reintroduced silently. The rotation is
+ * still worth having -- it is FAILOVER (a height one host cannot serve is
+ * retried on the others) and archive-depth coverage -- but those are
+ * reliability properties, not rate. Keeping the two apart in the type is what
+ * stops the next reader re-deriving the same wrong conclusion from the same
+ * reasonable intuition.
  */
 export function pacedLaneBudget(
   laneCount: number,
   cronMinutes: number,
   limitPerMinute: number = RPC_REQUESTS_PER_MINUTE_LIMIT,
-  hostCount = 1,
 ): { maxBlocks: number; minGapMs: number } {
-  const hosts = Math.max(1, Math.trunc(hostCount));
-  const callsPerMinute =
-    (limitPerMinute * RPC_BUDGET_UTILISATION * hosts) / laneCount;
+  const callsPerMinute = (limitPerMinute * RPC_BUDGET_UTILISATION) / laneCount;
   const blocksPerMinute = callsPerMinute / RPC_CALLS_PER_BLOCK;
   return {
     // Lanes run CONCURRENTLY, so each gets the whole spendable interval rather
@@ -539,11 +553,14 @@ async function runLane(
     // The per-host limit is what was measured, so the budget scales with the
     // hosts this tick actually has -- derived here rather than compiled in,
     // because the pool's membership changes without a deploy.
+    // NOT widened by `rpcUrls.length`. See pacedLaneBudget: the measured limit
+    // is per CLIENT, so more hosts spend one allowance faster rather than
+    // buying more of it. The rotation is failover and archive coverage; the
+    // rate is what it always was.
     const budget = pacedLaneBudget(
       RAW_CAPTURE_LANES.length,
       cronStepMinutes(RAW_CAPTURE_CRON),
       RPC_REQUESTS_PER_MINUTE_LIMIT,
-      rpcUrls.length,
     );
     const result = await captureTick({
       rpcUrls,
@@ -571,6 +588,37 @@ async function runLane(
         `[raw-capture-sync] ${lane.network} stopped at ${result.stoppedAt}: ${result.reason} (watermark ${result.watermark}, behind ${result.behind})`,
       );
     }
+    // THE TICK'S OWN THROUGHPUT, DURABLY.
+    //
+    // Everything above was a `console.warn`, which is why "is this lane gaining
+    // or losing?" could only be answered by polling `raw_capture_state` by hand
+    // across an hour and differencing it. The lane already KNOWS: `captured` is
+    // what this tick landed and `behind` is what remains. Throwing both away
+    // each tick is what let it lose ~3.8 blocks/min for 28 hours while every
+    // watchdog read a watermark that was, technically, advancing.
+    //
+    // `age_ms` is deliberately null: this is not a staleness verdict (the seam
+    // watchdog's rule 6 owns that question against the chain head). This is the
+    // RATE, so a reader can tell a lane that is behind-and-closing from one
+    // that is behind-and-widening -- two states an absolute lag cannot separate,
+    // and the difference between "wait" and "page someone".
+    //
+    // Never throws; recordLaneVerdict swallows its own failures.
+    await recordLaneVerdict(laneHealthStore(env), {
+      lane: `raw-capture:${lane.network}`,
+      // `ok` means the tick RAN and landed what it could. A short tick is not a
+      // fault -- the next one resumes at the same height -- so the verdict
+      // tracks whether the lane is keeping pace, not whether it stopped early.
+      verdict: result.captured > 0 ? "ok" : "stale",
+      age_ms: null,
+      detail:
+        `${result.captured} captured, ${result.behind} behind, ` +
+        `${rpcUrls.length} endpoint(s)` +
+        (result.stoppedAt === undefined
+          ? ""
+          : `, stopped at ${result.stoppedAt}: ${result.reason}`),
+      checked_at: now(),
+    });
     return { network: lane.network, ok: true, ...result, result };
   } catch (error) {
     const message = String((error as Error)?.message ?? error);

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -34,11 +34,10 @@
 import { chainRpc } from "./chain-rpc.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 
-// The key is DERIVED once in twox-storage-key.ts; re-exported here because this
-// module's own callers and tests have always addressed it through this module.
+// DERIVED once in twox-storage-key.ts, beside the vectors that prove it.
+// Re-exported here because this module's callers and tests have always
+// addressed the key through it.
 import { SYSTEM_EVENTS_STORAGE_KEY } from "./twox-storage-key.ts";
-// Re-exported because this module's callers and tests have always addressed
-// the key through it; the single declaration lives in twox-storage-key.ts.
 export { SYSTEM_EVENTS_STORAGE_KEY };
 
 export interface RawBlockCapture {
@@ -214,11 +213,11 @@ export async function captureTick(deps: {
   /**
    * The archive endpoints this tick may read from, in preference order.
    *
-   * A LIST, NOT A URL, because the binding constraint on this lane is a
-   * PER-HOST rate limit (~100 requests per client per minute, measured in
-   * #9378), and one host was the whole budget. Blocks rotate across the list,
-   * so each host sees the same per-host rate it saw before while the lane's
-   * aggregate rate multiplies by the number of hosts.
+   * A LIST, NOT A URL, for RELIABILITY -- not for rate. The measured limit
+   * (#9378) is per CLIENT, not per host, so reading more endpoints does not buy
+   * more throughput; see `stepGapMs` below. What the list buys is that a host
+   * which is down, or which cannot serve historical state at all, stops being a
+   * single point of failure for the whole lane.
    *
    * THE NO-GAP GUARANTEE IS UNCHANGED, and the rotation is why it needed care:
    * a height that fails on one endpoint is retried on the OTHERS before the
@@ -269,11 +268,21 @@ export async function captureTick(deps: {
   if (endpoints.length === 0) {
     throw new Error("captureTick: rpcUrls is empty; nothing to read from");
   }
-  // The gap the CALLER computed is per host. Rotating across N hosts means the
-  // wall gap between consecutive blocks is that divided by N -- each host still
-  // sees `minGapMs` between its own calls, which is the rate the measured limit
-  // applies to, while the lane's aggregate rate is N times what one host allowed.
-  const stepGapMs = Math.ceil(minGapMs / endpoints.length);
+  // THE GAP IS NOT DIVIDED BY THE ENDPOINT COUNT, and briefly was.
+  //
+  // Dividing assumes the rate limit is per HOST -- rotate across N hosts, let
+  // each see `minGapMs` between its own calls, and the lane's aggregate rate is
+  // N times one host's allowance. That is a reasonable model and it is not this
+  // endpoint's. #9378 measured the limit as per CLIENT: after exhausting it on
+  // one host, a DIFFERENT host refused too, "because the first probe had
+  // already spent the budget."
+  //
+  // Under a per-client limit the divisor spends one minute's allowance in a
+  // fraction of the minute and buys a 429 partway through the tick -- more
+  // hosts, same ceiling, worse pacing. So the gap between consecutive blocks is
+  // the caller's `minGapMs` whatever the rotation width, and the rotation buys
+  // FAILOVER and archive coverage rather than rate.
+  const stepGapMs = minGapMs;
   const stored = await deps.watermark.read();
   // An unset watermark starts just below the floor, so the first tick captures
   // the floor block itself rather than skipping it.

--- a/tests/raw-capture-sync.test.ts
+++ b/tests/raw-capture-sync.test.ts
@@ -835,3 +835,88 @@ describe("the archive endpoints a lane reads from", () => {
     assert.equal(hosts.size, RAW_CAPTURE_LANES.length);
   });
 });
+
+/**
+ * The budget must not scale with how many endpoints the lane reads.
+ *
+ * This is the correction of a wrong premise, pinned so it cannot come back.
+ * Adding hosts LOOKS like it should buy proportional throughput; #9378 measured
+ * that it does not, because the limit is per CLIENT -- "probing
+ * test.chain.opentensor.ai straight afterwards stopped after 4 blocks, because
+ * the first probe had already spent the budget."
+ *
+ * A multiplier here does not raise the ceiling, it spends one minute's
+ * allowance in a quarter of the minute and buys a 429 partway through the tick.
+ * The rotation stays for FAILOVER and archive coverage; the rate is unchanged.
+ */
+describe("the tick budget against the endpoint count", () => {
+  test("more endpoints do NOT widen the budget", async () => {
+    const hosts = new Set<string>();
+    const { env } = envWith();
+    const pool = (n: number) => ({
+      readArtifact: async () => ({
+        ok: true,
+        data: {
+          pools: [
+            {
+              id: "finney-rpc",
+              endpoints: Array.from({ length: n }, (_, i) => ({
+                id: `archive-${i}`,
+                url: `https://archive-${i}.example`,
+                kind: "subtensor-rpc",
+                auth_required: false,
+                public_safe: true,
+                pool_eligible: true,
+                archive_support: true,
+                status: "ok",
+              })),
+            },
+          ],
+        },
+      }),
+    });
+    const gaps: number[] = [];
+    for (const n of [1, 6]) {
+      hosts.clear();
+      await runRawCaptureSync(env as never, {
+        ctx: CTX,
+        endpointDeps: pool(n),
+        // The paced gap IS the budget's observable half, so recording it is
+        // how this asserts the rate rather than the endpoint list.
+        sleepFn: async (ms) => {
+          gaps.push(ms);
+        },
+        fetchImpl: (async (url: unknown, init?: { body?: string }) => {
+          hosts.add(new URL(String(url)).origin);
+          const req = JSON.parse(init?.body ?? "{}") as { method: string };
+          const reply = (result: unknown) =>
+            ({
+              ok: true,
+              json: async () => ({ result }),
+            }) as unknown as Response;
+          if (req.method === "chain_getHeader")
+            return reply({ number: "0x989680" });
+          if (req.method === "chain_getBlockHash") return reply("0xh1");
+          if (req.method === "chain_getBlock") {
+            return reply({
+              block: {
+                header: { number: "0x1", parentHash: "0xp" },
+                extrinsics: ["0xaa"],
+              },
+            });
+          }
+          return reply("0xevents");
+        }) as unknown as typeof fetch,
+      });
+    }
+    // Six endpoints were genuinely read -- the rotation is live, so this is not
+    // passing because the pool arm never ran.
+    assert.ok(hosts.size > 1, `rotation did not engage: ${[...hosts].length}`);
+    const distinct = [...new Set(gaps)];
+    assert.equal(
+      distinct.length,
+      1,
+      `the per-block gap must not depend on the endpoint count; saw ${distinct.join(", ")}`,
+    );
+  });
+});

--- a/tests/raw-chain-capture.test.ts
+++ b/tests/raw-chain-capture.test.ts
@@ -711,10 +711,13 @@ describe("captureTick — reading across several endpoints", () => {
     assert.equal(result.captured, 2);
   });
 
-  test("the per-block sleep is the per-host gap DIVIDED by the host count", async () => {
-    // Each host still sees `minGapMs` between its own calls; the wall gap
-    // between consecutive blocks is that over N. Getting this wrong is how a
-    // widened lane would silently exceed the limit it was measured against.
+  test("the per-block gap does NOT shrink as endpoints are added", async () => {
+    // The premise correction. Dividing the gap by the rotation width assumes a
+    // PER-HOST limit; #9378 measured this endpoint as per CLIENT -- after
+    // exhausting it on one host, a different host refused too. Under that model
+    // a divisor spends one minute's allowance in a fraction of the minute and
+    // buys a 429 partway through the tick: more hosts, same ceiling, worse
+    // pacing. The rotation is failover, not rate.
     const slept: number[] = [];
     const { store } = memoryStore();
     const { watermark } = memoryWatermark(99);
@@ -733,8 +736,8 @@ describe("captureTick — reading across several endpoints", () => {
     });
     assert.deepEqual(
       slept,
-      [300, 300],
-      "900 / 3 hosts, and never before the first",
+      [900, 900],
+      "the caller's gap, unscaled, and never before the first block",
     );
   });
 


### PR DESCRIPTION
#11396 gave this lane an endpoint rotation and scaled its budget by the number of
hosts, on the reasonable-sounding premise that N archives serve N allowances.

**That premise is wrong, and this repo had already measured it wrong.** From
`pacedLaneBudget`'s own header, citing #9378:

> It is per CLIENT, not per host — probing `test.chain.opentensor.ai` straight
> afterwards stopped after 4 blocks, because the first probe had already spent
> the budget. **So there is no sibling endpoint to spread across.**

I wrote a multiplier one function below a comment saying the multiplier cannot
work.

## What it actually did

Under a per-client limit the multiplier does not raise the ceiling, it
front-loads the minute. `stepGapMs = minGapMs / hosts` paced four endpoints at
1,125 ms instead of 4,500 — spending one minute's allowance in a quarter of the
minute, then taking a 429 partway through the tick. Same 33-block ceiling, worse
pacing, and a lane that stops early instead of running its interval.

Measured post-deploy: ~35 blocks/tick against a budget of 213, i.e. the tick was
stopping at ~16% of what it was allowed. Raising the budget would have changed
nothing, which is the tell that the budget was never the constraint.

## The fix

**Both halves of the multiplier are gone** — the `hostCount` argument on
`pacedLaneBudget`, and the divisor inside `captureTick` that was the one actually
setting the wall rate. A test pins the per-block gap against the endpoint count
in both places; it caught the second half after the first was removed, which is
exactly why it exists:

```
AssertionError: the per-block gap must not depend on the endpoint count;
saw 2250, 4500, 643
```

**The rotation stays**, because it was never really about rate. A height one host
cannot serve is retried on the others, and #11397's corrected `archive_support`
means a pruned host is no longer selected at all. Those are reliability
properties and they survive intact.

## And the lane now records its own throughput

`captured` and `behind` were computed every tick and thrown away in a
`console.warn`. That is why "is this lane gaining or losing?" could only be
answered by hand-polling `raw_capture_state` across an hour and differencing it —
the same blindness that let the lane lose ~3.8 blocks/min for 28 hours while
every watchdog read a watermark that was, technically, advancing.

Both now land in `lane_health` as `raw-capture:<network>` with the endpoint
count, so the rate is queryable and the seam watchdog's rule 6 can eventually
alarm on **trend** rather than only on an absolute lag.

## Verification

- 243 tests across capture, endpoint-selection, seam-watchdog and probe suites
- `unreferenced-exports`, `type-duplicates`, `boundary-casts`, `schemas`,
  `contract-drift`, `lane-topology`, `module-state-resets` all green
- tsc / eslint / prettier clean
