### PR TITLE
fix(capture): the watermark could move BACKWARDS, so a slow tick undid seven fast ones

### DIFF
--- a/src/capture-state-neon-write.ts
+++ b/src/capture-state-neon-write.ts
@@ -180,10 +180,54 @@ export async function mirrorRawCaptureStateToNeon(
     now,
     () =>
       sql.unsafe(
+        // MONOTONIC, by GREATEST -- a watermark that can move backwards is not
+        // a watermark.
+        //
+        // It means "every block at or below this height is durably in R2", so a
+        // write claiming LESS than the stored value is not new information, it
+        // is a stale writer reporting where it started. Taking the max is always
+        // safe: the larger value was itself only written after its own bytes
+        // were durable, so keeping it never claims a block that is missing.
+        //
+        // MEASURED IN PRODUCTION 2026-08-16, minutes after #11406 removed the
+        // buffer that had been serialising these writes. The lane drained a
+        // steady 395 blocks/min for eight ticks and then jumped BACKWARDS ~2,795
+        // blocks in one tick, losing seven ticks of work:
+        //
+        //     12:09  5683 behind
+        //     12:10  8478 behind   <-- regressed
+        //     12:11  8083 behind
+        //
+        // A tick reads the watermark once at its start and writes once per
+        // chunk, so a tick that overruns the one-minute cron overlaps the next
+        // one and its late, lower writes clobber the newer tick's progress. The
+        // no-gap guarantee survived that -- going backwards only re-captures
+        // blocks already durable, and the R2 keys are idempotent -- but the lane
+        // spends its budget re-reading what it already has.
+        //
+        // Same shape as the COALESCE guards on blocks_head above: an upsert
+        // whose job is to carry forward what an out-of-order write would erase.
+        // A deliberate rewind (say, after finding corruption) is a hand-written
+        // statement, not this lane's path.
+        //
+        // A CASE, not GREATEST, and not MAX. This text runs verbatim against
+        // BOTH engines -- Postgres in production, SQLite in the fixture that
+        // executes it -- which is the property this module's header is about.
+        // `GREATEST` is Postgres-only; `MAX(a, b)` is the scalar form in SQLite
+        // but an aggregate in Postgres, so each would pass on one engine and
+        // fail on the other. CASE is the portable spelling of the same thing.
+        //
+        // `updated_at` still takes the new value even when the block does not:
+        // it records that the lane wrote, which is what the freshness watchdog
+        // on this table asks. The monotonic claim is about the HEIGHT.
         `INSERT INTO raw_capture_state (network, last_contiguous_block, updated_at)
          VALUES (?, ?, ?)
          ON CONFLICT(network) DO UPDATE SET
-           last_contiguous_block = excluded.last_contiguous_block,
+           last_contiguous_block = CASE
+             WHEN excluded.last_contiguous_block > raw_capture_state.last_contiguous_block
+             THEN excluded.last_contiguous_block
+             ELSE raw_capture_state.last_contiguous_block
+           END,
            updated_at = excluded.updated_at`,
         [network, lastContiguousBlock, updatedAt],
       ),

--- a/tests/capture-state-neon-write.test.ts
+++ b/tests/capture-state-neon-write.test.ts
@@ -95,8 +95,43 @@ describe("raw_capture_state", () => {
     });
     const { text, values } = calls[0]!;
     assert.ok(text.includes("ON CONFLICT(network) DO UPDATE"));
-    assert.ok(text.includes("last_contiguous_block = excluded"));
+    // The height is carried through a monotonic CASE rather than assigned
+    // straight from `excluded` -- see the test below for why.
+    assert.ok(text.includes("last_contiguous_block = CASE"));
+    assert.ok(text.includes("THEN excluded.last_contiguous_block"));
     assert.deepEqual(values, ["mainnet", 4321, 999]);
+  });
+
+  test("the watermark is MONOTONIC -- a late, lower write cannot rewind it", async () => {
+    // Measured in production 2026-08-16, minutes after #11406 removed the
+    // buffer that had been serialising these writes: the lane drained a steady
+    // 395 blocks/min for eight ticks, then jumped BACKWARDS ~2,795 blocks in
+    // one tick (5,683 behind -> 8,478 behind), losing seven ticks of work. A
+    // tick reads the watermark once at its start and writes once per chunk, so
+    // a tick that overruns the one-minute cron overlaps the next and its late,
+    // lower writes clobber the newer tick's progress.
+    //
+    // Asserted on the STATEMENT rather than by running two writes, because the
+    // guard lives in the SQL and this suite's sql double records text.
+    const { sql, calls } = recordingSql();
+    await mirrorRawCaptureStateToNeon(env, ctx, "mainnet", 4321, 999, {
+      sql,
+      laneHealthDb: null,
+    });
+    const { text } = calls[0]!;
+    assert.match(
+      text,
+      /WHEN excluded\.last_contiguous_block > raw_capture_state\.last_contiguous_block/,
+      "an out-of-order write must not lower the height",
+    );
+    assert.ok(
+      !/GREATEST/i.test(text),
+      "GREATEST is Postgres-only; this text also runs against the SQLite fixture",
+    );
+    assert.ok(
+      !/\bMAX\s*\(/i.test(text),
+      "MAX(a, b) is scalar in SQLite but an aggregate in Postgres",
+    );
   });
 
   test("enabled but unbound is a verdict, not silence", async () => {

--- a/tests/raw-capture-sync.test.ts
+++ b/tests/raw-capture-sync.test.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { mirrorRawCaptureStateToNeon } from "../src/capture-state-neon-write.ts";
 
 // The watermark's store is Postgres now (#10179): both halves of it --
 // neonWatermark's read and mirrorRawCaptureStateToNeon's write -- build their
@@ -473,6 +474,46 @@ describe("watermarkRead", () => {
     ).run("testnet", 99, 7);
     assert.equal(await watermarkRead(runner() as never, "mainnet")(), 42);
     assert.equal(await watermarkRead(runner() as never, "testnet")(), 99);
+  });
+
+  // THE MONOTONIC GUARANTEE, executed rather than pattern-matched.
+  //
+  // Run against the real engine on purpose: the guard is a CASE inside the
+  // upsert, and a test that greps the statement text proves the string exists,
+  // not that the database honours it. Formatting alone would satisfy a regex.
+  test("a late, LOWER write cannot rewind the watermark", async () => {
+    // Measured in production 2026-08-16, minutes after #11406 removed the
+    // buffer that had been serialising these writes: the lane drained a steady
+    // 395 blocks/min for eight ticks, then jumped BACKWARDS ~2,795 blocks in
+    // one tick (5,683 behind -> 8,478 behind). A tick reads the watermark once
+    // at its start and writes once per chunk, so a tick that overruns the
+    // one-minute cron overlaps the next one and its late, lower writes clobber
+    // the newer tick's progress. Idempotent R2 keys meant no corruption -- just
+    // the lane spending its whole budget re-reading what it already had.
+    // Driven through the PRODUCTION writer, not a copy of its SQL: a test that
+    // re-types the statement proves SQLite honours the statement in the test,
+    // which is true no matter what mirrorRawCaptureStateToNeon actually sends.
+    const { env } = envWith();
+    const write = (block: number, at: number) =>
+      mirrorRawCaptureStateToNeon(env as never, CTX, "mainnet", block, at, {
+        laneHealthDb: null,
+      });
+    await write(8_850_529, 100);
+    // The overlapping tick, finishing late with the height it started from.
+    await write(8_847_734, 200);
+    assert.equal(
+      await watermarkRead(runner() as never, "mainnet")(),
+      8_850_529,
+      "the higher, already-durable height must survive the stale writer",
+    );
+    // ...and a genuinely NEW height still advances it, or the guard would have
+    // frozen the lane instead of protecting it.
+    await write(8_851_000, 300);
+    assert.equal(
+      await watermarkRead(runner() as never, "mainnet")(),
+      8_851_000,
+      "forward progress is unaffected",
+    );
   });
 
   // A value that is not a number is not a watermark of zero: the capture


### PR DESCRIPTION
Follow-on to #11406, and caused by it in the sense that it removed the thing that was hiding this.

#11406 took `raw-capture-state` off the write-behind buffer, because the lane reads that watermark back one tick later and a deferred write made it resume from a stale value. That was right. It also removed the accidental serialisation the buffer provided — and the upsert assigned the height **unconditionally**, so ordering mattered and nothing was enforcing it any more.

## Measured in production, minutes after the deploy

The lane drained a steady 395 blocks/min for eight consecutive ticks, then jumped backwards:

| tick | behind |
|---|---:|
| 12:09 | 5,683 |
| **12:10** | **8,478** ← +2,795, seven ticks undone |
| 12:11 | 8,083 |

A tick reads the watermark **once** at its start and writes once per chunk. At `*/1` a full tick spends ~45s of a 60s interval, so a tick that overruns overlaps the next one and finishes by writing the height it *started from* — over the newer tick's progress.

**The no-gap guarantee was never at risk.** Going backwards only re-captures blocks that are already durable, and the R2 key is derived from the block range, so a re-write is byte-identical rather than a duplicate. What it cost is the point of the lane: the budget went on re-reading blocks it already had — the same waste #11406 fixed, arriving by a different route.

## The fix

The height is carried through a monotonic `CASE`. A watermark means "every block at or below this is durably in R2", so a write claiming *less* is not new information — it is a stale writer reporting where it started. Keeping the max is always safe: the larger value was itself only written after its own bytes were durable.

Same shape as the `COALESCE` guards on `blocks_head` one function up — an upsert whose job is to carry forward what an out-of-order write would erase.

**A `CASE`, not `GREATEST`, and not `MAX`.** This statement runs verbatim against both engines — Postgres in production, SQLite in the fixture that executes it, which is what the module header is about. `GREATEST` is Postgres-only; `MAX(a, b)` is scalar in SQLite but an aggregate in Postgres. Either would pass on one engine and fail on the other.

`updated_at` still takes the new value even when the height does not: it records that the lane wrote, which is what the freshness watchdog on this table asks. The monotonic claim is about the height.

## Testing

Tested by **executing the production writer** against the real SQLite fixture, not by matching its SQL text — a regex over the statement proves the string exists, not that the database honours it. The test drives `mirrorRawCaptureStateToNeon` itself, so it cannot drift from the shipped statement.

Verified it **fails with the guard removed** and passes with it. The forward case is asserted in the same test, so the guard cannot pass by simply freezing the lane.

## Verification

- full suite: **947 files, 21,727 passed, 11 skipped, 0 failures**
- all **57** CI validators pass
- typecheck and format clean