### PR TITLE
feat(watchdog): the five lanes this repo does not run had no alarm at all

### DIFF
--- a/schemas-src/artifacts/container-lane-status.ts
+++ b/schemas-src/artifacts/container-lane-status.ts
@@ -1,0 +1,53 @@
+// The status object every container-written lane publishes (metagraphed-infra).
+//
+// LIVES HERE for the reason chain-rpc-envelope.ts states: a schema outside
+// schemas-src is outside `no-passthrough`, `schema-shape-duplicates` and
+// `schema-opacity`.
+//
+// ## Why one schema for five lanes that do not agree on their field names
+//
+// These objects are written by a container in ANOTHER REPOSITORY, by five
+// different scripts, and they diverge:
+//
+//   decode-run-status.json            updated_at, status: "ok",  detail
+//   account-summary-status.json       checked_at, ok: true,      phase, failures
+//   daily-rollup-status.json          checked_at, ok, complete
+//   state-mirror-status.json          checked_at, ok, complete,  failures
+//   account-events-rollup-status.json checked_at, ok,            failures
+//
+// Declaring five schemas would state five vocabularies this repo does not own
+// and cannot keep in step. Declaring ONE that accepts either spelling of each
+// idea -- a timestamp, an outcome, an explanation -- states exactly what the
+// watchdog depends on and nothing else, which is the honest inventory
+// foreign-wire.ts's header argues for.
+//
+// EVERY FIELD OPTIONAL AND `.catch`-GUARDED. The producer is deployed
+// independently of this reader, so a field that changes type must degrade to
+// "the watchdog could not measure this" -- a `unknown` verdict -- rather than
+// throw and take the other four lanes' verdicts down with it.
+import { z } from "zod";
+
+/**
+ * What a container lane's status object must carry for a verdict to be drawn.
+ *
+ * `checked_at` OR `updated_at`: four lanes publish the first and decode
+ * publishes the second. Both are accepted and the reader takes whichever is
+ * present, because which word a script chose is not a fact about lane health.
+ *
+ * `ok` OR `status`: same argument. A boolean and the string "ok" are the same
+ * claim, and a lane that reports neither is not asserting success -- it is
+ * simply not saying, which the rule treats as "cannot tell" rather than as a
+ * pass.
+ *
+ * `detail`, `phase` are carried purely so a `stale` verdict can quote the
+ * producer's own words instead of a message this repo invented about a process
+ * it does not run.
+ */
+export const ContainerLaneStatusSchema = z.object({
+  checked_at: z.string().nullable().optional().catch(null),
+  updated_at: z.string().nullable().optional().catch(null),
+  ok: z.boolean().nullable().optional().catch(null),
+  status: z.string().nullable().optional().catch(null),
+  detail: z.string().nullable().optional().catch(null),
+  phase: z.string().nullable().optional().catch(null),
+});

--- a/src/container-lane-watchdog.ts
+++ b/src/container-lane-watchdog.ts
@@ -1,0 +1,323 @@
+// The alarm for the lanes this repo does not run.
+//
+// ## What went unwatched, and for how long
+//
+// Five lanes run inside metagraphed-infra's decode container, one after another
+// in a single hourly pass: decode, the daily rollup, the state mirror, the
+// account-events rollup, and the account-summary projection. Every one of them
+// already publishes a status object to R2. NOTHING READ ANY OF THEM.
+//
+// `projection-staleness` cannot: it iterates PROJECTION_LANES, the thirteen
+// lanes this Worker computes, so anything container-written is structurally
+// outside it. A `lane_health` sweep on 2026-08-16 returned zero rows for
+// `%summary%`, `%decode%`, `%rollup%` and `%mirror%` -- not stale rows, NO
+// rows.
+//
+// Measured that day: the account-summary projection had not published a
+// generation since 2026-08-15T06:26:33Z -- 32 hours -- while the four lanes
+// either side of it in the same pass ran normally (decode 14:19:40Z, daily
+// rollup 14:23:58Z, state mirror 14:26:17Z, account-events rollup 14:26:18Z).
+// The cost was not abstract: `readRecent` declines without a generation
+// carrying `recent_limit`, so every account request fell back to an unbounded
+// lakehouse scan and /accounts/{ss58} served 503s and 8-20s responses all day.
+//
+// ## Why this is the systemic fix and not another patch
+//
+// It inverts the default. Today a lane is silent unless somebody wrote a
+// watchdog aimed at it, which is how a lane nobody was thinking about goes
+// dark for 32 hours. After this, any lane in the status namespace that stops
+// advancing produces a `stale` verdict on the next tick, and adding a sixth
+// lane to the container means adding one line here rather than remembering to
+// build an alarm.
+//
+// ## What it deliberately does NOT do
+//
+// It does not read the lakehouse, the Iceberg ledger, or anything the lanes
+// produce. It reads what each lane SAYS ABOUT ITSELF and how long ago it said
+// it. Verifying the output is `lakehouse-seam`'s job for decode and
+// `projection-staleness`'s for the Worker lanes; this answers the prior
+// question those two cannot -- did the producer run at all.
+import { ContainerLaneStatusSchema } from "../schemas-src/artifacts/container-lane-status.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+import type { StoreEnv } from "./read-store.ts";
+import type { TelemetryEnv } from "./usage-telemetry.ts";
+
+type ContainerLaneWatchdogEnv = StoreEnv & TelemetryEnv;
+
+/** One container-written lane: what to call it, and where it says how it went. */
+export interface ContainerLane {
+  /** The `lane_health` label. Prefixed so a sweep can name the whole family. */
+  lane: string;
+  /** The R2 key of its status object. */
+  key: string;
+}
+
+/**
+ * Every lane on metagraphed-infra's `entrypoint-decode-r2.sh`, in pass order.
+ *
+ * ORDER IS MEANINGFUL FOR TRIAGE and is why they are listed rather than
+ * globbed: the lanes run sequentially in one pass, so a contiguous tail going
+ * stale together says the pass stopped partway, while ONE stale lane between
+ * two healthy ones says that lane alone is failing. The 2026-08-16 incident was
+ * the second shape, and reading it off five verdicts at a glance is the point.
+ */
+export const CONTAINER_LANES: readonly ContainerLane[] = [
+  {
+    lane: "container:decode",
+    key: "metagraph/lakehouse/decode-run-status.json",
+  },
+  {
+    lane: "container:daily-rollup",
+    key: "metagraph/lakehouse/daily-rollup-status.json",
+  },
+  {
+    lane: "container:state-mirror",
+    key: "metagraph/lakehouse/state-mirror-status.json",
+  },
+  {
+    lane: "container:account-events-rollup",
+    key: "metagraph/lakehouse/account-events-rollup-status.json",
+  },
+  {
+    lane: "container:account-summary",
+    key: "metagraph/lakehouse/account-summary-status.json",
+  },
+];
+
+/**
+ * How often the container's pass runs, as a CROSS-REPOSITORY PIN.
+ *
+ * The authority is `wrangler.decode-r2.jsonc`'s `"17 * * * *"` in
+ * metagraphed-infra, which this repository cannot import. That makes this the
+ * one number here that can silently drift, so the bound built from it is
+ * deliberately generous rather than tight -- see CONTAINER_MISSED_PASSES.
+ */
+export const CONTAINER_PASS_INTERVAL_MS = 60 * 60_000;
+
+/**
+ * How many passes a lane may miss before it is a stall.
+ *
+ * SIX, and the width is doing a job. A tight bound on a cross-repo cadence is
+ * the worst of both: it false-alarms the day infra changes its cron, and this
+ * lane's whole value is that an operator believes it. Six hours still catches
+ * the incident this was written for on its sixth hour instead of its
+ * thirty-second, and a lane genuinely down for six hours is not a jitter story
+ * under any cadence between hourly and three-hourly.
+ */
+export const CONTAINER_MISSED_PASSES = 6;
+
+export const CONTAINER_LANE_THRESHOLD_MS =
+  CONTAINER_MISSED_PASSES * CONTAINER_PASS_INTERVAL_MS;
+
+export interface ContainerLaneEntry {
+  lane: string;
+  verdict: "ok" | "stale" | "unknown";
+  /** Why, in the producer's own words where it gave any. */
+  detail: string | null;
+  age_ms: number | null;
+}
+
+export interface ContainerLaneVerdict {
+  stale: boolean;
+  threshold_ms: number;
+  checked: number;
+  stale_lanes: string[];
+  entries: ContainerLaneEntry[];
+}
+
+/** One lane's status as this watchdog reads it. */
+export interface ContainerLaneStatus {
+  lane: string;
+  /** The parsed body, or null when absent/unreadable. */
+  body: {
+    checked_at?: string | null;
+    updated_at?: string | null;
+    ok?: boolean | null;
+    status?: string | null;
+    detail?: string | null;
+    phase?: string | null;
+  } | null;
+}
+
+/** Hours, to one decimal, for a message a human reads at 3am. */
+function hours(ms: number): string {
+  return (ms / 3_600_000).toFixed(1);
+}
+
+/**
+ * The rule alone, testable without a bucket or a clock.
+ *
+ * `unknown` VERSUS `stale`, and the distinction is the one #10215 exists about:
+ * `stale` asserts the lane is behind, `unknown` says this watchdog could not
+ * measure it. An absent or unreadable status is the second -- the lane may be
+ * perfectly healthy and its status object merely missing -- and reporting that
+ * as `stale` would be inventing a fault, while reporting it as `ok` would be
+ * inventing a measurement.
+ */
+export function evaluateContainerLanes(input: {
+  statuses: ContainerLaneStatus[];
+  nowMs: number;
+  thresholdMs: number;
+}): ContainerLaneVerdict {
+  const { statuses, nowMs, thresholdMs } = input;
+  const entries = statuses.map(({ lane, body }): ContainerLaneEntry => {
+    if (body === null) {
+      return {
+        lane,
+        verdict: "unknown",
+        detail: "no status object published",
+        age_ms: null,
+      };
+    }
+    // Either spelling. Which word the producing script chose is not a fact
+    // about lane health, so the reader takes whichever is there.
+    const stampedAt = body.checked_at ?? body.updated_at ?? null;
+    const at = stampedAt === null ? Number.NaN : Date.parse(stampedAt);
+    if (!Number.isFinite(at)) {
+      return {
+        lane,
+        verdict: "unknown",
+        detail: "status carries no readable timestamp",
+        age_ms: null,
+      };
+    }
+    const age = nowMs - at;
+
+    // A DECLARED FAILURE OUTRANKS AGE. A lane that just ran and said it failed
+    // is fresh, so the age rule would call it healthy -- and its own `ok:
+    // false` is a better signal than any inference this watchdog could make.
+    // Reported with the producer's own `detail`/`phase`, because a message
+    // invented here about a process running in another repository would be a
+    // guess dressed as a diagnosis.
+    const declaredFailure =
+      body.ok === false ||
+      (typeof body.status === "string" && body.status !== "ok");
+    if (declaredFailure) {
+      const said = body.detail ?? body.phase ?? body.status ?? null;
+      return {
+        lane,
+        verdict: "stale",
+        detail:
+          said === null ? "lane reported failure" : `lane failed: ${said}`,
+        age_ms: age,
+      };
+    }
+
+    if (age > thresholdMs) {
+      return {
+        lane,
+        verdict: "stale",
+        detail:
+          `${hours(age)}h since the last pass (threshold ${hours(thresholdMs)}h, ` +
+          `${CONTAINER_MISSED_PASSES} missed passes)`,
+        age_ms: age,
+      };
+    }
+    return { lane, verdict: "ok", detail: null, age_ms: age };
+  });
+
+  const staleLanes = entries
+    .filter((entry) => entry.verdict === "stale")
+    .map((entry) => entry.lane);
+  return {
+    stale: staleLanes.length > 0,
+    threshold_ms: thresholdMs,
+    checked: entries.length,
+    stale_lanes: staleLanes,
+    entries,
+  };
+}
+
+interface StatusBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+export interface ContainerLaneWatchdogDeps {
+  now?: () => number;
+  recordException?: typeof recordExceptionEvent;
+  laneHealthDb?: LaneHealthDb | null;
+  thresholdMs?: number;
+}
+
+/** One watchdog tick. Returns a summary rather than throwing, matching the
+ * family: a tick that cannot run is one missed report, not an outage. */
+export async function runContainerLaneWatchdog(
+  env: ContainerLaneWatchdogEnv | null | undefined,
+  deps: ContainerLaneWatchdogDeps = {},
+): Promise<Record<string, unknown>> {
+  const now = deps.now ?? Date.now;
+  const record = deps.recordException ?? recordExceptionEvent;
+  const bucket = (env as { METAGRAPH_ARCHIVE?: StatusBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get) return { ok: false, reason: "r2 binding unavailable" };
+  const thresholdMs = deps.thresholdMs ?? CONTAINER_LANE_THRESHOLD_MS;
+
+  const statuses: ContainerLaneStatus[] = [];
+  for (const { lane, key } of CONTAINER_LANES) {
+    // Declared without an initialiser: both arms below assign it, so a `= null`
+    // here is a value nothing reads (`no-useless-assignment`).
+    let body: ContainerLaneStatus["body"];
+    try {
+      const object = await bucket.get(key);
+      const parsed = object
+        ? ContainerLaneStatusSchema.safeParse(await object.json())
+        : null;
+      body = parsed?.success ? parsed.data : null;
+    } catch {
+      // Unreadable is reported as absent rather than skipped: a watchdog that
+      // quietly drops what it could not read reports healthy on exactly the
+      // lanes worth worrying about.
+      body = null;
+    }
+    statuses.push({ lane, body });
+  }
+
+  const verdict = evaluateContainerLanes({
+    statuses,
+    nowMs: now(),
+    thresholdMs,
+  });
+
+  if (verdict.stale) {
+    // ONE event naming every stale lane. Five alerts for one stopped pass is
+    // the failure mode where an alarm stops being read.
+    const detail = verdict.entries
+      .filter((entry) => entry.verdict === "stale")
+      .map((entry) => `${entry.lane} (${entry.detail})`)
+      .join(", ");
+    await record(env, {
+      error: new Error(
+        `container lanes stalled: ${detail} -- these run in metagraphed-infra's ` +
+          `decode container, so nothing in this Worker will recover them`,
+      ),
+      route: "watchdog:container-lanes",
+      errorCode: "stale_lane",
+    }).catch(() => false);
+  }
+
+  // The DURABLE record, written every tick rather than only when stale --
+  // #9330/#9340's rule. PostHog drops `$exception` once the free-tier quota is
+  // exhausted, and a dropped notification is indistinguishable from a fleet
+  // that was fine.
+  const db = laneHealthStore(env, deps.laneHealthDb);
+  const checkedAt = now();
+  for (const entry of verdict.entries) {
+    await recordLaneVerdict(db, {
+      lane: entry.lane,
+      verdict: entry.verdict,
+      age_ms: entry.age_ms,
+      detail: entry.detail,
+      checked_at: checkedAt,
+    });
+  }
+
+  return {
+    ok: true,
+    stale: verdict.stale,
+    threshold_ms: verdict.threshold_ms,
+    checked: verdict.checked,
+    stale_lanes: verdict.stale_lanes,
+  };
+}

--- a/src/projection-staleness-watchdog.ts
+++ b/src/projection-staleness-watchdog.ts
@@ -155,94 +155,102 @@ export function evaluateProjectionStaleness(input: {
     generatedAt: string | null | undefined;
     /** `row_count` from the artifact body; absent/unreadable => null. */
     rowCount?: number | null;
+    /**
+     * Whether ZERO rows is a fault for this lane. Defaults true so the rule is
+     * unchanged for any caller that does not express an opinion; `watchedLanes`
+     * sets it false for non-default networks, where an idle day is normal.
+     */
+    emptyIsFault?: boolean;
   }[];
   nowMs: number;
   thresholdMs: number;
 }): ProjectionStalenessVerdict {
   const { artifacts, nowMs, thresholdMs } = input;
-  const entries = artifacts.map(({ lane, generatedAt, rowCount }) => {
-    const rows = typeof rowCount === "number" ? rowCount : null;
-    if (generatedAt == null) {
-      // An artifact that is not there at all is a stall of infinite age, not a
-      // quiet lane: every lane in the registry is supposed to have written on
-      // the last tick, and a route over a missing card serves its zeroed floor.
+  const entries = artifacts.map(
+    ({ lane, generatedAt, rowCount, emptyIsFault }) => {
+      const rows = typeof rowCount === "number" ? rowCount : null;
+      if (generatedAt == null) {
+        // An artifact that is not there at all is a stall of infinite age, not a
+        // quiet lane: every lane in the registry is supposed to have written on
+        // the last tick, and a route over a missing card serves its zeroed floor.
+        return {
+          lane,
+          stale: true,
+          reason: "absent" as const,
+          age_ms: null,
+          generated_at: null,
+          row_count: rows,
+        };
+      }
+      const at = Date.parse(generatedAt);
+      if (!Number.isFinite(at)) {
+        // A body whose timestamp cannot be read is worse than a missing one: the
+        // route is serving it, and nothing can say how old it is.
+        return {
+          lane,
+          stale: true,
+          reason: "unreadable" as const,
+          age_ms: null,
+          generated_at: generatedAt,
+          row_count: rows,
+        };
+      }
+      const age = nowMs - at;
+      if (age > thresholdMs) {
+        return {
+          lane,
+          stale: true,
+          reason: "stale" as const,
+          age_ms: age,
+          generated_at: generatedAt,
+          row_count: rows,
+        };
+      }
+      // FRESH BUT EMPTY -- the failure this watchdog could not see.
+      //
+      // The module header says it exists because two lanes "stopped writing".
+      // This is the opposite shape and the age check cannot reach it: the lane
+      // runs on time, computes zero rows, and overwrites a good artifact with an
+      // empty one, so `generated_at` stays minutes old forever while every route
+      // over the card serves its zeroed floor.
+      //
+      // MEASURED 2026-08-16: `metagraph/projections/chain-alpha-volume.json` read
+      // `{generated_at: "…11:46:31Z", row_count: 0, windows: {24h: {rows: []}}}`
+      // -- minutes old -- because its rolling 24h window queried a lakehouse
+      // whose newest data was ~29h back, so no row it could return existed. The
+      // site's 24h on-chain volume showed an em-dash for a day and this watchdog
+      // reported `ok` every 30 minutes throughout.
+      //
+      // ONLY AN EXPLICIT ZERO, never a missing field: an artifact that does not
+      // report `row_count` is not making a claim about its own coverage, and
+      // treating silence as zero would fire this on every lane whose envelope
+      // predates the field.
+      //
+      // These lanes are rolling-window aggregates over a chain producing a block
+      // every 12s, so zero rows in the window is not a quiet period -- it means
+      // the window and the data no longer overlap. A lane that CAN legitimately
+      // be empty should be exempted by name, with the reason written down, rather
+      // than by weakening this into a rule that cannot fire.
+      if (rows === 0 && emptyIsFault !== false) {
+        return {
+          lane,
+          stale: true,
+          reason: "empty" as const,
+          age_ms: age,
+          generated_at: generatedAt,
+          row_count: 0,
+        };
+      }
       return {
         lane,
-        stale: true,
-        reason: "absent" as const,
-        age_ms: null,
-        generated_at: null,
-        row_count: rows,
-      };
-    }
-    const at = Date.parse(generatedAt);
-    if (!Number.isFinite(at)) {
-      // A body whose timestamp cannot be read is worse than a missing one: the
-      // route is serving it, and nothing can say how old it is.
-      return {
-        lane,
-        stale: true,
-        reason: "unreadable" as const,
-        age_ms: null,
-        generated_at: generatedAt,
-        row_count: rows,
-      };
-    }
-    const age = nowMs - at;
-    if (age > thresholdMs) {
-      return {
-        lane,
-        stale: true,
-        reason: "stale" as const,
+        stale: false,
+        reason: null,
         age_ms: age,
         generated_at: generatedAt,
         row_count: rows,
       };
-    }
-    // FRESH BUT EMPTY -- the failure this watchdog could not see.
-    //
-    // The module header says it exists because two lanes "stopped writing".
-    // This is the opposite shape and the age check cannot reach it: the lane
-    // runs on time, computes zero rows, and overwrites a good artifact with an
-    // empty one, so `generated_at` stays minutes old forever while every route
-    // over the card serves its zeroed floor.
-    //
-    // MEASURED 2026-08-16: `metagraph/projections/chain-alpha-volume.json` read
-    // `{generated_at: "…11:46:31Z", row_count: 0, windows: {24h: {rows: []}}}`
-    // -- minutes old -- because its rolling 24h window queried a lakehouse
-    // whose newest data was ~29h back, so no row it could return existed. The
-    // site's 24h on-chain volume showed an em-dash for a day and this watchdog
-    // reported `ok` every 30 minutes throughout.
-    //
-    // ONLY AN EXPLICIT ZERO, never a missing field: an artifact that does not
-    // report `row_count` is not making a claim about its own coverage, and
-    // treating silence as zero would fire this on every lane whose envelope
-    // predates the field.
-    //
-    // These lanes are rolling-window aggregates over a chain producing a block
-    // every 12s, so zero rows in the window is not a quiet period -- it means
-    // the window and the data no longer overlap. A lane that CAN legitimately
-    // be empty should be exempted by name, with the reason written down, rather
-    // than by weakening this into a rule that cannot fire.
-    if (rows === 0) {
-      return {
-        lane,
-        stale: true,
-        reason: "empty" as const,
-        age_ms: age,
-        generated_at: generatedAt,
-        row_count: 0,
-      };
-    }
-    return {
-      lane,
-      stale: false,
-      reason: null,
-      age_ms: age,
-      generated_at: generatedAt,
-      row_count: rows,
-    };
-  });
+    },
+  );
   const staleLanes = entries.filter((e) => e.stale).map((e) => e.lane);
   return {
     stale: staleLanes.length > 0,
@@ -267,7 +275,11 @@ export interface ProjectionStalenessDeps {
 }
 
 /** Every lane x every network, labelled the way the runner labels them. */
-function watchedLanes(): { lane: string; key: string }[] {
+function watchedLanes(): {
+  lane: string;
+  key: string;
+  emptyIsFault: boolean;
+}[] {
   return PROJECTION_NETWORKS.flatMap((network) =>
     PROJECTION_LANES.map((lane) => ({
       lane:
@@ -275,6 +287,25 @@ function watchedLanes(): { lane: string; key: string }[] {
           ? lane.name
           : `${lane.name}:${network}`,
       key: projectionKey(lane.artifactKey, network),
+      // ZERO ROWS IS A FAULT ON MAINNET ONLY, and the difference is not a
+      // narrowing to make an alarm quieter -- it is the claim the rule makes.
+      //
+      // "Empty means broken" says the chain produces enough activity that an
+      // empty window cannot be real. That holds for mainnet: a block every 12s
+      // with continuous staking, where 24h of zero stake events would itself be
+      // the incident. It does not hold for a TEST chain, which is allowed to be
+      // idle for a day and frequently is.
+      //
+      // Measured 2026-08-16, the tick after this rule shipped: it flagged
+      // `chain-alpha-volume:testnet`, whose artifact was fresh (12:24) with
+      // `row_count: 0` -- a quiet test chain, not a broken lane. A rule that
+      // stands permanently on testnet is how the whole lane becomes wallpaper,
+      // which costs more than the coverage it buys.
+      //
+      // Testnet keeps every OTHER rule: absent, unreadable and stale-by-age all
+      // still fire, and `chain-stake-moves:testnet` was correctly flagged for
+      // age in that same tick.
+      emptyIsFault: network === DEFAULT_CHAIN_NETWORK,
     })),
   );
 }
@@ -302,8 +333,9 @@ export async function runProjectionStalenessWatchdog(
     lane: string;
     generatedAt: string | null;
     rowCount: number | null;
+    emptyIsFault: boolean;
   }[] = [];
-  for (const { lane, key } of watchedLanes()) {
+  for (const { lane, key, emptyIsFault } of watchedLanes()) {
     let generatedAt: string | null;
     let rowCount: number | null;
     try {
@@ -328,7 +360,7 @@ export async function runProjectionStalenessWatchdog(
       generatedAt = null;
       rowCount = null;
     }
-    artifacts.push({ lane, generatedAt, rowCount });
+    artifacts.push({ lane, generatedAt, rowCount, emptyIsFault });
   }
 
   const verdict = evaluateProjectionStaleness({

--- a/tests/container-lane-watchdog.test.ts
+++ b/tests/container-lane-watchdog.test.ts
@@ -1,0 +1,410 @@
+// The alarm for the five lanes running inside metagraphed-infra's decode
+// container. Every assertion here is about a distinction the 2026-08-16
+// incident proved this repo could not draw: the account-summary projection was
+// dead for 32 hours while `lane_health` held not one stale row for it, but NO
+// row at all.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CONTAINER_LANES,
+  CONTAINER_LANE_THRESHOLD_MS,
+  CONTAINER_MISSED_PASSES,
+  CONTAINER_PASS_INTERVAL_MS,
+  evaluateContainerLanes,
+  runContainerLaneWatchdog,
+} from "../src/container-lane-watchdog.ts";
+
+const NOW = Date.parse("2026-08-16T14:36:00.000Z");
+const FRESH = "2026-08-16T14:26:18Z";
+
+describe("evaluateContainerLanes", () => {
+  test("replays the incident: one dead lane between four healthy ones", () => {
+    // Read off production 2026-08-16T14:36Z. The pass ran THROUGH
+    // account-summary's neighbours, so the shape is not "the container is
+    // down" -- it is one lane failing silently, which is exactly what no
+    // existing watchdog could express.
+    const verdict = evaluateContainerLanes({
+      statuses: [
+        {
+          lane: "container:decode",
+          body: { updated_at: "2026-08-16T14:19:40Z", status: "ok" },
+        },
+        {
+          lane: "container:daily-rollup",
+          body: { checked_at: "2026-08-16T14:23:58Z", ok: true },
+        },
+        {
+          lane: "container:state-mirror",
+          body: { checked_at: "2026-08-16T14:26:17Z", ok: true },
+        },
+        {
+          lane: "container:account-events-rollup",
+          body: { checked_at: FRESH, ok: true },
+        },
+        {
+          lane: "container:account-summary",
+          // `phase: complete, ok: true` -- it did not crash. It ran, succeeded,
+          // and was never invoked again. Only the AGE tells you.
+          body: {
+            checked_at: "2026-08-15T06:26:33Z",
+            ok: true,
+            phase: "complete",
+          },
+        },
+      ],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.deepEqual(verdict.stale_lanes, ["container:account-summary"]);
+    assert.match(
+      verdict.entries[4]!.detail ?? "",
+      /32\.2h since the last pass/,
+    );
+    assert.equal(
+      verdict.entries[4]!.age_ms,
+      NOW - Date.parse("2026-08-15T06:26:33Z"),
+    );
+    // ...and the four that ran are not swept up with it.
+    for (const entry of verdict.entries.slice(0, 4)) {
+      assert.equal(entry.verdict, "ok", entry.lane);
+      assert.equal(entry.detail, null);
+    }
+  });
+
+  test("a DECLARED failure outranks a fresh timestamp", () => {
+    // A lane that just ran and said it failed is FRESH, so the age rule alone
+    // would call it healthy. Its own `ok: false` is the better signal.
+    const verdict = evaluateContainerLanes({
+      statuses: [
+        {
+          lane: "container:decode",
+          body: {
+            updated_at: FRESH,
+            status: "failed",
+            detail: "load: pyiceberg commit conflict",
+          },
+        },
+        {
+          lane: "container:state-mirror",
+          body: { checked_at: FRESH, ok: false, phase: "mirror" },
+        },
+      ],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.deepEqual(verdict.stale_lanes, [
+      "container:decode",
+      "container:state-mirror",
+    ]);
+    // The producer's own words, not a message invented here about a process
+    // running in another repository.
+    assert.match(
+      verdict.entries[0]!.detail ?? "",
+      /lane failed: load: pyiceberg commit conflict/,
+    );
+    assert.match(verdict.entries[1]!.detail ?? "", /lane failed: mirror/);
+  });
+
+  test("a failure with nothing to quote still says so", () => {
+    // The producer is another repo's script; it may report `ok: false` and
+    // nothing else. A verdict that went blank there would report the lane as
+    // failing without saying it failed.
+    const verdict = evaluateContainerLanes({
+      statuses: [
+        { lane: "bare", body: { checked_at: FRESH, ok: false } },
+        // `status` alone, with neither detail nor phase to prefer over it.
+        { lane: "status-only", body: { updated_at: FRESH, status: "failed" } },
+      ],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(verdict.entries[0]!.detail, "lane reported failure");
+    assert.equal(verdict.entries[1]!.detail, "lane failed: failed");
+  });
+
+  test("absent and unreadable are UNKNOWN, never stale and never ok", () => {
+    // #10215's distinction. An absent status may mean a perfectly healthy lane
+    // whose object is merely missing: calling that `stale` invents a fault,
+    // calling it `ok` invents a measurement.
+    const verdict = evaluateContainerLanes({
+      statuses: [
+        { lane: "container:decode", body: null },
+        { lane: "container:daily-rollup", body: { ok: true } },
+        {
+          lane: "container:state-mirror",
+          body: { checked_at: "not a date", ok: true },
+        },
+      ],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, false, "unknown is not an alarm");
+    assert.deepEqual(verdict.stale_lanes, []);
+    for (const entry of verdict.entries) {
+      assert.equal(entry.verdict, "unknown", entry.lane);
+      assert.equal(entry.age_ms, null, "an unmeasured age is null, not 0");
+    }
+    assert.match(
+      verdict.entries[0]!.detail ?? "",
+      /no status object published/,
+    );
+    assert.match(verdict.entries[1]!.detail ?? "", /no readable timestamp/);
+  });
+
+  test("either timestamp spelling is accepted", () => {
+    // decode publishes `updated_at`; the other four publish `checked_at`.
+    // Which word a script chose is not a fact about lane health.
+    const verdict = evaluateContainerLanes({
+      statuses: [
+        { lane: "a", body: { updated_at: FRESH, ok: true } },
+        { lane: "b", body: { checked_at: FRESH, ok: true } },
+      ],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.deepEqual(
+      verdict.entries.map((e) => e.verdict),
+      ["ok", "ok"],
+    );
+  });
+
+  test("a healthy fleet is entirely quiet", () => {
+    const verdict = evaluateContainerLanes({
+      statuses: CONTAINER_LANES.map(({ lane }) => ({
+        lane,
+        body: { checked_at: FRESH, ok: true },
+      })),
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, false);
+    assert.equal(verdict.checked, 5);
+  });
+});
+
+describe("the bound", () => {
+  test("is six passes of the container's own cadence", () => {
+    assert.equal(CONTAINER_PASS_INTERVAL_MS, 3_600_000);
+    assert.equal(CONTAINER_MISSED_PASSES, 6);
+    assert.equal(CONTAINER_LANE_THRESHOLD_MS, 6 * 3_600_000);
+  });
+
+  test("catches the incident, and is not tripped by one missed pass", () => {
+    // The two properties the width has to satisfy at once: it must fire on the
+    // real 32-hour stall well before 32 hours, and it must NOT fire on a lane
+    // that skipped a pass for a redeploy.
+    const stall = evaluateContainerLanes({
+      statuses: [{ lane: "l", body: { checked_at: "2026-08-15T06:26:33Z" } }],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(stall.stale, true);
+
+    const skipped = evaluateContainerLanes({
+      statuses: [
+        {
+          lane: "l",
+          body: { checked_at: new Date(NOW - 2 * 3_600_000).toISOString() },
+        },
+      ],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(
+      skipped.stale,
+      false,
+      "two missed passes is jitter, not a stall",
+    );
+  });
+});
+
+describe("runContainerLaneWatchdog", () => {
+  /** A bucket serving the given bodies by key; anything else is absent. */
+  function bucketWith(bodies: Record<string, unknown>) {
+    return {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          if (!(key in bodies)) return null;
+          return {
+            async json() {
+              return bodies[key];
+            },
+          };
+        },
+      },
+    } as unknown as Record<string, unknown>;
+  }
+
+  /** Records what was written to lane_health. */
+  function laneSpy() {
+    const rows: unknown[][] = [];
+    return {
+      rows,
+      db: {
+        async query() {
+          return [];
+        },
+        async run(sql: string, values: unknown[] = []) {
+          if (sql.startsWith("INSERT")) rows.push(values);
+          return { changes: 1 };
+        },
+      },
+    };
+  }
+
+  test("writes a DURABLE verdict for every lane, every tick", async () => {
+    // #9330/#9340: PostHog drops `$exception` once the free-tier quota is
+    // exhausted, and a dropped notification is indistinguishable from a fleet
+    // that was fine. The row is the record; the event is the notification.
+    const spy = laneSpy();
+    const bodies = Object.fromEntries(
+      CONTAINER_LANES.map(({ key }) => [key, { checked_at: FRESH, ok: true }]),
+    );
+    const result = (await runContainerLaneWatchdog(bucketWith(bodies), {
+      now: () => NOW,
+      recordException: (async () => true) as never,
+      laneHealthDb: spy.db,
+    })) as { ok?: boolean; stale?: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, false);
+    assert.equal(spy.rows.length, 5, "one row per lane even when all are ok");
+    assert.deepEqual(
+      spy.rows.map((r) => r[0]),
+      CONTAINER_LANES.map((l) => l.lane),
+    );
+  });
+
+  test("reads the artifacts and names the stalled lane in ONE event", async () => {
+    const spy = laneSpy();
+    const messages: string[] = [];
+    const bodies = Object.fromEntries(
+      CONTAINER_LANES.map(({ key, lane }) => [
+        key,
+        lane === "container:account-summary"
+          ? { checked_at: "2026-08-15T06:26:33Z", ok: true, phase: "complete" }
+          : { checked_at: FRESH, ok: true },
+      ]),
+    );
+    const result = (await runContainerLaneWatchdog(bucketWith(bodies), {
+      now: () => NOW,
+      recordException: (async (_env: unknown, ev: { error?: unknown }) => {
+        messages.push(String((ev.error as Error)?.message));
+        return true;
+      }) as never,
+      laneHealthDb: spy.db,
+    })) as { stale?: boolean; stale_lanes?: string[] };
+    assert.equal(result.stale, true);
+    assert.deepEqual(result.stale_lanes, ["container:account-summary"]);
+    assert.equal(messages.length, 1, "one event, not five");
+    assert.match(messages[0]!, /container:account-summary/);
+    assert.match(
+      messages[0]!,
+      /nothing in this Worker will recover them/,
+      "the message must say where the fix lives",
+    );
+  });
+
+  test("a lane that has NEVER run is unknown, and the others still report", async () => {
+    // A real shape: a lane added to the container that has not completed a
+    // pass yet has no status object at all. It must not be reported as healthy,
+    // and it must not suppress the four lanes that did run.
+    const spy = laneSpy();
+    const bodies = Object.fromEntries(
+      CONTAINER_LANES.filter((l) => l.lane !== "container:account-summary").map(
+        ({ key }) => [key, { checked_at: FRESH, ok: true }],
+      ),
+    );
+    const result = (await runContainerLaneWatchdog(bucketWith(bodies), {
+      now: () => NOW,
+      recordException: (async () => true) as never,
+      laneHealthDb: spy.db,
+    })) as { stale?: boolean };
+    assert.equal(result.stale, false, "never-run is unknown, not an alarm");
+    const verdicts = Object.fromEntries(
+      spy.rows.map((r) => [String(r[0]), String(r[1])]),
+    );
+    assert.equal(verdicts["container:account-summary"], "unknown");
+    assert.equal(verdicts["container:decode"], "ok");
+  });
+
+  test("a body that is not an object reads as absent", async () => {
+    // Every field carries `.catch`, so the OBJECT parse is the only thing left
+    // that can fail -- a status key holding a string, or an array, which is
+    // what a half-written or wrong-keyed object looks like from here.
+    const spy = laneSpy();
+    const notObjects = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              return "not a status object";
+            },
+          };
+        },
+      },
+    } as unknown as Record<string, unknown>;
+    const result = (await runContainerLaneWatchdog(notObjects, {
+      now: () => NOW,
+      recordException: (async () => true) as never,
+      laneHealthDb: spy.db,
+    })) as { ok?: boolean; stale?: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, false, "unparseable is unknown, not an alarm");
+    assert.deepEqual(
+      spy.rows.map((r) => r[1]),
+      Array(5).fill("unknown"),
+    );
+  });
+
+  test("a telemetry failure does not take the tick down", async () => {
+    // The durable row is the record and the event is only the notification, so
+    // a rejecting capture must not cost the verdicts -- the inversion
+    // #9330/#9340 exist about.
+    const spy = laneSpy();
+    const bodies = Object.fromEntries(
+      CONTAINER_LANES.map(({ key }) => [
+        key,
+        { checked_at: "2026-08-15T06:26:33Z", ok: true },
+      ]),
+    );
+    const result = (await runContainerLaneWatchdog(bucketWith(bodies), {
+      now: () => NOW,
+      recordException: (async () => {
+        throw new Error("posthog quota exhausted");
+      }) as never,
+      laneHealthDb: spy.db,
+    })) as { ok?: boolean; stale?: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, true);
+    assert.equal(spy.rows.length, 5, "every verdict still recorded");
+  });
+
+  test("a missing binding is a stated no-op, not a silent pass", async () => {
+    const result = (await runContainerLaneWatchdog({}, {})) as {
+      ok?: boolean;
+      reason?: string;
+    };
+    assert.equal(result.ok, false);
+    assert.match(result.reason ?? "", /r2 binding unavailable/);
+  });
+
+  test("a throwing bucket reads as absent rather than taking the tick down", async () => {
+    const spy = laneSpy();
+    const throwing = {
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          throw new Error("r2 unreachable");
+        },
+      },
+    } as unknown as Record<string, unknown>;
+    const result = (await runContainerLaneWatchdog(throwing, {
+      now: () => NOW,
+      recordException: (async () => true) as never,
+      laneHealthDb: spy.db,
+    })) as { ok?: boolean; stale?: boolean };
+    assert.equal(result.ok, true);
+    assert.equal(result.stale, false, "unreadable is unknown, not an alarm");
+    assert.equal(spy.rows.length, 5, "and every lane still gets a row");
+  });
+});

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -160,6 +160,63 @@ describe("evaluateProjectionStaleness -- fresh but empty", () => {
     assert.equal(verdict.entries[0]!.row_count, 128);
   });
 
+  test("a QUIET TEST CHAIN is not a fault -- emptyIsFault gates it", () => {
+    // "Empty means broken" is a claim about ACTIVITY LEVEL, not about the lane.
+    // It holds for mainnet -- a block every 12s with continuous staking, where
+    // 24h of zero stake events would itself be the incident -- and not for a
+    // test chain, which is allowed to be idle for a day.
+    //
+    // Measured on the tick after this rule shipped: it flagged
+    // `chain-alpha-volume:testnet`, fresh at 12:24 with row_count 0. A rule
+    // that stands permanently on testnet turns the whole lane into wallpaper.
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [
+        { lane: "chain-alpha-volume", generatedAt: FRESH, rowCount: 0 },
+        {
+          lane: "chain-alpha-volume:testnet",
+          generatedAt: FRESH,
+          rowCount: 0,
+          emptyIsFault: false,
+        },
+      ],
+      nowMs: NOW,
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.deepEqual(
+      verdict.stale_lanes,
+      ["chain-alpha-volume"],
+      "mainnet still faults on the identical payload",
+    );
+    assert.equal(verdict.entries[1]!.reason, null);
+    assert.equal(
+      verdict.entries[1]!.row_count,
+      0,
+      "the count is still reported -- exempt from the verdict, not from the record",
+    );
+  });
+
+  test("an exempt lane keeps every OTHER rule", () => {
+    // The exemption is for emptiness alone. A testnet lane that stops being
+    // written, or goes unreadable, must still fire -- which is what happened to
+    // `chain-stake-moves:testnet` in the same production tick, correctly.
+    const verdict = evaluateProjectionStaleness({
+      artifacts: [
+        {
+          lane: "stale:testnet",
+          generatedAt: "2026-08-14T09:00:00.000Z",
+          rowCount: 0,
+          emptyIsFault: false,
+        },
+        { lane: "absent:testnet", generatedAt: null, emptyIsFault: false },
+      ],
+      nowMs: NOW,
+      thresholdMs: PROJECTION_STALENESS_THRESHOLD_MS,
+    });
+    assert.deepEqual(verdict.stale_lanes, ["stale:testnet", "absent:testnet"]);
+    assert.equal(verdict.entries[0]!.reason, "stale");
+    assert.equal(verdict.entries[1]!.reason, "absent");
+  });
+
   test("a MISSING row_count is not read as zero", () => {
     // Silence is not a claim. An envelope that predates the field would
     // otherwise fire this on every lane at once, which is how a new alarm gets

--- a/tests/staleness-watchdog-registry.test.ts
+++ b/tests/staleness-watchdog-registry.test.ts
@@ -107,6 +107,14 @@ describe("the staleness watchdog registry", () => {
         "top-holders-flow-staleness": 30,
         // was 54
         "hotkey-alpha-staleness": 60,
+        // NOT one of the eight, and it never had a cron of its own: it was
+        // added because the five lanes in metagraphed-infra's decode container
+        // had NO watchdog at all -- `lane_health` held zero rows for them, and
+        // the account-summary projection went dark for 32 hours unnoticed.
+        // Hourly because that is the container's own pass cadence; a
+        // quarter-hourly tick would buy four times the R2 GETs and no earlier
+        // detection.
+        "container-lanes": 60,
       },
     );
   });
@@ -163,6 +171,9 @@ describe("the staleness watchdog registry", () => {
       [],
       "a staleness lane took a cron minute back",
     );
-    assert.equal(STALENESS_WATCHDOGS.length, 8);
+    // Eight consolidated lanes plus `container-lanes`, which joined the
+    // heartbeat rather than claiming a ninth cron minute -- the whole point of
+    // the registry being the place a lane's cadence lives.
+    assert.equal(STALENESS_WATCHDOGS.length, 9);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -606,6 +606,7 @@ import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.t
 import { runLaneAlarm } from "../src/lane-alarm.ts";
 import { runNominatorPositionsStalenessWatchdog } from "../src/nominator-positions-staleness-watchdog.ts";
 import { runProjectionStalenessWatchdog } from "../src/projection-staleness-watchdog.ts";
+import { runContainerLaneWatchdog } from "../src/container-lane-watchdog.ts";
 import { runValidatorNominatorCountsStalenessWatchdog } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import { runAccountBalancesStalenessWatchdog } from "../src/account-balances-staleness-watchdog.ts";
 import { isFinneySs58Address } from "../src/account-balance.ts";
@@ -3438,6 +3439,23 @@ export const STALENESS_WATCHDOGS: ReadonlyArray<
     name: "projection-staleness",
     everyMinutes: 30,
     run: ({ env }) => runProjectionStalenessWatchdog(env),
+  },
+  {
+    // The five lanes inside metagraphed-infra's decode container, which no
+    // watchdog could see: `projection-staleness` iterates PROJECTION_LANES --
+    // the thirteen this Worker computes -- so anything container-written is
+    // structurally outside it. Measured 2026-08-16: `lane_health` held ZERO
+    // rows for `%summary%`, `%decode%`, `%rollup%` and `%mirror%`, and the
+    // account-summary projection had been dead 32 hours while the lanes either
+    // side of it in the same pass ran normally.
+    //
+    // HOURLY, matching the container's own pass rather than the 15/30-minute
+    // cadences around it: five R2 GETs against a lane that cannot advance
+    // faster than its cron, so a quarter-hourly tick would buy nothing but
+    // four times the reads.
+    name: "container-lanes",
+    everyMinutes: 60,
+    run: ({ env }) => runContainerLaneWatchdog(env),
   },
   {
     // #9273. That lane had no watchdog and no writer at all, and the gap was


### PR DESCRIPTION
Phases 0–1 of the plan that came out of *"we keep pushing this problem around."*

## The gap

Not a stale row. **No row.** A `lane_health` sweep on 2026-08-16 returned nothing for `%summary%`, `%decode%`, `%rollup%` or `%mirror%`. Every lane inside `metagraphed-infra`'s decode container was structurally invisible, because `projection-staleness` iterates `PROJECTION_LANES` — the thirteen lanes *this* Worker computes.

## What it cost

The account-summary projection had not published a generation since **2026-08-15T06:26:33Z — 32 hours** — while the four lanes either side of it in the same sequential pass ran normally:

| lane | last status |
|---|---|
| `container:decode` | 14:19:40Z ✓ |
| `container:daily-rollup` | 14:23:58Z ✓ |
| `container:state-mirror` | 14:26:17Z ✓ |
| `container:account-events-rollup` | 14:26:18Z ✓ |
| **`container:account-summary`** | **2026-08-15T06:26:33Z** — `phase: complete, ok: true` |

It did not crash. It ran, succeeded, and was never invoked again — so only its **age** says anything, and nothing was reading its age.

Downstream: `readRecent` declines without a generation carrying `recent_limit` (published by `metagraphed-infra#589`, which merged **two hours after** that last generation), so every account request fell back to an unbounded lakehouse scan and `/accounts/{ss58}` served 503s and 8–20s responses all day.

## Why this is the systemic fix

**It inverts the default.** Today a lane is silent unless somebody wrote a watchdog aimed at it — which is how a lane nobody was thinking about goes dark for 32 hours. After this, a lane that stops advancing produces a `stale` verdict on the next tick, and adding a sixth lane to the container is one line here rather than remembering to build an alarm.

It reads what each lane **says about itself**, and how long ago it said it — five status objects that were already being published and never read. Verifying the *output* stays `lakehouse-seam`'s job for decode and `projection-staleness`'s for the Worker lanes; this answers the prior question neither can: **did the producer run at all.**

## Design notes, each earned by a distinction the incident exposed

- **One schema for five lanes that disagree about their field names.** decode publishes `updated_at`/`status`, the other four `checked_at`/`ok`. Which word a script chose is not a fact about lane health. Five schemas would state five vocabularies this repo neither owns nor can keep in step.
- **A declared failure outranks age.** A lane that just ran and said it failed is *fresh*, so an age rule alone calls it healthy. Reported with the producer's own `detail`/`phase` — a message invented here about a process running in another repository would be a guess dressed as a diagnosis.
- **Absent and unreadable are `unknown`**, never `stale` and never `ok` (#10215's distinction). A missing status object may mean a perfectly healthy lane: calling that stale invents a fault, calling it ok invents a measurement.
- **Six missed passes, deliberately wide.** The container's cadence is a *cross-repository pin* (`wrangler.decode-r2.jsonc`, `17 * * * *`) this repo cannot import, so a tight bound would false-alarm the day infra changes its cron — and an alarm nobody believes is worth less than none. Six hours still catches this incident on its sixth hour instead of its thirty-second.
- **Joins `STALENESS_WATCHDOGS`** rather than claiming a cron minute, which is what that registry is for. Hourly, matching the container's own pass: a quarter-hourly tick buys four times the R2 GETs and no earlier detection.

## Also here: scoping the empty-projection rule to mainnet

The rule shipped in #11410 fired within the hour on `chain-alpha-volume:testnet`, whose artifact was fresh (12:24) with `row_count: 0`.

"Empty means broken" is a claim about **activity level** — true for a chain producing a block every 12 s with continuous staking, where 24 h of zero stake events would itself be the incident; false for a test chain that is allowed to be idle for a day. A rule that stands permanently on testnet turns the whole lane into wallpaper, which costs more than the coverage it buys.

Testnet keeps every other rule: absent, unreadable and stale-by-age all still fire, and `chain-stake-moves:testnet` was correctly flagged for **age** in that same tick.

## Verification

- full suite: **950 files, 21,791 passed, 11 skipped, 0 failures**
- the complete CI gate derived from the workflows — **79 targets**, including `lint`, `format:check`, `typecheck`, `scan:public-safety` — 0 failures
- no uncovered statements or branches in the changed lines
- the registry gate (`staleness-watchdog-registry`) updated deliberately: 8 → 9 lanes, with the reason recorded in the assertion