### PR TITLE
fix(lakehouse): three more readers published a timeout as data

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -5670,6 +5670,11 @@ type BlockDetail {
   Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve.
   """
   next_block_number: Int
+
+  """
+  Present ONLY on a decline. A null \`block\` WITHOUT this is a CONFIRMED ABSENCE -- the store was read and holds no such block, which is a measurement. With it, the read failed and nothing is known about whether the block exists.
+  """
+  degraded: DegradedInfo
 }
 
 """
@@ -6547,11 +6552,12 @@ type AccountStakeMoves {
   schema_version: Int!
   address: String!
   window: String
-  total_movements: Int!
-  subnet_count: Int!
+  total_movements: Int
+  subnet_count: Int
   concentration: Float
   dominant_netuid: Int
   subnets: [AccountStakeMoveSubnet!]!
+  degraded: DegradedInfo
 }
 
 """
@@ -6604,6 +6610,10 @@ type AccountEntities {
   schema_version: Int!
   ss58: String!
   labels: [AccountEntityLabel!]!
+
+  """
+  How many ownership ties were READ. A FLOOR rather than a total when \`degraded\` is present: this card composes the economics artifact with the transfer stream, and only the transfer half can decline -- so every tie counted here was measured, there are simply more that could not be read.
+  """
   ownership_tie_count: Int!
   ownership_ties: [AccountOwnershipTie!]!
 
@@ -6611,6 +6621,11 @@ type AccountEntities {
   When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An \`owns\` tie is never fresher than this stamp.
   """
   owners_observed_at: String
+
+  """
+  Present ONLY when the TRANSFER half declined. A PARTIAL degradation, unlike the other declining routes: the ownership ties beside it are still measured, which is why the counts stay real rather than going null.
+  """
+  degraded: DegradedInfo
 }
 
 """

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -181,9 +181,12 @@ export type AccountDeregistrations = {
 /** One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
 export type AccountEntities = {
   __typename?: 'AccountEntities';
+  /** Present ONLY when the TRANSFER half declined. A PARTIAL degradation, unlike the other declining routes: the ownership ties beside it are still measured, which is why the counts stay real rather than going null. */
+  degraded?: Maybe<DegradedInfo>;
   labels: Array<AccountEntityLabel>;
   /** When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
   owners_observed_at?: Maybe<Scalars['String']['output']>;
+  /** How many ownership ties were READ. A FLOOR rather than a total when `degraded` is present: this card composes the economics artifact with the transfer stream, and only the transfer half can decline -- so every tie counted here was measured, there are simply more that could not be read. */
   ownership_tie_count: Scalars['Int']['output'];
   ownership_ties: Array<AccountOwnershipTie>;
   schema_version: Scalars['Int']['output'];
@@ -615,11 +618,12 @@ export type AccountStakeMoves = {
   __typename?: 'AccountStakeMoves';
   address: Scalars['String']['output'];
   concentration?: Maybe<Scalars['Float']['output']>;
+  degraded?: Maybe<DegradedInfo>;
   dominant_netuid?: Maybe<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
-  subnet_count: Scalars['Int']['output'];
+  subnet_count?: Maybe<Scalars['Int']['output']>;
   subnets: Array<AccountStakeMoveSubnet>;
-  total_movements: Scalars['Int']['output'];
+  total_movements?: Maybe<Scalars['Int']['output']>;
   window?: Maybe<Scalars['String']['output']>;
 };
 
@@ -797,6 +801,8 @@ export type BlockChainEventsArtifactEvents = {
 export type BlockDetail = {
   __typename?: 'BlockDetail';
   block?: Maybe<Block>;
+  /** Present ONLY on a decline. A null `block` WITHOUT this is a CONFIRMED ABSENCE -- the store was read and holds no such block, which is a measurement. With it, the read failed and nothing is known about whether the block exists. */
+  degraded?: Maybe<DegradedInfo>;
   /** Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve. */
   next_block_number?: Maybe<Scalars['Int']['output']>;
   /** Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve. */
@@ -9522,6 +9528,7 @@ export type AccountDeregistrationsResolvers<ContextType = GqlContext, ParentType
 }>;
 
 export type AccountEntitiesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountEntities'] = ResolversParentTypes['AccountEntities']> = ResolversObject<{
+  degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
   labels?: Resolver<Array<ResolversTypes['AccountEntityLabel']>, ParentType, ContextType>;
   owners_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   ownership_tie_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -9873,11 +9880,12 @@ export type AccountStakeMoveSubnetResolvers<ContextType = GqlContext, ParentType
 export type AccountStakeMovesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountStakeMoves'] = ResolversParentTypes['AccountStakeMoves']> = ResolversObject<{
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   concentration?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
   dominant_netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  subnet_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   subnets?: Resolver<Array<ResolversTypes['AccountStakeMoveSubnet']>, ParentType, ContextType>;
-  total_movements?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  total_movements?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
@@ -10020,6 +10028,7 @@ export type BlockChainEventsArtifactEventsResolvers<ContextType = GqlContext, Pa
 
 export type BlockDetailResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockDetail'] = ResolversParentTypes['BlockDetail']> = ResolversObject<{
   block?: Resolver<Maybe<ResolversTypes['Block']>, ParentType, ContextType>;
+  degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
   next_block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   prev_block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   ref?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5322,6 +5322,8 @@ export interface components {
         };
         /** @description One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
+            /** @description Present ONLY when the TRANSFER half declined. A PARTIAL degradation, unlike the other declining routes: the ownership ties beside it are still measured, which is why the counts stay real rather than going null. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             labels: {
                 category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig") | null;
                 name?: string | null;
@@ -5331,6 +5333,7 @@ export interface components {
             }[];
             /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
             owners_observed_at: string | null;
+            /** @description How many ownership ties were READ. A FLOOR rather than a total when `degraded` is present: this card composes the economics artifact with the transfer stream, and only the transfer half can decline -- so every tie counted here was measured, there are simply more that could not be read. */
             ownership_tie_count: number;
             ownership_ties: {
                 block_number?: number | null;
@@ -5707,9 +5710,10 @@ export interface components {
         AccountStakeMovesArtifact: {
             address: string;
             concentration: number | null;
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             dominant_netuid: number | null;
             schema_version: number;
-            subnet_count: number;
+            subnet_count: number | null;
             subnets: {
                 first_moved_at: string | null;
                 last_moved_at: string | null;
@@ -5718,7 +5722,7 @@ export interface components {
                 /** @description Alpha price (TAO) on the UTC day of this subnet's most recent move; null when that day has no snapshot yet or there was no move. */
                 price_tao_at_last_move: number | null;
             }[];
-            total_movements: number;
+            total_movements: number | null;
             window: ("7d" | "30d" | "90d") | null;
         };
         /** @description One account's live cross-subnet registration footprint (the neurons snapshot), backing account_subnets. The lightweight sibling of AccountPortfolio -- registration facts only, no economics rollup. */
@@ -6295,6 +6299,8 @@ export interface components {
                 parent_hash: string | null;
                 spec_version: number | null;
             } | null;
+            /** @description Present ONLY on a decline. A null `block` WITHOUT this is a CONFIRMED ABSENCE -- the store was read and holds no such block, which is a measurement. With it, the read failed and nothing is known about whether the block exists. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             /** @description Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve. */
             next_block_number: number | null;
             /** @description Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve. */
@@ -14865,6 +14871,10 @@ export interface operations {
                      *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "spec_version": 1
                      *         },
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "next_block_number": 5000000,
                      *         "prev_block_number": 5000000,
                      *         "ref": "example",
@@ -20982,6 +20992,10 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "labels": [
                      *           {}
                      *         ],
@@ -22752,6 +22766,10 @@ export interface operations {
                      *       "data": {
                      *         "address": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "concentration": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "dominant_netuid": 1,
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
@@ -24442,6 +24460,10 @@ export interface operations {
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "spec_version": 1
+                     *         },
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
                      *         },
                      *         "next_block_number": 5000000,
                      *         "prev_block_number": 5000000,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -283,6 +283,10 @@
       "AccountEntitiesArtifactResponse": {
         "value": {
           "data": {
+            "degraded": {
+              "detail": "example",
+              "reason": "example"
+            },
             "labels": [
               {}
             ],
@@ -1111,6 +1115,10 @@
           "data": {
             "address": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
             "concentration": 1,
+            "degraded": {
+              "detail": "example",
+              "reason": "example"
+            },
             "dominant_netuid": 1,
             "schema_version": 1,
             "subnet_count": 1,
@@ -1960,6 +1968,10 @@
               "observed_at": "2026-06-01T00:00:00.000Z",
               "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
               "spec_version": 1
+            },
+            "degraded": {
+              "detail": "example",
+              "reason": "example"
             },
             "next_block_number": 5000000,
             "prev_block_number": 5000000,
@@ -14835,6 +14847,17 @@
         "additionalProperties": false,
         "description": "One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities.",
         "properties": {
+          "degraded": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DegradedInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Present ONLY when the TRANSFER half declined. A PARTIAL degradation, unlike the other declining routes: the ownership ties beside it are still measured, which is why the counts stay real rather than going null."
+          },
           "labels": {
             "items": {
               "additionalProperties": false,
@@ -14917,6 +14940,7 @@
             "description": "When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes \"we could not read who owns what\" from \"this address owns nothing\", which are the same empty list without it. An `owns` tie is never fresher than this stamp."
           },
           "ownership_tie_count": {
+            "description": "How many ownership ties were READ. A FLOOR rather than a total when `degraded` is present: this card composes the economics artifact with the transfer stream, and only the transfer half can decline -- so every tie counted here was measured, there are simply more that could not be read.",
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -17414,6 +17438,16 @@
               }
             ]
           },
+          "degraded": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DegradedInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "dominant_netuid": {
             "anyOf": [
               {
@@ -17432,9 +17466,16 @@
             "type": "integer"
           },
           "subnet_count": {
-            "maximum": 9007199254740991,
-            "minimum": 0,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "subnets": {
             "items": {
@@ -17495,9 +17536,16 @@
             "type": "array"
           },
           "total_movements": {
-            "maximum": 9007199254740991,
-            "minimum": 0,
-            "type": "integer"
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "window": {
             "anyOf": [
@@ -20714,6 +20762,17 @@
                 "type": "null"
               }
             ]
+          },
+          "degraded": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DegradedInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Present ONLY on a decline. A null `block` WITHOUT this is a CONFIRMED ABSENCE -- the store was read and holds no such block, which is a measurement. With it, the read failed and nothing is known about whether the block exists."
           },
           "next_block_number": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5322,6 +5322,8 @@ export interface components {
         };
         /** @description One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
+            /** @description Present ONLY when the TRANSFER half declined. A PARTIAL degradation, unlike the other declining routes: the ownership ties beside it are still measured, which is why the counts stay real rather than going null. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             labels: {
                 category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig") | null;
                 name?: string | null;
@@ -5331,6 +5333,7 @@ export interface components {
             }[];
             /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
             owners_observed_at: string | null;
+            /** @description How many ownership ties were READ. A FLOOR rather than a total when `degraded` is present: this card composes the economics artifact with the transfer stream, and only the transfer half can decline -- so every tie counted here was measured, there are simply more that could not be read. */
             ownership_tie_count: number;
             ownership_ties: {
                 block_number?: number | null;
@@ -5707,9 +5710,10 @@ export interface components {
         AccountStakeMovesArtifact: {
             address: string;
             concentration: number | null;
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             dominant_netuid: number | null;
             schema_version: number;
-            subnet_count: number;
+            subnet_count: number | null;
             subnets: {
                 first_moved_at: string | null;
                 last_moved_at: string | null;
@@ -5718,7 +5722,7 @@ export interface components {
                 /** @description Alpha price (TAO) on the UTC day of this subnet's most recent move; null when that day has no snapshot yet or there was no move. */
                 price_tao_at_last_move: number | null;
             }[];
-            total_movements: number;
+            total_movements: number | null;
             window: ("7d" | "30d" | "90d") | null;
         };
         /** @description One account's live cross-subnet registration footprint (the neurons snapshot), backing account_subnets. The lightweight sibling of AccountPortfolio -- registration facts only, no economics rollup. */
@@ -6295,6 +6299,8 @@ export interface components {
                 parent_hash: string | null;
                 spec_version: number | null;
             } | null;
+            /** @description Present ONLY on a decline. A null `block` WITHOUT this is a CONFIRMED ABSENCE -- the store was read and holds no such block, which is a measurement. With it, the read failed and nothing is known about whether the block exists. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             /** @description Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve. */
             next_block_number: number | null;
             /** @description Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve. */
@@ -14865,6 +14871,10 @@ export interface operations {
                      *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "spec_version": 1
                      *         },
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "next_block_number": 5000000,
                      *         "prev_block_number": 5000000,
                      *         "ref": "example",
@@ -20982,6 +20992,10 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "labels": [
                      *           {}
                      *         ],
@@ -22752,6 +22766,10 @@ export interface operations {
                      *       "data": {
                      *         "address": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
                      *         "concentration": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "dominant_netuid": 1,
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
@@ -24442,6 +24460,10 @@ export interface operations {
                      *           "observed_at": "2026-06-01T00:00:00.000Z",
                      *           "parent_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *           "spec_version": 1
+                     *         },
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
                      *         },
                      *         "next_block_number": 5000000,
                      *         "prev_block_number": 5000000,

--- a/schemas-src/routes/account-activity.ts
+++ b/schemas-src/routes/account-activity.ts
@@ -100,8 +100,10 @@ export const AccountStakeMovesArtifactSchema = z
     schema_version: z.int(),
     address: z.string(),
     window: z.enum(WINDOW_ENUM).nullable(),
-    total_movements: z.int().min(0),
-    subnet_count: z.int().min(0),
+    // NULL only on a decline (#11424): a failed read learns nothing about how
+    // many moves this account made, and a 0 reads as a measured 'never moved'.
+    total_movements: z.int().min(0).nullable(),
+    subnet_count: z.int().min(0).nullable(),
     concentration: z.number().nullable(),
     dominant_netuid: z.int().min(0).nullable(),
     subnets: z.array(
@@ -123,6 +125,8 @@ export const AccountStakeMovesArtifactSchema = z
           "One subnet's slice of an account's stake-movement footprint over the window.",
         ),
     ),
+    /** Present ONLY on a decline. An empty card WITHOUT it is a measurement. */
+    degraded: EventStreamDegradedSchema.nullable().optional(),
   })
   .strict();
 export type AccountStakeMovesArtifact = z.infer<

--- a/schemas-src/routes/account-entities.ts
+++ b/schemas-src/routes/account-entities.ts
@@ -22,6 +22,7 @@
 // (same cosmetic finding batch 4's account-summary.ts made for the
 // identical field).
 import { z } from "zod";
+import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 import { EntityCategorySchema } from "../shared.ts";
 
 /**
@@ -53,7 +54,12 @@ export const AccountEntitiesArtifactSchema = z
     schema_version: z.int(),
     ss58: z.string(),
     labels: z.array(EntityLabelSchema),
-    ownership_tie_count: z.int().min(0),
+    ownership_tie_count: z
+      .int()
+      .min(0)
+      .describe(
+        "How many ownership ties were READ. A FLOOR rather than a total when `degraded` is present: this card composes the economics artifact with the transfer stream, and only the transfer half can decline -- so every tie counted here was measured, there are simply more that could not be read.",
+      ),
     ownership_ties: z.array(
       z
         .object({
@@ -72,6 +78,11 @@ export const AccountEntitiesArtifactSchema = z
       .nullable()
       .describe(
         'When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp.',
+      ),
+    degraded: EventStreamDegradedSchema.nullable()
+      .optional()
+      .describe(
+        "Present ONLY when the TRANSFER half declined. A PARTIAL degradation, unlike the other declining routes: the ownership ties beside it are still measured, which is why the counts stay real rather than going null.",
       ),
   })
   .strict()

--- a/schemas-src/routes/blocks.ts
+++ b/schemas-src/routes/blocks.ts
@@ -8,6 +8,7 @@
 // in this same batch (verified via repo-wide $ref grep), so the hand-edited
 // Block component key becomes fully orphaned.
 import { z } from "zod";
+import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 
 export const BlockSchema = z
   .object({
@@ -59,6 +60,11 @@ export const BlockDetailArtifactSchema = z
       .nullable()
       .describe(
         "Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve.",
+      ),
+    degraded: EventStreamDegradedSchema.nullable()
+      .optional()
+      .describe(
+        "Present ONLY on a decline. A null `block` WITHOUT this is a CONFIRMED ABSENCE -- the store was read and holds no such block, which is a measurement. With it, the read failed and nothing is known about whether the block exists.",
       ),
   })
   .strict();

--- a/src/account-entities-answer.ts
+++ b/src/account-entities-answer.ts
@@ -36,7 +36,9 @@ import {
   type SubnetOwnerSnapshot,
 } from "./entity-labels.ts";
 import { readArtifact } from "../workers/storage.ts";
+import { isR2SqlConfigured } from "./r2-sql.ts";
 import type { R2SqlEnv } from "./r2-sql.ts";
+import { DEGRADED_UNAVAILABLE } from "./uncurated-event-streams.ts";
 import type { StoreEnv } from "./read-store.ts";
 import type { ArtifactEnv } from "../workers/storage.ts";
 import {
@@ -104,7 +106,7 @@ export async function answerAccountEntities(
   // Routing it through `entities()` added a `??` arm that cannot fire -- the
   // builder's own output always parses -- and an unreachable fallback is a
   // branch no test can honestly cover (#11339).
-  return withOwnedTies(
+  const floor = withOwnedTies(
     {
       schema_version: 1,
       ss58: coldkey,
@@ -116,6 +118,29 @@ export async function answerAccountEntities(
     coldkey,
     ownerSnapshot,
   );
+
+  // A PARTIAL decline, and the only one on this route (#11430).
+  //
+  // This card is composed from two independent sources and only one of them is
+  // the lakehouse: the ownership ties come from the economics artifact, which
+  // is readable whether or not the transfer stream is. So reaching here on a
+  // CONFIGURED deployment means the transfer half declined -- measured at
+  // 15,182ms, i.e. AT `QUERY_TIMEOUT_MS`, on 2026-08-16 -- while the ownership
+  // half above may have answered perfectly.
+  //
+  // The marker therefore rides a payload whose counts STAY REAL.
+  // `withOwnedTies` recomputes `ownership_tie_count` from the ties it merged,
+  // so it is a FLOOR -- every tie in it was measured, there are simply more
+  // that could not be read. Nulling it would throw away correct data and
+  // assert that nothing is known, which is false and worse than the confident
+  // zero it replaces. Same relationship `candle_count` has to
+  // `window_truncated` in #11414.
+  //
+  // Unconfigured (a self-hoster, CI) is not a fault: there is no transfer
+  // stream to have failed, so the floor stands unmarked.
+  return isR2SqlConfigured(env)
+    ? { ...floor, degraded: { reason: DEGRADED_UNAVAILABLE } }
+    : floor;
 }
 
 /** A tier's answer, parsed into the payload it claims to be -- or null. */

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -53,6 +53,7 @@ import {
 import {
   ACCOUNT_STAKE_MOVES_WINDOWS,
   buildAccountStakeMoves,
+  declineAccountStakeMoves,
   DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
   STAKE_MOVED_EVENT_KIND,
 } from "./account-stake-moves.ts";
@@ -99,7 +100,12 @@ import {
 } from "./validator-nominators.ts";
 import { storeAll } from "./analytics-live.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
-import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
+import {
+  isR2SqlConfigured,
+  r2SqlQuery,
+  safeBlockNumber,
+  safeSs58Literal,
+} from "./r2-sql.ts";
 import { windowedFloorRead, windowedRowRead } from "./account-events-window.ts";
 import {
   accountHistoryFloorMs,
@@ -376,7 +382,25 @@ export async function loadAccountStakeMovesColdTier(
       `AND event_kind = '${STAKE_MOVED_EVENT_KIND}' ` +
       `AND observed_at >= ${cutoff} GROUP BY netuid`,
   );
-  if (rows === null) return null;
+  // A CONFIGURED lakehouse that could not answer is a decline, not an empty
+  // card (#11424). This route was measured at 15,429ms -- i.e. AT the 15s
+  // `QUERY_TIMEOUT_MS` -- on 2026-08-16, so the failed read is routine, and a
+  // bare `null` here reached the caller's `?? emptyCard` as "this account has
+  // never moved stake". The same distinction `loadAccountSummaryColdTier`
+  // draws below in this same file, which this reader never picked up.
+  //
+  // With NO lakehouse bound (a self-hoster, CI) the null stands: there is no
+  // chain history to read, so the caller's empty card is correct.
+  if (rows === null) {
+    return isR2SqlConfigured(env)
+      ? {
+          data: declineAccountStakeMoves(ss58, label),
+          // No read, so no reading instant -- never `new Date()`, which would
+          // date an empty card to now.
+          generatedAt: null,
+        }
+      : null;
+  }
   return {
     data: buildAccountStakeMoves(rows, ss58, {
       window: label,

--- a/src/account-stake-moves.ts
+++ b/src/account-stake-moves.ts
@@ -1,4 +1,8 @@
 import { roundBelowOne } from "./lib/stats.ts";
+import {
+  DEGRADED_UNAVAILABLE,
+  type EventStreamDegraded,
+} from "./uncurated-event-streams.ts";
 // Per-account stake-movement (re-delegation) footprint: which subnets one account
 // (coldkey) moved stake out of over a recent window, broken down per subnet and
 // rolled up into a movement scorecard. Pure shaping (buildAccountStakeMoves) + a
@@ -88,11 +92,14 @@ export interface AccountStakeMovesResult {
   schema_version: 1;
   address: string;
   window: string | null;
-  total_movements: number;
-  subnet_count: number;
+  /** NULL only on a decline -- nothing was read, so nothing is known. */
+  total_movements: number | null;
+  subnet_count: number | null;
   concentration: number | null;
   dominant_netuid: number | null;
   subnets: AccountStakeMoveSubnet[];
+  /** Present ONLY on a decline. An empty card WITHOUT it is a measurement. */
+  degraded?: EventStreamDegraded;
 }
 
 export function buildAccountStakeMoves(
@@ -265,4 +272,29 @@ async function loadAlphaPricesForLastMoves(
     map.set(`${row.netuid}:${row.snapshot_date}`, price);
   }
   return map;
+}
+
+/**
+ * The decline payload: a configured lakehouse that could not answer (#11424).
+ *
+ * `total_movements: 0` beside `subnets: []` is a statement that this account
+ * has never moved stake, and after a failed read nobody knows that -- so both
+ * counts go NULL. `concentration` and `dominant_netuid` were already nullable
+ * for the same reason (undefined over an empty set), so they need no widening.
+ */
+export function declineAccountStakeMoves(
+  address: string,
+  window: string | null,
+): AccountStakeMovesResult {
+  return {
+    schema_version: 1,
+    address,
+    window,
+    total_movements: null,
+    subnet_count: null,
+    concentration: null,
+    dominant_netuid: null,
+    subnets: [],
+    degraded: { reason: DEGRADED_UNAVAILABLE },
+  };
 }

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -4,6 +4,10 @@
 // Taostats. This module holds the load contract, the row→API shaping, and the
 // retention prune. Pure + exported for tests; the Worker runs the D1 I/O.
 import {
+  DEGRADED_UNAVAILABLE,
+  type EventStreamDegraded,
+} from "./uncurated-event-streams.ts";
+import {
   BLOCK_PAGINATION,
   clampLimit,
   clampOffset,
@@ -93,6 +97,13 @@ export interface BlockDetail {
   block: BlockApi | null;
   prev_block_number: number | null;
   next_block_number: number | null;
+  /**
+   * Present ONLY on a decline. `block: null` WITHOUT it is a CONFIRMED
+   * ABSENCE -- the lakehouse was read and has no such block -- which is a
+   * measurement and the answer a caller wants. With it, the read failed and
+   * nothing is known about whether the block exists.
+   */
+  degraded?: EventStreamDegraded;
 }
 
 // Per-block detail artifact. `block` is null when the ref didn't resolve (cold
@@ -319,4 +330,32 @@ export async function loadBlock(
     next = nbr[0]?.next ?? null;
   }
   return buildBlock(rows[0], ref, { prev, next });
+}
+
+/**
+ * The decline payload: a configured lakehouse that could not answer (#11424).
+ *
+ * `/blocks/{ref}` was measured at 15,085ms -- AT the 15s `QUERY_TIMEOUT_MS` --
+ * on 2026-08-16, and `loadBlockFromR2Sql` already draws half this distinction:
+ * it returns `buildBlock(undefined, ref)` for a confirmed absence, with the
+ * comment "A confirmed absence is an ANSWER", and a bare `null` for a failed
+ * read. The caller turned that null back into the same "no such block" payload,
+ * so the two collapsed again one frame later.
+ */
+export function declineBlock(
+  /**
+   * REQUIRED and a string: the only caller has already parsed the ref out of
+   * the path before it reaches a query, so `ref?: unknown` would add a
+   * `?? null` branch standing in for a case that does not exist.
+   */
+  ref: string,
+): BlockDetail {
+  return {
+    schema_version: 1,
+    ref,
+    block: null,
+    prev_block_number: null,
+    next_block_number: null,
+    degraded: { reason: DEGRADED_UNAVAILABLE },
+  };
 }

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -22,7 +22,7 @@
 //   - ~1-2s per query, so every caller must sit behind the existing edge
 //     cache. See src/r2-sql.ts's header for the measurements.
 
-import { buildBlock, buildBlockFeed } from "./blocks.ts";
+import { buildBlock, buildBlockFeed, declineBlock } from "./blocks.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { type ChainNetworkId, chainTable } from "./chain-network.ts";
@@ -33,6 +33,7 @@ import {
   safeBlockNumber,
   safeHexLiteral,
   safeSs58Literal,
+  isR2SqlConfigured,
 } from "./r2-sql.ts";
 import type { R2SqlEnv } from "./r2-sql.ts";
 import { recordOrNull } from "./read-store.ts";
@@ -289,7 +290,16 @@ export async function loadBlockFromR2Sql(
     env,
     `SELECT ${BLOCK_COLUMNS} FROM ${chainTable("blocks", network)} WHERE ${predicate} LIMIT 1`,
   );
-  if (rows === null) return null;
+  // A CONFIGURED lakehouse that could not answer is a decline, not "no such
+  // block" (#11424). This route was measured at 15,085ms -- AT the 15s
+  // `QUERY_TIMEOUT_MS` -- on 2026-08-16, and the bare null reached the caller
+  // as the same payload a confirmed absence produces, which is the one
+  // distinction the comment below already insists on. With NO lakehouse bound
+  // the null stands: there is nothing to read and the caller's own floor is
+  // correct.
+  if (rows === null) {
+    return isR2SqlConfigured(env) ? declineBlock(ref) : null;
+  }
   // A confirmed absence is an ANSWER: buildBlock(undefined, ref) is the same
   // "no such block" payload the Postgres tier produces, and returning it here
   // (rather than null) stops the caller re-deriving it.

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -388,18 +388,28 @@ describe("loadAccountStakeMovesColdTier", () => {
     assert.equal(res!.generatedAt, null);
   });
 
-  test("declines a bad address without querying; a failed query yields null", async () => {
+  test("declines a bad address without querying", async () => {
     const q = sqlFetch([MOVE_ROW]);
     assert.equal(
       await loadAccountStakeMovesColdTier(TOKEN as never, "junk", {}),
       null,
     );
     assert.equal(q.length, 0);
+  });
+
+  test("a failed query on a CONFIGURED lakehouse is MARKED, not a null", async () => {
+    // #11424. It used to return the same bare null as an unusable address, and
+    // the caller spelled that `?? emptyCard` -- so a 15-second timeout (this
+    // route was measured AT `QUERY_TIMEOUT_MS` on 2026-08-16) published
+    // `total_movements: 0`, which reads as "this account has never moved
+    // stake".
     failingFetch();
-    assert.equal(
-      await loadAccountStakeMovesColdTier(TOKEN as never, ADDR, {}),
-      null,
-    );
+    const out = await loadAccountStakeMovesColdTier(TOKEN as never, ADDR, {});
+    assert.ok(out, "a decline still answers");
+    assert.deepEqual(out.data.degraded, { reason: "unavailable" });
+    assert.equal(out.data.total_movements, null);
+    assert.equal(out.data.subnet_count, null);
+    assert.equal(out.generatedAt, null);
   });
 });
 

--- a/tests/non-rollup-declines.test.ts
+++ b/tests/non-rollup-declines.test.ts
@@ -1,0 +1,224 @@
+// The two readers that reach the lakehouse WITHOUT the shared rollup (#11424).
+//
+// #11417/#11428 fixed `chain-event-rollup-cold-tier.ts` and its seven
+// consumers. These two get there by other paths and had the identical defect: a
+// failed read published as data.
+//
+// Both were measured sitting AT the 15s `QUERY_TIMEOUT_MS` on 2026-08-16 --
+// `/accounts/{ss58}/stake-moves` at 15,429ms and `/blocks/{ref}` at 15,085ms --
+// so the decline is routine, not exotic.
+//
+// The contrast cases carry the weight here, as they did in #11428: an answer
+// and a deployment with no lakehouse must stay UNMARKED, or the marker is noise.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import { loadAccountStakeMovesColdTier } from "../src/account-feeds-cold-tier.ts";
+import { loadBlockFromR2Sql } from "../src/r2-sql-blocks.ts";
+import { answerAccountEntities } from "../src/account-entities-answer.ts";
+import { DEGRADED_UNAVAILABLE } from "../src/uncurated-event-streams.ts";
+import { LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
+
+const SS58 = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+const DEGRADED = { reason: DEGRADED_UNAVAILABLE };
+
+/** A deployment WITH a lakehouse: the one where the rows exist. */
+const CONFIGURED = LAKEHOUSE_ENV as never;
+/** A self-hoster or CI: no lakehouse, so no rows to be wrong about. */
+const UNCONFIGURED = {} as never;
+
+function withFetch<T>(stub: typeof fetch, run: () => Promise<T>): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = stub;
+  return Promise.resolve(run()).finally(() => {
+    globalThis.fetch = real;
+  });
+}
+
+/** The transport refusing -- the shape a timeout takes by the time the reader
+ * sees it. */
+const refusing = (() => {
+  throw new Error("lakehouse unreachable");
+}) as unknown as typeof fetch;
+
+/** The transport answering, with the rows given. */
+const answering = (rows: unknown[]) =>
+  (async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    }) as unknown as Response) as unknown as typeof fetch;
+
+describe("/accounts/{ss58}/stake-moves", () => {
+  test("a failed read on a CONFIGURED lakehouse is marked, with NULL counts", async () => {
+    const out = await withFetch(refusing, () =>
+      loadAccountStakeMovesColdTier(CONFIGURED, SS58, { window: "30d" }),
+    );
+    assert.ok(out, "a decline still answers, it does not fall through");
+    assert.deepEqual(out.data.degraded, DEGRADED);
+    // NULL, not 0. `total_movements: 0` is a claim this account has never moved
+    // stake, and after a failed read nobody knows that.
+    assert.equal(out.data.total_movements, null);
+    assert.equal(out.data.subnet_count, null);
+    assert.deepEqual(out.data.subnets, []);
+    // No read, so no reading instant.
+    assert.equal(out.generatedAt, null);
+    // Known without reading anything, so still reported.
+    assert.equal(out.data.address, SS58);
+    assert.equal(out.data.window, "30d");
+  });
+
+  test("the SAME failure with no lakehouse configured falls through unmarked", async () => {
+    // A self-hoster has no chain history, so the caller's own empty card is
+    // correct -- which is why `gap` cannot simply be the default.
+    const out = await withFetch(refusing, () =>
+      loadAccountStakeMovesColdTier(UNCONFIGURED, SS58, { window: "30d" }),
+    );
+    assert.equal(out, null);
+  });
+
+  test("an account that genuinely never moved stake is a MEASUREMENT", async () => {
+    // The read succeeded and found nothing. Marking this would report a fault
+    // that did not happen.
+    const out = await withFetch(answering([]), () =>
+      loadAccountStakeMovesColdTier(CONFIGURED, SS58, { window: "30d" }),
+    );
+    assert.ok(out);
+    assert.equal("degraded" in out.data, false);
+    assert.equal(out.data.total_movements, 0);
+    assert.equal(out.data.subnet_count, 0);
+  });
+
+  test("a real answer is untouched, so this is not just declining everything", async () => {
+    // Non-vacuity: a reader that marked everything would satisfy the above.
+    const out = await withFetch(
+      answering([
+        {
+          netuid: 7,
+          movements: 3,
+          first_observed: 1_780_000_000_000,
+          last_observed: 1_785_000_000_000,
+        },
+      ]),
+      () => loadAccountStakeMovesColdTier(CONFIGURED, SS58, { window: "30d" }),
+    );
+    assert.ok(out);
+    assert.equal("degraded" in out.data, false);
+    assert.equal(out.data.total_movements, 3);
+    assert.equal(out.data.subnet_count, 1);
+  });
+});
+
+describe("/blocks/{ref}", () => {
+  test("a failed read is marked, and is NOT the same as no such block", async () => {
+    const out = await withFetch(refusing, () =>
+      loadBlockFromR2Sql(CONFIGURED, "8848204"),
+    );
+    assert.ok(out, "a decline still answers");
+    assert.deepEqual(out.degraded, DEGRADED);
+    assert.equal(out.block, null);
+    assert.equal(out.ref, "8848204");
+  });
+
+  test("a CONFIRMED ABSENCE is a measurement and carries no marker", async () => {
+    // The distinction this reader's own comment already insisted on -- "A
+    // confirmed absence is an ANSWER" -- and which the caller used to discard
+    // by rebuilding the same payload from a bare null. Both produce
+    // `block: null`; only one of them is a fact.
+    const out = await withFetch(answering([]), () =>
+      loadBlockFromR2Sql(CONFIGURED, "8848204"),
+    );
+    assert.ok(out);
+    assert.equal(out.block, null);
+    assert.equal(
+      "degraded" in out,
+      false,
+      "the store answered: this block does not exist",
+    );
+  });
+
+  test("no lakehouse configured falls through unmarked", async () => {
+    const out = await withFetch(refusing, () =>
+      loadBlockFromR2Sql(UNCONFIGURED, "8848204"),
+    );
+    assert.equal(out, null);
+  });
+
+  test("a block that exists comes back untouched", async () => {
+    const out = await withFetch(
+      answering([{ block_number: 8_848_204, block_hash: "0xabc" }]),
+      () => loadBlockFromR2Sql(CONFIGURED, "8848204"),
+    );
+    assert.ok(out);
+    assert.equal("degraded" in out, false);
+    assert.ok(out.block, "a real block is returned");
+  });
+});
+
+describe("/accounts/{ss58}/entities -- a PARTIAL decline", () => {
+  // This card composes TWO independent sources and only one is the lakehouse:
+  // ownership ties come from the economics artifact, transfer-derived ties from
+  // the cold tier. So a lakehouse timeout leaves REAL ownership data standing,
+  // and the marker must not claim otherwise.
+  const OWNERS = {
+    rows: [
+      { netuid: 7, owner_coldkey: SS58 },
+      { netuid: 12, owner_coldkey: SS58 },
+    ],
+    captured_at: "2026-08-16T00:00:00.000Z",
+  };
+
+  /** The cold tier failing, and the owner artifact answering. */
+  const declinedTier = async () => null;
+  const owners = () => Promise.resolve(OWNERS);
+
+  test("the transfer half failing is MARKED, and the ownership half survives", async () => {
+    const out = await answerAccountEntities(CONFIGURED, SS58, null, {
+      coldTier: declinedTier,
+      owners,
+    });
+    assert.deepEqual(out.degraded, DEGRADED);
+    // THE POINT. The counts stay REAL -- nulling them would discard ownership
+    // ties that were read successfully, which is worse than the confident zero
+    // the marker replaces.
+    // `AccountEntitiesRead` is the read-TOLERANT twin, so its fields are
+    // optional -- narrowed here rather than asserted through, which would pass
+    // vacuously on an absent field.
+    const count = out.ownership_tie_count;
+    assert.ok(
+      typeof count === "number" && count > 0,
+      "ownership ties read from the artifact must survive the decline",
+    );
+    assert.equal(out.ownership_ties?.length, count);
+  });
+
+  test("with NO lakehouse configured the same floor is unmarked", async () => {
+    // No transfer stream to have failed, so there is no fault to report.
+    const out = await answerAccountEntities(UNCONFIGURED, SS58, null, {
+      coldTier: declinedTier,
+      owners,
+    });
+    assert.equal("degraded" in out, false);
+    const unmarkedCount = out.ownership_tie_count;
+    assert.ok(typeof unmarkedCount === "number" && unmarkedCount > 0);
+  });
+
+  test("a tier that ANSWERED is never marked", async () => {
+    // Non-vacuity: the marker must track the tier's outcome, not merely the
+    // presence of a configured lakehouse.
+    const answered = async () => ({
+      schema_version: 1 as const,
+      ss58: SS58,
+      labels: [],
+      ownership_tie_count: 0,
+      ownership_ties: [],
+      owners_observed_at: null,
+    });
+    const out = await answerAccountEntities(CONFIGURED, SS58, null, {
+      coldTier: answered as never,
+      owners,
+    });
+    assert.equal("degraded" in out, false);
+  });
+});

--- a/tests/r2-sql-blocks.test.ts
+++ b/tests/r2-sql-blocks.test.ts
@@ -334,13 +334,21 @@ describe("loadBlockFromR2Sql", () => {
     assert.equal(queries.length, 0);
   });
 
-  test("a failed query yields null, not a false absence", async () => {
+  test("a failed query is MARKED, so it is not a false absence", async () => {
+    // This test's intent was always right and its assertion could not carry it
+    // (#11424): `null` was returned precisely so a failed read would not be
+    // "mistaken for 'no such block'", and the caller then rebuilt exactly that
+    // payload from the null. The distinction now rides on the payload itself,
+    // where a consumer can see it.
     globalThis.fetch = (async () => {
       throw new Error("down");
     }) as unknown as typeof fetch;
-    assert.equal(
-      await loadBlockFromR2Sql(mockEnv(TOKEN), "10"),
-      null,
+    const out = await loadBlockFromR2Sql(mockEnv(TOKEN), "10");
+    assert.ok(out, "a decline still answers");
+    assert.equal(out.block, null);
+    assert.deepEqual(
+      out.degraded,
+      { reason: "unavailable" },
       "must not be mistaken for 'no such block'",
     );
   });


### PR DESCRIPTION
Closes #11424. Part of #10312.

The non-rollup half of the ceiling cluster. #11428 fixed `chain-event-rollup-cold-tier.ts` and its seven consumers; these three reach the lakehouse by other paths and had the identical defect — a failed read published as data. All three were measured **AT** the 15s `QUERY_TIMEOUT_MS` on 2026-08-16: stake-moves **15,429ms**, entities **15,182ms**, blocks **15,085ms**.

## Two own their whole payload — counts go NULL

**`/accounts/{ss58}/stake-moves`** — `total_movements: 0` is a claim this account has never moved stake. Both counts go NULL and the card is marked. This is a **consistency** fix, not a new mechanism: `loadAccountSummaryColdTier`, a few hundred lines below **in the same file**, already returns `{ declined }` and its header already names *"every failure mode collapsed to a bare `null`"* as the defect. The reader beside it never picked it up.

**`/blocks/{ref}`** — `loadBlockFromR2Sql` already drew half this distinction: it returns a built payload for a **confirmed absence**, with the comment *"A confirmed absence is an ANSWER"*, and a bare `null` for a failed read. The caller rebuilt the same "no such block" payload from that null, so the two collapsed one frame later. The test pinning it was literally named *"a failed query yields null, not a false absence"* — the intent was right and the assertion couldn't carry it.

## The third is different, and treating it the same would be worse than the bug

**`/accounts/{ss58}/entities`** composes **two independent sources** and only one is the lakehouse. Ownership ties come from the economics artifact and survive a lakehouse timeout untouched — `answerAccountEntities` splits them precisely so *"the ownership half must not disappear just because the transfer half declined"*.

So its counts **stay real**. `ownership_tie_count` is a **FLOOR**: every tie in it was measured, there are simply more that couldn't be read. Nulling it would discard correct data to assert nothing is known — false, and worse than the confident zero it replaces. Only the marker is added, saying the transfer half declined. Same relationship `candle_count` has to `window_truncated` in #11414.

I originally split this to a separate issue and folded it back in — the split added an issue without adding work. #11430 is closed as part of this.

## In all three

An **unconfigured** lakehouse (self-hoster, CI) stays unmarked: no rows to be wrong about, so the empty payload is correct and always was. A **measured empty** — an account that genuinely never moved stake, a block that genuinely doesn't exist — also stays unmarked. Both are asserted, because a marker that fires on those means nothing.

## Verification

- Full suite: **954 files, 21,862 passed** (rebased onto `d010b240d`)
- **Patch coverage 100%** (23/23 lines+branches by diff intersection, unsharded); `test:coverage` exits 0
- `typecheck`, fresh `eslint`, `format:check`, `validate`, `validate:docs`, `validate:contract-doc-sync`, `validate:surface`, `validate:private-boundary`, `scan:public-safety`, `validate:client-sdk-sync`, `validate:artifact-budgets`, `worker:bundle:budget`, `validate:r2-sql-scan-bounds` — all pass
- Rebuilt on the rebased base with no artifact drift; backend-only, so no screenshots

Two existing tests changed meaning rather than being deleted — both asserted the bare `null` this replaces, and both had comments describing the behaviour they couldn't actually enforce. One unreachable `ref ?? null` branch was removed rather than tested.
