### PR TITLE
feat(lakehouse): declare the storage snapshot, the only axis where waiting loses data

### DIFF
--- a/src/storage-snapshot-contract.ts
+++ b/src/storage-snapshot-contract.ts
@@ -1,0 +1,169 @@
+// What a chain STORAGE snapshot is, and which items we snapshot (infra#452).
+//
+// ## Why storage is the only axis where waiting costs data
+//
+// Events and calls arrive INSIDE blocks, so decoding a block captures them by
+// construction -- 211 of 289 event variants and 225 of 298 calls are already
+// held, and the rest is a curation gap an indexer can close later. Storage is
+// STATE and is never emitted. If a height is not snapshotted, that height's
+// value survives only as long as an archive node serves it.
+//
+// Measured against `node-subtensor` spec 443: 371 declared storage items, 10
+// held. `get_all_metagraphs` covers much of `SubtensorModule` indirectly, so
+// that pallet overstates the gap -- but `Swap`, `Balances`, `Commitments` and
+// `Crowdloan` are touched by nothing at all, and each is a place where we
+// publish a DERIVED figure with no observed counterpart to check it against.
+// `alpha_price_tao`, `tao_in_pool_tao` and `alpha_in_pool` are all derived from
+// the AMM with nothing independent to reconcile them.
+//
+// ## Why the row carries the height, not just the value
+//
+// One row per `(pallet, item, key, height)`. A storage value with no height is
+// unfalsifiable: it cannot be re-read, re-derived or disagreed with. Carrying
+// the height is what makes a snapshot evidence rather than a reading.
+//
+// `observed_at` is OURS and `height` is the CHAIN's, and they are not
+// interchangeable. Pipelines does not preserve order across requests (measured
+// 2026-08-16), so nothing downstream may infer sequence from arrival -- the
+// height is the only ordering that means anything.
+//
+// ## Cadence is per item, and that is the whole cost control
+//
+// Storage reads are the poller's scarcest budget. `TotalIssuance` every block is
+// wasteful; `Swap` pools once a day is useless. So cadence is declared per item
+// rather than per lane, and the declaration is versioned: a cadence change is a
+// change to what the archive MEANS at a height, and a reader comparing two
+// spans needs to know the sampling changed under them.
+
+import { z } from "zod";
+
+/**
+ * One storage reading, at one height.
+ *
+ * `value` is the SCALE-encoded bytes as hex, NOT a decoded figure. Decoding
+ * belongs to whoever reads this, and storing a decode would freeze one
+ * interpretation of a value whose type can change across a runtime upgrade --
+ * the archive would then hold our 2026 reading of a 2027 type with no way to
+ * tell. Hex is what the chain actually returned.
+ *
+ * `.strict()` because this is the shape the stream carries, and an unknown key
+ * is silently STRIPPED at a Pipelines sink (measured 2026-08-16): the row lands
+ * looking correct with a field missing, which nothing downstream can notice.
+ */
+export const StorageSnapshotRow = z
+  .object({
+    pallet: z.string().min(1).describe("Pallet name, e.g. `Swap`."),
+    item: z.string().min(1).describe("Storage item name within the pallet."),
+    /**
+     * The map key, hex-encoded, or `""` for a plain (unkeyed) storage value.
+     *
+     * EMPTY STRING RATHER THAN NULL, and deliberately: the stream has no
+     * null-vs-absent distinction, so a nullable key would make every plain
+     * value a dropped row. A plain item genuinely has no key, and `""` says so
+     * without asking the transport to carry a concept it does not have.
+     */
+    key: z.string().describe('Hex map key, or "" for a plain storage value.'),
+    height: z
+      .int()
+      .min(0)
+      .describe("Block height the value was read AT. The only ordering."),
+    value: z
+      .string()
+      .describe("SCALE-encoded value as hex. Not decoded -- see the header."),
+    observed_at: z
+      .int()
+      .min(0)
+      .describe("Epoch ms when WE read it. Never a substitute for `height`."),
+  })
+  .strict();
+
+export type StorageSnapshotRow = z.infer<typeof StorageSnapshotRow>;
+
+/** One declared item and how often it is worth sampling. */
+export interface StorageSnapshotItem {
+  pallet: string;
+  item: string;
+  /**
+   * Minutes between samples. A FLOOR, quantised up to whatever clock the
+   * producer runs on -- the same contract as `ScheduledLane.everyMinutes`.
+   */
+  everyMinutes: number;
+  /** Why this cadence, in terms of what the value does. */
+  reason: string;
+}
+
+/**
+ * The declaration's version.
+ *
+ * BUMPED WHENEVER AN ITEM OR A CADENCE CHANGES, because both change what the
+ * archive means. A reader comparing a span sampled every 20 minutes against one
+ * sampled hourly is comparing two different datasets, and nothing in the rows
+ * themselves would say so.
+ */
+export const STORAGE_SNAPSHOT_VERSION = 1;
+
+/**
+ * The four pallets where a published figure currently has no observed check.
+ *
+ * DELIBERATELY NOT ALL 361. The gap is real but a list that tries to close it
+ * in one move prices itself out of the poller's storage budget and lands
+ * nothing. These four are the ones where we already publish a derived number:
+ * every row here can be reconciled against something we serve, which makes the
+ * lane falsifiable from its first pass rather than an archive nobody reads.
+ */
+export const STORAGE_SNAPSHOT_ITEMS: readonly StorageSnapshotItem[] = [
+  {
+    pallet: "Swap",
+    item: "AlphaSqrtPrice",
+    everyMinutes: 60,
+    reason:
+      "The AMM state behind `alpha_price_tao`, which we publish with no independent check. Hourly tracks a tempo without sampling inside one.",
+  },
+  {
+    pallet: "Swap",
+    item: "SwapV3Initialized",
+    everyMinutes: 1440,
+    reason:
+      "A per-subnet initialisation flag that changes once ever. Daily is a liveness sample, not a series.",
+  },
+  {
+    pallet: "Balances",
+    item: "TotalIssuance",
+    everyMinutes: 60,
+    reason:
+      "Chain-level supply, currently DERIVED rather than observed. Hourly is enough to bound emission arithmetic without reading every block.",
+  },
+  {
+    pallet: "Balances",
+    item: "InactiveIssuance",
+    everyMinutes: 60,
+    reason:
+      "The other half of the supply identity. Sampled with TotalIssuance so the two are always attributable to one height.",
+  },
+  {
+    pallet: "Commitments",
+    item: "CommitmentOf",
+    everyMinutes: 60,
+    reason:
+      "Commit-reveal state. We decode 7.35M of its events and hold none of its state, so a reveal cannot be checked against what was committed.",
+  },
+  {
+    pallet: "Crowdloan",
+    item: "Crowdloans",
+    everyMinutes: 60,
+    reason:
+      "Already a first-class pallet in `account_events`; the state is what those events move.",
+  },
+];
+
+/**
+ * The declared items, in a stable order, as `pallet.item`.
+ *
+ * Sorted so a diff of the declaration reads as an addition rather than a
+ * reshuffle, and so two producers reading this list schedule identically.
+ */
+export function storageSnapshotKeys(
+  items: readonly StorageSnapshotItem[] = STORAGE_SNAPSHOT_ITEMS,
+): string[] {
+  return items.map(({ pallet, item }) => `${pallet}.${item}`).sort();
+}

--- a/tests/storage-snapshot-contract.test.ts
+++ b/tests/storage-snapshot-contract.test.ts
@@ -1,0 +1,145 @@
+// The storage-snapshot declaration, and the stream schema it derives (infra#452).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import { streamSchemaFrom } from "../src/pipeline-stream-contract.ts";
+import {
+  STORAGE_SNAPSHOT_ITEMS,
+  STORAGE_SNAPSHOT_VERSION,
+  StorageSnapshotRow,
+  storageSnapshotKeys,
+} from "../src/storage-snapshot-contract.ts";
+
+describe("the row is what makes a reading evidence", () => {
+  test("it derives a stream schema with the height and our clock separate", () => {
+    // THE POINT OF DERIVING IT. Pipelines does not preserve order across
+    // requests, so `height` is the only ordering that means anything and
+    // `observed_at` must never stand in for it. Both are carried, both
+    // required, and the stream schema says so without anyone hand-writing it.
+    assert.deepEqual(streamSchemaFrom(StorageSnapshotRow), {
+      fields: [
+        { name: "pallet", type: "string", required: true },
+        { name: "item", type: "string", required: true },
+        { name: "key", type: "string", required: true },
+        { name: "height", type: "int64", required: true },
+        { name: "value", type: "string", required: true },
+        { name: "observed_at", type: "int64", required: true },
+      ],
+    });
+  });
+
+  test("a plain storage value has an empty key, not a null one", () => {
+    // A nullable key would make every unkeyed item a dropped row: the stream
+    // has no null-vs-absent distinction, so `required: false` plus a null is
+    // discarded at the sink with a 200 at the caller.
+    const row = {
+      pallet: "Balances",
+      item: "TotalIssuance",
+      key: "",
+      height: 8_848_204,
+      value: "0x00",
+      observed_at: 1_786_884_000_000,
+    };
+    assert.equal(StorageSnapshotRow.safeParse(row).success, true);
+    assert.equal(
+      StorageSnapshotRow.safeParse({ ...row, key: null }).success,
+      false,
+    );
+  });
+
+  test("an unknown field is refused, because the sink would strip it", () => {
+    const parsed = StorageSnapshotRow.safeParse({
+      pallet: "Swap",
+      item: "AlphaSqrtPrice",
+      key: "0x01",
+      height: 1,
+      value: "0x02",
+      observed_at: 1,
+      netuid: 7,
+    });
+    assert.equal(parsed.success, false);
+  });
+
+  test("a negative height is not a height", () => {
+    assert.equal(
+      StorageSnapshotRow.safeParse({
+        pallet: "Swap",
+        item: "AlphaSqrtPrice",
+        key: "",
+        height: -1,
+        value: "0x",
+        observed_at: 1,
+      }).success,
+      false,
+    );
+  });
+});
+
+describe("the declaration", () => {
+  test("every item names a pallet, an item, a cadence and a reason", () => {
+    for (const entry of STORAGE_SNAPSHOT_ITEMS) {
+      assert.ok(entry.pallet.length > 0, "pallet");
+      assert.ok(entry.item.length > 0, "item");
+      assert.ok(
+        Number.isInteger(entry.everyMinutes) && entry.everyMinutes > 0,
+        `${entry.pallet}.${entry.item} needs a positive cadence`,
+      );
+      // A cadence with no stated reason is a number nobody can audit, and this
+      // lane's whole cost is cadence.
+      assert.ok(
+        entry.reason.length > 20,
+        `${entry.pallet}.${entry.item} needs a reason for its cadence`,
+      );
+    }
+  });
+
+  test("it covers exactly the four pallets with no observed counterpart", () => {
+    // Scoped deliberately. 361 items are unread; a list that tried to close
+    // that in one move would price itself out of the poller's storage budget.
+    // These four are where we already publish a DERIVED figure, so every row
+    // is reconcilable from the first pass.
+    assert.deepEqual(
+      [...new Set(STORAGE_SNAPSHOT_ITEMS.map((i) => i.pallet))].sort(),
+      ["Balances", "Commitments", "Crowdloan", "Swap"],
+    );
+  });
+
+  test("no item is declared twice", () => {
+    const keys = storageSnapshotKeys();
+    assert.equal(
+      keys.length,
+      new Set(keys).size,
+      "a duplicated item would be sampled twice and stored twice per height",
+    );
+  });
+
+  test("keys are stable and sorted, so a diff reads as an addition", () => {
+    assert.deepEqual(storageSnapshotKeys(), [
+      "Balances.InactiveIssuance",
+      "Balances.TotalIssuance",
+      "Commitments.CommitmentOf",
+      "Crowdloan.Crowdloans",
+      "Swap.AlphaSqrtPrice",
+      "Swap.SwapV3Initialized",
+    ]);
+  });
+
+  test("the sort does not depend on the declared order", () => {
+    // Non-vacuity: `storageSnapshotKeys` must actually sort, or two producers
+    // reading the same list could schedule in different orders.
+    assert.deepEqual(
+      storageSnapshotKeys([
+        { pallet: "Z", item: "b", everyMinutes: 1, reason: "x" },
+        { pallet: "A", item: "a", everyMinutes: 1, reason: "x" },
+      ]),
+      ["A.a", "Z.b"],
+    );
+  });
+
+  test("the version is an integer that can be bumped", () => {
+    // It exists so a cadence change is visible to a reader comparing two
+    // spans -- the rows themselves would not say the sampling moved.
+    assert.ok(Number.isInteger(STORAGE_SNAPSHOT_VERSION));
+    assert.ok(STORAGE_SNAPSHOT_VERSION >= 1);
+  });
+});


### PR DESCRIPTION
infra#452 measured the chain's vocabulary against `node-subtensor` spec 443:
371 declared storage items, 10 held. Events and calls arrive INSIDE blocks, so
decoding one captures them by construction -- 211 of 289 event variants and 225
of 298 calls are already held, and the remainder is a curation gap an indexer
can close whenever. Storage is STATE and is never emitted. A height that is not
snapshotted survives only as long as an archive node serves it.

This is #10850's Phase 2 half that belongs in this repo: the row shape and the
declaration. The producer is the poller container, which reads chain state over
WebSocket -- not a Worker workload.

THE ROW CARRIES THE HEIGHT, and that is what makes it evidence. A storage value
with no height cannot be re-read, re-derived or disagreed with. `observed_at` is
OUR clock and `height` is the chain's, and they are not interchangeable: the
Phase 1 spike measured that Pipelines does not preserve order across requests,
so nothing downstream may infer sequence from arrival.

Two shapes follow directly from what that spike measured:

- `.strict()`, because an unknown field is silently STRIPPED at the sink. The
  row lands looking correct with a field missing, which nothing downstream can
  notice.
- `key` is `""` for a plain storage value rather than null. The stream has no
  null-vs-absent distinction, so a nullable key would make every unkeyed item a
  dropped row -- discarded at the sink with a 200 at the caller.

`value` is SCALE hex, NOT a decoded figure. Storing a decode would freeze one
interpretation of a value whose type can change across a runtime upgrade, and
the archive would then hold our 2026 reading of a 2027 type with no way to tell.

SCOPED TO FOUR PALLETS, deliberately, and not to all 361. `Swap`, `Balances`,
`Commitments` and `Crowdloan` are the ones where we already publish a DERIVED
figure with nothing observed to check it against -- `alpha_price_tao`,
`tao_in_pool_tao` and `alpha_in_pool` all come out of the AMM with no
independent counterpart. Every row here is reconcilable from the first pass,
which makes the lane falsifiable rather than an archive nobody reads. A list
that tried to close the whole gap in one move would price itself out of the
poller's storage budget and land nothing.

Cadence is per ITEM, because storage reads are the poller's scarcest budget:
`TotalIssuance` every block is wasteful and `Swap` pools once a day is useless.
Each cadence carries its reason, and a test enforces that -- a cadence with no
stated reason is a number nobody can audit, and cadence is this lane's entire
cost. `STORAGE_SNAPSHOT_VERSION` bumps whenever an item or a cadence changes,
because a reader comparing a span sampled hourly against one sampled daily is
comparing two datasets and the rows themselves would not say so.

The stream schema is DERIVED from the Zod row via `streamSchemaFrom`, so the
transport's schema cannot drift from ours -- and a drift there fails silently,
because the stream is the half that does not complain.

Refs #10850, metagraphed-infra#452