### PR TITLE
feat(pipelines): validate at our boundary, because the stream reports a drop as committed

### DIFF
--- a/src/pipeline-stream-contract.ts
+++ b/src/pipeline-stream-contract.ts
@@ -1,0 +1,232 @@
+// The boundary that stops a Pipelines stream losing rows silently (#10850).
+//
+// ## The measurement this exists for
+//
+// Phase 1's spike sent six events through a real stream on 2026-08-16. Two of
+// them never arrived, and the producer was told they had:
+//
+//   missing required field   -> HTTP 200  {"success":true,"result":{"committed":1}}
+//   type mismatch            -> HTTP 200  {"success":true,"result":{"committed":1}}
+//   unknown extra field      -> HTTP 200  landed, the extra field STRIPPED
+//   malformed JSON           -> HTTP 400  rejected
+//
+// So the ingest API reports `committed: 1` for a row it will later discard.
+// A caller checking `success`, or even `committed`, counts a dropped row as
+// written. The drop is visible afterwards in `pipelinesUserErrorsAdaptiveGroups`
+// -- but empty at 4 minutes and populated at 11, so it is a reconcile input and
+// never a synchronous check. The stripped-field case raises nothing at all, in
+// either channel.
+//
+// This repo already refuses that shape of failure everywhere else: a lane that
+// looks healthy and writes nothing is the exact class #10710, #472 and #10838
+// were. The answer is not to trust the stream's validation. It is to make
+// invalid events unable to reach it.
+//
+// ## One schema, as everywhere else here
+//
+// `schemas-src/` is the single source every published artifact derives from,
+// and openapi.json is generated rather than written. A Pipelines stream has its
+// own schema format, so declaring it by hand beside a Zod schema would be a
+// second copy of the same contract -- and a stream schema that drifts from the
+// Zod one fails in the silent direction above, because the stream is the half
+// that does not complain.
+//
+// So the Zod schema is the source, `streamSchemaFrom` derives the stream's
+// field list, and `validateStreamBatch` gates the send. Neither is optional:
+// derivation without validation still lets a bad row through at runtime, and
+// validation without derivation lets the two schemas disagree about what "bad"
+// means.
+//
+// ## What this deliberately does NOT do
+//
+// It does not retry, batch, or send. Pacing and the 429 the spike measured
+// (5 MB/request hard-capped, and a second large post refused for >20s) belong
+// to a caller that owns a cadence. This module is pure so both can be tested
+// without a network.
+
+import { z } from "zod";
+
+/** A field as `wrangler pipelines streams create --schema-file` declares it. */
+export interface StreamField {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+/** The whole file that command takes. */
+export interface StreamSchema {
+  fields: StreamField[];
+}
+
+/**
+ * The slice of JSON Schema `z.toJSONSchema` emits that this derivation reads.
+ *
+ * PARSED WITH ZOD, not cast. The input is a foreign document -- Zod's output
+ * format, which is free to change between versions -- and this repo's rule for
+ * a foreign document is `safeParse`, never an assertion. A shape we do not
+ * recognise must fail loudly here rather than silently produce a stream schema
+ * that drops rows at the sink.
+ */
+const JsonSchemaNode = z.object({
+  type: z.string().optional(),
+  minimum: z.number().optional(),
+  maximum: z.number().optional(),
+  anyOf: z.array(z.object({ type: z.string().optional() }).loose()).optional(),
+});
+
+const JsonSchemaObject = z.object({
+  properties: z.record(z.string(), JsonSchemaNode).default({}),
+  required: z.array(z.string()).default([]),
+});
+
+/**
+ * `int32` when the bounds say so, `int64` otherwise.
+ *
+ * THE BOUNDS ARE THE WIDTH. `z.int32()` emits
+ * `minimum: -2147483648, maximum: 2147483647`; `z.int()` emits the safe-integer
+ * range. Reading the declared range is what the document actually states, where
+ * reaching for a Zod-internal `format` string reads an implementation detail
+ * that carries the same information less durably.
+ */
+const INT32_MAX = 2_147_483_647;
+
+function pipelineTypeOf(
+  node: z.infer<typeof JsonSchemaNode>,
+  path: string,
+): string {
+  switch (node.type) {
+    case "string":
+      return "string";
+    case "boolean":
+      return "bool";
+    case "integer":
+      return typeof node.maximum === "number" && node.maximum <= INT32_MAX
+        ? "int32"
+        : "int64";
+    case "number":
+      // A bare `z.number()` is a float. Declaring it an integer would truncate
+      // every fractional value with no error anywhere.
+      return "float64";
+    default:
+      throw new Error(
+        `pipeline stream schema: ${path} has no representable JSON Schema type ` +
+          `(${JSON.stringify(node.type ?? null)}). Zod emits {} for types it cannot ` +
+          `express, such as bigint. Model the field as something the stream can ` +
+          `carry -- an unmapped type must not guess, because a wrong type is ` +
+          `dropped silently at the sink.`,
+      );
+  }
+}
+
+/**
+ * The stream schema a Zod object describes.
+ *
+ * DERIVED THROUGH `z.toJSONSchema`, Zod's own supported export, rather than by
+ * walking its class hierarchy. An `instanceof` chain over ZodString/ZodNumber/
+ * ZodOptional works until the library reorganises, and reading `.def` needs a
+ * double assertion this repo does not allow (#11194). JSON Schema is a stable
+ * published contract; Zod's internals are not.
+ *
+ * Field ORDER follows the Zod shape, so a regenerated file diffs against the
+ * previous one instead of reshuffling.
+ */
+export function streamSchemaFrom(
+  schema: z.ZodObject<z.ZodRawShape>,
+): StreamSchema {
+  // `io: "input"` because a stream carries what the PRODUCER sends, before any
+  // transform or default the schema would apply on the way out.
+  // `unrepresentable: "any"` so an unmappable type reaches pipelineTypeOf and
+  // is named, instead of throwing here as an opaque Zod error.
+  // `parse`, not `safeParse` with a hand-written rethrow. Both `properties` and
+  // `required` carry defaults, so every document `z.toJSONSchema` produces for a
+  // ZodObject satisfies this -- a bespoke failure branch would be unreachable
+  // through the signature above, and unreachable defensive code reads as a
+  // guard while guarding nothing. Zod's own error is the right one if the
+  // output format ever moves.
+  const { properties, required } = JsonSchemaObject.parse(
+    z.toJSONSchema(schema, { io: "input", unrepresentable: "any" }),
+  );
+  return {
+    fields: Object.entries(properties).map(([name, node]) => {
+      // A nullable field arrives as `anyOf: [{...}, {type: "null"}]` AND stays
+      // listed in `required`, because JSON Schema treats present-but-null as
+      // present. A stream has no null-vs-absent distinction, so carrying that
+      // through would declare the field required and drop every null row.
+      const branches = node.anyOf ?? [];
+      const nullable = branches.some((branch) => branch.type === "null");
+      const effective = nullable
+        ? (branches.find((branch) => branch.type !== "null") ?? node)
+        : node;
+      return {
+        name,
+        type: pipelineTypeOf(effective, name),
+        required: required.includes(name) && !nullable,
+      };
+    }),
+  };
+}
+
+/** One event the boundary refused, and why. */
+export interface RejectedEvent {
+  /** Index in the batch as submitted, so a caller can name the row. */
+  index: number;
+  /** `issue.path` joined, or "" for a whole-object failure. */
+  field: string;
+  message: string;
+}
+
+export interface StreamBatch<T> {
+  /** Parsed events, safe to send. */
+  accepted: T[];
+  /** Everything refused, with the reason. Never silently dropped. */
+  rejected: RejectedEvent[];
+}
+
+/**
+ * Parse a batch against its schema, keeping the good rows and naming the bad.
+ *
+ * REJECTED IS RETURNED, NOT THROWN. One malformed row in a 30,000-row pass
+ * must not cost the other 29,999 -- that is the same reasoning as the staleness
+ * heartbeat isolating each lane. But it is also not swallowed: the caller gets
+ * every rejection with its index and field, which is precisely what the stream
+ * would have thrown away.
+ *
+ * `safeParse` per event rather than an array schema, so the index survives.
+ * A `z.array(...)` parse reports a path into the array and stops being useful
+ * the moment a caller wants to log the row.
+ */
+export function validateStreamBatch<T>(
+  schema: z.ZodType<T>,
+  events: readonly unknown[],
+): StreamBatch<T> {
+  const accepted: T[] = [];
+  const rejected: RejectedEvent[] = [];
+  events.forEach((event, index) => {
+    const parsed = schema.safeParse(event);
+    if (parsed.success) {
+      accepted.push(parsed.data);
+      return;
+    }
+    for (const issue of parsed.error.issues) {
+      rejected.push({
+        index,
+        field: issue.path.join("."),
+        message: issue.message,
+      });
+    }
+  });
+  return { accepted, rejected };
+}
+
+/**
+ * Whether a batch may be sent at all.
+ *
+ * The stream cannot tell us it dropped something for eleven minutes, so a
+ * caller that wants a synchronous answer asks here. Separate from
+ * `validateStreamBatch` because "send the good ones and report the rest" and
+ * "refuse the whole batch" are both legitimate, and which one is right depends
+ * on whether the rows are independent -- a caller should have to choose.
+ */
+export function isSendable<T>(batch: StreamBatch<T>): boolean {
+  return batch.rejected.length === 0;
+}

--- a/tests/pipeline-stream-contract.test.ts
+++ b/tests/pipeline-stream-contract.test.ts
@@ -1,0 +1,189 @@
+// The boundary that makes Pipelines' silent drop unreachable (#10850).
+//
+// Each case below is one the SPIKE actually measured against a real stream on
+// 2026-08-16, where the ingest API answered HTTP 200 `{"success":true,
+// "result":{"committed":1}}` and the row never arrived. The assertions are that
+// our own boundary refuses what the stream would have accepted-and-discarded.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { z } from "zod";
+
+import {
+  isSendable,
+  streamSchemaFrom,
+  validateStreamBatch,
+} from "../src/pipeline-stream-contract.ts";
+
+/** The spike's own schema, as a Zod source. */
+const SpikeEvent = z
+  .object({
+    netuid: z.int().min(0),
+    observed_at: z.int(),
+    note: z.string().optional(),
+  })
+  .strict();
+
+describe("the stream schema is DERIVED, so it cannot drift from the Zod one", () => {
+  test("field names, types and requiredness come from the shape", () => {
+    assert.deepEqual(streamSchemaFrom(SpikeEvent), {
+      fields: [
+        { name: "netuid", type: "int64", required: true },
+        { name: "observed_at", type: "int64", required: true },
+        { name: "note", type: "string", required: false },
+      ],
+    });
+  });
+
+  test("a bare number is float64, an int is int64, an int32 is int32", () => {
+    // The distinction that matters: declaring `z.number()` an integer would
+    // truncate every fractional value at the sink, with no error anywhere.
+    const s = streamSchemaFrom(
+      z.object({ ratio: z.number(), count: z.int(), small: z.int32() }),
+    );
+    assert.deepEqual(
+      s.fields.map((f) => [f.name, f.type]),
+      [
+        ["ratio", "float64"],
+        ["count", "int64"],
+        ["small", "int32"],
+      ],
+    );
+  });
+
+  test("nullable is not required, exactly as optional is not", () => {
+    // A stream has no null-vs-absent distinction, so a nullable field declared
+    // required means every null row is dropped -- silently.
+    const s = streamSchemaFrom(
+      z.object({ a: z.string().nullable(), b: z.string().optional() }),
+    );
+    assert.deepEqual(
+      s.fields.map((f) => f.required),
+      [false, false],
+    );
+  });
+
+  test("strings and bools map", () => {
+    const s = streamSchemaFrom(z.object({ s: z.string(), b: z.boolean() }));
+    assert.deepEqual(
+      s.fields.map((f) => f.type),
+      ["string", "bool"],
+    );
+  });
+
+  test("a BIGINT refuses, rather than being guessed into int64", () => {
+    // Zod cannot express bigint in JSON Schema and emits `{}` for it. An
+    // earlier draft of this module mapped it to int64 by hand -- which is a
+    // guess, and the guess is unsafe: a bigint outside the int64 range would
+    // be truncated at the sink with no error at the caller. Refusing makes the
+    // author choose a representation the stream can actually carry.
+    assert.throws(
+      () => streamSchemaFrom(z.object({ big: z.bigint() })),
+      /big has no representable JSON Schema type/,
+    );
+  });
+
+  test("an anyOf of nothing BUT null has no type to carry, and says so", () => {
+    // Reachable, not theoretical: `z.union([z.null(), z.null()])` emits
+    // `anyOf: [{type:"null"},{type:"null"}]`. There is no non-null branch to
+    // take a type from, so the field falls through to the same refusal as any
+    // other unrepresentable type rather than defaulting to one.
+    assert.throws(
+      () =>
+        streamSchemaFrom(z.object({ nothing: z.union([z.null(), z.null()]) })),
+      /nothing has no representable JSON Schema type/,
+    );
+  });
+
+  test("an UNMAPPED type throws rather than guessing", () => {
+    // The whole reason this is a throw. A default would pick a Pipelines type
+    // nobody chose, and the cost of choosing wrong is a row dropped at the
+    // sink with a 200 at the caller.
+    assert.throws(
+      () => streamSchemaFrom(z.object({ when: z.date() })),
+      /when has no representable JSON Schema type/,
+    );
+  });
+});
+
+describe("the cases the real stream accepted and then discarded", () => {
+  test("a MISSING required field is refused here", () => {
+    const batch = validateStreamBatch(SpikeEvent, [
+      { observed_at: 1786882803000, note: "missing-required-netuid" },
+    ]);
+    assert.deepEqual(batch.accepted, []);
+    assert.equal(batch.rejected.length, 1);
+    assert.equal(batch.rejected[0]!.index, 0);
+    assert.equal(batch.rejected[0]!.field, "netuid");
+    assert.equal(isSendable(batch), false);
+  });
+
+  test("a TYPE MISMATCH is refused here", () => {
+    const batch = validateStreamBatch(SpikeEvent, [
+      { netuid: "not-an-int", observed_at: 1786882804000 },
+    ]);
+    assert.deepEqual(batch.accepted, []);
+    assert.equal(batch.rejected[0]!.field, "netuid");
+  });
+
+  test("an UNKNOWN extra field is refused, because the sink STRIPS it", () => {
+    // The nastiest of the three: the stream took this row, wrote it, and
+    // dropped `surprise` with no error in any channel. The row looks fine
+    // afterwards, so nothing downstream can notice. `.strict()` is what makes
+    // that a caller-side error instead.
+    const batch = validateStreamBatch(SpikeEvent, [
+      { netuid: 4, observed_at: 1786882805000, surprise: "hello" },
+    ]);
+    assert.deepEqual(batch.accepted, []);
+    assert.match(batch.rejected[0]!.message, /unrecognized|unknown/i);
+  });
+
+  test("valid rows pass through unchanged, so this is not just refusing everything", () => {
+    // Non-vacuity. A boundary that rejected every batch would satisfy every
+    // assertion above and be useless.
+    const rows = [
+      { netuid: 1, observed_at: 1786882800000, note: "seq-1" },
+      { netuid: 2, observed_at: 1786882801000, note: "seq-2" },
+    ];
+    const batch = validateStreamBatch(SpikeEvent, rows);
+    assert.deepEqual(batch.accepted, rows);
+    assert.deepEqual(batch.rejected, []);
+    assert.equal(isSendable(batch), true);
+  });
+});
+
+describe("a bad row costs its own row and no others", () => {
+  test("the good rows survive and the bad one is named by INDEX", () => {
+    // Same reasoning as the staleness heartbeat isolating each lane: one
+    // malformed row in a 30,000-row pass must not cost the other 29,999. But
+    // it is reported, not swallowed -- which is the entire difference from
+    // what the stream does.
+    const batch = validateStreamBatch(SpikeEvent, [
+      { netuid: 1, observed_at: 1 },
+      { netuid: "bad", observed_at: 2 },
+      { netuid: 3, observed_at: 3 },
+    ]);
+    assert.deepEqual(
+      batch.accepted.map((r) => r.netuid),
+      [1, 3],
+    );
+    assert.equal(batch.rejected.length, 1);
+    assert.equal(batch.rejected[0]!.index, 1);
+    assert.equal(isSendable(batch), false);
+  });
+
+  test("an empty batch is sendable and accepts nothing", () => {
+    const batch = validateStreamBatch(SpikeEvent, []);
+    assert.deepEqual(batch, { accepted: [], rejected: [] });
+    assert.equal(isSendable(batch), true);
+  });
+
+  test("a whole-object failure still reports a row", () => {
+    // `null` fails the object itself rather than a field, so `issue.path` is
+    // empty. It must still produce a rejection with a usable index, or a batch
+    // of nulls would read as "nothing to send".
+    const batch = validateStreamBatch(SpikeEvent, [null]);
+    assert.equal(batch.rejected.length, 1);
+    assert.equal(batch.rejected[0]!.index, 0);
+    assert.equal(batch.rejected[0]!.field, "");
+  });
+});


### PR DESCRIPTION
Phase 1's spike (#10850) sent six events through a real Pipelines stream on
2026-08-16. Two never arrived, and the producer was told they had:

  missing required field  ->  200  {"success":true,"result":{"committed":1}}
  type mismatch           ->  200  {"success":true,"result":{"committed":1}}
  unknown extra field     ->  200  landed, the extra field STRIPPED
  malformed JSON          ->  400  rejected

So the ingest API answers `committed: 1` for a row it later discards. A caller
checking `success`, or even `committed`, counts a dropped row as written. The
drop does surface in `pipelinesUserErrorsAdaptiveGroups` -- but empty at four
minutes and populated at eleven, so it is a reconcile input and never a
synchronous check. The stripped-field case raises nothing at all, in either
channel: the row looks correct afterwards, so nothing downstream can notice.

This repo refuses that shape everywhere else -- a lane that looks healthy and
writes nothing is what #10710, #472 and #10838 each turned out to be. The answer
is not to trust the stream's validation. It is to make an invalid event unable
to reach it.

ONE SCHEMA, as everywhere else here. `schemas-src/` is the single source every
published artifact derives from, and openapi.json is generated rather than
written. A Pipelines stream has its own schema format, so hand-declaring it
beside a Zod schema would be a second copy of the same contract -- and a stream
schema that drifts fails in the SILENT direction, because the stream is the half
that does not complain. `streamSchemaFrom` derives the stream's field list from
the Zod schema; `validateStreamBatch` gates the send with `safeParse`. Neither
is optional: derivation without validation still lets a bad row through at
runtime, and validation without derivation lets the two disagree about what
"bad" means.

Three decisions worth naming:

- An UNMAPPED Zod type throws rather than defaulting. A default picks a
  Pipelines type nobody chose, and the cost of choosing wrong is a row dropped
  at the sink with a 200 at the caller -- so it is a build-time error, which is
  the only place it stays cheap.
- A bare `z.number()` is `float64`, `z.int()` is `int64`, `z.int32()` is
  `int32`. Declaring a float an integer would truncate every fractional value
  with no error anywhere.
- `nullable` is not required, exactly as `optional` is not. A stream has no
  null-vs-absent distinction, so a nullable field declared required means every
  null row is dropped.

Rejections are RETURNED, not thrown: one malformed row in a 30,000-row pass must
not cost the other 29,999, the same reasoning as the staleness heartbeat
isolating each lane. But they are not swallowed either -- the caller gets every
rejection with its index and field, which is exactly what the stream threw away.
`isSendable` is separate because "send the good ones and report the rest" and
"refuse the whole batch" are both legitimate and a caller should have to choose.

Pure: no retry, no batching, no send. Pacing and the 429 the spike measured
(5 MB/request hard-capped, a second large post refused for over 20s) belong to a
caller that owns a cadence, and both halves stay testable without a network.

Refs #10850