### PR TITLE
fix(axon): the widened rule never ran, because the query that feeds it was not widened

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -7761,7 +7761,7 @@ type ChainAxonRemovalsDerivation {
   pending_confirmation: Int!
 
   """
-  Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160.
+  Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 130 of 224 confirmed removals over 30 days, measured 2026-08-16. Understated before that date: the narrowing query fetched only slots whose axon column went null, so a miner that merely moved was never read, and 79 of the 130 were missing.
   """
   moved_unroutable: Int!
 }

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1082,7 +1082,7 @@ export type ChainAxonRemovalsDerivation = {
   /** Days of `neuron_daily` the derivation had available. A removal older than this is outside the window, not absent. */
   lookback_days: Scalars['Int']['output'];
   method: Scalars['String']['output'];
-  /** Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160. */
+  /** Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 130 of 224 confirmed removals over 30 days, measured 2026-08-16. Understated before that date: the narrowing query fetched only slots whose axon column went null, so a miner that merely moved was never read, and 79 of the 130 were missing. */
   moved_unroutable: Scalars['Int']['output'];
   /** Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
   pending_confirmation: Scalars['Int']['output'];

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6601,7 +6601,7 @@ export interface components {
                 lookback_days: number;
                 /** @constant */
                 method: "axon-state-diff";
-                /** @description Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160. */
+                /** @description Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 130 of 224 confirmed removals over 30 days, measured 2026-08-16. Understated before that date: the narrowing query fetched only slots whose axon column went null, so a miner that merely moved was never read, and 79 of the 130 were missing. */
                 moved_unroutable: number;
                 /** @description Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
                 pending_confirmation: number;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22420,7 +22420,7 @@
                 "type": "string"
               },
               "moved_unroutable": {
-                "description": "Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160.",
+                "description": "Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 130 of 224 confirmed removals over 30 days, measured 2026-08-16. Understated before that date: the narrowing query fetched only slots whose axon column went null, so a miner that merely moved was never read, and 79 of the 130 were missing.",
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6601,7 +6601,7 @@ export interface components {
                 lookback_days: number;
                 /** @constant */
                 method: "axon-state-diff";
-                /** @description Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160. */
+                /** @description Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 130 of 224 confirmed removals over 30 days, measured 2026-08-16. Understated before that date: the narrowing query fetched only slots whose axon column went null, so a miner that merely moved was never read, and 79 of the 130 were missing. */
                 moved_unroutable: number;
                 /** @description Drops by a still-present hotkey with no later reading of that slot yet. Not removals and not discarded: a one-reading absence is indistinguishable from a missed poll, so confirmation waits for the next observation. The newest day of any window is structurally in this bucket. */
                 pending_confirmation: number;

--- a/schemas-src/routes/chain-network-rollups.ts
+++ b/schemas-src/routes/chain-network-rollups.ts
@@ -61,7 +61,7 @@ export const AxonRemovalDerivationSchema = z
       .int()
       .min(0)
       .describe(
-        "Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 166 of 271 same-hotkey losses over 38 days, and all but one of SN126's 160.",
+        "Of the confirmed removals, how many still announce an address nothing can reach -- RFC 5737 documentation space, RFC 1918 private space, loopback. A running but unreachable miner, not a departed one. The MAJORITY: 130 of 224 confirmed removals over 30 days, measured 2026-08-16. Understated before that date: the narrowing query fetched only slots whose axon column went null, so a miner that merely moved was never read, and 79 of the 130 were missing.",
       ),
   })
   .strict();

--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -56,6 +56,13 @@
 
 import { readStore, type StoreEnv } from "./read-store.ts";
 import { ROUTABLE_AXON_SQL } from "./axon-routable.ts";
+import {
+  AXON_LOSS_SQL,
+  AXON_MOVED_SQL,
+  AXON_SAME_HOTKEY_SQL,
+  AXON_VIA_REUSE_SQL,
+  axonSequenceSql,
+} from "./axon-transition.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
@@ -356,6 +363,13 @@ export function classifyAxonMechanism(
 /**
  * Split each subnet's axon losses by mechanism, over the same window.
  *
+ * The transition itself comes from src/axon-transition.ts, shared with the
+ * removal feeds, so the alarm and the API cannot come to disagree about what a
+ * loss is (#11394). What is NOT shared is the confirmation rule: the feeds hold
+ * a loss back until a later reading confirms it, which is right for an archive
+ * and wrong here, because the day that triggered this alarm has no later
+ * reading yet and would go permanently unexplained.
+ *
  * ONLY FOR SUBNETS ALREADY FLAGGED. The per-UID comparison is the expensive
  * read here -- 256 rows per subnet per day rather than one -- and on a typical
  * day the flag list is one to three subnets, so scoping it to those keeps the
@@ -394,21 +408,14 @@ export async function loadAxonLossMechanisms(
   const ids = (netuids ?? []).filter((n) => Number.isSafeInteger(n) && n >= 0);
   if (!db?.query || ids.length === 0) return out;
   try {
+    const sameHotkeyLoss = `${AXON_LOSS_SQL} AND ${AXON_SAME_HOTKEY_SQL}`;
     const rows = (await db.query(
-      "WITH seq AS (SELECT netuid, uid, snapshot_date, hotkey, axon, " +
-        `(${ROUTABLE_AXON_SQL}) AS has_axon, ` +
-        `LAG(${ROUTABLE_AXON_SQL}) OVER w AS prev_has, ` +
-        "LAG(hotkey) OVER w AS prev_hotkey, LAG(axon) OVER w AS prev_axon " +
-        "FROM neuron_daily " +
-        `WHERE snapshot_date >= ? AND netuid IN (${ids.map(() => "?").join(",")}) ` +
-        "WINDOW w AS (PARTITION BY netuid, uid ORDER BY snapshot_date)) " +
+      `WITH seq AS (${axonSequenceSql(`netuid IN (${ids.map(() => "?").join(",")})`)}) ` +
         "SELECT netuid, " +
-        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey IS DISTINCT FROM prev_hotkey) AS via_reuse, " +
-        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS same_hotkey, " +
-        "COUNT(*) FILTER (WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey " +
-        "AND axon IS NOT NULL AND axon <> '') AS moved_unroutable, " +
-        "COUNT(DISTINCT split_part(prev_axon, ':', 1)) FILTER " +
-        "(WHERE prev_has AND NOT has_axon AND hotkey = prev_hotkey) AS distinct_ips " +
+        `COUNT(*) FILTER (WHERE ${AXON_LOSS_SQL} AND ${AXON_VIA_REUSE_SQL}) AS via_reuse, ` +
+        `COUNT(*) FILTER (WHERE ${sameHotkeyLoss}) AS same_hotkey, ` +
+        `COUNT(*) FILTER (WHERE ${sameHotkeyLoss} AND ${AXON_MOVED_SQL}) AS moved_unroutable, ` +
+        `COUNT(DISTINCT prev_address) FILTER (WHERE ${sameHotkeyLoss}) AS distinct_ips ` +
         "FROM seq GROUP BY netuid",
       [sinceDate, ...ids],
     )) as Record<string, unknown>[];

--- a/src/axon-removal-derivation.ts
+++ b/src/axon-removal-derivation.ts
@@ -92,8 +92,15 @@ export interface AxonRemovalDerivation {
    * Of the confirmed removals, how many still announce something unreachable.
    *
    * Stated on the payload because it is the majority and a reader paging the
-   * list would otherwise have to count them: 166 of 271 same-hotkey losses
-   * over 38 days were moves, not departures (#11398).
+   * list would otherwise have to count them: 130 of 224 confirmed removals
+   * over 30 days are moves rather than departures (#11398).
+   *
+   * That figure is what this rule DERIVES; it is not what the feed served
+   * until 2026-08-16. The narrowing query upstream fetched only slots whose
+   * `axon` column went null, so 79 of the 130 never reached this function at
+   * all and the field read 51 (#11394). Both numbers are in the history for
+   * the same reason: a consumer comparing a cached answer against a fresh one
+   * across that date is looking at a fix, not at the network changing.
    */
   moved_unroutable: number;
 }

--- a/src/axon-removals-loader.ts
+++ b/src/axon-removals-loader.ts
@@ -12,11 +12,20 @@
 // building this (19 vs 14), from measuring with one rule and implementing
 // another.
 //
-// So SQL does only what SQL is for: narrowing. It finds the slots that had ANY
-// non-null -> null transition in the window and returns those slots' day
+// So SQL does only what SQL is for: narrowing. It finds the slots that lost a
+// REACHABLE axon at any point in the window and returns those slots' day
 // series. Everything else -- the hotkey test, the confirmation test, the
 // pending accounting -- happens in the derivation module, on rows it already
 // has tests for.
+//
+// ## The narrowing has to move whenever the rule does
+//
+// It did not, once, and the cost was measurable. #11399 widened the derivation
+// from a populated axon to a reachable one and left this predicate on presence,
+// so a slot that only ever moved routable -> unroutable was never fetched and
+// the widened rule never saw it: 79 of 224 confirmed removals over 30 days, all
+// of them moves, SN126 serving 50 against 128. Both ends now read the predicate
+// out of src/axon-transition.ts, which carries the measurement and the reason.
 //
 // ## The narrowing is what makes this affordable
 //
@@ -31,6 +40,7 @@ import {
   type NeuronAxonDayRow,
 } from "./axon-removal-derivation.ts";
 import { readStore } from "./read-store.ts";
+import { AXON_LOSS_SQL, axonSequenceSql } from "./axon-transition.ts";
 
 /** Days of `neuron_daily` to pull. The widest window any route offers. */
 export const AXON_REMOVALS_LOOKBACK_DAYS = 30;
@@ -58,22 +68,18 @@ export interface AxonRemovalsRollup {
 }
 
 /**
- * The day series for every slot that dropped an axon in the window.
+ * The day series for every slot that lost a reachable axon in the window.
  *
- * The inner query is the narrowing: `lag(axon)` over each slot finds the
- * transitions, and the outer query returns those slots WHOLE, because the
- * derivation needs the readings on either side to tell a teardown from a
- * missed poll.
+ * The inner query is the narrowing, and the outer query returns the matching
+ * slots WHOLE, because the derivation needs the readings on either side to tell
+ * a teardown from a missed poll. It projects only the five columns
+ * `NeuronAxonDayRow` names: the sequence carries `routable` and `prev_*` for
+ * the predicate's benefit, and re-deciding reachability in the derivation from
+ * the raw `axon` keeps `isRoutableAxon` the one place that answers it.
  */
 const CANDIDATE_SLOTS_SQL =
-  "WITH windowed AS (" +
-  "  SELECT netuid, uid, snapshot_date, hotkey, axon," +
-  "         lag(axon) OVER (PARTITION BY netuid, uid ORDER BY snapshot_date) AS prev_axon" +
-  "  FROM neuron_daily WHERE snapshot_date >= ?" +
-  "), dropped AS (" +
-  "  SELECT DISTINCT netuid, uid FROM windowed" +
-  "  WHERE prev_axon IS NOT NULL AND prev_axon <> ''" +
-  "    AND (axon IS NULL OR axon = '')" +
+  `WITH windowed AS (${axonSequenceSql()}), dropped AS (` +
+  ` SELECT DISTINCT netuid, uid FROM windowed WHERE ${AXON_LOSS_SQL}` +
   ")" +
   " SELECT w.netuid, w.uid, w.snapshot_date, w.hotkey, w.axon" +
   " FROM windowed w JOIN dropped d ON d.netuid = w.netuid AND d.uid = w.uid" +

--- a/src/axon-routable.ts
+++ b/src/axon-routable.ts
@@ -37,13 +37,20 @@ export const UNROUTABLE_AXON_PATTERN =
 export const UNROUTABLE_AXON_V6_PATTERN =
   "^(::$|::1$|[fF][cCdD]|[fF][eE][89aAbB])";
 
-/** SQL fragment: the axon is present AND points somewhere routable.
+/**
+ * SQL fragment: everything before the LAST colon of `column`.
  *
- * `left(axon, length(axon) - strpos(reverse(axon), ':'))` is "everything before
- * the LAST colon" -- the same address/port split `splitAxon` does, so an IPv6
- * announcement is not read as its first hex group. */
-export const AXON_ADDRESS_SQL =
-  "left(axon, length(axon) - strpos(reverse(axon), ':'))";
+ * The same address/port split `splitAxon` does, so an IPv6 announcement is not
+ * read as its first hex group. Parameterised by column because the transition
+ * readers need it over a lagged value too (`src/axon-transition.ts`), and a
+ * second spelling of the split is how one of them comes to disagree.
+ */
+export function axonAddressSql(column: string): string {
+  return `left(${column}, length(${column}) - strpos(reverse(${column}), ':'))`;
+}
+
+/** The address half of an announced `axon`, the column every reader starts at. */
+export const AXON_ADDRESS_SQL = axonAddressSql("axon");
 export const ROUTABLE_AXON_SQL =
   `axon IS NOT NULL AND axon <> '' AND ${AXON_ADDRESS_SQL} <> '' AND ` +
   `CASE WHEN ${AXON_ADDRESS_SQL} LIKE '%:%' ` +

--- a/src/axon-transition.ts
+++ b/src/axon-transition.ts
@@ -1,0 +1,112 @@
+// What "a UID lost a reachable axon" means -- in one place (#11394).
+//
+// ## The drift this closes had already shipped
+//
+// #11399 widened the removal derivation from a POPULATED axon to a REACHABLE
+// one: a miner that moves to RFC 5737 documentation space has stopped serving
+// exactly as much as one that cleared the field. The derivation was widened.
+// The SQL that decides which slots the derivation ever SEES was not.
+//
+// src/axon-removals-loader.ts narrows ~936,000 neuron-days down to the slots
+// worth pulling, and it narrowed on PRESENCE -- `prev_axon <> '' AND axon IS
+// NULL`. A slot that only ever moved routable -> unroutable never matched, so
+// it was never fetched, so the widened rule never ran on it.
+//
+// MEASURED ON NEON 2026-08-16, over the 30 retained days:
+//
+//   slots with a reachability drop                    1,483
+//   slots with a presence drop (all that was fetched) 1,410
+//   slots invisible to the loader entirely              103
+//
+//   confirmed removals                                  224
+//     ...delivered to the derivation                    145
+//     ...LOST to the narrowing                           79   35%
+//   of which moved-unroutable                           130
+//     ...LOST to the narrowing                           79   61%
+//
+// Every one of the 79 was a move, and SN126 is 78 of them: the feed served 50
+// removals against 128 confirmed -- 50 is what production returned when this
+// was found, which is how the model above was checked rather than assumed. The
+// widening shipped and was 61% inert for the case it was built for, and nothing
+// said so, because the two rules lived in two files and only one was edited.
+//
+// ## What is shared here, and what is deliberately NOT
+//
+// SHARED: the day sequence, the loss predicate, and the mechanism split. Those
+// are claims about the chain, and two answers to them is the defect above.
+//
+// NOT SHARED: the confirmation rule. src/axon-removal-derivation.ts requires a
+// later reading of the same hotkey still unreachable, because a one-day absence
+// is indistinguishable from a missed poll and an archive must not file one as a
+// teardown. The watchdog must NOT adopt it: the watchdog exists to explain a
+// count drop observed TODAY, and a rule needing tomorrow's reading would leave
+// the triggering day permanently unexplained. Different jobs, honestly
+// different rules -- so this module carries the transition and neither
+// consumer's verdict.
+//
+// ## The invariant, and why it is one-directional
+//
+// The narrowing may be WIDER than the derivation (it over-fetches a slot the
+// derivation then discards, which costs rows and nothing else) but it must
+// never be NARROWER, because a slot that is not fetched cannot be judged at
+// all. tests/axon-transition.test.ts pins that direction on real Postgres.
+
+import { axonAddressSql, ROUTABLE_AXON_SQL } from "./axon-routable.ts";
+
+/**
+ * The per-slot day sequence every axon-loss reader starts from.
+ *
+ * `extraWhere` is appended to the fixed `snapshot_date >= ?` bound and must
+ * carry placeholders only -- the one caller that passes it builds a
+ * `netuid IN (?, ?, ...)` list from integers it has already filtered, never an
+ * interpolated value.
+ *
+ * `prev_address` rather than `prev_axon` because every consumer wanted the
+ * address: taking it here means the port is split ONCE, by the same
+ * last-colon rule as `splitAxon`. The watchdog previously did its own
+ * `split_part(prev_axon, ':', 1)`, which reads an IPv6 announcement's first hex
+ * group as the whole address and merges unrelated hosts into one (#11379).
+ */
+export function axonSequenceSql(extraWhere = ""): string {
+  return (
+    "SELECT netuid, uid, snapshot_date, hotkey, axon, " +
+    `(${ROUTABLE_AXON_SQL}) AS routable, ` +
+    `LAG(${ROUTABLE_AXON_SQL}) OVER w AS prev_routable, ` +
+    "LAG(hotkey) OVER w AS prev_hotkey, " +
+    `LAG(${axonAddressSql("axon")}) OVER w AS prev_address ` +
+    "FROM neuron_daily WHERE snapshot_date >= ?" +
+    (extraWhere ? ` AND ${extraWhere}` : "") +
+    " WINDOW w AS (PARTITION BY netuid, uid ORDER BY snapshot_date)"
+  );
+}
+
+/**
+ * A reachable axon became unreachable -- whether or not a field was cleared.
+ *
+ * The first reading of a slot has a NULL `prev_routable`, so this is NULL there
+ * rather than true, and three-valued logic drops it from every `FILTER` and
+ * `WHERE` for free. That is the wanted answer: we did not observe a transition,
+ * we observed a beginning.
+ */
+export const AXON_LOSS_SQL = "prev_routable AND NOT routable";
+
+/**
+ * The slot changed hands, so the loss belongs to the deregistration family.
+ *
+ * Decided BEFORE the other two: on a reused UID the newcomer's axon says
+ * nothing about the miner that left, and counting it here would report one
+ * event twice under two names. 93.8% of raw drops are this.
+ */
+export const AXON_VIA_REUSE_SQL = "hotkey IS DISTINCT FROM prev_hotkey";
+
+/** The same miner is still in the slot, so the loss is about that miner. */
+export const AXON_SAME_HOTKEY_SQL = "hotkey = prev_hotkey";
+
+/**
+ * Still announcing, just nowhere anyone can reach -- a move, not a withdrawal.
+ *
+ * Only meaningful alongside `AXON_LOSS_SQL`, which has already established that
+ * whatever is announced is unroutable. Kept apart from the loss predicate
+ * because it partitions the losses rather than selecting them.
+ */
+export const AXON_MOVED_SQL = "axon IS NOT NULL AND axon <> ''";

--- a/tests/axon-removals-loader.test.ts
+++ b/tests/axon-removals-loader.test.ts
@@ -7,6 +7,7 @@ import {
   loadAxonRemovals,
   subnetAxonRemovalRow,
 } from "../src/axon-removals-loader.ts";
+import { AXON_LOSS_SQL } from "../src/axon-transition.ts";
 
 function day(
   date: string,
@@ -151,9 +152,13 @@ describe("loadAxonRemovals", () => {
         },
       },
     );
-    assert.match(sql, /lag\(axon\) OVER \(PARTITION BY netuid, uid/);
+    assert.match(sql, /WINDOW w AS \(PARTITION BY netuid, uid/);
     assert.match(sql, /JOIN dropped/);
     assert.match(sql, /snapshot_date >= \?/);
+    // The predicate itself is the SHARED one, not a copy that reads the same
+    // today. Pinning the literal is how the narrowing stayed on presence while
+    // the derivation moved to reachability (#11394).
+    assert.ok(sql.includes(`WHERE ${AXON_LOSS_SQL}`));
   });
 });
 

--- a/tests/axon-transition.test.ts
+++ b/tests/axon-transition.test.ts
@@ -1,0 +1,295 @@
+// The narrowing and the derivation must agree about what a loss is (#11394).
+//
+// These run on real Postgres because the defect they pin was invisible to
+// every fixture-level test in the family. `deriveAxonRemovals` had correct
+// unit tests for moved-unroutable; `loadAxonRemovals` had correct unit tests
+// against an injected row list. Neither could see that the SQL between them
+// never SELECTS a moved-unroutable slot, because neither ran the SQL.
+//
+// Measured on Neon 2026-08-16 before the fix: 224 confirmed removals over 30
+// days, 145 reaching the derivation, 79 lost -- every one a move, 78 of them
+// SN126, which served 50 removals against 128.
+import fs from "node:fs";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { PGlite } from "@electric-sql/pglite";
+import { beforeAll, beforeEach, describe, test } from "vitest";
+
+import { axonAddressSql, ROUTABLE_AXON_SQL } from "../src/axon-routable.ts";
+import {
+  AXON_LOSS_SQL,
+  AXON_MOVED_SQL,
+  AXON_SAME_HOTKEY_SQL,
+  AXON_VIA_REUSE_SQL,
+  axonSequenceSql,
+} from "../src/axon-transition.ts";
+import {
+  deriveAxonRemovals,
+  type NeuronAxonDayRow,
+} from "../src/axon-removal-derivation.ts";
+import { loadAxonRemovals } from "../src/axon-removals-loader.ts";
+import { toPositionalPlaceholders } from "../src/pg-sql.ts";
+
+describe("the shared fragments", () => {
+  test("reachability comes from axon-routable, not a second spelling", () => {
+    const sql = axonSequenceSql();
+    assert.ok(
+      sql.includes(`(${ROUTABLE_AXON_SQL}) AS routable`),
+      "the current reading is the shared predicate verbatim",
+    );
+    assert.ok(
+      sql.includes(`LAG(${ROUTABLE_AXON_SQL}) OVER w AS prev_routable`),
+      "and so is the previous one",
+    );
+  });
+
+  test("prev_address splits at the LAST colon, so IPv6 survives it", () => {
+    // The watchdog counted distinct IPs with `split_part(prev_axon, ':', 1)`,
+    // which reads `2607:fb90:...:1036:10000` as the host `2607` and merges
+    // every IPv6 announcement into one bucket (#11379).
+    const sql = axonSequenceSql();
+    assert.ok(sql.includes(`LAG(${axonAddressSql("axon")}) OVER w`));
+    assert.doesNotMatch(sql, /split_part/);
+  });
+
+  test("the extra predicate lands AFTER the date bound", () => {
+    // Placeholder ORDER is the contract: the watchdog binds
+    // `[sinceDate, ...netuids]`, so a predicate appended before the date bound
+    // would bind a netuid as the date and never throw.
+    const sql = axonSequenceSql("netuid IN (?,?)");
+    assert.ok(
+      sql.indexOf("snapshot_date >= ?") < sql.indexOf("netuid IN (?,?)"),
+    );
+    assert.match(sql, /WHERE snapshot_date >= \? AND netuid IN \(\?,\?\)/);
+  });
+
+  test("no predicate leaves no dangling AND", () => {
+    assert.match(
+      axonSequenceSql(),
+      /WHERE snapshot_date >= \? WINDOW w AS \(PARTITION BY netuid, uid ORDER BY snapshot_date\)$/,
+    );
+  });
+
+  test("a first reading is not a loss", () => {
+    // `prev_routable` is NULL on the first row of a partition, and the
+    // predicate must evaluate to NULL there rather than true -- otherwise
+    // every slot's first appearance in the window reads as a teardown.
+    assert.equal(AXON_LOSS_SQL, "prev_routable AND NOT routable");
+  });
+
+  test("reuse and same-hotkey partition the losses between them", () => {
+    assert.equal(AXON_VIA_REUSE_SQL, "hotkey IS DISTINCT FROM prev_hotkey");
+    assert.equal(AXON_SAME_HOTKEY_SQL, "hotkey = prev_hotkey");
+    // IS DISTINCT FROM rather than <>, so a NULL hotkey on either side is
+    // reuse rather than dropping out of both counts.
+    assert.doesNotMatch(AXON_VIA_REUSE_SQL, /hotkey <> prev_hotkey/);
+  });
+
+  test("moved is about what is announced now, not what was", () => {
+    assert.equal(AXON_MOVED_SQL, "axon IS NOT NULL AND axon <> ''");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executed against Postgres.
+// ---------------------------------------------------------------------------
+
+const MIGRATIONS = ["migrations/neon/0007_hand_created_tables.sql"].map((f) =>
+  fs.readFileSync(path.join(process.cwd(), f), "utf8"),
+);
+
+/** Fixed clock, so `isoDaysAgo(now, 30)` is a known date the fixtures sit in. */
+const NOW = Date.UTC(2026, 7, 16);
+
+/** The presence narrowing this replaced, kept as the positive control. */
+const PRESENCE_NARROWING_SQL =
+  "WITH windowed AS (" +
+  "  SELECT netuid, uid, snapshot_date, hotkey, axon," +
+  "         lag(axon) OVER (PARTITION BY netuid, uid ORDER BY snapshot_date) AS prev_axon" +
+  "  FROM neuron_daily WHERE snapshot_date >= $1" +
+  "), dropped AS (" +
+  "  SELECT DISTINCT netuid, uid FROM windowed" +
+  "  WHERE prev_axon IS NOT NULL AND prev_axon <> ''" +
+  "    AND (axon IS NULL OR axon = '')" +
+  ")" +
+  " SELECT w.netuid, w.uid, w.snapshot_date, w.hotkey, w.axon" +
+  " FROM windowed w JOIN dropped d ON d.netuid = w.netuid AND d.uid = w.uid" +
+  " ORDER BY w.netuid, w.uid, w.snapshot_date";
+
+let db: PGlite;
+
+/** The `deps.query` seam, with `?` rewritten exactly as production does. */
+const query = async (text: string, values: unknown[]) =>
+  (await db.query(toPositionalPlaceholders(text), values as never[]))
+    .rows as Record<string, unknown>[];
+
+/**
+ * Every shape the derivation distinguishes, one slot each.
+ *
+ * `uid 2` is the case the presence narrowing could not see: a miner that keeps
+ * announcing and moves to RFC 5737 documentation space. Nothing about its
+ * `axon` column is ever null, so `axon IS NULL` never matched it.
+ */
+const DAYS: Array<[number, number, string, string, string | null]> = [
+  // uid 1 -- cleared the field, and stayed cleared. A removal.
+  [7, 1, "2026-08-01", "hkA", "1.2.3.4:8091"],
+  [7, 1, "2026-08-02", "hkA", null],
+  [7, 1, "2026-08-03", "hkA", null],
+  // uid 2 -- moved to documentation space, and stayed. Also a removal.
+  [7, 2, "2026-08-01", "hkB", "5.6.7.8:8091"],
+  [7, 2, "2026-08-02", "hkB", "192.0.2.1:8091"],
+  [7, 2, "2026-08-03", "hkB", "192.0.2.1:8091"],
+  // uid 3 -- came back on the next reading. A missed poll, not a teardown.
+  [7, 3, "2026-08-01", "hkC", "9.9.9.9:8091"],
+  [7, 3, "2026-08-02", "hkC", null],
+  [7, 3, "2026-08-03", "hkC", "9.9.9.9:8091"],
+  // uid 4 -- the slot changed hands. A deregistration, counted elsewhere.
+  [7, 4, "2026-08-01", "hkD", "8.8.8.8:8091"],
+  [7, 4, "2026-08-02", "hkE", null],
+  [7, 4, "2026-08-03", "hkE", null],
+  // uid 5 -- dropped on the newest day, with nothing after it. Pending.
+  [7, 5, "2026-08-01", "hkF", "4.4.4.4:8091"],
+  [7, 5, "2026-08-02", "hkF", null],
+  // uid 6 -- never stopped. No transition at all.
+  [7, 6, "2026-08-01", "hkG", "1.1.1.1:8091"],
+  [7, 6, "2026-08-02", "hkG", "1.1.1.1:8091"],
+  // uid 7 -- unroutable throughout. Never reachable, so nothing was lost.
+  [7, 7, "2026-08-01", "hkH", "10.0.0.5:8091"],
+  [7, 7, "2026-08-02", "hkH", null],
+  // uid 8 -- IPv6, moved to link-local. A move the naive port split misreads.
+  [8, 8, "2026-08-01", "hkI", "2607:fb90:1036:1:8091"],
+  [8, 8, "2026-08-02", "hkI", "fe80::1:8091"],
+  [8, 8, "2026-08-03", "hkI", "fe80::1:8091"],
+];
+
+const FULL_ROWS: NeuronAxonDayRow[] = DAYS.map(
+  ([netuid, uid, snapshot_date, hotkey, axon]) => ({
+    netuid,
+    uid,
+    snapshot_date,
+    hotkey,
+    axon,
+  }),
+);
+
+beforeAll(async () => {
+  db = new PGlite();
+  for (const sql of MIGRATIONS) await db.exec(sql);
+});
+
+beforeEach(async () => {
+  await db.exec("TRUNCATE neuron_daily");
+  for (const [netuid, uid, snapshot_date, hotkey, axon] of DAYS) {
+    await db.query(
+      "INSERT INTO neuron_daily (netuid, uid, hotkey, axon, snapshot_date, captured_at, updated_at)" +
+        " VALUES ($1,$2,$3,$4,$5,$6,$6)",
+      [netuid, uid, hotkey, axon, snapshot_date, NOW] as never[],
+    );
+  }
+});
+
+describe("the narrowing, executed", () => {
+  test("a slot that only ever MOVED reaches the derivation", async () => {
+    const out = await loadAxonRemovals({}, { query, now: () => NOW });
+    const moved = out!.removals.filter((r) => r.kind === "moved-unroutable");
+    assert.deepEqual(
+      moved.map((r) => `${r.netuid}:${r.uid}:${r.current_axon}`),
+      ["7:2:192.0.2.1:8091", "8:8:fe80::1:8091"],
+      "both moves are served, including the IPv6 one",
+    );
+  });
+
+  test("the presence narrowing it replaced could NOT see them", async () => {
+    // The positive control. Without this the test above would pass on a
+    // narrowing that never changed, because every OTHER shape survives both.
+    const rows = (
+      await db.query(PRESENCE_NARROWING_SQL, ["2026-07-17"] as never[])
+    ).rows as NeuronAxonDayRow[];
+    const derived = deriveAxonRemovals(rows, { lookbackDays: 30 });
+    assert.deepEqual(
+      derived.removals.filter((r) => r.kind === "moved-unroutable"),
+      [],
+      "the old predicate fetched no slot whose axon column never went null",
+    );
+    assert.equal(
+      derived.derivation.moved_unroutable,
+      0,
+      "so the payload's own count of moves was structurally zero",
+    );
+  });
+
+  test("narrowing loses nothing the full series would have found", async () => {
+    // THE INVARIANT, stated the only way that catches the next drift: whatever
+    // the derivation would conclude from every row in the window, it must also
+    // conclude from the rows the SQL chose to fetch. The narrowing is allowed
+    // to be wider (it over-fetches a slot the derivation then discards); it is
+    // never allowed to be narrower.
+    const narrowed = await loadAxonRemovals({}, { query, now: () => NOW });
+    const full = deriveAxonRemovals(FULL_ROWS, { lookbackDays: 30 });
+    assert.deepEqual(narrowed!.removals, full.removals);
+    assert.deepEqual(narrowed!.derivation, full.derivation);
+  });
+
+  test("and the shapes that are not removals stay out", async () => {
+    const out = await loadAxonRemovals({}, { query, now: () => NOW });
+    assert.deepEqual(
+      out!.removals.map((r) => `${r.netuid}:${r.uid}:${r.kind}`),
+      [
+        "7:1:stopped-announcing",
+        "7:2:moved-unroutable",
+        "8:8:moved-unroutable",
+      ],
+      "the flap, the reuse, the pending, the steady and the never-routable " +
+        "slots are all absent",
+    );
+    assert.equal(out!.derivation.excluded_uid_reuse, 1);
+    assert.equal(out!.derivation.pending_confirmation, 1);
+    assert.equal(out!.derivation.moved_unroutable, 2);
+  });
+});
+
+describe("the mechanism split, executed", () => {
+  test("the watchdog's aggregate runs and partitions the same losses", async () => {
+    // The watchdog builds this shape from the same fragments. Running it here
+    // proves the composed SQL parses and that the three counts partition the
+    // losses rather than overlapping -- `via_reuse + same_hotkey` is every
+    // loss, and `moved_unroutable` is a subset of `same_hotkey`.
+    const same = `${AXON_LOSS_SQL} AND ${AXON_SAME_HOTKEY_SQL}`;
+    const sql =
+      `WITH seq AS (${axonSequenceSql("netuid IN (?)")}) ` +
+      "SELECT netuid, " +
+      `COUNT(*) FILTER (WHERE ${AXON_LOSS_SQL} AND ${AXON_VIA_REUSE_SQL}) AS via_reuse, ` +
+      `COUNT(*) FILTER (WHERE ${same}) AS same_hotkey, ` +
+      `COUNT(*) FILTER (WHERE ${same} AND ${AXON_MOVED_SQL}) AS moved_unroutable, ` +
+      `COUNT(DISTINCT prev_address) FILTER (WHERE ${same}) AS distinct_ips ` +
+      "FROM seq GROUP BY netuid";
+    const rows = await query(sql, ["2026-07-17", 7]);
+    // Counts read back as numbers here: pglite parses int8, node-postgres
+    // hands back strings. `loadAxonLossMechanisms` coerces either, and the
+    // watchdog suite pins the string case against its own driver double.
+    assert.deepEqual(rows, [
+      {
+        netuid: 7,
+        // uid 4 changed hands.
+        via_reuse: 1,
+        // uids 1, 3 and 5 lost reachability with the same hotkey in the slot;
+        // uid 2 moved. The watchdog counts the flap and the pending drop
+        // because it explains TODAY's fall, which is the difference from the
+        // archive and the reason the confirmation rule is not shared.
+        same_hotkey: 4,
+        moved_unroutable: 1,
+        // 1.2.3.4, 9.9.9.9, 4.4.4.4 and 5.6.7.8 -- the addresses they left.
+        distinct_ips: 4,
+      },
+    ]);
+  });
+
+  test("the IPv6 address is one host, not its first hex group", async () => {
+    const rows = await query(
+      `WITH seq AS (${axonSequenceSql("netuid IN (?)")}) ` +
+        `SELECT prev_address FROM seq WHERE ${AXON_LOSS_SQL}`,
+      ["2026-07-17", 8],
+    );
+    assert.deepEqual(rows, [{ prev_address: "2607:fb90:1036:1" }]);
+  });
+});


### PR DESCRIPTION
#11399 widened the removal derivation from a POPULATED axon to a REACHABLE
one. `src/axon-removals-loader.ts` narrows ~936,000 neuron-days down to the
slots worth pulling, and it kept narrowing on presence -- `prev_axon <> '' AND
axon IS NULL`. A slot that only ever moved routable -> unroutable never
matched, so it was never fetched, so the widened rule never ran on it.

Measured on Neon over the 30 retained days, and confirmed against the live
feed rather than inferred:

| | derivable | served |
| --- | ---: | ---: |
| confirmed removals | 224 | 145 |
| of which moved-unroutable | 130 | 51 |
| SN126 | 128 | 50 |

`/api/v1/chain/axon-removals?window=30d` returns `moved_unroutable: 51` and
SN126 at 50 right now, which is what the model predicted to the unit. Every
one of the 79 missing removals is a move; 78 of them are SN126. The widening
shipped and was 61% inert for the case it was built for.

Nothing said so because the two rules lived in two files and only one was
edited. `src/axon-transition.ts` now owns the transition -- the day sequence,
the loss predicate, and the reuse/moved split -- and the loader and the
watchdog both read it from there.

What is deliberately NOT shared is the confirmation rule. The feeds hold a
loss back until a later reading confirms it, which is right for an archive and
wrong for the alarm: the day that triggered the alarm has no later reading yet
and would go permanently unexplained. Different jobs, honestly different
rules, recorded as such.

Two things fall out of having one owner:

- The watchdog counted distinct IPs with `split_part(prev_axon, ':', 1)`,
  which reads an IPv6 announcement as its first hex group and merges
  unrelated hosts -- the bug #11379 fixed everywhere else. It now takes the
  address from the shared last-colon split.
- `moved_unroutable`'s schema description claimed a ratio measured under the
  watchdog's rules, not the derivation's. It now states 130 of 224, and says
  the field was understated before today so a caller comparing a cached answer
  against a fresh one can tell a fix from a change in the network.

tests/axon-transition.test.ts runs on real Postgres, because the defect was
invisible to every fixture-level test in the family: the derivation had
correct unit tests for moved-unroutable and the loader had correct unit tests
against an injected row list, and neither ran the SQL between them. It pins
the invariant in the only direction that matters -- whatever the derivation
concludes from every row in the window, it must also conclude from the rows
the SQL chose to fetch -- and keeps the old presence predicate as the positive
control, so the suite fails if the narrowing ever silently reverts.

Closes #11394
