### PR TITLE
perf(accounts): the account family had no server-side cache at all, and its own limiter said so

### DIFF
--- a/tests/account-edge-cache.test.ts
+++ b/tests/account-edge-cache.test.ts
@@ -1,0 +1,345 @@
+// The edge cache over the address-shaped account routes.
+//
+// Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC: three identical back-to-back GETs
+// of `/accounts/{ss58}/events?limit=5` took 16.9s, 15.2s and 16.3s, none of
+// them carrying a `cf-cache-status`. A Worker's own response is not stored by
+// Cloudflare unless the Cache API is used explicitly, and
+// `request-handlers/entities.ts` -- 41 cold-tier call sites -- reaches
+// `withEdgeCache` from none of them.
+//
+// These tests count the LAKEHOUSE READS, not the responses. A cache that
+// returns the right body while still paying for it is exactly the failure this
+// is about, and it is invisible in the payload.
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import { CONTRACT_VERSION } from "../src/contracts.ts";
+import {
+  decodeWatermarkKey,
+  resetDecodeWatermarkCache,
+} from "../src/decode-watermark.ts";
+import { isMainnetOnlyApiPath } from "../workers/api.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+import { readFileSync } from "node:fs";
+
+const openapi = JSON.parse(
+  readFileSync("public/metagraph/openapi.json", "utf8"),
+) as { paths: Record<string, unknown> };
+
+const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+const OTHER = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+/**
+ * The Workers `caches.default`, as a Map, recording every key it is handed.
+ *
+ * The real global is ambient (`declare const caches: CacheStorage`) rather than
+ * a `globalThis` property, so installing a stub goes through a cast -- the same
+ * pattern `workers/request-handlers/analytics.ts` uses in its own handler code.
+ */
+function mockCaches() {
+  const store = new Map<string, Response>();
+  const putKeys: string[] = [];
+  return {
+    store,
+    putKeys,
+    install() {
+      (globalThis as unknown as { caches: Row | undefined }).caches = {
+        default: {
+          async match(request: Request) {
+            const hit = store.get(request.url);
+            return hit ? hit.clone() : undefined;
+          },
+          async put(request: Request, response: Response) {
+            putKeys.push(request.url);
+            store.set(request.url, response.clone());
+          },
+        },
+      } as unknown as Row;
+    },
+  };
+}
+
+/** An env whose archive publishes one decode watermark, and nothing else. */
+function envAt(decodedThrough: number) {
+  const key = decodeWatermarkKey("mainnet");
+  return {
+    ...mockEnv(),
+    R2_SQL_TOKEN: "cfut_test",
+    METAGRAPH_ARCHIVE: {
+      get: async (asked: string) =>
+        asked === key
+          ? {
+              // `.text()`, not `.json()`: readDecodeWatermark parses the string
+              // itself, and a double that only offers `json` would make the
+              // watermark unreadable and silently disable the whole cache --
+              // every assertion below would then pass for the wrong reason.
+              text: async () =>
+                JSON.stringify({ decoded_through: decodedThrough }),
+            }
+          : null,
+    },
+  } as unknown as Parameters<typeof handleRequest>[1];
+}
+
+/** Counts the R2 SQL the request family actually issues. */
+function countLakehouse() {
+  const queries: string[] = [];
+  globalThis.fetch = (async (_url: string, init: RequestInit) => {
+    queries.push(String(JSON.parse(String(init.body)).query));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows: [] } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+const ctx = { waitUntil: (promise: Promise<unknown>) => promise };
+const get = (path: string, env: Parameters<typeof handleRequest>[1]) =>
+  handleRequest(new Request(`https://api.metagraph.sh${path}`), env, ctx);
+
+const EVENTS = `/api/v1/accounts/${ADDR}/events?limit=5`;
+
+/** A contract path with every parameter filled, so the route patterns match. */
+const fill = (route: string) =>
+  route.replace("{ss58}", ADDR).replace("{netuid}", "3");
+
+let originalCaches: Row | undefined;
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  // The watermark memo is module-level and survives between tests in a file, so
+  // whichever test resolved it first would decide every later test's stamp.
+  resetDecodeWatermarkCache();
+  originalCaches = (globalThis as unknown as { caches: Row | undefined })
+    .caches;
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  (globalThis as unknown as { caches: Row | undefined }).caches =
+    originalCaches;
+  globalThis.fetch = originalFetch;
+});
+
+describe("the account edge cache", () => {
+  test("THREE IDENTICAL GETS ISSUE ONE SET OF LAKEHOUSE READS", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const queries = countLakehouse();
+    const env = envAt(8_800_000);
+
+    const first = await get(EVENTS, env);
+    assert.equal(first.status, 200);
+    const afterFirst = queries.length;
+    assert.ok(afterFirst > 0, "premise: the first request read the lakehouse");
+
+    const second = await get(EVENTS, env);
+    const third = await get(EVENTS, env);
+    assert.equal(second.status, 200);
+    assert.equal(third.status, 200);
+    assert.equal(
+      queries.length,
+      afterFirst,
+      `two repeats added ${queries.length - afterFirst} reads`,
+    );
+    assert.deepEqual(
+      await second.json(),
+      await first.clone().json(),
+      "a hit must be the same body, not merely a fast one",
+    );
+  });
+
+  test("a NEW DECODE GENERATION writes to a different key", async () => {
+    // Correctness comes from the key, not from an expiry racing the data: the
+    // lakehouse changes when decode publishes and at no other time, so an
+    // answer belongs to a generation and a new one must never consult the old
+    // entry.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+
+    await get(EVENTS, envAt(8_800_000));
+    resetDecodeWatermarkCache();
+    await get(EVENTS, envAt(8_900_000));
+
+    assert.equal(cache.putKeys.length, 2, "both answers were stored");
+    assert.notEqual(cache.putKeys[0], cache.putKeys[1]);
+    assert.ok(cache.putKeys[0]!.includes("8800000"), cache.putKeys[0]);
+    assert.ok(cache.putKeys[1]!.includes("8900000"), cache.putKeys[1]);
+  });
+
+  test("the key carries the CONTRACT VERSION, so a deploy cannot serve across it", async () => {
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    await get(EVENTS, envAt(8_800_000));
+    assert.ok(
+      cache.putKeys[0]!.includes(encodeURIComponent(CONTRACT_VERSION)),
+      cache.putKeys[0],
+    );
+  });
+
+  test("BOTH SPELLINGS OF MAINNET share one entry", async () => {
+    // `/api/v1/…` and `/finney/api/v1/…` are the same request. Keying on the
+    // raw path would compute the same body twice and store it twice, which is
+    // a hit rate this can simply not lose.
+    const cache = mockCaches();
+    cache.install();
+    const queries = countLakehouse();
+    const env = envAt(8_800_000);
+
+    await get(EVENTS, env);
+    const afterFirst = queries.length;
+    await get(`/finney${EVENTS}`, env);
+
+    assert.equal(queries.length, afterFirst, "the prefixed form re-read");
+    assert.equal(cache.putKeys.length, 1);
+  });
+
+  test("THE PARTITION IS EXACTLY the live-chain routes vs the store-backed ones", async () => {
+    // The gate's whole justification, and it caught a real error in this
+    // module's first draft. Four members of the family -- balance, children,
+    // parents, root-claim -- read chain state through `state_getStorage` at
+    // request time. Their answer changes every block and owes nothing to the
+    // decode lane, so stamping them with a watermark that advances hourly would
+    // hold a balance across up to an hour of blocks.
+    //
+    // PINNED HERE rather than asserted in prose, and read from the published
+    // contract so an account route added later is covered without anyone
+    // remembering to. If a store-backed route becomes network-aware, or a
+    // live-chain one becomes mainnet-only, this fails and the gate is revisited
+    // BEFORE anything can be served under the wrong key.
+    const routes = Object.keys(openapi.paths).filter(
+      (path) =>
+        path.includes("/accounts/{ss58}") && !path.includes("{network}"),
+    );
+    assert.ok(
+      routes.length >= 25,
+      `found only ${routes.length} account routes`,
+    );
+    const live = routes
+      .filter((route) => !isMainnetOnlyApiPath(fill(route)))
+      .map((route) => route.replace("/api/v1/accounts/{ss58}", ""));
+    assert.deepEqual(live.sort(), [
+      "/balance",
+      "/children",
+      "/parents",
+      "/root-claim",
+    ]);
+  });
+
+  test("a LIVE-CHAIN account route is never cached", async () => {
+    // Its answer changes every block. The decode watermark is not a stamp for
+    // it, and a cache that cannot say when an answer expires must not hold one.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    await get(`/api/v1/accounts/${ADDR}/balance`, envAt(8_800_000));
+    assert.deepEqual(cache.putKeys, []);
+  });
+
+  test("a TESTNET-ADDRESSED account route is not cached", async () => {
+    // It 404s (mainnet-only), and a 404 must never be stored -- but the gate
+    // refuses it before dispatch either way, which is the property here.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    const res = await get(`/testnet${EVENTS}`, envAt(8_800_000));
+    assert.equal(res.status, 404);
+    assert.deepEqual(cache.putKeys, []);
+  });
+
+  test("A DIFFERENT ADDRESS is a different entry", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const queries = countLakehouse();
+    const env = envAt(8_800_000);
+
+    await get(EVENTS, env);
+    const afterFirst = queries.length;
+    await get(`/api/v1/accounts/${OTHER}/events?limit=5`, env);
+    assert.ok(
+      queries.length > afterFirst,
+      "a second address must not be served another account's body",
+    );
+  });
+
+  test("NO WATERMARK DISABLES THE CACHE rather than pinning a constant", async () => {
+    // An unreadable watermark means we cannot say which generation an answer
+    // belongs to. A key that cannot express that would hold one generation's
+    // body across the next publish -- the exact failure the stamp prevents,
+    // arrived at by trying to be helpful.
+    const cache = mockCaches();
+    cache.install();
+    const queries = countLakehouse();
+    const env = {
+      ...mockEnv(),
+      R2_SQL_TOKEN: "cfut_test",
+      METAGRAPH_ARCHIVE: { get: async () => null },
+    } as unknown as Parameters<typeof handleRequest>[1];
+
+    await get(EVENTS, env);
+    const afterFirst = queries.length;
+    assert.ok(afterFirst > 0, "premise: the first request read the lakehouse");
+    await get(EVENTS, env);
+
+    assert.ok(queries.length > afterFirst, "an unstamped answer was cached");
+    assert.equal(cache.putKeys.length, 0);
+  });
+
+  test("CSV IS NOT CACHED", async () => {
+    // Same route, different body, and a one-shot download is the traffic shape
+    // a cache helps least.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    await get(`${EVENTS}&format=csv`, envAt(8_800_000));
+    assert.equal(cache.putKeys.length, 0);
+  });
+
+  test("a NON-ACCOUNT route is untouched", async () => {
+    // The gate is scoped to the address-shaped family. `/accounts` and
+    // `/accounts/top-holders` are bounded list reads that this must not claim.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    await get("/api/v1/accounts/top-holders", envAt(8_800_000));
+    assert.deepEqual(cache.putKeys, []);
+  });
+
+  test("a NON-200 IS NEVER STORED", async () => {
+    // A bad-checksum address is a 400 from the guard that runs inside dispatch,
+    // and persisting it would answer a later, valid request with the error.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    const bad = "5EYCAe5jLQhn6ofDSvqFmCXAEZUZ2VZbtnPZmZmnUJVEexHY";
+    const res = await get(`/api/v1/accounts/${bad}/events`, envAt(8_800_000));
+    assert.equal(res.status, 400);
+    assert.deepEqual(cache.putKeys, []);
+  });
+
+  test("HEAD is served from the GET entry, with no body", async () => {
+    // `withEdgeCache` folds HEAD into the GET key only when the builder accepts
+    // the normalized request. A builder closing over the original HEAD would
+    // seed the GET entry with an empty body for every later caller, so this
+    // asserts the direction that is safe and the property that makes it so.
+    const cache = mockCaches();
+    cache.install();
+    const queries = countLakehouse();
+    const env = envAt(8_800_000);
+
+    await get(EVENTS, env);
+    const afterGet = queries.length;
+    const head = await handleRequest(
+      new Request(`https://api.metagraph.sh${EVENTS}`, { method: "HEAD" }),
+      env,
+      ctx,
+    );
+
+    assert.equal(head.status, 200);
+    assert.equal(await head.text(), "", "a HEAD must carry no body");
+    assert.equal(queries.length, afterGet, "the HEAD re-read the lakehouse");
+    assert.equal(cache.putKeys.length, 1, "the HEAD stored its own entry");
+  });
+});

--- a/workers/account-edge-cache.ts
+++ b/workers/account-edge-cache.ts
@@ -1,0 +1,135 @@
+// The edge cache for the address-shaped account routes: eligibility, scope and
+// stamp. PURE -- the lookup, the put and the degraded guards are
+// `withEdgeCache`'s, which already owns every one of them.
+//
+// ## What was uncached, and what it cost
+//
+// `workers/request-handlers/entities.ts` holds 41 cold-tier call sites and uses
+// `withEdgeCache` ZERO times, against 33 uses in analytics.ts. A Worker's own
+// response is not stored by Cloudflare unless the Cache API is used explicitly,
+// so `cache-control: public, max-age=60` on these bodies only ever reached
+// browsers -- every request, first or repeat, paid a full lakehouse read.
+//
+// Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC, three identical back-to-back GETs
+// of `/accounts/{ss58}/events?limit=5`: 16.9s, 15.2s, 16.3s, with no
+// `cf-cache-status` on any of them. The account page issues 28 such requests.
+//
+// The dispatch-level static cache could not reach them: this family is matched
+// by anchored regexes that RETURN early, hundreds of lines before the
+// `isStaticEdgeCacheEligible` block that caches the route-table families. And
+// `dataRouteRateLimit`'s own docstring names the gap in passing -- "lakehouse-
+// backed and billed per byte scanned, no edge cache".
+//
+// ## Why the stamp is the decode watermark, and why that makes it SAFE
+//
+// These routes read `chain.account_events` in the lakehouse. That table changes
+// when the decode container publishes and at no other time, so an answer is a
+// pure function of (contract version, decode watermark, path, query). Putting
+// the watermark IN THE KEY means a new generation writes to a DIFFERENT key and
+// the old entry is never consulted again -- correctness comes from the key, not
+// from an expiry racing the data.
+//
+// The response's own `max-age` still bounds how long an entry survives, which
+// is what keeps the USD-at-tx overlay honest: it prices each event against the
+// newest index reading at-or-before that event's instant, and for an event
+// seconds old that reading may not exist yet. The declared 60s is already the
+// contract for that, so this changes no freshness promise -- it only stops the
+// same answer being recomputed inside the window it was already allowed to be
+// reused in.
+//
+// ## What this does NOT fix
+//
+// The FIRST view. A cache absorbs repeat and burst load; it cannot make a cold
+// read fast. The bound pushed into these queries is what does that, and the two
+// are complements rather than alternatives.
+import { DEFAULT_CHAIN_NETWORK } from "../src/chain-network.ts";
+import { resolveDecodeWatermark } from "../src/decode-watermark.ts";
+
+/** The `keyParts` namespace segment for the family. */
+export const ACCOUNT_EDGE_CACHE_LABEL = "accounts";
+
+/**
+ * Whether this request may be served from, or written to, the account cache.
+ *
+ * TWO NETWORK CONDITIONS, and they are not the same one twice.
+ *
+ * `storeBacked` is `isMainnetOnlyApiPath`, and it is what selects the routes
+ * the decode watermark is a valid stamp FOR. Four members of this family --
+ * `balance`, `children`, `parents`, `root-claim` -- are network-aware because
+ * they read chain state through `state_getStorage` at request time. Their
+ * answer changes every block and owes nothing to the decode lane, so stamping
+ * them with a watermark that advances hourly would hold a balance across up to
+ * an hour of blocks. They are excluded, not scoped.
+ *
+ * That the two sets coincide is not luck: a route is declared mainnet-only
+ * precisely when it reads a store that carries no network column, and a route
+ * is network-aware precisely when it reads the chain itself. "Answered from a
+ * store" and "stamped by a producer" are the same property.
+ *
+ * `isDefaultNetwork` is the SEPARATE, mandatory guard. Without it a
+ * `/testnet/api/v1/accounts/{ss58}/events` request -- whose resolved path IS
+ * mainnet-only -- would look up the mainnet key and be served mainnet's body.
+ * That the route then 404s is no protection: the lookup happens first. It also
+ * covers both spellings of mainnet (`/api/v1/…` and `/finney/api/v1/…`), which
+ * is what lets those two share one entry.
+ *
+ * Both are pinned by tests rather than by this comment: if a store-backed
+ * account route becomes network-aware, or a live-chain one becomes
+ * mainnet-only, the assertion fails and this gate is revisited BEFORE anything
+ * can be served under the wrong key.
+ *
+ * `pathname` is the RESOLVED path -- the `/{network}/` prefix already stripped
+ * -- so the two mainnet spellings do not compute the same body under two keys.
+ *
+ * CSV shares the route but not the body. `format=csv` rides in the search
+ * string and so would key separately anyway; refusing it outright means the
+ * question is settled here rather than resting on that -- and a one-shot
+ * download is the traffic shape a cache helps least.
+ *
+ * HEAD is eligible: `withEdgeCache` normalizes it into the GET key and strips
+ * the body on the way out, but ONLY when the builder takes the normalized
+ * request. The call site passes it; see the wiring in `workers/api.ts`.
+ *
+ * `addressShaped` is passed IN rather than re-derived here, and the caller
+ * passes `ACCOUNT_SS58_SEGMENT_PATH_PATTERN` -- the same predicate the rate
+ * limiter uses. The two gates protect the same family for the same reason, and
+ * a cache whose idea of "the account routes" could drift from the limiter's is
+ * a cache that silently stops covering whatever drifted.
+ */
+export function accountEdgeCacheEligible(input: {
+  method: string;
+  isDefaultNetwork: boolean;
+  addressShaped: boolean;
+  storeBacked: boolean;
+  search: URLSearchParams;
+}): boolean {
+  const { method, isDefaultNetwork, addressShaped, storeBacked, search } =
+    input;
+  if (method !== "GET" && method !== "HEAD") return false;
+  if (!isDefaultNetwork) return false;
+  if (!addressShaped || !storeBacked) return false;
+  return search.get("format") !== "csv";
+}
+
+/**
+ * The published decode height as a cache stamp, or null.
+ *
+ * NULL DISABLES CACHING rather than falling back to a constant, and
+ * `withEdgeCache` already treats a null stamp that way -- it is the same guard
+ * that keeps a cold health-meta read from seeding an analytics entry. An
+ * unreadable watermark means we cannot say which generation an answer belongs
+ * to, and a key that cannot express that would pin one generation's body across
+ * the next publish: the exact failure the stamp exists to prevent, arrived at
+ * by trying to be helpful.
+ *
+ * Memoized upstream (`resolveDecodeWatermark`, 5-minute TTL), so this is one R2
+ * GET per isolate per TTL rather than one per request.
+ */
+export async function accountCacheStamp(env: unknown): Promise<string | null> {
+  const watermark = await resolveDecodeWatermark(
+    env,
+    {},
+    DEFAULT_CHAIN_NETWORK,
+  );
+  return watermark === null ? null : String(watermark.decodedThrough);
+}

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -292,6 +292,11 @@ import {
   resolveGlobalIncidentsForFeed,
   withEdgeCache,
 } from "./request-handlers/analytics.ts";
+import {
+  ACCOUNT_EDGE_CACHE_LABEL,
+  accountCacheStamp,
+  accountEdgeCacheEligible,
+} from "./account-edge-cache.ts";
 import { parseRouteQuery, routeQuery, routeText } from "../src/route-query.ts";
 import {
   handleSubnetMetagraph,
@@ -6052,9 +6057,61 @@ async function handleChainFirehoseIngest(request: Request, env: Env) {
  */
 export async function handleRequest(request: Request, env: Env, ctx: Ctx = {}) {
   const before = degradedSnapshot();
-  const response = await dispatchRequest(request, env, ctx);
+  const response = await dispatchCached(request, env, ctx);
   labelDegradedResponse(response, before);
   return response;
+}
+
+/**
+ * `dispatchRequest`, with the account family behind the edge cache (#11017's
+ * own docstring names the gap: "lakehouse-backed and billed per byte scanned,
+ * no edge cache").
+ *
+ * HERE, for the reason the two gates above it are here. The rate limiter and
+ * the degraded label both sit at this dispatch point rather than at ~40 call
+ * sites, and a cache placed per-handler is the version of this that the 42nd
+ * handler forgets -- `request-handlers/entities.ts` has 41 cold-tier call sites
+ * and reaches `withEdgeCache` from none of them.
+ *
+ * INSIDE the cache, not outside it. The limiter runs within `dispatchRequest`,
+ * so a cache HIT skips it -- deliberately. The limiter exists to bound
+ * lakehouse bytes, and a hit reads none; the enumeration traffic it was written
+ * for walks distinct addresses, which miss by construction and still meet it.
+ *
+ * The stamp is the decode watermark rather than the health cron's `last_run_at`
+ * that every analytics route uses, which is what `withEdgeCache`'s
+ * `resolveCacheStamp` hook was declared for -- until now no call site passed
+ * one. These routes read the lakehouse, which changes when decode publishes and
+ * at no other time, so the health cron's clock would be a stamp for a different
+ * producer entirely: it would evict answers that had not changed and, worse,
+ * hold answers across a decode publish that had.
+ */
+async function dispatchCached(request: Request, env: Env, ctx: Ctx = {}) {
+  const url = new URL(request.url);
+  // The RESOLVED path, so `/api/v1/accounts/…` and `/finney/api/v1/accounts/…`
+  // reach one entry instead of computing the same body under two keys.
+  const { network, url: resolved } = resolveNetworkPrefix(url);
+  const eligible = accountEdgeCacheEligible({
+    method: request.method,
+    isDefaultNetwork: network.isDefault,
+    addressShaped: ACCOUNT_SS58_SEGMENT_PATH_PATTERN.test(resolved.pathname),
+    storeBacked: isMainnetOnlyApiPath(resolved.pathname),
+    search: resolved.searchParams,
+  });
+  if (!eligible) return dispatchRequest(request, env, ctx);
+  return withEdgeCache(
+    request,
+    ctx,
+    env,
+    ACCOUNT_EDGE_CACHE_LABEL,
+    // Takes the argument on purpose: `withEdgeCache` only folds HEAD into the
+    // GET key when the builder accepts the normalized request, and a builder
+    // closing over the original HEAD would seed the GET entry with an empty
+    // body for every later caller.
+    (cacheRequest) => dispatchRequest(cacheRequest, env, ctx),
+    `${resolved.pathname}${resolved.search}`,
+    accountCacheStamp,
+  );
 }
 
 async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {


### PR DESCRIPTION
## Measured

2026-08-16, `5EEmaGFEAtAWCviYezuMbutPummVsk9zMXJzcnNo5oM3qDSC`, three identical back-to-back GETs of `/accounts/{ss58}/events?limit=5`:

| | | |
|---|---|---|
| 16.9s | 15.2s | 16.3s |

No `cf-cache-status` on any of them. The account page issues **28** such requests.

A Worker's own response is not stored by Cloudflare unless the Cache API is used explicitly. `request-handlers/entities.ts` holds **41** cold-tier call sites and reaches `withEdgeCache` from **none** of them, against 33 uses in `analytics.ts` — so `cache-control: public, max-age=60` on these bodies only ever reached browsers. `dataRouteRateLimit`'s own docstring names the gap in passing: *"lakehouse-backed and billed per byte scanned, no edge cache"*.

The dispatch-level static cache could not reach them either: the family is matched by anchored regexes that return early, hundreds of lines before the `isStaticEdgeCacheEligible` block.

## One gate, not 41 wrapped call sites

At the dispatch point, beside the rate limiter and the degraded label, for the reason both of those are there: a cache placed per-handler is the version of this that the 42nd handler forgets.

**Inside** the cache, not outside — a hit skips the limiter, deliberately. The limiter exists to bound lakehouse bytes and a hit reads none; the enumeration traffic it was written for walks distinct addresses, which miss by construction and still meet it.

## The stamp is the decode watermark

Which is what `withEdgeCache`'s `resolveCacheStamp` hook was declared for. No call site passed one until now — the branch carried a `/* v8 ignore */` and the comment *"genuinely unreachable right now"*.

These routes read the lakehouse, which changes when decode publishes and at no other time. The health cron's `last_run_at` would be a stamp for a different producer entirely: it would evict answers that had not changed, and hold answers across a decode publish that had. A new generation writes to a **different key**, so correctness comes from the key rather than from an expiry racing the data. The response's own `max-age=60` still bounds retention, which is what keeps the USD-at-tx overlay honest — so no freshness promise changes.

## The partition the tests caught

The first draft of this module cached the whole address-shaped family. Four members — `balance`, `children`, `parents`, `root-claim` — read chain state through `state_getStorage` at request time. Their answer changes every block and owes nothing to decode, so stamping them with an hourly watermark would have held a balance across up to an hour of blocks. **The contract-derived test is what found it**, not review.

They are excluded by `isMainnetOnlyApiPath`, and that the two sets coincide is not luck: a route is declared mainnet-only precisely when it reads a store carrying no network column, and network-aware precisely when it reads the chain itself. "Answered from a store" and "stamped by a producer" are the same property.

`isDefaultNetwork` is a **separate, mandatory** guard. Without it a `/testnet/api/v1/accounts/{ss58}/events` request — whose *resolved* path is mainnet-only — would look up the mainnet key and be served mainnet's body. That the route then 404s is no protection: the lookup happens first.

Both couplings are pinned by tests read from the published contract, so a route added later is covered without anyone remembering to.

## Verification

- **Three identical GETs issue one set of lakehouse reads** — the test counts R2 SQL, not responses. A cache that returns the right body while still paying for it is exactly the failure this is about, and it is invisible in the payload.
- **Falsified**: with the gate short-circuited, 5 of the 13 tests fail.
- Also pinned: a new decode generation writes a different key; the contract version is in the key; both spellings of mainnet share one entry; a different address does not; a null watermark disables caching rather than pinning a constant; CSV, non-account routes, live-chain routes and non-200s are never stored; HEAD is served from the GET entry with no body.
- Production cache-control confirmed cacheable: `public, max-age=60, stale-while-revalidate=300`, while the declining card returns `no-store` + 503 that the non-200 guard already refuses.
- **Patch coverage 15/15 lines, 15/15 branches** by diff intersection.
- **Full suite** 952 files / 21,835 passed; **full CI gate** 79 targets, 0 failed.

## What this does not fix

The **first** view. A cache absorbs repeat and burst load; it cannot make a cold read fast. #11425's bound is what does that.