### PR TITLE
fix(cron): dispatch declined an unknown tick and the usage record called it the health prober

### DIFF
--- a/tests/api-crons-have-handlers.test.ts
+++ b/tests/api-crons-have-handlers.test.ts
@@ -14,8 +14,8 @@ import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, test } from "vitest";
-import { API_HANDLED_CRONS } from "../workers/api.ts";
-import { HEALTH_PROBER_CRON } from "../workers/config.ts";
+import { API_HANDLED_CRONS, cronLabel } from "../workers/api.ts";
+import { HEALTH_PROBER_CRON, HEALTH_PRUNE_CRON } from "../workers/config.ts";
 import { stripJsonComments } from "../scripts/lib.ts";
 
 const CONFIG = "wrangler.jsonc";
@@ -218,5 +218,53 @@ describe("wrangler.jsonc crons and their handlers", () => {
       `these are in API_HANDLED_CRONS but no branch dispatches on them, so they ` +
         `would fire and do nothing:\n${unbranched.join("\n")}`,
     );
+  });
+});
+
+describe("the usage label agrees with dispatch about what ran", () => {
+  // #10815 made `dispatchScheduled` explicit -- a branch for HEALTH_PROBER_CRON
+  // and an `unknown cron` decline after it -- and left `cronLabel` on the old
+  // fall-through. The two then disagreed about the same tick: dispatch reported
+  // `{ok: false, reason: "unknown cron"}` while the usage record called it a
+  // health-prober run. The label is the only one of the two a reader browsing
+  // usage data ever sees.
+  test("every declared cron has a label of its own", () => {
+    // DERIVED from the config, so a cron added tomorrow with no label branch
+    // fails here rather than being filed under someone else's lane. This is the
+    // same both-directions argument as the handler tests above, for the half
+    // that reporting depends on.
+    const unlabelled = declaredCrons(CONFIG).filter(
+      (cron) => cronLabel(cron) === "unknown-cron",
+    );
+    assert.deepEqual(
+      unlabelled,
+      [],
+      `these declared crons fall through to "unknown-cron", so their ticks are ` +
+        `recorded under no lane: ${unlabelled.join(", ")}`,
+    );
+  });
+
+  test("the health prober is labelled by its own branch, not by falling through", () => {
+    assert.equal(cronLabel(HEALTH_PROBER_CRON), "health-prober");
+  });
+
+  test("an ORPHANED expression is named unknown, not health-prober", () => {
+    // The regression. `*/15 * * * *` used to BE the fall-through, so a typo'd or
+    // retired expression was both dispatched to and reported as the prober.
+    // Dispatch stopped doing that; this is the reporting half.
+    for (const orphan of ["44 4 * * *", "*/9 * * * *", "not-a-cron"]) {
+      assert.equal(
+        cronLabel(orphan),
+        "unknown-cron",
+        `${orphan} matches no branch and must not borrow a working lane's name`,
+      );
+    }
+  });
+
+  test("a real lane is still labelled, so the above is not vacuous", () => {
+    // Guards the guard: if `cronLabel` returned "unknown-cron" for everything,
+    // the orphan test would pass while the sweep above failed -- but a reader
+    // seeing only this file should be able to tell the two apart.
+    assert.equal(cronLabel(HEALTH_PRUNE_CRON), "health-prune");
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2854,7 +2854,7 @@ export { composeCompareData } from "./request-handlers/analytics-routes.ts";
 // from wrangler.jsonc so they are bounded today, but a label built from input
 // is the shape #9001 removed elsewhere, and a name survives a schedule change
 // where "0 * * * *" does not.
-function cronLabel(cron: string): string {
+export function cronLabel(cron: string): string {
   // Membership, not equality: the heartbeat runs on more than one expression
   // (see LANE_HEARTBEAT_CRONS), and every one of them is the same lane for
   // reporting purposes -- a per-expression label would split one lane's cron
@@ -2897,8 +2897,26 @@ function cronLabel(cron: string): string {
   if (cron === SUBNET_DEREGISTRATION_DAILY_CRON)
     return "subnet-deregistration-daily";
   if (cron === LIVE_ECONOMICS_REFRESH_CRON) return "live-economics-refresh";
-  // Every unmatched cron falls through to the health prober, matching dispatch.
-  return "health-prober";
+  // FOUND BY THE SWEEP, not by reading: webhook-dispatch had a dispatch
+  // branch and no label branch, so every one of its ticks has been filed
+  // under `health-prober` since it shipped.
+  if (cron === WEBHOOK_DISPATCH_CRON) return "webhook-dispatch";
+  // A BRANCH, mirroring dispatch. #10815 made `dispatchScheduled` explicit --
+  // `if (cron === HEALTH_PROBER_CRON)` with an `unknown cron` decline after it
+  // -- and left this function on the old fall-through, so the two disagreed
+  // about the same tick: dispatch reported `{ok: false, reason: "unknown
+  // cron"}` while the usage record called it a health-prober run.
+  if (cron === HEALTH_PROBER_CRON) return "health-prober";
+  // NAMED AS UNKNOWN, not as somebody else's lane. An expression no branch
+  // matched is an orphaned schedule -- a typo, or a handler that was deleted --
+  // and labelling it `health-prober` filed the one event that would reveal it
+  // under a lane that is working fine. A reader chasing "why did health-prober
+  // fail?" is then looking at the wrong lane, which is the same
+  // name-a-cause-you-did-not-measure failure the dispatch side already fixed.
+  //
+  // tests/api-crons-have-handlers.test.ts makes an undeclared expression hard to
+  // reach at all; this is what it looks like when one gets there anyway.
+  return "unknown-cron";
 }
 
 /**


### PR DESCRIPTION
#10815 made `dispatchScheduled` explicit -- a branch for HEALTH_PROBER_CRON and
an `{ok: false, reason: "unknown cron"}` decline after it -- and left
`cronLabel` on the old fall-through. So the two disagreed about the same tick:
dispatch declined it, and the usage event filed it under `health-prober`. The
label is the half a reader browsing usage data ever sees, so an orphaned
schedule showed up as a working lane failing.

Same shape as the dispatch bug it half-fixed, and the same one this repo keeps
paying for: a default that NAMES a cause it did not measure sends the reader to
the wrong lane.

THE SWEEP FOUND A LIVE ONE IMMEDIATELY. Asserting that every cron declared in
wrangler.jsonc gets a label of its own -- derived from the config, not a list --
fails on `29,59 * * * *`. `WEBHOOK_DISPATCH_CRON` has a dispatch branch and had
no label branch, so every webhook-dispatch tick has been recorded as
`health-prober` since it shipped. That is two ticks an hour attributed to
another lane, and it is exactly what a hand-written label list cannot tell you.

The derived direction is the point: a cron added tomorrow with no label branch
fails here rather than borrowing a working lane's name.

`cronLabel` is exported to be tested. It is the reporting twin of
`API_HANDLED_CRONS`, which the same file already exports for the same reason.