### PR TITLE
fix(accounts): the card contradicted itself, and its own suggested fallback was the slowest read

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1055,6 +1055,54 @@ async function headProbe(
 }
 
 /**
+ * The projection's groups PLUS everything it was folded too early to see.
+ *
+ * The aggregate leg served `found.groups` verbatim, which is the projection's
+ * count as of its `through` day -- so a card could report `event_count: 1` while
+ * its own feed listed two events. Measured 2026-08-16 on
+ * 5EEmaGFE...5oM3qDSC: groups held one NeuronRegistered at block 8836052, the
+ * feed's newest row was block 8850439, and the card published both numbers side
+ * by side. Whichever is right, they cannot both be, and a card that disagrees
+ * with itself is worse than a slow one.
+ *
+ * The fix is the fold edge the feed already uses. Everything at or before it is
+ * in the groups; everything after it is one bounded read away. CONCATENATED
+ * rather than merged key-by-key, because `foldSummaryGroups` already sums
+ * `count` per kind, unions the netuids and min/maxes the block and observed
+ * bounds -- and the two ranges are disjoint by construction, so a (kind, netuid)
+ * appearing in both is two real disjoint tallies of the same pair.
+ *
+ * NO SPAN, NO PROBE. Without `through` there is no edge to read from, and
+ * guessing one would either double-count or leave a hole; serving the groups
+ * alone is what this did before and is at worst stale, never wrong-by-overlap.
+ */
+async function postFoldGroups(
+  env: R2SqlEnv | null | undefined,
+  options: {
+    query: R2SqlReader;
+    scan: (bound: string) => string;
+    published: Record<string, unknown>[];
+    span: { foldFloorMs: number } | null;
+  },
+): Promise<Record<string, unknown>[] | null> {
+  const { query, scan, published, span } = options;
+  if (span === null) return published;
+  const bound = ` AND observed_at >= ${Math.trunc(span.foldFloorMs)}`;
+  const above = await query(
+    env,
+    `WITH scan AS (${scan(bound)}) SELECT event_kind AS kind, netuid AS netuid, ` +
+      `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
+      `min(observed_at) AS fo, max(observed_at) AS lo ` +
+      `FROM scan GROUP BY event_kind, netuid`,
+  );
+  // A failed probe DECLINES rather than falling back to the groups alone: the
+  // caller would publish the same self-contradicting card this exists to fix,
+  // and it would do it silently.
+  if (!above) return null;
+  return [...published, ...above];
+}
+
+/**
  * The feed for an account the projection HAS, in two bounded reads.
  *
  * THE CASE THAT IS ACTUALLY IN PRODUCTION. `headProbe` above needs `recent` --
@@ -1224,7 +1272,13 @@ export async function loadAccountSummaryColdTier(
           { onError: track("summary-groups-bounded") },
         )
       : found
-        ? Promise.resolve(found.groups)
+        ? postFoldGroups(env, {
+            query: (e, sql) =>
+              query(e, sql, { onError: track("summary-groups-postfold") }),
+            scan,
+            published: found.groups,
+            span: found.span,
+          })
         : windowedFloorRead<Record<string, unknown>[]>(env, {
             query,
             attempt: (bound, run) =>

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -40,7 +40,12 @@ import {
   type ChainEventApi,
 } from "./chain-detail-hot-tier.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
-import { type ChainNetworkId, chainTable } from "./chain-network.ts";
+import {
+  type ChainNetworkId,
+  chainTable,
+  DEFAULT_CHAIN_NETWORK,
+} from "./chain-network.ts";
+import { loadAccountSummaryProjection } from "./account-summary-projection.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -125,6 +130,41 @@ export async function loadAccountEventsColdTier(
       `(observed_at, block_number, event_index) < ` +
         `(${cursor[0]}, ${cursor[1]}, ${cursor[2]})`,
     );
+  }
+
+  // THE SAME FLOOR THE SUMMARY CARD USES (#11410/#11411), on the route the
+  // summary's own 503 told callers to fall back to -- which made the documented
+  // fallback the slowest read of the three. Measured 2026-08-16 on
+  // 5EEmaGFE...5oM3qDSC: 26.7s for `?limit=5`, against 8.1s for the card the
+  // projection now bounds.
+  //
+  // ONE LOWER BOUND, and it holds for BOTH projection answers:
+  //   - ABSENT: the producer writes every shard, so absence from a shard that
+  //     exists proves there is nothing at or before `through`.
+  //   - PRESENT: the groups are a lifetime aggregate, so nothing exists before
+  //     `firstMs`. Post-fold events sit above `foldFloorMs`, which is itself
+  //     above `firstMs` -- so the single floor covers the whole history.
+  //
+  // A LOWER BOUND ONLY, deliberately. The summary can split its read in two
+  // because it answers one shape; this route carries cursors, an offset and
+  // three optional filters, and a second window would have to compose with all
+  // of them. A floor composes with anything: it removes rows that cannot exist,
+  // whatever else is being asked.
+  //
+  // MAINNET ONLY. The projection is written for the default network, so reading
+  // it for another chain would floor a feed against the wrong history. Other
+  // networks keep the unbounded walk -- correct, just not faster.
+  if (network === undefined || network === DEFAULT_CHAIN_NETWORK) {
+    const projected = await loadAccountSummaryProjection(env, ss58, {
+      // The aggregate leg only: this route wants the FLOOR, not the published
+      // rows, and asking for rows would read a map it then throws away.
+      recentLimit: 0,
+    });
+    const floorMs =
+      projected?.absent === true
+        ? projected.floorMs
+        : (projected?.span?.firstMs ?? null);
+    if (floorMs !== null) where.push(`observed_at >= ${Math.trunc(floorMs)}`);
   }
 
   // Cursor pages never carry an offset, mirroring data-api.

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -884,6 +884,76 @@ describe("the projection short-circuits the FEED leg too (#11222)", () => {
     }
   });
 
+  test("the card's COUNT includes what the fold was too early to see", async () => {
+    // Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC: the projection's groups held
+    // ONE NeuronRegistered at block 8836052, the feed's newest row was block
+    // 8850439, and the card published `event_count: 1` beside a two-row feed.
+    // The aggregate leg served the projection verbatim, so it reported the count
+    // as of the fold while the feed reported it as of now. Whichever is right,
+    // they cannot both be.
+    const postFold = {
+      kind: "NeuronRegistered",
+      netuid: 105,
+      count: 1,
+      fb: 8_850_439,
+      lb: 8_850_439,
+      fo: FLOOR + 3_600_000,
+      lo: FLOOR + 3_600_000,
+    };
+    const seen: string[] = [];
+    // The GROUPED read is the one under test, so it answers only the post-fold
+    // window -- the folded half comes from the projection, not from here.
+    const engine = async (
+      _env: unknown,
+      sql: string,
+      _deps?: { onError?: (d: string) => void },
+    ) => {
+      seen.push(sql);
+      if (sql.includes("GROUP BY event_kind, netuid")) return [postFold];
+      return [];
+    };
+    const cold = await loadAccountSummaryColdTier(archive(null), SS58, {
+      query: engine as never,
+    });
+    assert.equal(cold.declined, undefined);
+    // The projection's groupsSummingTo(1) plus the one event above the fold.
+    assert.equal(
+      cold.agg?.c,
+      2,
+      "the count must span the fold, not stop at it",
+    );
+    // ...and the probe that found it is BOUNDED to the post-fold window, so the
+    // accuracy does not cost the lifetime scan back.
+    const grouped = seen.filter((q) =>
+      q.includes("GROUP BY event_kind, netuid"),
+    );
+    assert.equal(grouped.length, 1);
+    assert.match(grouped[0]!, new RegExp(`observed_at >= ${FLOOR}\\b`));
+  });
+
+  test("a failed post-fold probe DECLINES rather than publishing the stale count", async () => {
+    // Falling back to the groups alone would republish the self-contradicting
+    // card this exists to fix, and would do it silently.
+    const engine = async (
+      _env: unknown,
+      sql: string,
+      deps?: { onError?: (d: string) => void },
+    ) => {
+      if (sql.includes("GROUP BY event_kind, netuid")) {
+        deps?.onError?.("r2 sql: HTTP 500 (stubbed failure)");
+        return null;
+      }
+      return [];
+    };
+    const cold = await loadAccountSummaryColdTier(archive(null), SS58, {
+      query: engine as never,
+    });
+    assert.ok(
+      cold.declined?.some((r) => r.startsWith("summary-groups-postfold:")),
+      `expected a postfold decline, got ${JSON.stringify(cold.declined)}`,
+    );
+  });
+
   /**
    * GROUPS BUT NO RECENT MAP -- which is every account in production today.
    *

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -75,6 +75,136 @@ afterAll(() => {
   vi.useRealTimers();
 });
 
+/**
+ * The floor the account-summary projection already knows, applied to the feed
+ * route the summary's own 503 message names as the fallback.
+ *
+ * Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC: `/events?limit=5` took 26.7s
+ * against 8.1s for the card, because this read consulted no projection at all
+ * and walked to the beginning of time.
+ */
+describe("loadAccountEventsColdTier -- the projection floor", () => {
+  const FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
+  const FIRST = 1_786_629_372_000;
+
+  /** An archive publishing one generation; `entry` is this account's shard row. */
+  function archive(entry: unknown, { through = "2026-08-14" } = {}) {
+    const GEN = "20260815T000000Z";
+    const SHARDS = 16384;
+    let h = 0x811c9dc5;
+    for (const b of new TextEncoder().encode(ADDR)) {
+      h ^= b;
+      h = Math.imul(h, 0x01000193) >>> 0;
+    }
+    const shardKey = `metagraph/projections/account-summary/${GEN}/${h % SHARDS}.json`;
+    return {
+      METAGRAPH_ARCHIVE: {
+        get: async (key: string) => {
+          if (key === "metagraph/projections/account-summary/current.json") {
+            return {
+              json: async () => ({
+                schema_version: 1,
+                generation: GEN,
+                shard_count: SHARDS,
+                generated_at: new Date().toISOString(),
+                account_count: 1,
+                through,
+              }),
+            };
+          }
+          if (key === shardKey) {
+            return {
+              json: async () => ({
+                schema_version: 1,
+                shard_count: SHARDS,
+                accounts: entry === null ? {} : { [ADDR]: entry },
+              }),
+            };
+          }
+          return null;
+        },
+      },
+    };
+  }
+
+  test("a PRESENT account floors at its earliest folded event", async () => {
+    const q = sqlFetch([eventRow(10, 0)]);
+    await loadAccountEventsColdTier(
+      {
+        ...TOKEN,
+        ...archive([
+          {
+            kind: "NeuronRegistered",
+            netuid: 105,
+            count: 1,
+            fb: 8_836_052,
+            lb: 8_836_052,
+            fo: FIRST,
+            lo: FIRST,
+          },
+        ]),
+      } as never,
+      ADDR,
+      { limit: 5 },
+    );
+    assert.ok(q.length > 0, "premise: a read was issued");
+    assert.ok(
+      q.every((sql) => sql.includes(`observed_at >= ${FIRST}`)),
+      `unfloored read: ${q.find((sql) => !sql.includes(`observed_at >= ${FIRST}`))?.slice(0, 120)}`,
+    );
+  });
+
+  test("an ABSENT account floors at the generation's edge", async () => {
+    // The producer writes every shard, so absence PROVES there is nothing at or
+    // before `through` -- the strongest floor available.
+    const q = sqlFetch([eventRow(10, 0)]);
+    await loadAccountEventsColdTier(
+      { ...TOKEN, ...archive(null) } as never,
+      ADDR,
+      { limit: 5 },
+    );
+    assert.ok(q.length > 0, "premise: a read was issued");
+    assert.ok(
+      q.every((sql) => sql.includes(`observed_at >= ${FLOOR}`)),
+      "an absent account must bound to the generation edge",
+    );
+  });
+
+  test("NO projection means the walk is unchanged", async () => {
+    // The floor is an optimization over a correct read, never a precondition
+    // for one: with no artifact bound, this must behave exactly as before.
+    const q = sqlFetch([eventRow(10, 0)]);
+    const data = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    assert.ok(data);
+    assert.ok(q.every((sql) => !sql.includes("observed_at >= 1786")));
+  });
+
+  test("a NON-DEFAULT network reads no projection at all", async () => {
+    // The projection describes mainnet, so flooring a testnet feed with it
+    // would bound a feed against another chain's history.
+    let asked = 0;
+    const bucket = {
+      METAGRAPH_ARCHIVE: {
+        get: async () => {
+          asked += 1;
+          return null;
+        },
+      },
+    };
+    const q = sqlFetch([eventRow(10, 0)]);
+    await loadAccountEventsColdTier(
+      { ...TOKEN, ...bucket } as never,
+      ADDR,
+      { limit: 5 },
+      "testnet",
+    );
+    assert.equal(asked, 0, "no projection read for another chain");
+    assert.ok(q.length > 0);
+  });
+});
+
 describe("loadAccountEventsColdTier", () => {
   test("reads both key sides with one disjunction, newest first", async () => {
     const q = sqlFetch([eventRow(10, 1), eventRow(10, 0)]);


### PR DESCRIPTION
Two accuracy/latency fixes on the account page, both found while verifying #11410 on the account that started this.

## 1. The card disagreed with itself

The 503 is gone — and the card it now returns publishes two numbers that cannot both be right:

```
GET /api/v1/accounts/5EEmaGFE…5oM3qDSC     (2026-08-16, post-#11410)

  event_count    1
  event_kinds    [{"kind":"NeuronRegistered","count":1}]
  recent_events  2 rows, newest at block 8850439
```

The projection's groups held **one** `NeuronRegistered` at block 8836052. The feed's newest row was block **8850439** — 14,000 blocks later, past the generation's `through`.

**Why.** #11131 moved the aggregate leg onto the projection because a lifetime aggregate over a scattered key has no window to bound it (measured 4,374 MB, ~14 s). That was right, and it served `found.groups` **verbatim** — the tally as of the last folded day. The feed leg has always read to *now*. The gap is one fold interval, widening every hour until the next generation lands.

**Fix:** the fold edge #11410 gave the feed. Everything at or before it is in the groups; everything after is one bounded read away — the same `WITH scan` aggregate the absent-account arm already issues, floored at `foldFloorMs`. The count spans the fold without buying back the lifetime scan.

**Concatenated, not merged key-by-key.** `foldSummaryGroups` already sums `count` per kind, unions netuids, and min/maxes the bounds — and the ranges are **disjoint by construction**, so a `(kind, netuid)` in both arrays is two real tallies over non-overlapping time.

**A failed probe declines**, rather than republishing the self-contradicting card silently.

## 2. The 503's own fallback was the slowest read

`/accounts/{ss58}` declines with *"read `/api/v1/accounts/{ss58}/events` for the same stream"*. Measured after #11410:

| route | status | time |
|---|---|---:|
| `/accounts/{ss58}` | 200 | 8.1 s |
| `/accounts/{ss58}/events?limit=5` | 200 | **26.7 s** |

The message pointed at the one read that consulted **no projection at all** — it built its predicate and handed it to `windowedRowRead`, whose last step has no floor.

**One lower bound**, from the projection the card already reads, sound for both answers: an **absent** account has nothing at or before `through`; a **present** one has nothing before `min(fo)` (post-fold events sit above `foldFloorMs`, itself above `min(fo)`).

**A lower bound only, deliberately.** The card can split its read in two because it answers one fixed shape; this route carries a cursor, an offset and three optional filters, and a second window would have to compose with all of them. A floor composes with anything.

**Mainnet only** — the projection describes the default network, and a test asserts the artifact is not even *read* for another chain, so this cannot regress into a cross-chain floor. It stays an optimization over a correct read: with no artifact bound, behaviour is exactly what it was.

## Testing

Every new bound is verified to **fail with the fix reverted** — the count test, and both floor tests. The count test also asserts its probe is floored, so it cannot pass by quietly restoring the lifetime scan.

## Verification

- full suite: **948 files, 21,764 passed, 11 skipped, 0 failures**
- the complete CI gate derived from the workflows — **79 targets** including `lint`, `format:check`, `typecheck`, `scan:public-safety` — 0 failures
- no uncovered statements or branches in the changed lines