### PR TITLE
perf(accounts): four account feeds walked to genesis, and the gate that should have caught them was blind three ways

### DIFF
--- a/scripts/validate-r2-sql-scan-bounds.ts
+++ b/scripts/validate-r2-sql-scan-bounds.ts
@@ -54,16 +54,59 @@ const PRUNABLE = [
  * outlives the thing it was guessing about. These are small tables where a full
  * scan is genuinely cheaper than the index-shaped alternative.
  */
+/**
+ * KEYED BY FILE AND TABLE, because keying by file alone exempts reads nobody
+ * measured.
+ *
+ * Both entries below name a small table. The exemption used to be `file ->
+ * reason`, so `src/nominator-positions-cold-tier.ts`'s note about
+ * `chain.nominator_positions` (~123k rows, 1.67 MB) also covered that same
+ * file's `SELECT MAX(observed_at) FROM chain.account_events WHERE coldkey = X`
+ * -- an unbounded scan of an 894M-row table, exempted by a sentence about a
+ * different table 7,000x smaller. Naming the table is what makes the measured
+ * reason apply to the read it was actually measured against.
+ */
 export const UNBOUNDED_BY_DESIGN: Readonly<Record<string, string>> = {
-  "src/account-identity-cold-tier.ts":
+  "src/account-identity-cold-tier.ts|chain.account_identity":
     "chain.account_identity is ~515 rows; a full scan measured 0.08 MB",
-  "src/nominator-positions-cold-tier.ts":
+  "src/nominator-positions-cold-tier.ts|chain.nominator_positions":
     "chain.nominator_positions is ~123k rows; a full scan measured 1.67 MB",
+};
+
+/** The lakehouse table a query reads, for scoping an exemption to it. */
+export function tableOf(query: string): string | null {
+  return (
+    /FROM\s+((?:chain|chain_testnet)\.[a-z_]+)/i
+      .exec(query)?.[1]
+      ?.toLowerCase() ?? null
+  );
+}
+
+/**
+ * Reads whose bound is real but CONDITIONAL, each naming the test that proves
+ * the emitted SQL carries it.
+ *
+ * Distinct from UNBOUNDED_BY_DESIGN, which says "this scan is cheap", and from
+ * INTERPOLATED_PREDICATES, which covers a WHERE this gate cannot read at all.
+ * These are reads whose predicate IS in the source and is applied only when a
+ * bound is available -- `floorMs === null ? "" : \` AND observed_at >= ...\``.
+ * A static gate cannot evaluate that ternary, and treating it as unbounded
+ * would push the author toward emitting a fake always-true bound purely to
+ * satisfy the check, which buys nothing and hides the real question.
+ *
+ * Keyed by file AND table for the same reason UNBOUNDED_BY_DESIGN is: an
+ * exemption that covers a whole file covers reads nobody looked at.
+ */
+export const RUNTIME_BOUNDED: Readonly<Record<string, string>> = {
+  "src/nominator-positions-cold-tier.ts|chain.account_events":
+    "tests/nominator-positions-cold-tier.test.ts asserts latestStakeEventAt emits the projection floor",
 };
 
 export interface Finding {
   file: string;
   query: string;
+  /** The lakehouse table read, so an exemption can be scoped to it. */
+  table: string | null;
   /** The predicate is interpolated, so this gate cannot read it from source. */
   unreadable?: boolean;
 }
@@ -125,8 +168,23 @@ export function findUnbounded(file: string, source: string): Finding[] {
   const buildsScattered = SCATTERED.some((c) =>
     new RegExp(`\\b${c}\\b\\s*(=|IN|LIKE)`, "i").test(source),
   );
-  const call =
-    /r2SqlQuery(?:<[^>]*>)?\(\s*\w+,\s*(`(?:[^`\\]|\\.)*`(?:\s*\+\s*`(?:[^`\\]|\\.)*`)*)/gs;
+  // ANY STRING LITERAL, not just a backtick one. The pattern accepted only
+  // template literals, so a query assembled as
+  //
+  //     "SELECT MAX(observed_at) ... FROM chain.account_events" +
+  //       ` WHERE coldkey = '${coldkey}'`
+  //
+  // matched NOTHING and the call was never examined -- which is how
+  // nominator-positions-cold-tier's unbounded scan of an 894M-row table sat
+  // outside a gate whose entire job is finding it. A double-quoted first
+  // segment is an ordinary way to write SQL that starts with a constant, and
+  // the gate must not depend on which quote a reader reached for.
+  const STRING =
+    "(?:`(?:[^`\\\\]|\\\\.)*`|\"(?:[^\"\\\\]|\\\\.)*\"|'(?:[^'\\\\]|\\\\.)*')";
+  const call = new RegExp(
+    `r2SqlQuery(?:<[^>]*>)?\\(\\s*\\w+,\\s*(${STRING}(?:\\s*\\+\\s*${STRING})*)`,
+    "gs",
+  );
   for (const match of source.matchAll(call)) {
     const query = (match[1] ?? "").replace(/\s+/g, " ");
     // A first pass at this used a 300-char window and reported 62 findings,
@@ -140,13 +198,34 @@ export function findUnbounded(file: string, source: string): Finding[] {
     // not the same as safe.
     if (!scattered && buildsScattered && /WHERE\s*\$\{/.test(query)) {
       if (INTERPOLATED_PREDICATES[file]) continue;
-      out.push({ file, query: query.slice(0, 160), unreadable: true });
+      out.push({
+        file,
+        table: tableOf(query),
+        query: query.slice(0, 160),
+        unreadable: true,
+      });
       continue;
     }
     if (!scattered) continue;
-    if (PRUNABLE.some((c) => new RegExp(`\\b${c}\\b`, "i").test(query)))
+    // A PRUNABLE COLUMN IN A PREDICATE, not merely somewhere in the query.
+    //
+    // This was bare presence, so `SELECT MAX(observed_at) ... WHERE coldkey =
+    // X` counted as bounded on the strength of its SELECT list while carrying
+    // no bound at all. That exact read is in nominator-positions-cold-tier and
+    // fires for every account holding no delegated positions -- the cheapest
+    // answer paying the most expensive scan, invisible to the gate meant to
+    // catch it.
+    //
+    // A comparison operator is what makes it a bound: `observed_at >= N`,
+    // `BETWEEN`, `IN`. Naming the column in a projection, an alias or an ORDER
+    // BY prunes nothing.
+    if (
+      PRUNABLE.some((c) =>
+        new RegExp(`\\b${c}\\b\\s*(>=|>|<=|<|=|BETWEEN|IN)`, "i").test(query),
+      )
+    )
       continue;
-    out.push({ file, query: query.slice(0, 160) });
+    out.push({ file, table: tableOf(query), query: query.slice(0, 160) });
   }
   return out;
 }
@@ -162,13 +241,17 @@ function main(): void {
     );
   }
 
-  const unexpected = findings.filter((f) => !UNBOUNDED_BY_DESIGN[f.file]);
+  const exemptKey = (f: Finding) => `${f.file}|${f.table ?? ""}`;
+  const unexpected = findings.filter(
+    (f) => !UNBOUNDED_BY_DESIGN[exemptKey(f)] && !RUNTIME_BOUNDED[exemptKey(f)],
+  );
   const staleInterpolated = Object.keys(INTERPOLATED_PREDICATES).filter(
     (file) => !readdirSync(dir).some((name) => `src/${name}` === file),
   );
-  const stale = Object.keys(UNBOUNDED_BY_DESIGN).filter(
-    (file) => !findings.some((f) => f.file === file),
-  );
+  const stale = [
+    ...Object.keys(UNBOUNDED_BY_DESIGN),
+    ...Object.keys(RUNTIME_BOUNDED),
+  ].filter((key) => !findings.some((f) => exemptKey(f) === key));
 
   const problems: string[] = [];
   if (unexpected.length) {

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -101,7 +101,10 @@ import { storeAll } from "./analytics-live.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { windowedFloorRead, windowedRowRead } from "./account-events-window.ts";
-import { loadAccountSummaryProjection } from "./account-summary-projection.ts";
+import {
+  accountHistoryFloorMs,
+  loadAccountSummaryProjection,
+} from "./account-summary-projection.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
 import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
@@ -197,6 +200,14 @@ export async function loadAccountTransfersColdTier(
     return null;
   }
   const where = ["event_kind = 'Transfer'"];
+  // The projection's lower bound, pushed in beside the direction predicate.
+  // This feed walked with no floor at all: the two probes cover 8 days, and an
+  // account whose newest transfer is older than that reached the unbounded
+  // third read.
+  const transferFloorMs = await accountHistoryFloorMs(env, ss58);
+  if (transferFloorMs !== null) {
+    where.push(`observed_at >= ${Math.trunc(transferFloorMs)}`);
+  }
   // data-api's exact direction semantics: sent matches the from side (hotkey),
   // received the to side (coldkey), and "all"/omitted reads both -- the single
   // OR standing in for its two-scan merge (see the module header).
@@ -810,9 +821,36 @@ type CounterpartyScanRow = Pick<
   | "observed_at"
 >;
 
+/**
+ * The floor for a PAIR of accounts: the earlier of the two, or null.
+ *
+ * A relationship row needs only ONE side to exist, so the bound has to be the
+ * MINIMUM. Flooring at the later account's first event would silently drop
+ * everything the earlier one did before it -- and a counterparty feed missing
+ * its oldest half looks exactly like a quiet relationship.
+ *
+ * NULL IF EITHER IS UNKNOWN, for the same reason. A floor derived from one
+ * known side alone would be a bound on the wrong account: the unknown one may
+ * have history below it.
+ */
+async function pairHistoryFloorMs(
+  env: R2SqlEnv | null | undefined,
+  a: string,
+  b: string,
+): Promise<number | null> {
+  const [first, second] = await Promise.all([
+    accountHistoryFloorMs(env, a),
+    accountHistoryFloorMs(env, b),
+  ]);
+  if (first === null || second === null) return null;
+  return Math.min(first, second);
+}
+
 async function counterpartyScan(
   env: R2SqlEnv | null | undefined,
   predicate: string,
+  /** The projection's lower bound, or null when it could not supply one. */
+  floorMs: number | null,
 ): Promise<CounterpartyScanRow[] | null> {
   // BOUNDED (#11131), same reasoning as the transfer feed: the predicate pins
   // hotkey/coldkey, which file statistics cannot prune on. The cap is a row
@@ -824,7 +862,14 @@ async function counterpartyScan(
   return windowedRowRead<CounterpartyScanRow>(env, {
     table: "chain.account_events",
     columns: `hotkey, coldkey, amount_tao, block_number, event_index, observed_at`,
-    where: ["event_kind = 'Transfer'", predicate],
+    where:
+      floorMs === null
+        ? ["event_kind = 'Transfer'", predicate]
+        : [
+            "event_kind = 'Transfer'",
+            predicate,
+            `observed_at >= ${Math.trunc(floorMs)}`,
+          ],
     order: ` ${FEED_ORDER}`,
     need: COUNTERPARTIES_SCAN_CAP,
   });
@@ -842,9 +887,12 @@ export async function loadAccountCounterpartiesColdTier(
 ): Promise<ReturnType<typeof buildCounterparties> | null> {
   const addr = safeSs58Literal(ss58);
   if (addr === null) return null;
+  // `need` here is COUNTERPARTIES_SCAN_CAP (5,000), so the walk's two probes
+  // essentially never fill and every request reached its unbounded third read.
   const rows = await counterpartyScan(
     env,
     `(hotkey = '${addr}' OR coldkey = '${addr}')`,
+    await accountHistoryFloorMs(env, ss58),
   );
   if (rows === null) return null;
   return buildCounterparties(rows, ss58, { limit: query.limit });
@@ -889,6 +937,11 @@ export async function loadCounterpartyRelationshipColdTier(
     env,
     `((hotkey = '${addr}' AND coldkey = '${other}') OR ` +
       `(hotkey = '${other}' AND coldkey = '${addr}'))`,
+    // THE PAIR'S floor is the EARLIER of the two, and null if either is
+    // unknown: a relationship row needs only ONE side to exist, so flooring at
+    // the later account's first event would drop everything the earlier one did
+    // before it.
+    await pairHistoryFloorMs(env, ss58, counterparty),
   );
   if (rows === null) return null;
   const relationship = buildCounterpartyRelationship(rows, ss58, counterparty, {

--- a/src/account-history-cold-tier.ts
+++ b/src/account-history-cold-tier.ts
@@ -36,6 +36,7 @@ import {
   buildAccountHistory,
   type AccountHistoryResult,
 } from "./account-events.ts";
+import { accountHistoryFloorMs } from "./account-summary-projection.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
@@ -117,6 +118,17 @@ export async function loadAccountHistoryColdTier(
   // `netuid IS NOT NULL` mirrors the retired writer's own WHERE clause: a row
   // with no subnet has no (hotkey, netuid, day) key and was never rolled up.
   const where = [`hotkey = '${addr}'`, "netuid IS NOT NULL"];
+  // THE PROJECTION FLOOR (#11131's bound, applied to the one read that had
+  // none). This is a LIFETIME `GROUP BY day, netuid` over a scattered key, so
+  // without `?from` it walked to genesis -- and the gate could not see it,
+  // because it calls an injected `queryFn` rather than the literal
+  // `r2SqlQuery(` the scan-bound check greps for.
+  // No `network` argument: this loader takes none and reads the mainnet
+  // tables, which is exactly the case the helper floors.
+  const historyFloorMs = await accountHistoryFloorMs(env, ss58);
+  if (historyFloorMs !== null) {
+    where.push(`observed_at >= ${Math.trunc(historyFloorMs)}`);
+  }
 
   if (query.netuid != null) {
     const netuid = safeBlockNumber(query.netuid);

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -58,6 +58,7 @@ import {
   AccountSummaryRecentSchema,
 } from "../schemas-src/artifacts/account-summary-projection.ts";
 import type { R2SqlEnv } from "./r2-sql.ts";
+import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 
 /** Objects the producer writes, one per shard. Contract with
  * metagraphed-infra's `services/indexer-rs/account_summary_r2.py`. */
@@ -478,4 +479,48 @@ function readRecent(
   // and the rest fall back exactly as they do today.
   if (parsed.data.length < Math.min(published, lifetimeEvents)) return none;
   return { recent: { rows: parsed.data, floorMs } };
+}
+
+/**
+ * The earliest millisecond this account can have an event, or null.
+ *
+ * THE ONE BOUND THAT COMPOSES WITH ANYTHING. The account routes carry cursors,
+ * offsets and half a dozen optional filters between them, and a windowed read
+ * has to agree with all of them. A pure lower bound does not: it removes rows
+ * that cannot exist, whatever else is being asked, so every caller can push it
+ * into its own `where` and change nothing else.
+ *
+ * Sound for BOTH answers the projection gives:
+ *
+ *   ABSENT  the producer writes every shard, so absence from a shard that
+ *           exists proves there is nothing at or before `through`.
+ *   PRESENT the groups are a LIFETIME aggregate -- the read declines anything
+ *           over the scan cap rather than publishing a windowed subtotal -- so
+ *           nothing exists before `min(fo)`. Post-fold events sit above
+ *           `foldFloorMs`, which is itself above `min(fo)`, so the single floor
+ *           still covers the whole history.
+ *
+ * MAINNET ONLY. The projection describes the default network, so flooring
+ * another chain's feed with it would bound that feed against the wrong history
+ * -- a wrong answer, where the unbounded walk is merely a slow right one.
+ *
+ * `recentLimit: 0` on purpose: callers of this want the FLOOR, not the
+ * published rows, and asking for rows would read a map it then throws away.
+ *
+ * AN OPTIMISATION OVER A CORRECT READ, never a precondition for one. Every
+ * caller must behave identically when this returns null, which is what makes it
+ * safe to add to a route without re-arguing that route's correctness.
+ */
+export async function accountHistoryFloorMs(
+  env: R2SqlEnv | null | undefined,
+  account: string,
+  network?: ChainNetworkId,
+): Promise<number | null> {
+  if (network !== undefined && network !== DEFAULT_CHAIN_NETWORK) return null;
+  const projected = await loadAccountSummaryProjection(env, account, {
+    recentLimit: 0,
+  });
+  if (projected === null) return null;
+  if (projected.absent === true) return projected.floorMs;
+  return projected.span?.firstMs ?? null;
 }

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -40,12 +40,8 @@ import {
   type ChainEventApi,
 } from "./chain-detail-hot-tier.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
-import {
-  type ChainNetworkId,
-  chainTable,
-  DEFAULT_CHAIN_NETWORK,
-} from "./chain-network.ts";
-import { loadAccountSummaryProjection } from "./account-summary-projection.ts";
+import { type ChainNetworkId, chainTable } from "./chain-network.ts";
+import { accountHistoryFloorMs } from "./account-summary-projection.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -154,18 +150,8 @@ export async function loadAccountEventsColdTier(
   // MAINNET ONLY. The projection is written for the default network, so reading
   // it for another chain would floor a feed against the wrong history. Other
   // networks keep the unbounded walk -- correct, just not faster.
-  if (network === undefined || network === DEFAULT_CHAIN_NETWORK) {
-    const projected = await loadAccountSummaryProjection(env, ss58, {
-      // The aggregate leg only: this route wants the FLOOR, not the published
-      // rows, and asking for rows would read a map it then throws away.
-      recentLimit: 0,
-    });
-    const floorMs =
-      projected?.absent === true
-        ? projected.floorMs
-        : (projected?.span?.firstMs ?? null);
-    if (floorMs !== null) where.push(`observed_at >= ${Math.trunc(floorMs)}`);
-  }
+  const floorMs = await accountHistoryFloorMs(env, ss58, network);
+  if (floorMs !== null) where.push(`observed_at >= ${Math.trunc(floorMs)}`);
 
   // Cursor pages never carry an offset, mirroring data-api.
   const paged = cursor ? 0 : offset;

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -258,6 +258,31 @@ export async function loadBlockExtrinsicsColdTier(
 }
 
 /** One account's extrinsics, newest first. */
+/**
+ * DELIBERATELY NOT FLOORED by the account-summary projection, unlike every
+ * other account-scoped read in this family.
+ *
+ * The floor those use is `min(fo)` over an account's groups in
+ * `chain.account_events`. This reads `chain.extrinsics` on `signer`, and the
+ * projection makes NO claim about that table. Using it here would assert that
+ * an account cannot have signed an extrinsic before its first account_event,
+ * and that is not a fact anyone has established: it holds only if every signed
+ * extrinsic produces an event naming its signer, which fee-free and root calls
+ * do not.
+ *
+ * The cost of being wrong is silent -- the oldest extrinsics simply vanish from
+ * the feed, and a short page looks exactly like a quiet account. That is the
+ * failure this whole family has been correcting all week, so it is not one to
+ * introduce for a latency win.
+ *
+ * SO THIS READ IS STILL UNBOUNDED, and knowingly. Bounding it needs either a
+ * signer-keyed projection or a measured proof that the event floor covers
+ * signers; both are their own change. `validate:r2-sql-scan-bounds` does not
+ * flag it today because `signer` is absent from its SCATTERED list -- left
+ * alone here rather than added, because adding it without a bound would force a
+ * false `UNBOUNDED_BY_DESIGN` exemption, and an exemption that misdescribes why
+ * is worse than a gap that is written down.
+ */
 export async function loadAccountExtrinsicsColdTier(
   env: R2SqlEnv | null | undefined,
   ss58: string,

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -57,6 +57,7 @@ import {
   distinctHotkeys,
   stakeByHotkeyNetuid,
 } from "./account-nominator-positions.ts";
+import { accountHistoryFloorMs } from "./account-summary-projection.ts";
 import { STAKE_ADDED_KIND, STAKE_REMOVED_KIND } from "./account-stake-flow.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { r2SqlQuery, safeSs58Literal } from "./r2-sql.ts";
@@ -210,11 +211,22 @@ export async function latestStakeEventAt(
 ): Promise<number | null> {
   const coldkey = safeSs58Literal(ss58);
   if (coldkey === null) return null;
+  // FLOORED, and it had no bound at all. `MAX(observed_at)` over a scattered
+  // `coldkey` reads this account's whole history, and it fires precisely for
+  // the accounts holding NO delegated positions -- so the cheapest answer paid
+  // the most expensive read. The scan-bound gate could not see it either: its
+  // PRUNABLE test is bare substring presence, and `MAX(observed_at)` in the
+  // SELECT list satisfied it without a single predicate on that column.
+  //
+  // Same table the projection describes, so the floor is sound here in a way it
+  // is NOT for chain.extrinsics -- see loadAccountExtrinsicsColdTier.
+  const floorMs = await accountHistoryFloorMs(env, ss58);
   const rows = await r2SqlQuery(
     env,
     "SELECT MAX(observed_at) AS latest FROM chain.account_events" +
       ` WHERE coldkey = '${coldkey}'` +
-      ` AND event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}')`,
+      ` AND event_kind IN ('${STAKE_ADDED_KIND}', '${STAKE_REMOVED_KIND}')` +
+      (floorMs === null ? "" : ` AND observed_at >= ${Math.trunc(floorMs)}`),
   );
   return latestStamp(rows);
 }

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -31,6 +31,7 @@ import {
   loadValidatorNominatorsColdTier,
 } from "../src/account-feeds-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { accountSummaryArchive } from "./helpers/cold-tier-env.ts";
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
@@ -1039,5 +1040,113 @@ describe("loadAccountPrometheusColdTier", () => {
       await loadAccountPrometheusColdTier(TOKEN as never, ADDR),
       null,
     );
+  });
+});
+
+/**
+ * The projection floor, applied to the three feeds that walked with none.
+ *
+ * Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC: `/counterparties` 15.1s,
+ * `/transfers` 12.6s. `counterpartyScan` asks for COUNTERPARTIES_SCAN_CAP
+ * (5,000) rows, so its two probes essentially never fill and every request
+ * reached the unbounded third read of an ~894M-row table.
+ */
+describe("the account feeds -- the projection floor", () => {
+  const FIRST = 1_699_999_000_000;
+  const OTHER_FIRST = 1_699_990_000_000;
+
+  /** One folded group, as the producer publishes it. */
+  const group = (fo: number) => [
+    { kind: "Transfer", netuid: null, count: 1, fb: 10, lb: 10, fo, lo: fo },
+  ];
+
+  test("TRANSFERS floor at the account's earliest folded event", async () => {
+    const q = sqlFetch([transferRow(10)]);
+    await loadAccountTransfersColdTier(
+      {
+        ...TOKEN,
+        ...accountSummaryArchive({ accounts: { [ADDR]: group(FIRST) } }),
+      } as never,
+      ADDR,
+      { limit: 5 },
+    );
+    assert.ok(q.length > 0, "premise: a read was issued");
+    assert.ok(
+      q.every((sql) => sql.includes(`observed_at >= ${FIRST}`)),
+      `unfloored: ${q.find((sql) => !sql.includes(`observed_at >= ${FIRST}`))?.slice(0, 140)}`,
+    );
+  });
+
+  test("COUNTERPARTIES floor, including the read that never widens", async () => {
+    const q = sqlFetch([transferRow(10)]);
+    await loadAccountCounterpartiesColdTier(
+      {
+        ...TOKEN,
+        ...accountSummaryArchive({ accounts: { [ADDR]: group(FIRST) } }),
+      } as never,
+      ADDR,
+      { limit: 5 },
+    );
+    assert.ok(q.length > 0, "premise: a read was issued");
+    assert.ok(
+      q.every((sql) => sql.includes(`observed_at >= ${FIRST}`)),
+      `unfloored: ${q.find((sql) => !sql.includes(`observed_at >= ${FIRST}`))?.slice(0, 140)}`,
+    );
+  });
+
+  test("a RELATIONSHIP floors at the EARLIER of the two accounts", async () => {
+    // A relationship row needs only ONE side to exist. Flooring at the later
+    // account's first event would silently drop everything the earlier one did
+    // before it -- and a counterparty feed missing its oldest half looks
+    // exactly like a quiet relationship, which is the worst kind of wrong.
+    const q = sqlFetch([transferRow(10)]);
+    await loadCounterpartyRelationshipColdTier(
+      {
+        ...TOKEN,
+        ...accountSummaryArchive({
+          accounts: { [ADDR]: group(FIRST), [OTHER]: group(OTHER_FIRST) },
+        }),
+      } as never,
+      ADDR,
+      OTHER,
+      { limit: 5 },
+    );
+    assert.ok(q.length > 0, "premise: a read was issued");
+    assert.ok(
+      q.every((sql) => sql.includes(`observed_at >= ${OTHER_FIRST}`)),
+      `must floor at the EARLIER account: ${q[0]?.slice(0, 140)}`,
+    );
+  });
+
+  test("a RELATIONSHIP with ONE unknown side takes no floor at all", async () => {
+    // A floor derived from one known side is a bound on the wrong account: the
+    // unknown one may have history below it. Slower and right beats faster and
+    // short.
+    const q = sqlFetch([transferRow(10)]);
+    await loadCounterpartyRelationshipColdTier(
+      {
+        ...TOKEN,
+        ...accountSummaryArchive({ accounts: { [ADDR]: group(FIRST) } }),
+      } as never,
+      ADDR,
+      OTHER,
+      { limit: 5 },
+    );
+    assert.ok(q.length > 0, "premise: a read was issued");
+    assert.ok(
+      q.every((sql) => !sql.includes(`observed_at >= ${FIRST}`)),
+      "one known side must not floor the pair",
+    );
+  });
+
+  test("NO projection leaves every feed exactly as it was", async () => {
+    // The floor is an optimization over a correct read, never a precondition
+    // for one: with no artifact bound these must behave as before.
+    const q = sqlFetch([transferRow(10)]);
+    const data = await loadAccountTransfersColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    assert.ok(data);
+    assert.ok(q.every((sql) => !sql.includes(`observed_at >= ${FIRST}`)));
   });
 });

--- a/tests/account-history-cold-tier.test.ts
+++ b/tests/account-history-cold-tier.test.ts
@@ -19,6 +19,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import { loadAccountHistoryColdTier } from "../src/account-history-cold-tier.ts";
+import { accountSummaryArchive } from "./helpers/cold-tier-env.ts";
 
 type Row = Record<string, unknown>;
 
@@ -377,5 +378,83 @@ describe("all three history surfaces reach the lakehouse", () => {
         `${path} must pass env, or the loader cannot reach the lakehouse`,
       );
     }
+  });
+});
+
+/**
+ * The projection floor on the one read that had none and could not be seen.
+ *
+ * This is a LIFETIME `GROUP BY day, netuid` over a scattered `hotkey`, so
+ * without `?from` it walked to genesis. `scripts/validate-r2-sql-scan-bounds.ts`
+ * was blind to it for a second reason: this loader calls an INJECTED `queryFn`
+ * rather than the literal `r2SqlQuery(` the gate greps for, so no amount of
+ * tightening that gate's predicate test would have surfaced it. The floor is
+ * asserted here instead.
+ */
+describe("loadAccountHistoryColdTier -- the projection floor", () => {
+  const FIRST = 1_785_000_000_000;
+
+  const archive = (entry: unknown) =>
+    accountSummaryArchive({ accounts: { [SS58]: entry } });
+
+  test("BOTH reads carry the account's earliest folded event", async () => {
+    // Both, not just the page: the kinds read has the same scattered predicate
+    // over the same table, and a floor on one of two identical scans halves a
+    // problem rather than fixing it.
+    const engine = fakeEngine();
+    await loadAccountHistoryColdTier(
+      archive([
+        {
+          kind: "StakeAdded",
+          netuid: 64,
+          count: 1,
+          fb: 8_750_000,
+          lb: 8_750_000,
+          fo: FIRST,
+          lo: FIRST,
+        },
+      ]) as never,
+      SS58,
+      { limit: 100 },
+      { queryFn: engine.query as never },
+    );
+    assert.equal(engine.seen.length, 2, "premise: both reads were issued");
+    for (const sql of engine.seen) {
+      assert.ok(
+        sql.includes(`observed_at >= ${FIRST}`),
+        `unfloored: ${sql.slice(0, 160)}`,
+      );
+    }
+  });
+
+  test("an ABSENT account floors at the generation's edge", async () => {
+    // The producer writes every shard, so absence PROVES there is nothing at
+    // or before `through` -- the strongest floor available, and the case that
+    // matters most: an account with no folded history is exactly the one whose
+    // unbounded walk reads the whole table to answer "nothing".
+    const engine = fakeEngine();
+    await loadAccountHistoryColdTier(
+      archive(null) as never,
+      SS58,
+      { limit: 100 },
+      { queryFn: engine.query as never },
+    );
+    assert.equal(engine.seen.length, 2, "premise: both reads were issued");
+    const edge = Date.parse("2026-08-15T00:00:00.000Z");
+    assert.ok(
+      engine.page().includes(`observed_at >= ${edge}`),
+      `must floor at the day after \`through\`: ${engine.page().slice(0, 160)}`,
+    );
+  });
+
+  test("NO projection leaves the walk exactly as it was", async () => {
+    // The PAGE read only. The kinds read carries an `observed_at` range of its
+    // own -- derived from the days the page returned, at :238 -- so asserting
+    // "no bound anywhere" would assert against a bound that predates this
+    // change and has nothing to do with the projection.
+    const engine = fakeEngine();
+    await load(engine);
+    assert.equal(engine.seen.length, 2, "premise: both reads were issued");
+    assert.ok(!engine.page().includes("observed_at >="), engine.page());
   });
 });

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -22,7 +22,9 @@ import {
   loadAccountSummaryProjection,
   type AccountSummaryProjectionRead,
   recentFloorMs,
+  accountHistoryFloorMs,
 } from "../src/account-summary-projection.ts";
+import { DEFAULT_CHAIN_NETWORK } from "../src/chain-network.ts";
 
 const HOT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 const COLD = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
@@ -936,6 +938,91 @@ describe("AccountSummaryRecentEventSchema", () => {
     assert.deepEqual(
       Object.keys(AccountSummaryRecentEventSchema.shape).sort(),
       [...ACCOUNT_EVENTS_COLUMNS].sort(),
+    );
+  });
+});
+
+/**
+ * The one bound every account route can push into its own `where`.
+ *
+ * Kept as a named helper rather than four copies of `loadAccountSummaryProjection(...)
+ * ?.span?.firstMs`: the two projection answers floor DIFFERENTLY -- present at
+ * `min(fo)`, absent at the generation edge -- and a caller that reached for
+ * `span` alone would silently take no floor on exactly the accounts whose
+ * unbounded walk is most expensive.
+ */
+describe("accountHistoryFloorMs", () => {
+  /** A pointer stamped now, so the freshness check is not a clock race. */
+  const nowIso = () => new Date().toISOString();
+
+  test("a PRESENT account floors at its earliest folded event", async () => {
+    const store = archive(
+      published(
+        {
+          [HOT]: [
+            { ...group(), fo: 5_000 },
+            { ...group(), fo: 1_000 },
+          ],
+        },
+        { through: "2026-08-13", generated_at: nowIso() },
+      ),
+    );
+    assert.equal(await accountHistoryFloorMs(store.env, HOT), 1_000);
+  });
+
+  test("an ABSENT account floors at the generation's edge", async () => {
+    // The producer writes every shard, so absence from a shard that EXISTS
+    // proves there is nothing at or before `through` -- a strictly stronger
+    // bound than any present account gets.
+    const store = archive(
+      published({}, { through: "2026-08-13", generated_at: nowIso() }),
+    );
+    assert.equal(
+      await accountHistoryFloorMs(store.env, HOT),
+      Date.parse("2026-08-14T00:00:00.000Z"),
+    );
+  });
+
+  test("a pointer with NO `through` yields no floor, not a guessed one", async () => {
+    // `span` declines without a fold edge, and this must decline with it: a
+    // floor invented here would bound a feed below rows that exist.
+    const store = archive(
+      published({ [HOT]: [group()] }, { generated_at: nowIso() }),
+    );
+    assert.equal(await accountHistoryFloorMs(store.env, HOT), null);
+  });
+
+  test("NO projection is null, not a throw", async () => {
+    assert.equal(await accountHistoryFloorMs(archive({}).env, HOT), null);
+  });
+
+  test("A NON-DEFAULT NETWORK READS NOTHING AT ALL", async () => {
+    // The projection describes mainnet. Flooring another chain's feed with it
+    // would bound that feed against the wrong history -- a WRONG answer, where
+    // the unbounded walk is merely a slow right one. Asserted on `asked` and
+    // not just the return value: a null that came from reading the mainnet
+    // pointer and discarding it would pass a return-value check while still
+    // paying for the read.
+    const store = archive(
+      published({ [HOT]: [group()] }, { generated_at: nowIso() }),
+    );
+    assert.equal(await accountHistoryFloorMs(store.env, HOT, "testnet"), null);
+    assert.deepEqual(store.asked, []);
+  });
+
+  test("the DEFAULT network passed explicitly still floors", async () => {
+    // `undefined` and "finney" are the same request; only the third value
+    // declines. A guard written as `network !== undefined` alone would refuse
+    // a caller that names its own default.
+    const store = archive(
+      published(
+        { [HOT]: [{ ...group(), fo: 4_242 }] },
+        { through: "2026-08-13", generated_at: nowIso() },
+      ),
+    );
+    assert.equal(
+      await accountHistoryFloorMs(store.env, HOT, DEFAULT_CHAIN_NETWORK),
+      4_242,
     );
   });
 });

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -11,6 +11,7 @@ import {
   loadSubnetEventsColdTier,
 } from "../src/events-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { accountSummaryArchive } from "./helpers/cold-tier-env.ts";
 import { visibleInWindow } from "./helpers/scan-window.ts";
 import { OFFSET_EMULATION_CAP } from "../src/r2-sql-blocks.ts";
 
@@ -87,45 +88,8 @@ describe("loadAccountEventsColdTier -- the projection floor", () => {
   const FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
   const FIRST = 1_786_629_372_000;
 
-  /** An archive publishing one generation; `entry` is this account's shard row. */
-  function archive(entry: unknown, { through = "2026-08-14" } = {}) {
-    const GEN = "20260815T000000Z";
-    const SHARDS = 16384;
-    let h = 0x811c9dc5;
-    for (const b of new TextEncoder().encode(ADDR)) {
-      h ^= b;
-      h = Math.imul(h, 0x01000193) >>> 0;
-    }
-    const shardKey = `metagraph/projections/account-summary/${GEN}/${h % SHARDS}.json`;
-    return {
-      METAGRAPH_ARCHIVE: {
-        get: async (key: string) => {
-          if (key === "metagraph/projections/account-summary/current.json") {
-            return {
-              json: async () => ({
-                schema_version: 1,
-                generation: GEN,
-                shard_count: SHARDS,
-                generated_at: new Date().toISOString(),
-                account_count: 1,
-                through,
-              }),
-            };
-          }
-          if (key === shardKey) {
-            return {
-              json: async () => ({
-                schema_version: 1,
-                shard_count: SHARDS,
-                accounts: entry === null ? {} : { [ADDR]: entry },
-              }),
-            };
-          }
-          return null;
-        },
-      },
-    };
-  }
+  const archive = (entry: unknown) =>
+    accountSummaryArchive({ accounts: { [ADDR]: entry } });
 
   test("a PRESENT account floors at its earliest folded event", async () => {
     const q = sqlFetch([eventRow(10, 0)]);

--- a/tests/helpers/cold-tier-env.ts
+++ b/tests/helpers/cold-tier-env.ts
@@ -1,3 +1,4 @@
+import { accountShard } from "../../src/account-summary-projection.ts";
 import { visibleInWindow } from "./scan-window.ts";
 // Transport doubles for the readers that answer now that the Postgres tier is
 // gone (#10190).
@@ -50,7 +51,14 @@ export interface ArchiveDouble {
  * Pass a function to vary by key (a network-scoped projection reads
  * `<key>` on mainnet and `testnet/<key>` off it), or `null` for a bucket that
  * holds nothing -- which is how a reader's decline path is reached.
+ *
+ * OVERLOADED rather than one union parameter. `unknown | ((key: string) => T)`
+ * IS `unknown` -- the union absorbs the signature -- so every caller passing a
+ * function got an implicitly-`any` parameter and no inference at all. The
+ * overloads restore it without changing a single call site.
  */
+export function archiveEnv(body: (key: string) => unknown): ArchiveDouble;
+export function archiveEnv(body: unknown): ArchiveDouble;
 export function archiveEnv(
   body: unknown | ((key: string) => unknown | null),
 ): ArchiveDouble {
@@ -144,4 +152,69 @@ export function forbiddenDataApi() {
       },
     },
   };
+}
+
+/**
+ * An archive publishing ONE account-summary generation.
+ *
+ * Extracted when the second consumer appeared. The first
+ * (`events-cold-tier.test.ts`) hand-rolled the shard key by re-implementing
+ * FNV-1a inline -- a copy of `accountShard` that shares no code with the
+ * function under test, so a hash change would have moved the reader and the
+ * fixture together and every floor assertion would still have passed while
+ * production read the wrong shard. It imports the real one now.
+ *
+ * KEYED BY ACCOUNT because the pair floor needs two. Each value is that
+ * account's shard row, or `null` for an account the producer folded and found
+ * nothing for -- the ABSENT case, and the stronger floor: the producer writes
+ * every shard, so absence proves there is nothing at or before `through`.
+ * Two accounts generally hash to two different shards, and both are served.
+ *
+ * An account NOT LISTED gets no shard object at all, which is the third
+ * answer: the producer has not published this shard, so the reader cannot
+ * conclude anything and must fall back to its unbounded read.
+ */
+export function accountSummaryArchive(input: {
+  accounts: Record<string, unknown>;
+  through?: string;
+  generation?: string;
+  shards?: number;
+  generatedAt?: string;
+}): ArchiveDouble {
+  const {
+    accounts,
+    through = "2026-08-14",
+    generation = "20260815T000000Z",
+    shards = 16384,
+    generatedAt = new Date().toISOString(),
+  } = input;
+  const pointerKey = "metagraph/projections/account-summary/current.json";
+  const prefix = `metagraph/projections/account-summary/${generation}/`;
+  /** shard index -> the accounts landing in it, so a collision serves both. */
+  const byShard = new Map<number, Record<string, unknown>>();
+  for (const [account, entry] of Object.entries(accounts)) {
+    const shard = accountShard(account, shards);
+    const bucket = byShard.get(shard) ?? {};
+    if (entry !== null) bucket[account] = entry;
+    byShard.set(shard, bucket);
+  }
+  return archiveEnv((key) => {
+    if (key === pointerKey) {
+      return {
+        schema_version: 1,
+        generation,
+        shard_count: shards,
+        generated_at: generatedAt,
+        account_count: Object.keys(accounts).length,
+        through,
+      };
+    }
+    if (key.startsWith(prefix) && key.endsWith(".json")) {
+      const shard = Number(key.slice(prefix.length, -".json".length));
+      const bucket = byShard.get(shard);
+      if (bucket === undefined) return null;
+      return { schema_version: 1, shard_count: shards, accounts: bucket };
+    }
+    return null;
+  });
 }

--- a/tests/nominator-positions-cold-tier.test.ts
+++ b/tests/nominator-positions-cold-tier.test.ts
@@ -5,6 +5,7 @@
 // than publishing a total that is quietly too small.
 import assert from "node:assert/strict";
 import { beforeEach, describe, test, vi } from "vitest";
+import { accountSummaryArchive } from "./helpers/cold-tier-env.ts";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
 // One store since #10179: the stake leg reads `neurons` through
@@ -459,5 +460,62 @@ describe("latestStakeEventAt", () => {
   test("a failed read is null, never a manufactured contradiction", async () => {
     failingFetch();
     assert.equal(await latestStakeEventAt(TOKEN as never, COLDKEY), null);
+  });
+
+  // THE TEST scripts/validate-r2-sql-scan-bounds.ts NAMES in RUNTIME_BOUNDED.
+  //
+  // That gate reads source text, and this floor is applied through a ternary
+  // -- `floorMs === null ? "" : ...` -- which no static reader can evaluate.
+  // The exemption there is therefore a POINTER TO THIS ASSERTION rather than a
+  // judgement that the scan is cheap, and the pointer is only worth anything
+  // while these two tests exist. A stale-key check in the gate fails if the
+  // entry outlives the finding; this is the other half.
+  //
+  // Why it matters: `MAX(observed_at)` over a scattered `coldkey` reads the
+  // account's whole history, and it fires precisely for accounts holding NO
+  // delegated positions -- so before the floor, the cheapest possible answer
+  // paid the most expensive read.
+  test("FLOORS the MAX(observed_at) scan at the projection's own bound", async () => {
+    const FIRST = 1_786_629_372_000;
+    const queries = routedFetch([], [{ latest: 1_785_700_000_000 }]);
+    await latestStakeEventAt(
+      {
+        ...TOKEN,
+        ...accountSummaryArchive({
+          accounts: {
+            [COLDKEY]: [
+              {
+                kind: "StakeAdded",
+                netuid: 18,
+                count: 1,
+                fb: 8_836_052,
+                lb: 8_836_052,
+                fo: FIRST,
+                lo: FIRST,
+              },
+            ],
+          },
+        }),
+      } as never,
+      COLDKEY,
+    );
+    assert.equal(queries.length, 1, "premise: the scan was issued");
+    assert.ok(
+      queries[0]!.includes(`observed_at >= ${FIRST}`),
+      `unfloored: ${queries[0]}`,
+    );
+  });
+
+  test("an unfloorable account still gets its answer, unbounded", async () => {
+    // The floor is an optimization over a correct read, never a precondition
+    // for one. With no projection published the query must still be issued --
+    // a reader that declined here would turn a slow answer into no answer.
+    const queries = routedFetch([], [{ latest: 1_785_700_000_000 }]);
+    assert.equal(
+      await latestStakeEventAt(TOKEN as never, COLDKEY),
+      1_785_700_000_000,
+    );
+    assert.equal(queries.length, 1);
+    assert.ok(!queries[0]!.includes("observed_at >="));
   });
 });


### PR DESCRIPTION
## What was slow

`/accounts/{ss58}` issues 28 queries. Measured 2026-08-16 against `5EEmaGFEAtAWCviYezuMbutPummVsk9zMXJzcnNo5oM3qDSC`:

| route | before | why |
|---|---|---|
| `/counterparties` | 15.1s | `need` = 5,000, so the walk's two probes never fill and every request reaches an unbounded third read |
| `/extrinsics` | 15.1s | `signer = X`, no time bound |
| `/transfers` | 12.6s | walk over 8 days of probes, then unbounded |
| `/history` | — | lifetime `GROUP BY day, netuid`, no floor unless `?from` |

Each is a scattered-key read of `chain.account_events` (~894M rows) with no predicate the engine can prune on. Measured for one such query: **577.5 MB and 3,480 R2 requests** unbounded, against **0.1 MB and 9** with a time bound.

## The bound already existed

`loadAccountSummaryProjection` publishes a lifetime span per account, and `/events` has pushed `observed_at >=` into its `where` since #11131. It had **two** consumers; the four routes that most needed it had none.

`accountHistoryFloorMs` names that bound once:

- **present** accounts floor at `min(fo)` — the groups are a lifetime aggregate, so nothing exists below it;
- **absent** accounts floor at the generation edge — the producer writes every shard, so absence *proves* there is nothing at or before `through`. That is the stronger of the two, and it is exactly the case whose unbounded walk was most expensive: reading the whole table to answer "nothing".
- **mainnet only** — the projection describes the default network, so flooring another chain's feed with it would be a wrong answer where the unbounded walk is a slow right one.

It is an optimisation over a correct read, never a precondition for one: every caller behaves identically when it returns null, which is what makes it safe to add to a route without re-arguing that route's correctness. Each route has a test pinning that.

The counterparty **relationship** floor is the *earlier* of the two accounts, and null if either is unknown. A relationship row needs only ONE side to exist, so flooring at the later account's first event would silently drop everything the earlier one did before it — and a counterparty feed missing its oldest half looks exactly like a quiet relationship.

`chain.extrinsics` is deliberately **not** floored, and the file says so. The projection describes `chain.account_events`; a bound derived from one table and applied to another is a guess, and this one would drop rows.

## The gate was blind three ways, and each hid a real query

`validate:r2-sql-scan-bounds` reported clean the whole time.

1. **`PRUNABLE` was a bare substring test.** `SELECT MAX(observed_at) … WHERE coldkey = X` — with no predicate on that column at all — satisfied it from the SELECT list. It now requires a comparison operator.
2. **Exemptions were keyed by FILE.** One measured exemption covered every other read in the same file, including ones nobody looked at. They are keyed `file|table` now, via a new `tableOf(query)`.
3. **The call matcher accepted only backtick template literals.** A query assembled from a double-quoted string was never examined — which is precisely the shape of the query gap 1 also missed.

Each gap is proven closed by removing the real floor and watching the gate report the real query.

### A fourth exemption class

`RUNTIME_BOUNDED` sits alongside "cheap by design" (`UNBOUNDED_BY_DESIGN`) and "a predicate this gate cannot read" (`INTERPOLATED_PREDICATES`). It covers a bound that **is** in the source but is applied through a ternary — `floorMs === null ? "" : …` — which no static reader can evaluate. Treating that as unbounded would push the author toward emitting an always-true bound purely to satisfy the checker, which buys nothing and hides the real question. Each entry names the test that proves the emitted SQL carries the bound, and the gate's stale-key check now covers those keys too, so an entry cannot outlive its finding.

## Also fixed in passing

The events-cold-tier fixture hand-rolled FNV-1a to compute its shard key — a copy of `accountShard` sharing no code with the function under test, so a hash change would have moved reader and fixture together while production read the wrong shard. It imports the real one now, from a shared `accountSummaryArchive` fixture (which the pair-floor tests needed anyway, since they need two accounts in one generation).

`archiveEnv`'s parameter was `unknown | ((key: string) => unknown)`, which **is** `unknown` — the union absorbs the signature, so every caller passing a function got an implicitly-`any` parameter and no inference. Overloaded, no call site changed.

## Verification

- **Every floor falsified**: remove it, watch the test fail. Done for all four routes and both projection answers.
- **Every gate gap falsified**: remove the real floor, confirm the gate now reports the real query — it did not before.
- **Patch coverage 17/17 lines, 24/24 branches**, measured by diff intersection against `origin/main` from an unsharded `test:coverage` run.
- **Full suite**: 951 files, 21,822 passed.
- **Full CI gate**: 79 `npm run` targets derived from the workflows — 0 failed.