### PR TITLE
chore(ui): add the talent.app domain-ownership verification tag

### DIFF
--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -31,6 +31,18 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
         // health-tokens.ts/og-image.ts.
         // eslint-disable-next-line no-restricted-syntax -- see comment above
         { name: "theme-color", content: "#0B1F1A" },
+        // talent.app domain-ownership verification for metagraph.sh (Metagraphed
+        // listed there as a project). It lives in the root route rather than in
+        // server.ts's SEO_DEFAULT_TAGS because that injection path is
+        // HTMLRewriter-only -- absent under `vite dev` (Node) -- and a
+        // verification token must be present wherever the site is served, not
+        // only on workerd. Emitted site-wide; the homepage is what talent.app
+        // fetches.
+        {
+          name: "talentapp:project_verification",
+          content:
+            "171a1b6c33acbfa216c340c922339cc6bf4f50f44d4c9300d03e4cb5339e1a1be7f961f957cf0499eb33ecbd05cebe77a94259cc187f77d140281791e649747a",
+        },
       ],
       links: [
         { rel: "stylesheet", href: appCss },


### PR DESCRIPTION
## Summary

Metagraphed is being listed as a project on talent.app, which verifies the domain by fetching the site and looking for its own verification meta tag. This adds it to `metagraph.sh`.

```html
<meta name="talentapp:project_verification" content="171a1b6c...e649747a">
```

## Why the root route rather than `SEO_DEFAULT_TAGS`

`src/server.ts`'s `SEO_DEFAULT_TAGS` is appended by `HTMLRewriter`, which is a workerd global — the injection is explicitly skipped under `vite dev` (Node). A verification token that only exists on workerd disappears the moment the site is served any other way, and the failure mode is a silently unverified domain, noticed only when the listing drops. `__root.tsx`'s `head()` renders wherever the app renders.

Emitted site-wide, which is what the root route already does for every other identity tag; the homepage is the page talent.app actually fetches.

## Verification

- Rendered the real `RootRoute.options.head()` through `renderToStaticMarkup` — emits the tag with the token intact (throwaway check, not committed).
- Token is 128 hex chars, matching the value talent.app issued, chunk-for-chunk.
- `npm run scan:public-safety` — passes. Worth stating explicitly: a 128-char hex literal is the shape a secret scanner flags, and it does not trip this one. The token is a public proof-of-control value, not a credential.
- `lint` (0 errors; 8 pre-existing `react-refresh` warnings, none in this file) · `format:check` · `typecheck` · `test` (268 files / 2324 tests) · `build` — all green in `apps/ui`.
- Skipped `test:e2e`: it replays recorded HAR traffic to check responsive overflow, and this change adds no API call and no rendered output.

## Screenshots

None — the change is head metadata, so there is no visual output to diff.
