### PR TITLE
perf(capture): run the lane every minute, so a tick finishes instead of being truncated

### DIFF
--- a/workers/config.ts
+++ b/workers/config.ts
@@ -64,12 +64,29 @@ export const GITHUB_SIGNALS_SYNC_CRON = "20 6 * * *";
 // docs link rots on a scale of weeks, not minutes. Must match a wrangler.jsonc
 // `triggers.crons` entry.
 export const LINK_STATUS_SYNC_CRON = "35 7 * * *";
-// Raw chain capture (extrinsics/events bytes -> R2), every 5 minutes. The
-// chain produces ~5 blocks/minute and a tick captures up to 150, so this
-// out-runs head by ~6x -- a backlog DRAINS rather than merely holding, which
-// is what lets the lane heal an outage instead of just surviving one. See
-// src/raw-chain-capture.ts for the no-gap guarantee itself.
-export const RAW_CAPTURE_CRON = "*/5 * * * *";
+// Raw chain capture (extrinsics/events bytes -> R2), EVERY MINUTE.
+//
+// It was */5, and the cadence is the whole reason the lane under-performed its
+// own budget. `pacedLaneBudget` derives the tick from this interval, so at */5 a
+// tick was sized to spend ~4 minutes reading -- and a Worker invocation does not
+// reliably live that long. Measured against production 2026-08-16: the watermark
+// advanced ~35 blocks per tick against a budget of 53, in exact multiples of the
+// flush chunk, which is the signature of an invocation killed partway with its
+// banked chunks kept. The lane was using 27 of its 100 RPC calls/minute: the
+// rate ceiling was never the constraint, the invocation lifetime was.
+//
+// At */1 the same derivation yields ~10 blocks over ~45 s -- comfortably inside
+// one invocation, so ticks COMPLETE instead of being truncated. The sustained
+// rate rises (7.5 -> ~10 blocks/min measured against a chain producing 5) purely
+// by not throwing away the tail of every tick, and the per-minute RPC spend is
+// unchanged because the budget is derived per minute either way.
+//
+// The paired budget tests hold at this cadence and are written against
+// `cronStepMinutes` rather than a literal, so they move with it: a tick still
+// finishes inside its interval (45 s < 60 s) and still out-runs the chain
+// (600 blocks/h against 300). See src/raw-chain-capture.ts for the no-gap
+// guarantee itself.
+export const RAW_CAPTURE_CRON = "*/1 * * * *";
 
 /**
  * metagraphed's own uptime probe (#9836).

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1086,10 +1086,13 @@
       // LINK_STATUS_SYNC_CRON in workers/config.ts and
       // src/link-status-sync.ts's header.
       "35 7 * * *",
-      // */5 = raw chain capture (extrinsic/event bytes -> R2). Out-runs the
-      // chain ~6x so an outage backlog drains; see RAW_CAPTURE_CRON in
-      // workers/config.ts and src/raw-chain-capture.ts's no-gap guarantee.
-      "*/5 * * * *",
+      // */1 = raw chain capture (extrinsic/event bytes -> R2). Every minute,
+      // not every five: the tick is sized from this interval, and a */5 tick was
+      // sized to read for ~4 minutes -- longer than a Worker invocation
+      // reliably lives, so it was truncated mid-tick. See RAW_CAPTURE_CRON in
+      // workers/config.ts for the measurement and src/raw-chain-capture.ts for
+      // the no-gap guarantee.
+      "*/1 * * * *",
       // #9402: the registration-cost capture lane. 1/16/31/46 is the only 15-minute
       // grid that collides with none of the crons above. See
       // SUBNET_BURN_CAPTURE_CRON for why the cadence is resolution-driven.


### PR DESCRIPTION
Lever 1 of the throughput work, and the one with no tradeoff.

## The tick is sized from the cron interval

`pacedLaneBudget` reads `cronStepMinutes(RAW_CAPTURE_CRON)`, so at `*/5` the tick
was sized to spend **~4 minutes reading** — longer than a Worker invocation
reliably lives.

Measured against production 2026-08-16, after #11396 made partial progress
durable: the watermark advanced **~35 blocks per tick against a budget of 53**, in
exact multiples of the 5-block flush chunk. That is the signature of an
invocation killed partway with its banked chunks kept — not a lane hitting a rate
limit.

The corroborating number: the lane was spending **27 of its 100 RPC calls per
minute**. The rate ceiling was never the constraint. The invocation lifetime was.

## What changes

| cadence | budget/tick | tick length | sustained | actual |
| --- | ---: | ---: | ---: | ---: |
| `*/5` | 53 | 245 s | 10.60/min | **7.48/min** (truncated) |
| `*/1` | 10 | 46 s | 10.00/min | ~10/min (completes) |

The theoretical budget goes *down* and the real throughput goes *up*, because the
tail of every tick stops being discarded.

Against a chain producing 5.03 blocks/min that takes the net drain from
**+2.45/min to +4.97/min** — roughly halving the time to close the current
~8,450-block backlog.

**Per-minute RPC spend is unchanged.** The budget is derived per minute either
way; this is the same call rate in smaller, completable units.

## Safety

- Nothing else uses the `*/5` slot — it appears once in `workers/config.ts` and
  once in `wrangler.jsonc`, and the scheduled dispatcher matches by exact cron
  string.
- Both budget tests are written against `cronStepMinutes` rather than a literal,
  so they move with the cadence and still hold: a tick finishes inside its
  interval (46 s < 60 s) and still out-runs the chain (600 blocks/h against 300).

## Verification

- 403 tests across capture, chain-capture and api-coverage
- `workflows`, `lane-topology`, `startup-budget`, `schemas`, `contract-drift` green
- tsc / prettier clean

## Not in scope

The two larger levers, deliberately left out because they are decisions rather
than fixes: temporarily giving mainnet the whole client allowance (testnet is a
declared best-effort lane; this would drain the backlog in ~7 h instead of ~28 h,
at the cost of testnet falling further behind), and moving capture to a container
class (its own egress identity, hence its own rate allowance, and no invocation
ceiling at all — infra#519/#526). The second is the one that ends this
permanently rather than tuning around it.
