### PR TITLE
perf(accounts): the windowed walk read a range its own predicate had already emptied

### DIFF
--- a/src/account-events-window.ts
+++ b/src/account-events-window.ts
@@ -141,6 +141,15 @@ export interface WindowedRowReadOptions extends WindowWalkDeps {
    * from now. Null starts at the newest end.
    */
   ceiling?: number | null;
+  /**
+   * The projection's lower bound, when the caller already pushed one into
+   * `where`. Null when it could not supply one.
+   *
+   * PASSED SEPARATELY rather than parsed back out of `where`, which is an
+   * opaque string array by design. The walk cannot otherwise know that the
+   * range it is about to read is empty -- and it was reading it anyway.
+   */
+  floorMs?: number | null;
 }
 
 /**
@@ -169,7 +178,15 @@ export async function windowedRowRead<Row>(
   env: R2SqlEnv | null | undefined,
   options: WindowedRowReadOptions,
 ): Promise<Row[] | null> {
-  const { table, columns, where, order, need, ceiling = null } = options;
+  const {
+    table,
+    columns,
+    where,
+    order,
+    need,
+    ceiling = null,
+    floorMs = null,
+  } = options;
   const query = options.query ?? r2SqlQuery;
   const now = options.now ?? Date.now;
 
@@ -181,17 +198,35 @@ export async function windowedRowRead<Row>(
         `${order} LIMIT ${need - collected.length}`,
     )) as Row[] | null;
 
+  // The BOTTOM of the walk, and it is the projection's floor when there is one.
+  //
+  // Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC, whose whole folded history is a
+  // single event on 2026-08-11: the two probes cover ten days, so they already
+  // spanned everything the account can have -- and the walk then issued a THIRD
+  // query for `observed_at <= now - 10d`, against a `where` that also carries
+  // `observed_at >= 2026-08-11`. Floor above ceiling: a range that cannot hold
+  // a row, read at full R2 SQL latency, on every request.
+  //
+  // Zero when there is no floor, which is exactly the behaviour before this:
+  // `Math.max(0, ...)` was already the bottom and `floor === 0` already ended
+  // the walk.
+  const bottom = floorMs === null ? 0 : Math.trunc(floorMs);
+
   let top: number | null = ceiling;
   let window = ACCOUNT_EVENTS_WINDOW_MS;
   for (let step = 0; step < PROBE_STEPS && collected.length < need; step++) {
-    const floor = Math.max(0, (top ?? now()) - window);
+    const floor = Math.max(bottom, (top ?? now()) - window);
     const slice = await read(windowBound(floor, top));
     // A failed slice fails the read. Returning what landed so far would publish
     // a page that is short for a reason the caller cannot see, which is the
     // silently-truncated answer this whole family declines rather than serves.
     if (slice === null) return null;
     collected.push(...slice);
-    if (floor === 0) return collected;
+    // THE WHOLE RANGE IS NOW READ. A window whose floor reached the bottom
+    // covers everything at or above it, and the caller's own predicate excludes
+    // everything below -- so a short page here is the complete answer, not an
+    // unfinished one. Widening cannot find a row and neither can the tail read.
+    if (floor <= bottom) return collected;
     top = floor - 1;
     window *= WINDOW_GROWTH;
   }

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -250,6 +250,9 @@ export async function loadAccountTransfersColdTier(
     // A cursor page resumes from its own `observed_at` -- cursor[0] of the
     // 3-part token -- rather than from now.
     ceiling: cursor ? safeBlockNumber(cursor[0]) : null,
+    // The same floor already pushed into `where`, so the walk stops when it
+    // reaches it rather than reading a range its own predicate excludes.
+    floorMs: transferFloorMs,
   });
   if (rows === null) return null;
 
@@ -872,6 +875,7 @@ async function counterpartyScan(
           ],
     order: ` ${FEED_ORDER}`,
     need: COUNTERPARTIES_SCAN_CAP,
+    floorMs,
   });
 }
 

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -163,6 +163,9 @@ export async function loadAccountEventsColdTier(
     need: limit + paged,
     // cursor[0] is the token's `observed_at`, the column the walk slices on.
     ceiling: cursor ? (cursor[0] as number) : null,
+    // The same floor already in `where`, told to the walk so it stops when it
+    // reaches it instead of reading a range its own predicate excludes.
+    floorMs,
   });
   if (rows === null) return null;
 

--- a/tests/account-events-window.test.ts
+++ b/tests/account-events-window.test.ts
@@ -36,9 +36,19 @@ function engine(rows: Row[], { fail = -1 }: { fail?: number } = {}) {
   const query = async (_env: unknown, sql: string) => {
     seen.push(sql);
     if (seen.length - 1 === fail) return null;
-    const lo = Number(/observed_at >= (\d+)/.exec(sql)?.[1] ?? 0);
-    const hiMatch = /observed_at <= (\d+)/.exec(sql);
-    const hi = hiMatch ? Number(hiMatch[1]) : Number.POSITIVE_INFINITY;
+    // EVERY `observed_at >=`, not the first. A caller that pushed the
+    // projection floor into `where` produces two of them, and AND means the
+    // TIGHTEST -- taking the first made both probes read the same range and
+    // return the same row twice, which reads as a paging bug in the walk rather
+    // than as a fact about this double.
+    const lows = [...sql.matchAll(/observed_at >= (\d+)/g)].map((m) =>
+      Number(m[1]),
+    );
+    const lo = lows.length ? Math.max(...lows) : 0;
+    const highs = [...sql.matchAll(/observed_at <= (\d+)/g)].map((m) =>
+      Number(m[1]),
+    );
+    const hi = highs.length ? Math.min(...highs) : Number.POSITIVE_INFINITY;
     const limit = Number(/LIMIT (\d+)\s*$/.exec(sql)?.[1] ?? rows.length);
     return rows
       .filter((r) => Number(r.observed_at) >= lo && Number(r.observed_at) <= hi)
@@ -325,5 +335,116 @@ describe("the default reader", () => {
       }),
       null,
     );
+  });
+});
+
+/**
+ * The walk clamped to the caller's own floor.
+ *
+ * Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC, whose whole folded history is a
+ * single event on 2026-08-11: the two probes cover ten days, so they already
+ * spanned everything the account can have -- and the walk then issued a THIRD
+ * query for `observed_at <= now - 10d`, against a `where` that also carries
+ * `observed_at >= 2026-08-11`. Floor above ceiling: a range that cannot hold a
+ * row, read at full R2 SQL latency, on every request.
+ */
+describe("windowedRowRead -- the floor the caller already knows", () => {
+  test("STOPS at the floor instead of reading below it", async () => {
+    // One row, five days back, page never fills. Without the clamp this is
+    // three queries: two probes and a tail below them that the caller's own
+    // predicate has already emptied.
+    const e = engine(rowsAgedDays(5));
+    const rows = await feed(5, {
+      query: e.query,
+      floorMs: NOW - 6 * DAY,
+      where: [`hotkey = 'x'`, `observed_at >= ${NOW - 6 * DAY}`],
+    });
+    assert.equal(rows!.length, 1, "the row is still returned");
+    assert.equal(e.seen.length, 2, e.seen.join("\n"));
+    // No query may reach below the floor. Asserting on the low bounds rather
+    // than on the presence of a `<=` clause: the probes carry one too, so a
+    // shape check would have matched them and passed for the wrong reason.
+    for (const sql of e.seen) {
+      const low = Math.max(
+        ...[...sql.matchAll(/observed_at >= (\d+)/g)].map((m) => Number(m[1])),
+      );
+      assert.ok(low >= NOW - 6 * DAY, `read below the floor: ${sql}`);
+    }
+  });
+
+  test("the LAST probe is clamped to the floor, not widened past it", async () => {
+    const e = engine(rowsAgedDays(5));
+    await feed(5, {
+      query: e.query,
+      floorMs: NOW - 6 * DAY,
+      where: [`hotkey = 'x'`, `observed_at >= ${NOW - 6 * DAY}`],
+    });
+    const lows = e.seen.map((sql) =>
+      Number(/observed_at >= (\d+)/.exec(sql)![1]),
+    );
+    assert.equal(
+      Math.min(...lows),
+      NOW - 6 * DAY,
+      "the deepest window must sit exactly on the floor",
+    );
+  });
+
+  test("SAME ROWS as the unclamped walk -- the clamp is not a narrowing", async () => {
+    // The property that matters. The floor is the caller's own predicate, so
+    // every row it excludes was already excluded; stopping there must change
+    // the cost and nothing else.
+    const aged = rowsAgedDays(1, 3, 5, 5.5);
+    const floor = NOW - 6 * DAY;
+    const where = [`hotkey = 'x'`, `observed_at >= ${floor}`];
+    const clamped = engine(aged);
+    const walked = engine(aged);
+    assert.deepEqual(
+      await feed(50, { query: clamped.query, where, floorMs: floor }),
+      await feed(50, { query: walked.query, where }),
+    );
+    assert.ok(
+      clamped.seen.length < walked.seen.length,
+      `clamped ${clamped.seen.length} vs walked ${walked.seen.length}`,
+    );
+  });
+
+  test("a floor BELOW the probes changes nothing", async () => {
+    // An account with genuinely old history still gets the full walk: the
+    // clamp only ever removes reads the caller's predicate had emptied.
+    const deep = NOW - 400 * DAY;
+    const where = [`hotkey = 'x'`, `observed_at >= ${deep}`];
+    const clamped = engine(rowsAgedDays(300));
+    const walked = engine(rowsAgedDays(300));
+    assert.deepEqual(
+      await feed(5, { query: clamped.query, where, floorMs: deep }),
+      await feed(5, { query: walked.query, where }),
+    );
+    assert.equal(clamped.seen.length, walked.seen.length);
+  });
+
+  test("NO floor is byte-identical to before", async () => {
+    // Every caller that cannot supply one -- another network, an absent
+    // projection -- must walk exactly as it did.
+    const withNull = engine(rowsAgedDays(300));
+    const without = engine(rowsAgedDays(300));
+    assert.deepEqual(
+      await feed(5, { query: withNull.query, floorMs: null }),
+      await feed(5, { query: without.query }),
+    );
+    assert.deepEqual(withNull.seen, without.seen);
+  });
+
+  test("a FILLED page still stops early, floor or no floor", async () => {
+    // The clamp must not turn a one-query answer into a wider one: a busy
+    // account whose first probe fills the page reads two days, not the floor's
+    // whole span.
+    const e = engine(rowsAgedDays(0.1, 0.2, 0.3));
+    const rows = await feed(2, {
+      query: e.query,
+      floorMs: NOW - 300 * DAY,
+      where: [`hotkey = 'x'`, `observed_at >= ${NOW - 300 * DAY}`],
+    });
+    assert.equal(rows!.length, 2);
+    assert.equal(e.seen.length, 1, e.seen.join("\n"));
   });
 });


### PR DESCRIPTION
## Measured

`5EEmaGFEAtAWCviYezuMbutPummVsk9zMXJzcnNo5oM3qDSC`'s entire folded history is **one event**, on 2026-08-11. Its projection shard:

```json
[{"kind":"NeuronRegistered","netuid":105,"count":1,"fb":8836052,"lb":8836052,
  "fo":1786629372000,"lo":1786629372000}]
```

So #11425's floor lands at 2026-08-11 and is pushed into `where`. The walk then does this:

| query | range | rows |
|---|---|---|
| probe 1 | `[now-2d, now]` | 0 |
| probe 2 | `[now-10d, now-2d)` | 1 |
| **tail** | **`observed_at <= now-10d` AND `observed_at >= 2026-08-11`** | **impossible** |

The two probes cover ten days, which already spans everything the account can have. The third query asks for rows below `now-10d` in a statement that also demands rows at or above `now-5d`. Floor above ceiling — a range that cannot hold a row, read at full R2 SQL latency, on every request.

That is a third of the wall clock on a route whose answer is one row, and it is the shape of **every quiet account**, which is most of them.

## Why the walk could not see it

The bound lives in `where`, an opaque `readonly string[]` by design. So the floor is passed in explicitly rather than parsed back out: each window clamps to it instead of to zero, and the walk returns as soon as a window's floor reaches it.

That early return is sound for a specific reason: a window whose floor reached the bottom covers everything at or above it, and the caller's own predicate excludes everything below — so a short page there is the **complete** answer, not an unfinished one.

## Strictly a cost change

The clamp only removes reads the caller's predicate had already emptied. Pinned by a test that runs the clamped and unclamped walks over one fixture and compares **both** the rows and the query count:

- **same rows, fewer queries** for a floored quiet account
- a floor **below** the probes changes nothing — an account with genuinely old history still gets the full walk
- a caller with **no** floor walks byte-for-byte as before, `seen` arrays deep-equal
- a **busy** account whose first probe fills the page still stops after one query, rather than widening to the floor's whole span (the clamp must not turn a one-query answer into a wider one)

**Falsified**: with the clamp neutralised, 2 of the new tests fail.

## A test double that was lying

`engine` read only the **first** `observed_at >=` in a query. AND means the *tightest*. A caller that pushed a floor into `where` produces two lower bounds, so both probes read the same effective range and returned the same row twice — which reads as a paging bug in the walk rather than as a fact about the double. It now takes the maximum of the lower bounds and the minimum of the upper ones, and that is what surfaced the double-count while this was being written.

## Verification

- **Patch coverage 5/5 lines, 12/12 branches** by diff intersection.
- **Full suite** 21,850 passed; **full CI gate** 79 targets, 0 failed.