### PR TITLE
fix(accounts): the feed leg's projection short-circuit was inert, so every account still took the lifetime scan

### DIFF
--- a/schemas-src/artifacts/projection-envelope.ts
+++ b/schemas-src/artifacts/projection-envelope.ts
@@ -1,0 +1,46 @@
+// The envelope every scheduled projection artifact carries (#9146).
+//
+// LIVES HERE for the reason chain-rpc-envelope.ts states: a schema outside
+// schemas-src is outside `no-passthrough`, `schema-shape-duplicates` and
+// `schema-opacity`, which is exactly where an unreasoned open object survives.
+//
+// PARSED, NOT CAST. The watchdog that reads these objects had:
+//
+//   const value = (body as { generated_at?: unknown } | null)?.generated_at;
+//
+// which types the access without checking a byte. These bodies come out of R2,
+// were written by whatever deploy was live at the time, and are the sole input
+// to the only alarm covering the projection lanes -- so "looks about right" is
+// the wrong standard for the one thing that decides whether an operator is told.
+import { z } from "zod";
+
+/**
+ * What a projection artifact must carry for the staleness watchdog to judge it.
+ *
+ * DELIBERATELY LOOSE ABOUT THE PAYLOAD. Each lane's body differs (`windows`,
+ * `summary`, `rows`, ...) and this schema is not the place to state thirteen
+ * shapes -- the reader only needs the two fields every lane writes. Zod strips
+ * what it does not declare, so the payload is accepted and simply not carried
+ * forward; `.passthrough()` would be openness without a reason and
+ * `no-passthrough` rejects it, correctly.
+ *
+ * PER-FIELD `.catch(null)`, and that is the whole design. A body whose
+ * `generated_at` is a number is not a body the watchdog should refuse to read:
+ * it should read the field as UNREADABLE and let the rule say so, because
+ * "absent" and "malformed" are already two of its four verdicts. Failing the
+ * whole parse would collapse both into "the object could not be read", which is
+ * the distinction the watchdog exists to draw.
+ *
+ * `row_count` is `.nullable()` rather than defaulted to 0, and the difference is
+ * the point: a lane that does not report a count is not a lane that computed
+ * none. Treating silence as zero would fire the empty-projection alarm on every
+ * lane whose envelope predates the field.
+ */
+// NO INFERRED TYPE EXPORT. The one consumer reads the two fields straight off
+// `safeParse` and needs no name for the pair, so exporting one would be a
+// declaration nothing references -- which `validate:unreferenced-exports`
+// ratchets on, and a ratchet only ever falls.
+export const ProjectionArtifactEnvelopeSchema = z.object({
+  generated_at: z.string().nullable().optional().catch(null),
+  row_count: z.number().finite().nullable().optional().catch(null),
+});

--- a/schemas-src/internal-wire.ts
+++ b/schemas-src/internal-wire.ts
@@ -433,3 +433,66 @@ export const QuotaSpendResponseSchema = z
   })
   .catchall(z.unknown());
 export type QuotaSpendResponse = z.infer<typeof QuotaSpendResponseSchema>;
+
+/**
+ * One buffered statement, exactly as the lane would have executed it.
+ *
+ * MOVED HERE from src/neon-write-buffer.ts, which is where it was declared and
+ * therefore where it escaped `no-passthrough`, `schema-shape-duplicates` and
+ * `schema-opacity` -- the three gates this file's header exists to keep it
+ * inside. It belongs with the other hub shapes on this module's own rule (who
+ * wrote the bytes): NeonWriteBufferHub is one of our Durable Objects, and this
+ * is both its request body and its storage value.
+ *
+ * A SCHEMA rather than a hand-written type guard, because this shape crosses a
+ * trust boundary twice: the Durable Object parses it from a request body, and
+ * the flush parses it back out of durable storage written by a possibly OLDER
+ * deploy. Both are places where "looks about right" is not good enough, and a
+ * hand-rolled check drifts from the type it is meant to enforce the moment a
+ * field is added.
+ *
+ * `.strict()` on purpose, and permitted here for the reason the header gives:
+ * these bytes are OURS. An unknown key means the writer and the reader disagree
+ * about the format, which is worth failing on rather than ignoring -- the
+ * opposite of the foreign-wire rule, where an added field is routine.
+ */
+export const BufferedStatementSchema = z
+  .object({
+    /** The lane that produced it, so the flush can attribute a verdict. */
+    lane: z.string().min(1),
+    text: z.string().min(1),
+    // Deliberately NOT z.array(z.unknown()).nonempty(): a parameterless
+    // DELETE is an ordinary statement here, and rejecting it would drop it.
+    values: z.array(z.unknown()),
+  })
+  .strict();
+
+export type BufferedStatement = z.infer<typeof BufferedStatementSchema>;
+
+/**
+ * Our own `/graphql` endpoint's response, as the MCP `query_graphql` tool reads
+ * it back over HTTP.
+ *
+ * MOVED HERE from src/mcp-server.ts, and the move is not cosmetic: declared
+ * there, it carried `.passthrough()` -- an open object that survived only
+ * because `validate-no-passthrough` cannot see outside schemas-src. The
+ * passthrough is DROPPED rather than justified, because nothing depended on it.
+ * The one reader takes `payload.data` and `payload.errors` and nothing else, so
+ * Zod's default (strip what is not declared) leaves its behaviour identical --
+ * the same argument foreign-wire.ts's header makes for its own shapes.
+ *
+ * INTERNAL rather than foreign by this module's rule: the bytes come from our
+ * data-api Worker, so a drift here is a bug we can fix.
+ *
+ * Deliberately LOOSER than the tool's own output schema. `data` is legitimately
+ * `null` on a failed query, and the error entries are only ever summarized into
+ * one line, never re-published -- so neither is narrowed here. `.catch` keeps a
+ * malformed envelope from throwing inside a path whose whole job is reporting
+ * that something has already gone wrong.
+ */
+export const GraphqlResponsePayloadSchema = z
+  .object({
+    data: z.unknown().optional(),
+    errors: z.array(z.unknown()).catch([]).optional(),
+  })
+  .catch({});

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1054,6 +1054,57 @@ async function headProbe(
   return mergeNewestEvents(published, head, limit);
 }
 
+/**
+ * The feed for an account the projection HAS, in two bounded reads.
+ *
+ * THE CASE THAT IS ACTUALLY IN PRODUCTION. `headProbe` above needs `recent` --
+ * the published event map from metagraphed-infra#575 -- and no generation
+ * carries one yet: measured 2026-08-16, the live pointer publishes no
+ * `recent_limit` and shard 12350 of generation 20260815T062657Z holds 43
+ * accounts, all groups-only. So `readRecent` declines for EVERY account and
+ * every present account fell through to the unbounded lifetime scan, which is
+ * the 15s abort behind the 503 on /accounts/{ss58}.
+ *
+ * The groups alone are enough to bound it. They are a lifetime aggregate, so
+ * `[firstMs, lastMs]` provably contains every event at or before the fold, and
+ * `foldFloorMs` is where the fold stops -- the two ranges MEET, so together
+ * they cover the account's whole history with nothing outside them.
+ *
+ * ABOVE THE FOLD FIRST, and short-circuiting, because that window is small (one
+ * fold interval) and an account with `limit` events in it needs no second read
+ * at all -- those ARE the newest. Only an account quieter than that pays for
+ * the second query, and that one is bounded to its own active span instead of
+ * to all of time.
+ */
+async function spanProbe(
+  env: R2SqlEnv | null | undefined,
+  options: {
+    query: R2SqlReader;
+    where: string;
+    span: { firstMs: number; lastMs: number; foldFloorMs: number };
+    limit: number;
+  },
+): Promise<Record<string, unknown>[] | null> {
+  const { query, where, span, limit } = options;
+  const select = `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} `;
+  const above = await query(
+    env,
+    `${select}AND observed_at >= ${Math.trunc(span.foldFloorMs)} ${FEED_ORDER} LIMIT ${limit}`,
+  );
+  if (!above) return null;
+  if (above.length >= limit) return above.slice(0, limit);
+  // The folded remainder, bounded on BOTH sides by where the groups say this
+  // account's events are. `lastMs` is at or below the fold edge by
+  // construction, so this can never double-count a row the probe above found.
+  const folded = await query(
+    env,
+    `${select}AND observed_at >= ${Math.trunc(span.firstMs)} ` +
+      `AND observed_at <= ${Math.trunc(span.lastMs)} ${FEED_ORDER} LIMIT ${limit}`,
+  );
+  if (!folded) return null;
+  return mergeNewestEvents(above, folded, limit);
+}
+
 export async function loadAccountSummaryColdTier(
   env: R2SqlEnv | null | undefined,
   ss58: string,
@@ -1232,14 +1283,23 @@ export async function loadAccountSummaryColdTier(
             limit,
             published: found.recent.rows,
           })
-        : windowedRowRead<AccountEventsRow>(env, {
-            query: (e, sql) => query(e, sql, { onError: track("recent-feed") }),
-            table: "chain.account_events",
-            columns: EVENT_COLUMNS,
-            where: [where],
-            order: ` ${FEED_ORDER}`,
-            need: limit,
-          }),
+        : found?.span
+          ? spanProbe(env, {
+              query: (e, sql) =>
+                query(e, sql, { onError: track("recent-span") }),
+              where,
+              span: found.span,
+              limit,
+            })
+          : windowedRowRead<AccountEventsRow>(env, {
+              query: (e, sql) =>
+                query(e, sql, { onError: track("recent-feed") }),
+              table: "chain.account_events",
+              columns: EVENT_COLUMNS,
+              where: [where],
+              order: ` ${FEED_ORDER}`,
+              need: limit,
+            }),
   ]);
 
   // Either half missing is a decline: a card mixing measured aggregates with a

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -146,6 +146,28 @@ export interface AccountSummaryProjectionRead {
    * validated them.
    */
   recent: { rows: AccountSummaryRecentEvent[]; floorMs: number } | null;
+  /**
+   * WHERE THIS ACCOUNT'S FOLDED EVENTS LIE, from the groups' own first/last
+   * observed columns, plus the first millisecond the fold does not cover.
+   *
+   * The weaker half of `recent`, and the one that works TODAY. `recent` needs a
+   * producer publishing the map from metagraphed-infra#575; every generation in
+   * production carries groups and no map, so that leg declines for every
+   * account and the feed goes back to an unbounded lifetime scan. These three
+   * numbers come out of groups the producer has always written.
+   *
+   * WHAT MAKES IT A BOUND rather than a hint: the groups are a LIFETIME
+   * aggregate (the read above declines anything over the scan cap rather than
+   * publishing a windowed subtotal), so every event at or before the fold sits
+   * inside `[firstMs, lastMs]` by construction. Nothing older than `firstMs`
+   * exists to miss, and everything newer than `lastMs` is above `foldFloorMs`.
+   * The two ranges therefore MEET rather than overlapping or leaving a gap --
+   * the same edge argument `recentFloorMs` makes for `recent`.
+   *
+   * Null when the generation left any of the three unreadable: a partial bound
+   * is not a bound, and guessing one would drop events off the end of a feed.
+   */
+  span: { firstMs: number; lastMs: number; foldFloorMs: number } | null;
   /** Never set on a read that FOUND the account. The discriminant against
    * `AccountSummaryProjectionAbsent`, so a caller cannot confuse "here are the
    * account's groups" with "this account has no history before `floorMs`". */
@@ -343,11 +365,47 @@ export async function loadAccountSummaryProjection(
 
   return {
     groups,
+    span: groupsSpan(groups, pointer.through),
     // `scanned` is the account's lifetime event count, already summed above to
     // apply the cap -- reused rather than recomputed so the two decisions
     // cannot disagree about how many events this account has.
     ...readRecent(payload, account, pointer, recentLimit, scanned),
   };
+}
+
+/**
+ * The window the groups prove this account's folded events sit inside.
+ *
+ * ALL THREE OR NOTHING. A first without a last bounds only one end, and a
+ * bound without `foldFloorMs` cannot say where the folded range stops and the
+ * live one begins -- so a caller handed two of the three would have to invent
+ * the missing edge, which is how a feed silently loses its newest or oldest
+ * rows. Returning null sends that caller back to the unbounded read it already
+ * knows how to do.
+ */
+function groupsSpan(
+  groups: readonly Record<string, unknown>[],
+  through: string | undefined,
+): { firstMs: number; lastMs: number; foldFloorMs: number } | null {
+  const foldFloorMs = recentFloorMs(through);
+  if (foldFloorMs === null) return null;
+  // BOTH FINITE BY CONSTRUCTION, so there is no emptiness guard below: the
+  // caller returns before this on `!groups.length`, and every group that
+  // reaches the loop contributes two numbers or returns null. A
+  // `Number.isFinite` check on the result would be a branch nothing can take,
+  // which codecov counts and which reads as safety without being any.
+  let firstMs = Number.POSITIVE_INFINITY;
+  let lastMs = Number.NEGATIVE_INFINITY;
+  for (const group of groups) {
+    const fo = group.fo;
+    const lo = group.lo;
+    // A single null makes the span a guess: this group's events are somewhere
+    // unknown, so the range no longer provably contains every event.
+    if (typeof fo !== "number" || typeof lo !== "number") return null;
+    if (fo < firstMs) firstMs = fo;
+    if (lo > lastMs) lastMs = lo;
+  }
+  return { firstMs, lastMs, foldFloorMs };
 }
 
 /**

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
 import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
+import { GraphqlResponsePayloadSchema } from "../schemas-src/internal-wire.ts";
 import {
   DECLARATIONS_REQUIRING_A_GPU,
   MIN_COMPUTE_SURFACES_REGISTERED,
@@ -4662,19 +4663,10 @@ const GraphqlErrorEntrySchema = z
   .catch({ message: "(no message)" });
 
 // The GraphQL-over-HTTP response envelope, as read back through
-// Response.json(). Deliberately looser than QueryGraphqlOutputSchema (which
-// describes what this TOOL returns): `data` is legitimately `null` on a failed
-// query, which that schema's `.optional()` does not admit, and the error
-// entries are only ever summarized, never re-published. `.catch` keeps a
-// malformed envelope from throwing inside a path whose whole job is reporting
-// that something already went wrong.
-const GraphqlResponsePayloadSchema = z
-  .object({
-    data: z.unknown().optional(),
-    errors: z.array(z.unknown()).catch([]).optional(),
-  })
-  .passthrough()
-  .catch({});
+// The schema lives in schemas-src/internal-wire.ts (#11194's rule). Declared
+// here it also carried `.passthrough()`, which survived only because
+// `validate-no-passthrough` cannot see outside schemas-src; nothing read the
+// undeclared keys, so the move drops it with no change in behaviour.
 
 /** Flatten a GraphQL errors[] into one bounded, human-readable line. */
 function summarizeGraphqlErrors(errors: unknown[]): string {

--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -51,7 +51,12 @@
 // lets the ordering and chunking guarantees be asserted directly instead of
 // inferred from a mock.
 
-import { z } from "zod";
+import {
+  BufferedStatementSchema,
+  type BufferedStatement,
+} from "../schemas-src/internal-wire.ts";
+export { BufferedStatementSchema };
+export type { BufferedStatement };
 import {
   createPgSql,
   type HyperdriveLike,
@@ -93,31 +98,14 @@ export type NeonWriteEnv = StoreEnv &
 
 type NeonWriteBufferEnv = NeonWriteEnv;
 
-/**
- * One buffered statement, exactly as the lane would have executed it.
- *
- * A ZOD SCHEMA rather than a hand-written type guard, because this shape
- * crosses a trust boundary: the Durable Object parses it from a request body,
- * and the flush parses it back out of durable storage written by a possibly
- * older deploy. Both are places where "looks about right" is not good enough,
- * and a hand-rolled check drifts from the type it is supposed to enforce the
- * moment a field is added.
- *
- * `.strict()` on purpose -- an unknown key means the writer and the reader
- * disagree about the format, which is worth failing on rather than ignoring.
- */
-export const BufferedStatementSchema = z
-  .object({
-    /** The lane that produced it, so the flush can attribute a verdict. */
-    lane: z.string().min(1),
-    text: z.string().min(1),
-    // Deliberately NOT z.array(z.unknown()).nonempty(): a parameterless
-    // DELETE is an ordinary statement here, and rejecting it would drop it.
-    values: z.array(z.unknown()),
-  })
-  .strict();
-
-export type BufferedStatement = z.infer<typeof BufferedStatementSchema>;
+// THE SCHEMA LIVES IN schemas-src (#11194's rule). It was declared here, which
+// put it outside `no-passthrough`, `schema-shape-duplicates` and
+// `schema-opacity` -- the gates that keep a declared vocabulary honest. It is
+// one of our Durable Objects' wire AND storage shapes, so it sits with the
+// other hub shapes in internal-wire.ts.
+//
+// IMPORTED THEN RE-EXPORTED, not `export ... from`: a bare re-export does not
+// bind the name locally, and decodeStatement below parses with it.
 
 /**
  * Durable Object storage caps a single value at 128 KiB.
@@ -373,6 +361,23 @@ export const NEVER_BUFFER_LANES: ReadonlySet<string> = new Set([
   // in the flag -- `raw-capture-state` was the FIRST lane named in
   // NEON_WRITE_BUFFER_LANES, added as an obvious low-frequency write, and
   // nothing about the write site says its reader is one minute away.
+  //
+  // THE HAZARD IS CURSOR TABLES: a single row whose value is a POSITION that a
+  // later pass resumes from. That is the property to check before adding a lane
+  // to the flag, and it is not the same as "something reads this table" -- every
+  // buffered table is read by a route. The question is whether the read's result
+  // decides the next WRITE. `tao_usd_index` is the instructive contrast: also
+  // buffered, also read constantly, but append-only on (block_number,
+  // observed_at) with ON CONFLICT DO NOTHING, so its producer never consults it
+  // and a deferred write costs a stale chart rather than repeated work.
+  //
+  // Deliberately a sentence and not a gate. A derived sweep was attempted and
+  // abandoned: "imports the lane's writer AND selects the lane's table" reports
+  // eight offenders, all of them workers/data-api.ts, which is both the producer
+  // entry point and the serving layer -- so the import edge cannot separate a
+  // cursor read from a route read, and shipping it would have required an
+  // eight-entry suppression list on day one. `raw-capture-state` is the only
+  // cursor table in the buffered set today.
   "raw-capture-state",
 ]);
 

--- a/src/projection-staleness-watchdog.ts
+++ b/src/projection-staleness-watchdog.ts
@@ -13,10 +13,20 @@
 // with a plausible-looking blank. What was missing is the other half: someone
 // asking how long that has been going on.
 //
+// AND THE OPPOSITE SHAPE, which the age check cannot see (#11406's aftermath).
+// A lane that runs on time and computes ZERO rows overwrites the good artifact
+// with an empty one, so `generated_at` never ages and this watchdog reported
+// `ok` every 30 minutes for a day while the site's 24h on-chain volume showed
+// an em-dash. The all-or-nothing contract only covers a FAILED query (`null`);
+// an empty answer (`[]`) is stored, and of the thirteen lanes only
+// computeBlocksSummary declines to store it. So freshness is not coverage, and
+// `evaluateProjectionStaleness` now reads `row_count` as well as the timestamp.
+//
 // Same shape as src/nominator-positions-staleness-watchdog.ts deliberately --
 // a pure rule, a summary rather than a throw, and one exception event per
 // stale tick. Zero alerts is the correct steady state.
 
+import { ProjectionArtifactEnvelopeSchema } from "../schemas-src/artifacts/projection-envelope.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { DEFAULT_CHAIN_NETWORK, projectionKey } from "./chain-network.ts";
 import { PROJECTION_LANES, PROJECTION_NETWORKS } from "./projection-lanes.ts";
@@ -123,9 +133,11 @@ export interface ProjectionStalenessEntry {
    * runProjectionLanes uses, so an alert and a run summary name one thing. */
   lane: string;
   stale: boolean;
-  reason: "absent" | "unreadable" | "stale" | null;
+  reason: "absent" | "unreadable" | "stale" | "empty" | null;
   age_ms: number | null;
   generated_at: string | null;
+  /** Rows the lane last computed, or null when the artifact does not say. */
+  row_count: number | null;
 }
 
 export interface ProjectionStalenessVerdict {
@@ -138,12 +150,18 @@ export interface ProjectionStalenessVerdict {
 
 /** The rule alone, testable without a bucket or a clock. */
 export function evaluateProjectionStaleness(input: {
-  artifacts: { lane: string; generatedAt: string | null | undefined }[];
+  artifacts: {
+    lane: string;
+    generatedAt: string | null | undefined;
+    /** `row_count` from the artifact body; absent/unreadable => null. */
+    rowCount?: number | null;
+  }[];
   nowMs: number;
   thresholdMs: number;
 }): ProjectionStalenessVerdict {
   const { artifacts, nowMs, thresholdMs } = input;
-  const entries = artifacts.map(({ lane, generatedAt }) => {
+  const entries = artifacts.map(({ lane, generatedAt, rowCount }) => {
+    const rows = typeof rowCount === "number" ? rowCount : null;
     if (generatedAt == null) {
       // An artifact that is not there at all is a stall of infinite age, not a
       // quiet lane: every lane in the registry is supposed to have written on
@@ -154,6 +172,7 @@ export function evaluateProjectionStaleness(input: {
         reason: "absent" as const,
         age_ms: null,
         generated_at: null,
+        row_count: rows,
       };
     }
     const at = Date.parse(generatedAt);
@@ -166,15 +185,62 @@ export function evaluateProjectionStaleness(input: {
         reason: "unreadable" as const,
         age_ms: null,
         generated_at: generatedAt,
+        row_count: rows,
       };
     }
     const age = nowMs - at;
+    if (age > thresholdMs) {
+      return {
+        lane,
+        stale: true,
+        reason: "stale" as const,
+        age_ms: age,
+        generated_at: generatedAt,
+        row_count: rows,
+      };
+    }
+    // FRESH BUT EMPTY -- the failure this watchdog could not see.
+    //
+    // The module header says it exists because two lanes "stopped writing".
+    // This is the opposite shape and the age check cannot reach it: the lane
+    // runs on time, computes zero rows, and overwrites a good artifact with an
+    // empty one, so `generated_at` stays minutes old forever while every route
+    // over the card serves its zeroed floor.
+    //
+    // MEASURED 2026-08-16: `metagraph/projections/chain-alpha-volume.json` read
+    // `{generated_at: "…11:46:31Z", row_count: 0, windows: {24h: {rows: []}}}`
+    // -- minutes old -- because its rolling 24h window queried a lakehouse
+    // whose newest data was ~29h back, so no row it could return existed. The
+    // site's 24h on-chain volume showed an em-dash for a day and this watchdog
+    // reported `ok` every 30 minutes throughout.
+    //
+    // ONLY AN EXPLICIT ZERO, never a missing field: an artifact that does not
+    // report `row_count` is not making a claim about its own coverage, and
+    // treating silence as zero would fire this on every lane whose envelope
+    // predates the field.
+    //
+    // These lanes are rolling-window aggregates over a chain producing a block
+    // every 12s, so zero rows in the window is not a quiet period -- it means
+    // the window and the data no longer overlap. A lane that CAN legitimately
+    // be empty should be exempted by name, with the reason written down, rather
+    // than by weakening this into a rule that cannot fire.
+    if (rows === 0) {
+      return {
+        lane,
+        stale: true,
+        reason: "empty" as const,
+        age_ms: age,
+        generated_at: generatedAt,
+        row_count: 0,
+      };
+    }
     return {
       lane,
-      stale: age > thresholdMs,
-      reason: age > thresholdMs ? ("stale" as const) : null,
+      stale: false,
+      reason: null,
       age_ms: age,
       generated_at: generatedAt,
+      row_count: rows,
     };
   });
   const staleLanes = entries.filter((e) => e.stale).map((e) => e.lane);
@@ -232,21 +298,37 @@ export async function runProjectionStalenessWatchdog(
     Number(env?.PROJECTION_STALENESS_THRESHOLD_MS) ||
     PROJECTION_STALENESS_THRESHOLD_MS;
 
-  const artifacts: { lane: string; generatedAt: string | null }[] = [];
+  const artifacts: {
+    lane: string;
+    generatedAt: string | null;
+    rowCount: number | null;
+  }[] = [];
   for (const { lane, key } of watchedLanes()) {
     let generatedAt: string | null;
+    let rowCount: number | null;
     try {
       const object = await bucket.get(key);
       const body = object ? ((await object.json()) as unknown) : null;
-      const value = (body as { generated_at?: unknown } | null)?.generated_at;
-      generatedAt = typeof value === "string" ? value : null;
+      // PARSED, not cast (#11194's rule, one boundary further out). The cast
+      // this replaces typed the access without checking a byte of it, and these
+      // bodies come out of R2 written by whatever deploy was live at the time.
+      // Both fields come off ONE parse of the SAME body, so the count and the
+      // timestamp can never describe two different objects, and a malformed
+      // field lands as null through the schema's own `.catch` rather than
+      // through a typeof check restated at each read site.
+      const envelope = ProjectionArtifactEnvelopeSchema.safeParse(body);
+      generatedAt = envelope.success
+        ? (envelope.data.generated_at ?? null)
+        : null;
+      rowCount = envelope.success ? (envelope.data.row_count ?? null) : null;
     } catch {
       // An unreadable object is reported as absent rather than skipped: a
       // watchdog that quietly drops what it could not read is a watchdog that
       // reports healthy on exactly the lanes worth worrying about.
       generatedAt = null;
+      rowCount = null;
     }
-    artifacts.push({ lane, generatedAt });
+    artifacts.push({ lane, generatedAt, rowCount });
   }
 
   const verdict = evaluateProjectionStaleness({
@@ -260,14 +342,14 @@ export async function runProjectionStalenessWatchdog(
     // for one dead cron is the failure mode where an alarm stops being read.
     const detail = verdict.entries
       .filter((entry) => entry.stale)
-      .map(
-        (entry) =>
-          `${entry.lane} (${
-            entry.age_ms === null
-              ? entry.reason
-              : `${(entry.age_ms / 3_600_000).toFixed(1)} h old`
-          })`,
-      )
+      .map((entry) => {
+        // An EMPTY lane is fresh, so reporting its age would say "0.2 h old"
+        // about the one entry whose age is not the problem. Each reason states
+        // the fact that made it stale.
+        if (entry.reason === "empty") return `${entry.lane} (fresh, 0 rows)`;
+        if (entry.age_ms === null) return `${entry.lane} (${entry.reason})`;
+        return `${entry.lane} (${(entry.age_ms / 3_600_000).toFixed(1)} h old)`;
+      })
       .join(", ");
     await record(env, {
       error: new Error(
@@ -275,7 +357,7 @@ export async function runProjectionStalenessWatchdog(
           thresholdMs / 3_600_000
         ).toFixed(
           1,
-        )} h, ${PROJECTION_STALENESS_MISSED_TICKS} missed ticks of ${PROJECTION_LANES_CRON}) -- the routes over these are answering from a card nothing is refreshing`,
+        )} h, ${PROJECTION_STALENESS_MISSED_TICKS} missed ticks of ${PROJECTION_LANES_CRON}) -- the routes over these are answering from a card that is either not being refreshed or is being refreshed with nothing`,
       ),
       route: "watchdog:projection-staleness",
       errorCode: "stale_lane",

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -34,6 +34,12 @@ import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
 import { missedTicksMs, type ProducerLane } from "./producer-cadence.ts";
+// DERIVED, not quoted. This read "RAW_CAPTURE_CRON every 5 min" until #11402
+// moved the lane to */1 and left the prose behind -- the drift
+// project-derived-floors-go-stale-in-prose is about. Reading the cadence from
+// the cron itself means the sentence cannot outlive the schedule it describes.
+import { RAW_CAPTURE_CRON } from "../workers/config.ts";
+import { cronStepMinutes } from "./raw-capture-sync.ts";
 
 /** This watchdog's own lane. */
 export const TABLE_FRESHNESS_LANE = "table-freshness";
@@ -181,7 +187,7 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     column: "updated_at",
     kind: "ms",
     maxAgeMs: 2 * HOUR,
-    reason: "RAW_CAPTURE_CRON every 5 min",
+    reason: `RAW_CAPTURE_CRON every ${cronStepMinutes(RAW_CAPTURE_CRON)} min`,
   },
   // `raw_capture_state_v2` was declared here purely to satisfy the old
   // invariant -- "account for every table tests/fixtures/sqlite-schema names"

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -885,6 +885,104 @@ describe("the projection short-circuits the FEED leg too (#11222)", () => {
   });
 
   /**
+   * GROUPS BUT NO RECENT MAP -- which is every account in production today.
+   *
+   * The probe above needs metagraphed-infra#575's published event map. Measured
+   * 2026-08-16, no generation carries one: the live pointer publishes no
+   * `recent_limit`, and shard 12350 of generation 20260815T062657Z held 43
+   * accounts, all groups-only. So `readRecent` declined for EVERY account and
+   * the feed fell through to the unbounded lifetime scan -- which is the 15s
+   * abort behind the 503 the account page was serving.
+   *
+   * The groups alone bound it: they are a LIFETIME aggregate, so every folded
+   * event sits inside [fo, lo], and `through` says where the fold stops.
+   */
+  describe("an account with groups but no published recent map", () => {
+    test("bounds BOTH reads instead of scanning all of history", async () => {
+      const engine = fakeEngine({ recent: [] });
+      // `archive(null)` publishes no recent_limit and no recent map -- the
+      // production shape, verbatim.
+      const cold = await loadAccountSummaryColdTier(archive(null), SS58, {
+        query: engine.query as never,
+      });
+      assert.equal(cold.declined, undefined);
+      const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
+      assert.equal(feed.length, 2, "above the fold, then the folded remainder");
+      // The live half starts exactly where the fold stops.
+      assert.match(feed[0]!, new RegExp(`observed_at >= ${FLOOR}\\b`));
+      // The folded half is bounded on BOTH sides by the groups' own columns.
+      assert.match(feed[1]!, new RegExp(`observed_at >= ${AGG.fo}\\b`));
+      assert.match(feed[1]!, new RegExp(`observed_at <= ${AGG.lo}\\b`));
+      // The defect coming back would be a read with no lower bound at all.
+      for (const sql of feed) {
+        assert.match(
+          sql,
+          /observed_at >= /,
+          `unbounded read: ${sql.slice(0, 90)}`,
+        );
+      }
+    });
+
+    test("either bounded read FAILING declines -- never a half feed", async () => {
+      // Both halves are load-bearing: serving the live half alone would publish
+      // a feed silently missing everything the fold covers, and serving the
+      // folded half alone would freeze it at the last complete day. A null from
+      // the engine is a decline, exactly as the unbounded walk's was.
+      const first = fakeEngine({ recent: null });
+      const coldFirst = await loadAccountSummaryColdTier(archive(null), SS58, {
+        query: first.query as never,
+      });
+      assert.ok(
+        coldFirst.declined?.some((r) => r.startsWith("recent-span:")),
+        "the first probe's failure must be reported as a decline",
+      );
+
+      // The SECOND read failing is the harder case: the first one succeeded, so
+      // there are rows in hand that a careless implementation would serve.
+      let call = 0;
+      const flaky = async (
+        env: unknown,
+        sql: string,
+        deps?: { onError?: (detail: string) => void },
+      ) => {
+        if (sql.includes("GROUP BY")) return good.query(env, sql, deps);
+        call += 1;
+        if (call === 1) return good.query(env, sql, deps);
+        deps?.onError?.("r2 sql: HTTP 500 (stubbed failure)");
+        return null;
+      };
+      const good = fakeEngine({ recent: [event()] });
+      const coldSecond = await loadAccountSummaryColdTier(archive(null), SS58, {
+        query: flaky as never,
+      });
+      assert.ok(
+        coldSecond.declined?.some((r) => r.startsWith("recent-span:")),
+        "a failed folded read must not serve the live half alone",
+      );
+    });
+
+    test("a full page above the fold needs no second read", async () => {
+      // Those rows ARE the newest, so the folded half cannot contribute one.
+      const engine = fakeEngine({
+        // ABOVE the fold floor, or the first probe's own predicate filters
+        // them out and there is nothing to short-circuit on.
+        recent: Array.from({ length: ACCOUNT_SUMMARY_RECENT_LIMIT }, (_, i) =>
+          event({
+            block_number: 8_800_000 + i,
+            event_index: i,
+            observed_at: FLOOR + 60_000 + i,
+          }),
+        ),
+      });
+      await loadAccountSummaryColdTier(archive(null), SS58, {
+        query: engine.query as never,
+      });
+      const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
+      assert.equal(feed.length, 1, "the second query must not be issued");
+    });
+  });
+
+  /**
    * The account the projection has NEVER seen -- every account registered since
    * the last generation, and the case that used to be the slowest thing here.
    *
@@ -1011,9 +1109,11 @@ describe("the projection short-circuits the FEED leg too (#11222)", () => {
     );
   });
 
-  test("no published recent list falls back to the walk, unchanged", async () => {
-    // Every generation before metagraphed-infra#575 lands here, and the route
-    // must behave exactly as it did -- the aggregate leg still short-circuits.
+  test("no published recent list still bounds, on the GROUPS instead", async () => {
+    // This asserted the unbounded walk until the span bound existed, because
+    // without a published list there was nothing for a floor to MEET. The
+    // groups supply that edge themselves, so the fallback is now bounded --
+    // which matters, since every generation in production lands here.
     const engine = fakeEngine();
     const cold = await loadAccountSummaryColdTier(archive(null), SS58, {
       query: engine.query as never,
@@ -1021,14 +1121,19 @@ describe("the projection short-circuits the FEED leg too (#11222)", () => {
     assert.equal(cold.declined, undefined);
     const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
     assert.ok(feed.length >= 1);
-    assert.equal(
-      feed.some((s) => s.includes(`observed_at >= ${FLOOR}`)),
-      false,
-      "no floor is placed without a published list to meet it",
-    );
+    for (const sql of feed) {
+      assert.match(
+        sql,
+        /observed_at >= /,
+        `the walk is back: ${sql.slice(0, 90)}`,
+      );
+    }
   });
 
-  test("a published limit under the caller's need falls back too", async () => {
+  test("a published limit under the caller's need falls back to the span", async () => {
+    // The recent map is still refused -- serving a list shorter than the caller
+    // asked for would publish a feed missing its tail -- but the fallback is
+    // the bounded span read rather than the walk.
     const engine = fakeEngine();
     const cold = await loadAccountSummaryColdTier(
       archive([event()], { limit: ACCOUNT_SUMMARY_RECENT_LIMIT - 1 }),
@@ -1037,10 +1142,10 @@ describe("the projection short-circuits the FEED leg too (#11222)", () => {
     );
     assert.equal(cold.declined, undefined);
     const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
-    assert.equal(
-      feed.some((s) => s.includes(`observed_at >= ${FLOOR}`)),
-      false,
-    );
+    assert.ok(feed.length >= 1);
+    for (const sql of feed) {
+      assert.match(sql, /observed_at >= /);
+    }
   });
 });
 

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -132,6 +132,107 @@ async function readFound(
   return got;
 }
 
+/**
+ * The span the GROUPS prove, which is the bound that works today.
+ *
+ * `recent` needs metagraphed-infra#575's published event map, and no generation
+ * carries one: measured 2026-08-16 the live pointer publishes no `recent_limit`
+ * and shard 12350 of generation 20260815T062657Z held 43 accounts, every one of
+ * them groups-only. So the feed leg declined for EVERY account and fell to an
+ * unbounded lifetime scan -- the 15s abort behind the 503 on /accounts/{ss58}.
+ */
+describe("the span the groups prove", () => {
+  test("brackets every folded event, and says where the fold stops", async () => {
+    const store = archive(
+      published(
+        {
+          // THREE groups, deliberately unordered: the middle one moves both
+          // ends outward and the last moves neither, so the running min/max
+          // are exercised in both directions. Two ordered groups would leave
+          // half of each comparison untaken.
+          [HOT]: [
+            { ...group(), fo: 5_000, lo: 3_000 },
+            { ...group(), kind: "Transfer", fo: 1_000, lo: 9_000 },
+            { ...group(), kind: "StakeAdded", fo: 7_000, lo: 8_000 },
+          ],
+        },
+        { through: "2026-08-13" },
+      ),
+    );
+    const found = await readFound(store.env, HOT, FRESH);
+    assert.deepEqual(found.span, {
+      // The EARLIEST first-observed and the LATEST last-observed across every
+      // group -- one group's window alone would not contain the other's rows.
+      firstMs: 1_000,
+      lastMs: 9_000,
+      // Midnight after the last complete day folded, so the bounded range and
+      // the live probe MEET rather than overlapping or leaving a gap.
+      foldFloorMs: Date.parse("2026-08-14T00:00:00.000Z"),
+    });
+  });
+
+  test("one null fo or lo declines the whole span", async () => {
+    // A partial bound is not a bound: the caller would have to invent the
+    // missing edge, which drops rows off one end of the feed.
+    for (const bad of [{ fo: null }, { lo: null }]) {
+      const store = archive(
+        published(
+          {
+            [HOT]: [
+              { ...group(), fo: 1_000, lo: 2_000 },
+              { ...group(), ...bad },
+            ],
+          },
+          { through: "2026-08-13" },
+        ),
+      );
+      const found = await readFound(store.env, HOT, FRESH);
+      assert.equal(found.span, null, JSON.stringify(bad));
+    }
+  });
+
+  test("no `through` means no fold edge, so no span", async () => {
+    const store = archive(
+      published({ [HOT]: [{ ...group(), fo: 1_000, lo: 2_000 }] }),
+    );
+    assert.equal((await readFound(store.env, HOT, FRESH)).span, null);
+  });
+
+  test("the production shape -- groups only, no recent map -- still bounds", async () => {
+    // Read verbatim out of R2 on 2026-08-16: one group, no `recent` map on the
+    // shard and no `recent_limit` on the pointer. Before this, exactly this
+    // payload sent the feed to an unbounded scan.
+    const store = archive(
+      published(
+        {
+          [HOT]: [
+            {
+              kind: "NeuronRegistered",
+              netuid: 105,
+              count: 1,
+              fb: 8836052,
+              lb: 8836052,
+              fo: 1786629372000,
+              lo: 1786629372000,
+            },
+          ],
+        },
+        { through: "2026-08-14" },
+      ),
+    );
+    const found = await readFound(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 25,
+    });
+    assert.equal(found.recent, null, "premise: no recent map is published");
+    assert.deepEqual(found.span, {
+      firstMs: 1786629372000,
+      lastMs: 1786629372000,
+      foldFloorMs: Date.parse("2026-08-15T00:00:00.000Z"),
+    });
+  });
+});
+
 describe("loadAccountSummaryProjection", () => {
   test("reads the pointer, THEN the account's shard in that generation", async () => {
     const store = archive(published({ [HOT]: [group()] }));
@@ -155,6 +256,9 @@ describe("loadAccountSummaryProjection", () => {
       // No `recentLimit` asked for, so the feed leg is not read at all -- the
       // aggregate leg is what every caller before #575 wanted and still gets.
       recent: null,
+      // No `through` on this pointer, so there is no fold edge to bound
+      // against and the span declines rather than guessing one.
+      span: null,
     });
   });
 
@@ -340,6 +444,8 @@ describe("loadAccountSummaryProjection", () => {
     );
     assert.deepEqual(await readFound(store.env, HOT, FRESH), {
       recent: null,
+      // Null `fo`/`lo` make the range a guess, so there is no span to offer.
+      span: null,
       groups: [
         {
           kind: "Transfer",

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -20,7 +20,7 @@ import {
   PROJECTION_NETWORKS,
 } from "../src/projection-lanes.ts";
 import { PROJECTION_LANES_CRON } from "../workers/config.ts";
-import { projectionKey } from "../src/chain-network.ts";
+import { DEFAULT_CHAIN_NETWORK, projectionKey } from "../src/chain-network.ts";
 import { runStalenessLane } from "./helpers/staleness-lane.ts";
 
 const HOUR = 3_600_000;
@@ -114,6 +114,86 @@ describe("evaluateProjectionStaleness", () => {
   });
 });
 
+/**
+ * The OTHER shape: a lane that runs on time and computes nothing.
+ *
+ * The age check cannot see it -- `generated_at` is minutes old on every tick
+ * -- so this went unreported for a day while the site served an em-dash.
+ */
+describe("evaluateProjectionStaleness -- fresh but empty", () => {
+  const FRESH = "2026-08-16T11:46:31.923Z";
+  const NOW = Date.parse("2026-08-16T12:00:00.000Z");
+
+  test("catches the real chain-alpha-volume artifact, verbatim", () => {
+    // Read out of R2 on 2026-08-16 while /api/v1/chain/alpha-volume was
+    // answering total_volume_tao: 0 with observed_at: null. Minutes old, and
+    // empty because its rolling 24h window queried a lakehouse whose newest
+    // data was ~29h back -- the raw-capture stall #11406 fixed.
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [
+        { lane: "chain-alpha-volume", generatedAt: FRESH, rowCount: 0 },
+      ],
+      nowMs: NOW,
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true, "the watchdog reported ok for a day");
+    assert.deepEqual(verdict.stale_lanes, ["chain-alpha-volume"]);
+    const entry = verdict.entries[0]!;
+    assert.equal(entry.reason, "empty");
+    assert.equal(entry.row_count, 0);
+    assert.ok(
+      (entry.age_ms ?? 0) < PROJECTION_STALENESS_THRESHOLD_MS,
+      "premise: it is FRESH -- the age rule could never have caught this",
+    );
+  });
+
+  test("a lane with rows is healthy, so the rule is not vacuous", () => {
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [
+        { lane: "chain-alpha-volume", generatedAt: FRESH, rowCount: 128 },
+      ],
+      nowMs: NOW,
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, false);
+    assert.equal(verdict.entries[0]!.reason, null);
+    assert.equal(verdict.entries[0]!.row_count, 128);
+  });
+
+  test("a MISSING row_count is not read as zero", () => {
+    // Silence is not a claim. An envelope that predates the field would
+    // otherwise fire this on every lane at once, which is how a new alarm gets
+    // muted on the day it ships.
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [{ lane: "chain-fees", generatedAt: FRESH }],
+      nowMs: NOW,
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, false);
+    assert.equal(verdict.entries[0]!.reason, null);
+    assert.equal(verdict.entries[0]!.row_count, null);
+  });
+
+  test("an OLD and empty lane still reports its AGE, not its emptiness", () => {
+    // Both are true; the age is the bigger fact, and reporting "0 rows" for a
+    // lane nothing has written in two days would name the wrong problem.
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [
+        {
+          lane: "chain-stake-moves",
+          generatedAt: "2026-08-14T09:13:53.426Z",
+          rowCount: 0,
+        },
+      ],
+      nowMs: NOW,
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.equal(verdict.entries[0]!.reason, "stale");
+    assert.equal(verdict.entries[0]!.row_count, 0, "still reported, not lost");
+  });
+});
+
 describe("runProjectionStalenessWatchdog", () => {
   /** A bucket whose objects carry the given ages, keyed by artifact key. */
   function bucketWith(ages: Record<string, string | null>, fail = false) {
@@ -144,6 +224,98 @@ describe("runProjectionStalenessWatchdog", () => {
     }
     return out;
   }
+
+  /** Like bucketWith, but every object also carries a `row_count`. */
+  function bucketWithRows(
+    ages: Record<string, string>,
+    rows: Record<string, number>,
+  ) {
+    return {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          const generated = ages[key];
+          if (generated === undefined) return null;
+          return {
+            async json() {
+              return {
+                schema_version: 1,
+                generated_at: generated,
+                ...(key in rows ? { row_count: rows[key] } : {}),
+              };
+            },
+          };
+        },
+      },
+    } as unknown as Record<string, unknown>;
+  }
+
+  test("reads row_count off the SAME body and names the empty lane", async () => {
+    // The wiring, not the rule: the runner has to pull `row_count` out of the
+    // artifact it already parsed for `generated_at`, or the rule above is
+    // exercised by tests alone and never by production.
+    const now = Date.parse("2026-08-16T12:00:00.000Z");
+    const ages = allFresh(12, now);
+    const emptyKey = projectionKey(
+      PROJECTION_LANES.find((l) => l.name === "chain-alpha-volume")!
+        .artifactKey,
+      DEFAULT_CHAIN_NETWORK,
+    );
+    const messages: string[] = [];
+    const result = (await runProjectionStalenessWatchdog(
+      bucketWithRows(ages, { [emptyKey]: 0 }),
+      {
+        now: () => now,
+        recordException: (async (_env: unknown, ev: { error?: unknown }) => {
+          messages.push(String((ev.error as Error)?.message));
+          return true;
+        }) as never,
+        laneHealthDb: null,
+      },
+    )) as { stale?: boolean; stale_lanes?: string[] };
+    assert.equal(result.stale, true, "a fresh, empty lane is not healthy");
+    assert.deepEqual(result.stale_lanes, ["chain-alpha-volume"]);
+    assert.equal(messages.length, 1, "one event, naming the lane");
+    assert.match(
+      messages[0]!,
+      /chain-alpha-volume \(fresh, 0 rows\)/,
+      "the detail must not report an AGE for the one entry whose age is fine",
+    );
+  });
+
+  test("a body with NO generated_at is absent, not silently fresh", async () => {
+    // The artifact exists and parses, but carries no timestamp. Reading that
+    // as anything other than "absent" would let a lane whose writer stopped
+    // stamping its output sit in the fleet looking healthy forever -- the
+    // schema's per-field `.catch` deliberately keeps the OBJECT parseable so
+    // this stays a verdict rather than a thrown read.
+    const now = Date.parse("2026-08-16T12:00:00.000Z");
+    const ages = allFresh(12, now);
+    const untimed = projectionKey(
+      PROJECTION_LANES.find((l) => l.name === "chain-fees")!.artifactKey,
+      DEFAULT_CHAIN_NETWORK,
+    );
+    const bucket = {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          if (ages[key] === undefined) return null;
+          return {
+            async json() {
+              return key === untimed
+                ? { schema_version: 1, row_count: 12 }
+                : { schema_version: 1, generated_at: ages[key] };
+            },
+          };
+        },
+      },
+    } as unknown as Record<string, unknown>;
+    const result = (await runProjectionStalenessWatchdog(bucket, {
+      now: () => now,
+      recordException: (async () => true) as never,
+      laneHealthDb: null,
+    })) as { stale?: boolean; stale_lanes?: string[] };
+    assert.equal(result.stale, true);
+    assert.deepEqual(result.stale_lanes, ["chain-fees"]);
+  });
 
   test("a healthy fleet records nothing at all", async () => {
     const now = Date.parse("2026-08-04T17:00:00.000Z");


### PR DESCRIPTION
Two fixes from the same investigation, plus the zod work folded in.

## 1. The account page's 503 — the fix that was shipped but never ran

#11222 moved the account-summary **feed leg** onto the projection. In production it has never engaged once, and `/api/v1/accounts/{ss58}` has been answering **503** for the account this was reported on.

`readRecent` needs two things the producer does not publish yet (`metagraphed-infra#575`). Measured 2026-08-16 against production:

```
pointer  {"generation":"20260815T062657Z","shard_count":16384,
          "through":"2026-08-14", ...}          ← no recent_limit
shard    keys: schema_version, generated_at, shard,
         shard_count, account_count, accounts   ← no recent map
shard 12350: 43 accounts, 43 groups-only, 0 with recent
```

So the leg declined for **every** account and fell to `windowedRowRead`, whose last step has no floor at all — the unbounded scattered scan that aborts at the 15 s ceiling. The reported account is *in* its shard with one group; it was never a projection miss.

**The groups alone bound it.** They are a lifetime aggregate (the read declines anything over the scan cap rather than publishing a windowed subtotal), so every event at or before the fold sits inside `[min(fo), max(lo)]`, and `through` says where the fold stops. Those three numbers are in every generation the producer has ever written.

The feed now answers from **two bounded reads** instead of one unbounded one:

1. **Above the fold** — one fold interval wide. A full page here *is* the newest, and the second read is never issued.
2. **The folded remainder** — bounded on *both* sides by the groups' own columns.

The ranges **meet** rather than overlapping or leaving a gap (`lastMs` is at or below the fold edge by construction) — the same edge argument `recentFloorMs` makes for `recent`. `recent` still wins when a generation carries it; this is the weaker bound that works *today*.

Two existing tests asserted the unbounded fallback and are **rewritten rather than deleted** — "no published recent list falls back to the walk" was correct when there was nothing for a floor to meet, and now asserts that the groups supply that edge themselves.

## 2. A projection refreshed with nothing is not healthy

The projection-staleness watchdog measures **time since write**, so it cannot see a lane that runs on time and computes zero rows — `generated_at` never ages.

```json
// metagraph/projections/chain-alpha-volume.json, read 2026-08-16
{"generated_at":"2026-08-16T11:46:31.923Z","row_count":0,
 "windows":{"24h":{"days":1,"rows":[]}}}
```

Minutes old and empty, because its 24 h window queried a lakehouse whose newest data was ~29 h back (the capture stall fixed in #11406). Every route over that card served its zeroed floor while the watchdog recorded `ok` every 30 minutes.

The all-or-nothing contract only covers a **failed** query (`null`); an **empty** answer (`[]`) is stored, and of the thirteen lanes only `computeBlocksSummary` declines to store it. So the rule now reads `row_count` alongside the timestamp.

Two guards, both about not making the alarm useless on day one: a **missing** `row_count` is never read as zero, and an artifact that is both **old and empty** still reports its **age**.

## 3. Zod: parsed not cast, and schemas moved into `schemas-src`

- **new** `schemas-src/artifacts/projection-envelope.ts` — the watchdog read its artifacts through `(body as { generated_at?: unknown })`. Both fields now come off **one** parse of the **same** body. Per-field `.catch(null)` on purpose: a body whose `generated_at` is a number should read as *unreadable*, not refuse the whole parse, since "absent" and "malformed" are distinct verdicts here.
- `BufferedStatementSchema` and `GraphqlResponsePayloadSchema` moved out of `src/` into `schemas-src/internal-wire.ts` — both are produced by our own Workers, which is that module's own rule. The second one shows why it matters: it carried **`.passthrough()`**, which survived only because the gate cannot see outside `schemas-src`. Dropped rather than justified, since the one reader takes `data` and `errors` and nothing else.

After this the only `z.object(...)` outside `schemas-src` is `src/contracts.ts`, which builds schemas *dynamically* from route metadata — a builder, not a declared vocabulary.

## 4. Smaller things from the same incident

- `src/table-freshness-watchdog.ts` read `"RAW_CAPTURE_CRON every 5 min"` after #11402 moved that lane to `*/1`. Now **derived** from `cronStepMinutes(RAW_CAPTURE_CRON)`.
- `NEVER_BUFFER_LANES` records *why* `raw-capture-state` is there: the hazard is a **cursor table** — a single row whose value is a position a later pass resumes from. Not "something reads this table" (every buffered table is read by a route) but "does the read's result decide the next **write**". `tao_usd_index` is the contrast. A derived sweep for this was attempted and abandoned; the note records why, so it is not rebuilt.
- Removed a `Number.isFinite` guard on the computed span — a branch nothing could take.

## Verification

- full suite: **947 files, 21,744 passed, 11 skipped, 0 failures**
- the complete CI gate derived from the workflows — **79 targets** including `lint`, `format:check`, `typecheck` and `scan:public-safety`, not just validators — 0 failures
- no uncovered statements or branches in the changed lines