### PR TITLE
fix(watchdog): a container lane's failure reported the phase that finished, not the reason it failed

### DIFF
--- a/schemas-src/artifacts/container-lane-status.ts
+++ b/schemas-src/artifacts/container-lane-status.ts
@@ -50,4 +50,22 @@ export const ContainerLaneStatusSchema = z.object({
   status: z.string().nullable().optional().catch(null),
   detail: z.string().nullable().optional().catch(null),
   phase: z.string().nullable().optional().catch(null),
+  /**
+   * The producer's own per-step failures, `{ step: message }`.
+   *
+   * ADDED AFTER THE WATCHDOG'S FIRST REAL CATCH. On 2026-08-16T16:30:40Z the
+   * account-summary lane published `ok: false, phase: "complete", failures:
+   * { _lane: "ArrowInvalid: Schema at index 1 was different: ..." }` and the
+   * durable record read `lane failed: complete` -- the reader fell through
+   * `detail` (absent) to `phase`, which names the step that finished rather
+   * than the reason it failed. An alarm that reports the phase of a failure
+   * says less than one that stays silent, because it reads like an answer.
+   *
+   * `unknown` VALUES, not `z.string()`: three of the five producers write this
+   * key and this repo owns none of them, so a step that records a structured
+   * failure rather than a string must not invalidate the whole status and take
+   * the other four lanes' verdicts down with it. The reader takes what it can
+   * render and ignores the rest.
+   */
+  failures: z.record(z.string(), z.unknown()).nullable().optional().catch(null),
 });

--- a/src/container-lane-watchdog.ts
+++ b/src/container-lane-watchdog.ts
@@ -138,7 +138,61 @@ export interface ContainerLaneStatus {
     status?: string | null;
     detail?: string | null;
     phase?: string | null;
+    failures?: Record<string, unknown> | null;
   } | null;
+}
+
+/**
+ * How long a quoted producer message may be.
+ *
+ * The real one that prompted this carried a 700-character pyarrow traceback in
+ * a sibling key. A `$exception` nobody can read at a glance is a `$exception`
+ * nobody reads, and the full text is in the status object either way -- this
+ * names the fault, it does not replace the artifact.
+ */
+export const LANE_DETAIL_MAX = 200;
+
+/**
+ * The producer's own words for why a lane failed, or null when it gave none.
+ *
+ * FAILURES FIRST, and this is the whole point. On 2026-08-16 the
+ * account-summary lane published `ok: false, phase: "complete", failures: {
+ * _lane: "ArrowInvalid: Schema at index 1 was different: ..." }` and this
+ * watchdog recorded `lane failed: complete` -- it fell through `detail`
+ * (absent) to `phase`, which names the step that FINISHED rather than the
+ * reason it failed. An alarm that reports the phase of a failure says less than
+ * one that stays silent, because it reads like an answer.
+ *
+ * EVERY entry, joined, not just the first: the map is per-step, so a pass that
+ * failed three ways has three things worth knowing and picking one would be an
+ * arbitrary choice presented as a summary.
+ *
+ * NON-STRING VALUES ARE SKIPPED rather than stringified. This repo does not own
+ * the producers, and `[object Object]` in an alarm is worse than the key's
+ * absence -- it looks like a message and carries none.
+ */
+export function laneFailureDetail(body: {
+  detail?: string | null;
+  phase?: string | null;
+  status?: string | null;
+  failures?: Record<string, unknown> | null;
+}): string | null {
+  const failures = body.failures;
+  if (failures && typeof failures === "object") {
+    const said = Object.entries(failures)
+      .filter(([, value]) => typeof value === "string" && value.trim() !== "")
+      .map(([step, value]) => `${step}: ${clip(String(value))}`);
+    if (said.length > 0) return said.join("; ");
+  }
+  return body.detail ?? body.phase ?? body.status ?? null;
+}
+
+/** One producer message, on one line, bounded. */
+function clip(text: string): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length <= LANE_DETAIL_MAX
+    ? flat
+    : `${flat.slice(0, LANE_DETAIL_MAX - 1)}\u2026`;
 }
 
 /** Hours, to one decimal, for a message a human reads at 3am. */
@@ -195,7 +249,7 @@ export function evaluateContainerLanes(input: {
       body.ok === false ||
       (typeof body.status === "string" && body.status !== "ok");
     if (declaredFailure) {
-      const said = body.detail ?? body.phase ?? body.status ?? null;
+      const said = laneFailureDetail(body);
       return {
         lane,
         verdict: "stale",

--- a/tests/container-lane-watchdog.test.ts
+++ b/tests/container-lane-watchdog.test.ts
@@ -10,7 +10,9 @@ import {
   CONTAINER_LANE_THRESHOLD_MS,
   CONTAINER_MISSED_PASSES,
   CONTAINER_PASS_INTERVAL_MS,
+  LANE_DETAIL_MAX,
   evaluateContainerLanes,
+  laneFailureDetail,
   runContainerLaneWatchdog,
 } from "../src/container-lane-watchdog.ts";
 
@@ -406,5 +408,91 @@ describe("runContainerLaneWatchdog", () => {
     assert.equal(result.ok, true);
     assert.equal(result.stale, false, "unreadable is unknown, not an alarm");
     assert.equal(spy.rows.length, 5, "and every lane still gets a row");
+  });
+});
+
+/**
+ * The detail a `stale` verdict carries, after the watchdog's first real catch.
+ *
+ * 2026-08-16T16:30:40Z, production: the account-summary lane published
+ * `ok: false, phase: "complete", failures: { _lane: "ArrowInvalid: ..." }` and
+ * `lane_health` recorded `lane failed: complete`. The reader fell through
+ * `detail` (absent) to `phase`, which names the step that FINISHED rather than
+ * the reason it failed.
+ */
+describe("laneFailureDetail", () => {
+  test("QUOTES THE FAILURE, not the phase that finished", () => {
+    assert.equal(
+      laneFailureDetail({
+        phase: "complete",
+        failures: { _lane: "ArrowInvalid: Schema at index 1 was different" },
+      }),
+      "_lane: ArrowInvalid: Schema at index 1 was different",
+    );
+  });
+
+  test("EVERY step that failed, not an arbitrary one", () => {
+    // The map is per-step, so a pass that failed three ways has three things
+    // worth knowing, and picking one would be an arbitrary choice presented as
+    // a summary.
+    assert.equal(
+      laneFailureDetail({ failures: { a: "first broke", b: "second broke" } }),
+      "a: first broke; b: second broke",
+    );
+  });
+
+  test("a long message is FLATTENED AND BOUNDED", () => {
+    // The real one carried a 700-character pyarrow traceback. A `$exception`
+    // nobody can read at a glance is a `$exception` nobody reads, and the full
+    // text is in the status object either way.
+    const said = laneFailureDetail({
+      failures: { _where: `line one\n  line two ${"x".repeat(500)}` },
+    });
+    assert.ok(said!.length <= LANE_DETAIL_MAX + "_where: ".length, said!);
+    assert.ok(!said!.includes("\n"), "a newline in an alarm line");
+    assert.ok(said!.endsWith("\u2026"), said!.slice(-20));
+  });
+
+  test("a NON-STRING value is skipped rather than stringified", () => {
+    // `[object Object]` in an alarm is worse than the key's absence: it looks
+    // like a message and carries none. This repo owns none of the producers.
+    assert.equal(
+      laneFailureDetail({ detail: "the real one", failures: { a: { b: 1 } } }),
+      "the real one",
+    );
+  });
+
+  test("an EMPTY failures map falls through, it does not report nothing", () => {
+    // Every successful pass publishes `failures: {}`, so treating the key's
+    // presence as the signal would silence the fallback for the lanes that
+    // report most carefully.
+    assert.equal(laneFailureDetail({ failures: {}, detail: "d" }), "d");
+    assert.equal(laneFailureDetail({ failures: {}, phase: "p" }), "p");
+    assert.equal(laneFailureDetail({ failures: null }), null);
+  });
+
+  test("the RUNNER carries it into the verdict", () => {
+    // The unit above is the rule; this is the property that matters -- the
+    // durable record is what an operator reads at 3am.
+    const verdict = evaluateContainerLanes({
+      statuses: [
+        {
+          lane: "container:account-summary",
+          body: {
+            checked_at: "2026-08-16T16:30:40Z",
+            ok: false,
+            phase: "complete",
+            failures: { _lane: "ArrowInvalid: Schema at index 1" },
+          },
+        },
+      ],
+      nowMs: Date.parse("2026-08-16T16:31:00Z"),
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(verdict.stale, true);
+    assert.equal(
+      verdict.entries[0]!.detail,
+      "lane failed: _lane: ArrowInvalid: Schema at index 1",
+    );
   });
 });


### PR DESCRIPTION
## The catch, and what it said

#11413's container-lane watchdog caught its first real fault at 2026-08-16T16:30:40Z. The durable record read:

```
container:account-summary   stale   "lane failed: complete"
```

The producer had published:

```json
{ "phase": "complete", "ok": false, "checked_at": "2026-08-16T16:30:40Z",
  "failures": { "_lane": "ArrowInvalid: Schema at index 1 was different: account: string ... vs account: large_string" } }
```

The reader fell through `detail` (absent) to `phase` — which names the step that **finished**, not the reason it failed. The one field carrying the diagnosis was the one field the schema did not declare.

An alarm that reports the phase of a failure says **less** than one that stays silent, because it reads like an answer. An operator paged on `lane failed: complete` learns nothing and has been told something.

## The fix

`failures` is declared and read first.

- **Every entry, joined.** The map is per-step, so a pass that failed three ways has three things worth knowing; picking one would be an arbitrary choice presented as a summary.
- **Non-string values are skipped, not stringified.** This repo owns none of the five producers, and `[object Object]` in an alarm is worse than the key's absence — it looks like a message and carries none. The same argument makes the schema values `z.unknown()`: a producer that starts recording a structured failure degrades one lane's detail rather than invalidating the status and taking the other four lanes' verdicts down with it.
- **Bounded and flattened at 200 characters.** The real one carried a 700-character pyarrow traceback in a sibling `_where` key. An exception nobody can read at a glance is an exception nobody reads; the full text stays in the status object, so this names the fault rather than replacing the artifact.
- **An empty `failures` map falls through.** Every successful pass publishes `{}`, so treating the key's presence as the signal would silence the fallback for the lanes that report most carefully.

## Verification

- **Falsified**: with the old fallback restored, 4 of the 21 tests fail.
- The runner test asserts the property that actually matters — what lands in `lane_health`, which is what an operator reads at 3am — not just the pure rule.
- **Patch coverage 11/11 lines, 14/14 branches** by diff intersection.
- **Full CI gate**: 79 targets, 0 failed.

The underlying lane failure is fixed separately in metagraphed-infra#601.