### PR TITLE
fix(graphql): a failed proxied read errored here and answered on the other two surfaces

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -8652,6 +8652,11 @@ type SubnetOwnershipHistory {
   The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read.
   """
   observed_through: String
+
+  """
+  Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement.
+  """
+  degraded: DegradedInfo
 }
 
 type SubnetOwnershipHistoryArtifactOwnershipChanges {
@@ -8680,6 +8685,11 @@ type SubnetConviction {
   Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.
   """
   field_sources: JSON!
+
+  """
+  Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement.
+  """
+  degraded: DegradedInfo
 }
 
 type SubnetConvictionArtifactLeaderboard {
@@ -8727,6 +8737,11 @@ type SubnetLeaseHistory {
   event_kinds: [String!]!
   count: Int!
   lease_events: [SubnetLeaseHistoryArtifactLeaseEvents!]!
+
+  """
+  Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement.
+  """
+  degraded: DegradedInfo
 }
 
 type SubnetLeaseHistoryArtifactLeaseEvents {

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6251,6 +6251,8 @@ export type SubnetConcentrationHistoryPoint = {
 export type SubnetConviction = {
   __typename?: 'SubnetConviction';
   count: Scalars['Int']['output'];
+  /** Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+  degraded?: Maybe<DegradedInfo>;
   /** Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
   field_sources: Scalars['JSON']['output'];
   king?: Maybe<Scalars['String']['output']>;
@@ -6847,6 +6849,8 @@ export type SubnetLeaseArtifactLease = {
 export type SubnetLeaseHistory = {
   __typename?: 'SubnetLeaseHistory';
   count: Scalars['Int']['output'];
+  /** Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+  degraded?: Maybe<DegradedInfo>;
   event_kinds: Array<Scalars['String']['output']>;
   event_pallet: Scalars['String']['output'];
   lease_events: Array<SubnetLeaseHistoryArtifactLeaseEvents>;
@@ -7189,6 +7193,8 @@ export type SubnetOwnerCaptureUid = {
 export type SubnetOwnershipHistory = {
   __typename?: 'SubnetOwnershipHistory';
   count: Scalars['Int']['output'];
+  /** Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+  degraded?: Maybe<DegradedInfo>;
   /** The chain_events method the authoritative records are decoded from. */
   event_method: Scalars['String']['output'];
   /** The chain_events pallet the authoritative records are decoded from. */
@@ -13031,6 +13037,7 @@ export type SubnetConcentrationHistoryPointResolvers<ContextType = GqlContext, P
 
 export type SubnetConvictionResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetConviction'] = ResolversParentTypes['SubnetConviction']> = ResolversObject<{
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
   field_sources?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
   king?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   leaderboard?: Resolver<Array<ResolversTypes['SubnetConvictionArtifactLeaderboard']>, ParentType, ContextType>;
@@ -13475,6 +13482,7 @@ export type SubnetLeaseArtifactLeaseResolvers<ContextType = GqlContext, ParentTy
 
 export type SubnetLeaseHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetLeaseHistory'] = ResolversParentTypes['SubnetLeaseHistory']> = ResolversObject<{
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
   event_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   event_pallet?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   lease_events?: Resolver<Array<ResolversTypes['SubnetLeaseHistoryArtifactLeaseEvents']>, ParentType, ContextType>;
@@ -13725,6 +13733,7 @@ export type SubnetOwnerCaptureUidResolvers<ContextType = GqlContext, ParentType 
 
 export type SubnetOwnershipHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetOwnershipHistory'] = ResolversParentTypes['SubnetOwnershipHistory']> = ResolversObject<{
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  degraded?: Resolver<Maybe<ResolversTypes['DegradedInfo']>, ParentType, ContextType>;
   event_method?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   event_pallet?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10924,6 +10924,8 @@ export interface components {
         /** @description Live per-subnet conviction leaderboard -- who currently holds the most rolled conviction, rolled forward from a periodically-captured snapshot using the current live-queried unlock_rate/maturity_rate. Mirrors GET /api/v1/subnets/{netuid}/conviction. */
         SubnetConvictionArtifact: {
             count: number;
+            /** @description Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
                 [key: string]: {
@@ -11972,6 +11974,8 @@ export interface components {
         /** @description Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had, decoded from the account_events stream. Mirrors GET /api/v1/subnets/{netuid}/lease/history. */
         SubnetLeaseHistoryArtifact: {
             count: number;
+            /** @description Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             event_kinds: string[];
             event_pallet: string;
             lease_events: {
@@ -12446,6 +12450,8 @@ export interface components {
         /** @description Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history. */
         SubnetOwnershipHistoryArtifact: {
             count: number;
+            /** @description Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             /** @description The chain_events method the authoritative records are decoded from. */
             event_method: string;
             /** @description The chain_events pallet the authoritative records are decoded from. */
@@ -42181,6 +42187,10 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "field_sources": {
                      *           "example": {
                      *             "kind": "measured",
@@ -45244,6 +45254,10 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "event_kinds": [
                      *           "example"
                      *         ],
@@ -46794,6 +46808,10 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "event_method": "GET",
                      *         "event_pallet": "example",
                      *         "netuid": 7,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9329,6 +9329,10 @@
         "value": {
           "data": {
             "count": 1,
+            "degraded": {
+              "detail": "example",
+              "reason": "example"
+            },
             "field_sources": {
               "example": {
                 "kind": "measured",
@@ -10703,6 +10707,10 @@
         "value": {
           "data": {
             "count": 1,
+            "degraded": {
+              "detail": "example",
+              "reason": "example"
+            },
             "event_kinds": [
               "example"
             ],
@@ -11481,6 +11489,10 @@
         "value": {
           "data": {
             "count": 1,
+            "degraded": {
+              "detail": "example",
+              "reason": "example"
+            },
             "event_method": "GET",
             "event_pallet": "example",
             "netuid": 7,
@@ -46812,6 +46824,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "degraded": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DegradedInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement."
+          },
           "field_sources": {
             "additionalProperties": {
               "additionalProperties": false,
@@ -53395,6 +53418,17 @@
             "minimum": 0,
             "type": "integer"
           },
+          "degraded": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DegradedInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement."
+          },
           "event_kinds": {
             "items": {
               "type": "string"
@@ -55925,6 +55959,17 @@
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "degraded": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DegradedInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement."
           },
           "event_method": {
             "description": "The chain_events method the authoritative records are decoded from.",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10924,6 +10924,8 @@ export interface components {
         /** @description Live per-subnet conviction leaderboard -- who currently holds the most rolled conviction, rolled forward from a periodically-captured snapshot using the current live-queried unlock_rate/maturity_rate. Mirrors GET /api/v1/subnets/{netuid}/conviction. */
         SubnetConvictionArtifact: {
             count: number;
+            /** @description Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
             field_sources: {
                 [key: string]: {
@@ -11972,6 +11974,8 @@ export interface components {
         /** @description Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had, decoded from the account_events stream. Mirrors GET /api/v1/subnets/{netuid}/lease/history. */
         SubnetLeaseHistoryArtifact: {
             count: number;
+            /** @description Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             event_kinds: string[];
             event_pallet: string;
             lease_events: {
@@ -12446,6 +12450,8 @@ export interface components {
         /** @description Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history. */
         SubnetOwnershipHistoryArtifact: {
             count: number;
+            /** @description Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement. */
+            degraded?: components["schemas"]["DegradedInfo"] | null;
             /** @description The chain_events method the authoritative records are decoded from. */
             event_method: string;
             /** @description The chain_events pallet the authoritative records are decoded from. */
@@ -42181,6 +42187,10 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "field_sources": {
                      *           "example": {
                      *             "kind": "measured",
@@ -45244,6 +45254,10 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "event_kinds": [
                      *           "example"
                      *         ],
@@ -46794,6 +46808,10 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "count": 1,
+                     *         "degraded": {
+                     *           "detail": "example",
+                     *           "reason": "example"
+                     *         },
                      *         "event_method": "GET",
                      *         "event_pallet": "example",
                      *         "netuid": 7,

--- a/schemas-src/routes/subnet-conviction.ts
+++ b/schemas-src/routes/subnet-conviction.ts
@@ -5,6 +5,7 @@
 // it replaces. No query params (verified: the DATA_API route reads only the
 // netuid path segment).
 import { z } from "zod";
+import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 import { ChainU64Schema, FieldSourcesSchema } from "../shared.ts";
 
 const SubnetConvictionEntrySchema = z
@@ -29,6 +30,11 @@ export const SubnetConvictionArtifactSchema = z
     // #9108. Every leaderboard row is an extrapolation to `queried_at_block`,
     // not a reading at it -- this is where the response says so.
     field_sources: FieldSourcesSchema,
+    degraded: EventStreamDegradedSchema.nullable()
+      .optional()
+      .describe(
+        "Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement.",
+      ),
   })
   .strict()
   .describe(

--- a/schemas-src/routes/subnet-lease.ts
+++ b/schemas-src/routes/subnet-lease.ts
@@ -8,6 +8,7 @@
 // params (verified: handleSubnetLease doesn't even accept a `url` argument;
 // the lease/history DATA_API route reads only the netuid path segment).
 import { z } from "zod";
+import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 const SubnetLeaseSchema = z
@@ -66,6 +67,11 @@ export const SubnetLeaseHistoryArtifactSchema = z
     event_kinds: z.array(z.string()),
     count: z.int().min(0),
     lease_events: z.array(SubnetLeaseEventSchema),
+    degraded: EventStreamDegradedSchema.nullable()
+      .optional()
+      .describe(
+        "Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement.",
+      ),
   })
   .strict()
   .describe(

--- a/schemas-src/routes/subnet-ownership-history.ts
+++ b/schemas-src/routes/subnet-ownership-history.ts
@@ -5,6 +5,7 @@
 // SubnetOwnershipChange components it replaces. No query params (verified:
 // the DATA_API route reads only the netuid path segment).
 import { z } from "zod";
+import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 
 // objectItems-equivalent looseness: no field required at the item level,
 // matching the hand-written original exactly.
@@ -62,6 +63,11 @@ export const SubnetOwnershipHistoryArtifactSchema = z
       .optional()
       .describe(
         "The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read.",
+      ),
+    degraded: EventStreamDegradedSchema.nullable()
+      .optional()
+      .describe(
+        "Present ONLY when the tier could not answer. All three surfaces publish the SAME marked empty for this route (#11423); an empty result WITHOUT it is a measurement.",
       ),
   })
   .strict()

--- a/src/chain-events-degraded.ts
+++ b/src/chain-events-degraded.ts
@@ -98,6 +98,54 @@ function statsWindowBlocks(url: URL): number {
 }
 
 /**
+ * The reason a proxied route's degraded empty carries.
+ *
+ * DECLARED HERE rather than in `src/mcp-server.ts`, where it used to live, so
+ * that GraphQL can use it too (#11423). GraphQL could not import it from there
+ * -- `mcp-server.ts` imports `handleGraphQLRequest` from `graphql.ts`, so the
+ * dependency only goes one way -- and that import barrier is a large part of
+ * why the third surface never got the marked empty the other two serve.
+ */
+export const TIER_UNAVAILABLE_REASON = "tier_unavailable";
+
+/**
+ * The degraded empty for a proxied route, MARKED.
+ *
+ * The unmarked map below plus #9120's in-band marker, which every surface needs
+ * for the same reason MCP documented: a tool result has no headers to put it
+ * in, and neither does a GraphQL field.
+ */
+export function markedChainEventsPayload(pathname: string): Row | null {
+  const payload = degradedChainEventsPayload(new URL(`https://d${pathname}`));
+  return payload
+    ? { ...payload, degraded: { reason: TIER_UNAVAILABLE_REASON } }
+    : null;
+}
+
+/**
+ * The marked empty for a proxied route, or the original failure rethrown.
+ *
+ * The decision a failing tier reader has to make, expressed once: a path the
+ * map covers answers with the marked empty, and a path it does not keeps the
+ * error that brought it here. Living here rather than at the call site is what
+ * makes BOTH arms directly testable -- inside a `catch` in `graphql.ts` the
+ * rethrow is unreachable, because every caller there passes a literal path the
+ * map covers.
+ *
+ * The rethrow is the guard the map's own header asks for: a seventh proxied
+ * route added without a map entry must fail loudly rather than return null,
+ * which each resolver spells `?? empty` -- an UNMARKED empty, silently.
+ */
+export function markedChainEventsPayloadOrThrow(
+  pathname: string,
+  err: unknown,
+): Row {
+  const payload = markedChainEventsPayload(pathname);
+  if (!payload) throw err;
+  return payload;
+}
+
+/**
  * The schema-stable empty for whichever proxied route this URL names, or null
  * when the path is not one of the six.
  *

--- a/src/crowdloans.ts
+++ b/src/crowdloans.ts
@@ -294,10 +294,13 @@ export function decodeCrowdloan(hex: unknown): Row | null {
  */
 export const CROWDLOANS_FIELD_SOURCES = {
   crowdloan_count: { kind: "reconstructed", storage: null },
-  // Ours too, and about the READ rather than the chain: it reports that the
-  // storage batch did not land, which is exactly what `crowdloan_count: 0`
-  // used to be published as instead (#9898).
-  degraded: { kind: "reconstructed", storage: null },
+  // NO `degraded` ENTRY, and the note that used to sit here is why: it said
+  // the field is "about the READ rather than the chain", then declared it
+  // `reconstructed` anyway because the gate required every served field to
+  // carry provenance. That was an empty claim -- nothing derives a failure to
+  // read. `degraded` is exempt in PROVENANCE_EXEMPT_FIELDS now, alongside the
+  // other response metadata, so every route that gains the marker gets the
+  // same answer instead of each inventing one (#11423).
   next_crowdloan_id: {
     kind: "measured",
     storage: "Crowdloan.NextCrowdloanId",

--- a/src/field-provenance.ts
+++ b/src/field-provenance.ts
@@ -127,11 +127,20 @@ export const STORAGE_ITEM_PATTERN =
  * Labelling any of them `measured` would be a false claim and `reconstructed`
  * an empty one — /api/v1/chain/emission-pipeline draws the same line, mapping
  * its row fields and none of its envelope.
+ *
+ * `degraded` belongs here for the same reason and is the sharpest case of it:
+ * it is a statement that the READ could not be made, so it describes the
+ * response rather than the chain. Calling it `measured` would assert we
+ * observed a failure on chain; calling it `reconstructed` would claim we
+ * derived it from something. Neither is true — it is the absence of a
+ * measurement, which is exactly what a provenance map has nothing to say
+ * about (#11423).
  */
 export const PROVENANCE_EXEMPT_FIELDS = new Set([
   "schema_version",
   "queried_at",
   "netuid",
+  "degraded",
 ]);
 
 /**

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -514,7 +514,10 @@ import { answerAccountEntities } from "./account-entities-answer.ts";
 import { loadValidatorNominatorsColdTier } from "./account-feeds-cold-tier.ts";
 import { loadAccountPositionsColdTier } from "./nominator-positions-cold-tier.ts";
 import { loadAccountPositionsFromStore } from "./nominator-positions-hot-tier.ts";
-import { coldTierChainEventsPayload } from "./chain-events-degraded.ts";
+import {
+  coldTierChainEventsPayload,
+  markedChainEventsPayloadOrThrow,
+} from "./chain-events-degraded.ts";
 import { subnetOwnershipHistoryNode } from "./subnet-ownership-answer.ts";
 import { SUBNET_CONVICTION_FIELD_SOURCES } from "./subnet-conviction.ts";
 import { buildSubnetLeaseHistory } from "./subnet-lease-history.ts";
@@ -1642,7 +1645,25 @@ async function fetchAllEventsTier(
     // resolver a `{ data, source }` object that structurally satisfies Row and
     // would therefore fail at runtime rather than at the type level (#9319).
     if (cold) return cold.data;
-    throw err;
+    // THE DEGRADED EMPTY REST AND MCP ALREADY SERVE (#11423).
+    //
+    // Without this, GraphQL was the only surface that ERRORED where the other
+    // two answered. Measured live 2026-08-16 on `/subnets/64/lease/history`:
+    // MCP returned `count: 0, lease_events: [], degraded: {reason:
+    // "tier_unavailable"}` while `subnet_lease_history` returned `data: null`
+    // with a 503 error -- same route, same instant, two contracts. It is the
+    // one operation the latency sweep reports as "did not answer".
+    //
+    // The resolvers were written expecting this: `subnet_lease_history` ends
+    // `?? empty` and the other two spell `data?.field ?? default` throughout.
+    // Those fallbacks were unreachable, because a throw here never lets a null
+    // reach them.
+    //
+    // `markedChainEventsPayload` is the same map the REST proxy and MCP read,
+    // so all THREE surfaces now answer one route the same way. A path the map
+    // does not cover keeps the original error, which is what stops a seventh
+    // proxied route silently acquiring an empty that satisfies no schema.
+    return markedChainEventsPayloadOrThrow(pathname, err);
   }
 }
 
@@ -9333,6 +9354,7 @@ const rootValue = {
       king: data?.king ?? null,
       count: data?.count ?? 0,
       leaderboard: Array.isArray(data?.leaderboard) ? data.leaderboard : [],
+      degraded: data?.degraded ?? null,
     };
   },
 
@@ -9372,6 +9394,11 @@ const rootValue = {
       netuid,
       count: data.count ?? 0,
       lease_events: Array.isArray(data.lease_events) ? data.lease_events : [],
+      // FORWARDED, not dropped (#11423). The tier's marked empty says the read
+      // could not be made, and a projection that kept everything except the
+      // marker would restate on this surface the confident zero the marker
+      // exists to prevent.
+      degraded: data.degraded ?? null,
     };
   },
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1748,7 +1748,8 @@ import { isCrowdloanId, loadCrowdloan, loadCrowdloans } from "./crowdloans.ts";
 // through here -- it has one, and this tool answers from it below.
 import {
   coldTierChainEventsPayload,
-  degradedChainEventsPayload,
+  markedChainEventsPayload,
+  TIER_UNAVAILABLE_REASON,
 } from "./chain-events-degraded.ts";
 import {
   answerSubnetOwnershipHistory,
@@ -3410,10 +3411,9 @@ async function loadSubnetEconomics(
 // because an MCP result has no headers to put it in. Null when the path is
 // unmapped, which keeps the throw for anything this map does not cover.
 function degradedDataApiRead(path: string): Row | null {
-  const payload = degradedChainEventsPayload(new URL(`https://d${path}`));
-  return payload
-    ? { ...payload, degraded: { reason: MCP_DEGRADED_REASON } }
-    : null;
+  // The shared marker+map, so this surface, REST and GraphQL cannot disagree
+  // about a proxied route's empty (#11423).
+  return markedChainEventsPayload(path);
 }
 
 // get_subnet_ownership_history, with the lakehouse behind DATA_API.
@@ -16835,7 +16835,6 @@ function scheduleTraceSpan(
  * way -- a false "degraded" makes good data look suspect, where the bug it
  * replaces made missing data look measured.
  */
-export const MCP_DEGRADED_REASON = "tier_unavailable";
 
 /**
  * A `call_module`-scoped request that reached the empty floor did NOT measure
@@ -16957,7 +16956,7 @@ export function markMcpTierDegraded(
   // GraphQL both can -- and every one of those answers is already degraded, so
   // keeping the specific reason never loses the signal this marker exists for.
   if ("degraded" in (data as Row)) return data;
-  return { ...(data as Row), degraded: { reason: MCP_DEGRADED_REASON } };
+  return { ...(data as Row), degraded: { reason: TIER_UNAVAILABLE_REASON } };
 }
 
 async function dispatchTool(

--- a/src/uncurated-event-streams.ts
+++ b/src/uncurated-event-streams.ts
@@ -47,6 +47,19 @@ export interface EventStreamDegraded {
  * Spelled once because the same word is the whole contract on eight declining
  * routes and in `UnavailableDegradedSchema`, and three modules had written the
  * bare literal.
+ *
+ * NOT THE ONLY DECLINE REASON THE API PUBLISHES, and the split is by TIER
+ * rather than by accident. This one marks a LAKEHOUSE read that could not be
+ * made, and its routes declare it through `UnavailableDegradedSchema`, whose
+ * enum admits this value alone. `TIER_UNAVAILABLE_REASON`
+ * ("tier_unavailable", `src/chain-events-degraded.ts`) marks the six PROXIED
+ * chain-events routes, whose empties come from that module's own map.
+ *
+ * The two are emitted by disjoint code paths, so no route can publish both,
+ * and neither is a rename of the other -- a consumer reading `degraded.reason`
+ * on a given route sees one stable value. Stated here because two words for
+ * "the read failed" is the kind of thing that grows a third: anything new
+ * belongs to one of these, not beside them.
  */
 export const DEGRADED_UNAVAILABLE = "unavailable";
 

--- a/tests/graphql-degraded-parity.test.ts
+++ b/tests/graphql-degraded-parity.test.ts
@@ -1,0 +1,129 @@
+// GraphQL answered a failed proxied read with an ERROR where REST and MCP
+// answered with a marked empty (#11423).
+//
+// Measured live on 2026-08-16, same route and same instant:
+//
+//   MCP      get_subnet_lease_history(64)  -> 200, count 0, lease_events [],
+//                                            degraded { reason tier_unavailable }
+//   GraphQL  subnet_lease_history(netuid:64) -> data null, errors [503]
+//
+// It is the ONE operation the latency sweep reports as "did not answer", and
+// the cause is that `fetchAllEventsTier` rethrows where the other two surfaces
+// fall to `degradedChainEventsPayload`. The resolvers were written expecting
+// otherwise -- `subnet_lease_history` ends `?? empty` and its siblings spell
+// `data?.field ?? default` throughout -- so those fallbacks were unreachable.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  markedChainEventsPayload,
+  markedChainEventsPayloadOrThrow,
+  TIER_UNAVAILABLE_REASON,
+} from "../src/chain-events-degraded.ts";
+import { handleGraphQLRequest } from "../src/graphql.ts";
+
+/** A DATA_API binding that fails the way the live one did: a 503. */
+const failingDataApi = {
+  fetch: async () => new Response("upstream down", { status: 503 }),
+};
+
+/**
+ * No lakehouse token, so the cold tier declines too and the degraded fallback
+ * is the arm under test. With one bound, the cold tier would answer and this
+ * would prove nothing about the fallback.
+ */
+const ENV = {
+  METAGRAPH_ACCOUNT_EVENTS_SOURCE: "data-api",
+  DATA_API: failingDataApi,
+} as unknown as Env;
+
+async function gql(query: string) {
+  const res = await handleGraphQLRequest(
+    new Request("https://api.test/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query }),
+    }),
+    ENV,
+  );
+  return (await res.json()) as {
+    data?: Record<string, Record<string, unknown>>;
+    errors?: unknown[];
+  };
+}
+
+describe("a failed proxied read ANSWERS on GraphQL, as it does on REST and MCP", () => {
+  test("subnet_lease_history returns a marked empty, not a 503", async () => {
+    const body = await gql(
+      "{ subnet_lease_history(netuid: 64) { schema_version netuid count lease_events { event_kind } degraded { reason } } }",
+    );
+    assert.equal(
+      body.errors,
+      undefined,
+      "this route used to be the one operation the sweep called unanswerable",
+    );
+    const out = body.data?.subnet_lease_history;
+    assert.ok(out);
+    assert.equal(out.count, 0);
+    assert.deepEqual(out.lease_events, []);
+    // The marker is what makes the zero honest -- without it this would be the
+    // confident empty, which is a different bug rather than a fix.
+    assert.deepEqual(out.degraded, { reason: TIER_UNAVAILABLE_REASON });
+  });
+
+  test("subnet_conviction answers and carries the marker too", async () => {
+    const body = await gql(
+      "{ subnet_conviction(netuid: 64) { schema_version netuid count degraded { reason } } }",
+    );
+    assert.equal(body.errors, undefined);
+    const out = body.data?.subnet_conviction;
+    assert.ok(out);
+    assert.deepEqual(out.degraded, { reason: TIER_UNAVAILABLE_REASON });
+  });
+
+  test("subnet_ownership_history answers and carries the marker too", async () => {
+    const body = await gql(
+      "{ subnet_ownership_history(netuid: 64) { schema_version netuid count degraded { reason } } }",
+    );
+    assert.equal(body.errors, undefined);
+    const out = body.data?.subnet_ownership_history;
+    assert.ok(out);
+    assert.deepEqual(out.degraded, { reason: TIER_UNAVAILABLE_REASON });
+  });
+
+  test("the three surfaces read the SAME map, so their empties cannot drift", () => {
+    // The shared helper REST's proxy, MCP's `degradedDataApiRead` and
+    // GraphQL's `fetchAllEventsTier` all now call. Asserting the map directly
+    // is what makes "the same empty" a fact rather than three coincidences.
+    const marked = markedChainEventsPayload("/api/v1/subnets/64/lease/history");
+    assert.ok(marked);
+    assert.deepEqual(marked.degraded, { reason: TIER_UNAVAILABLE_REASON });
+    assert.equal(marked.count, 0);
+  });
+
+  test("an UNMAPPED path keeps its error rather than inventing an empty", () => {
+    // Non-vacuity, and the guard the map's own header asks for: a seventh
+    // proxied route added without a map entry must fail loudly instead of
+    // serving an empty that satisfies no schema.
+    assert.equal(markedChainEventsPayload("/api/v1/not/a/proxied/route"), null);
+  });
+
+  test("the OR-THROW form answers a mapped path and rethrows an unmapped one", () => {
+    // Both arms of the decision a failing reader makes. It lives in this
+    // module rather than inside GraphQL's `catch` precisely so the rethrow is
+    // reachable: at the call site every path is a literal the map covers, so
+    // that arm could never be exercised there.
+    const boom = new Error("upstream down");
+    const answered = markedChainEventsPayloadOrThrow(
+      "/api/v1/subnets/64/lease/history",
+      boom,
+    );
+    assert.deepEqual(answered.degraded, { reason: TIER_UNAVAILABLE_REASON });
+
+    assert.throws(
+      () => markedChainEventsPayloadOrThrow("/api/v1/not/proxied", boom),
+      /upstream down/,
+      "an unmapped path must keep the failure that brought it here",
+    );
+  });
+});

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { markedChainEventsPayload } from "../src/chain-events-degraded.ts";
 import { MIN_INCIDENT_SAMPLES } from "../src/health-serving.ts";
 import { visibleInWindow } from "./helpers/scan-window.ts";
 import {
@@ -6769,12 +6770,22 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     });
   });
 
-  test("surfaces a missing DATA_API binding as a GraphQL error", async () => {
+  test("a missing DATA_API binding answers with the MARKED empty, as REST and MCP do", async () => {
+    // WAS "surfaces a missing DATA_API binding as a GraphQL error" (#11423).
+    // That was never a cross-surface contract -- it was this surface diverging
+    // from the other two. REST's proxy falls to `degradedChainEventsPayload`
+    // (workers/api.ts) and MCP's `degradedDataApiRead` reads the same map;
+    // only GraphQL rethrew. Measured live 2026-08-16 on
+    // /subnets/64/lease/history: MCP answered a marked empty while GraphQL
+    // returned a 503, at the same instant.
     const { body } = await gql(
-      "{ subnet_ownership_history(netuid: 7) { count } }",
+      "{ subnet_ownership_history(netuid: 7) { count degraded { reason } } }",
     );
-    assert.ok(body.errors?.length);
-    assert.equal(body.data, null);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_ownership_history.count, 0);
+    assert.deepEqual(body.data.subnet_ownership_history.degraded, {
+      reason: "tier_unavailable",
+    });
   });
 
   // #9146's cold-tier lane. The SubnetOwnerChanged stream is in the lakehouse
@@ -6895,7 +6906,14 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     // erroring -- the right observation with the wrong conclusion, since the
     // reader now makes exactly those reads and the lock maps in the same pass.
     // Its own case is below.
-    test("lease_history keeps its error — no reader covers it", async () => {
+    test("lease_history answers the marked empty when no COLD-TIER reader covers it", async () => {
+      // WAS "lease_history keeps its error — no reader covers it" (#11423).
+      // "No reader" meant no COLD-TIER reader, which is still true here: the
+      // lakehouse leg is inconclusive, so `coldTierChainEventsPayload`
+      // declines. What does not follow is the error -- the DEGRADED map covers
+      // this path (SUBNET_LEASE_HISTORY is one of its six), and REST and MCP
+      // have always served it from there. This is the operation the latency
+      // sweep reports as the one that "did not answer".
       await withLakehouse(OWNERSHIP_ROWS, async () => {
         const env = {
           ...TOKEN_ENV,
@@ -6904,11 +6922,15 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
           },
         };
         const { body } = await gql(
-          "{ subnet_lease_history(netuid: 7) { count } }",
+          "{ subnet_lease_history(netuid: 7) { count lease_events { event_kind } degraded { reason } } }",
           env as unknown as Env,
         );
-        assert.ok(body.errors?.length, "lease_history should still error");
-        assert.equal(body.data, null);
+        assert.equal(body.errors, undefined, "lease_history must answer");
+        const out = body.data.subnet_lease_history;
+        assert.equal(out.count, 0);
+        assert.deepEqual(out.lease_events, []);
+        // The marker is what keeps this from being the confident empty.
+        assert.deepEqual(out.degraded, { reason: "tier_unavailable" });
       });
     });
   });
@@ -6917,19 +6939,23 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     // #9319: conviction now has a SECOND tier behind DATA_API -- a live chain
     // read. "DATA_API is down" is no longer sufficient for this field to fail,
     // so the chain has to be unreachable too, or this asserts against finney
-    // over the network. GraphQL's deliberate contract is unchanged: when
-    // NOTHING can answer, it errors rather than null-degrading.
+    // over the network. When NOTHING can answer, GraphQL now publishes the
+    // same MARKED empty REST and MCP do rather than erroring (#11423) -- the
+    // marker is what distinguishes it from a measured zero.
     const env = { DATA_API: dataApi(new Response("err", { status: 502 })) };
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (() =>
       Promise.reject(new Error("no network in tests"))) as typeof fetch;
     try {
       const { body } = await gql(
-        "{ subnet_conviction(netuid: 7) { count } }",
+        "{ subnet_conviction(netuid: 7) { count degraded { reason } } }",
         env as unknown as Env,
       );
-      assert.ok(body.errors?.length);
-      assert.equal(body.data, null);
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.subnet_conviction.count, 0);
+      assert.deepEqual(body.data.subnet_conviction.degraded, {
+        reason: "tier_unavailable",
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -6964,7 +6990,11 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     }
   });
 
-  test("surfaces a DATA_API fetch failure as a GraphQL error", async () => {
+  test("a DATA_API fetch failure answers the MARKED empty, on every surface alike", async () => {
+    // WAS "surfaces a DATA_API fetch failure as a GraphQL error" (#11423). A
+    // thrown binding and a non-ok status are the same thing to a caller, and
+    // both now land on the shared degraded map -- the one REST's proxy and
+    // MCP's `degradedDataApiRead` already read.
     const env = {
       DATA_API: {
         fetch: async () => {
@@ -6973,11 +7003,25 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       },
     };
     const { body } = await gql(
-      "{ subnet_lease_history(netuid: 9) { count } }",
+      "{ subnet_lease_history(netuid: 9) { count degraded { reason } } }",
       env as unknown as Env,
     );
-    assert.ok(body.errors?.length);
-    assert.equal(body.data, null);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_lease_history.count, 0);
+    assert.deepEqual(body.data.subnet_lease_history.degraded, {
+      reason: "tier_unavailable",
+    });
+  });
+
+  test("an UNMAPPED proxied path still errors, so the map cannot silently grow", async () => {
+    // The guard the degraded map's own header asks for, and the reason the
+    // change above is safe: a seventh proxied route added without a map entry
+    // must fail loudly rather than serve an empty that satisfies no schema.
+    // Asserted at the map, because the router admits only mapped paths.
+    assert.equal(
+      markedChainEventsPayload("/api/v1/chain-events/not-a-route"),
+      null,
+    );
   });
 
   test("FIELD_COMPLEXITY weights all three like their sibling Postgres-tier fields", () => {


### PR DESCRIPTION
Closes #11423. Part of #10312.

Measured live on 2026-08-16, **same route, same instant**:

| surface | answer |
|---|---|
| MCP `get_subnet_lease_history(64)` | `200` — `count: 0, lease_events: [], degraded: { reason: tier_unavailable }` |
| GraphQL `subnet_lease_history(netuid: 64)` | `data: null`, `errors: [503]` |

This is the **one operation** the latency sweep reports as "did not answer", and it is **not a fixture gap** — the resolver genuinely fails. REST's proxy and MCP's `degradedDataApiRead` both fall to `degradedChainEventsPayload`, the shared map of schema-stable empties. `fetchAllEventsTier` rethrows instead, so GraphQL alone errored where its siblings publish a marked empty.

## The resolvers were already written for this

`subnet_lease_history` ends `?? empty`; its two siblings spell `data?.field ?? default` throughout. **Every one of those fallbacks was unreachable** — a throw never lets a null reach them.

Three existing tests pinned the old behaviour, and their own comments show it was never a cross-surface decision. *"lease_history keeps its error — no reader covers it"* meant no **cold-tier** reader, which is still true and does not imply an error: the **degraded map** covers this path (it is one of its six) and always did. I verified REST before overriding them — `workers/api.ts` serves the marked empty here and errors only on an *unmapped* path, exactly as MCP does.

## Where the decision now lives

The marker moves to `chain-events-degraded.ts`, beside the empties it marks. GraphQL could not import it from `mcp-server.ts` — that module imports `handleGraphQLRequest`, so the dependency runs one way — and that barrier is much of why the third surface never got this.

`markedChainEventsPayloadOrThrow` expresses the whole decision (marked empty for a mapped path, rethrow otherwise) **in the module where both arms are reachable by a test**, rather than inside a `catch` where every caller passes a literal the map covers. The rethrow still matters: dropping it would make an unmapped seventh route return null, which each resolver spells `?? empty` — an *unmarked* empty, silently.

## Fixed alongside, in this PR

- **`degraded` joins `PROVENANCE_EXEMPT_FIELDS`.** It states that the read could not be made, so it describes the response, not the chain — neither `measured` nor `reconstructed` is true of it. `/api/v1/crowdloans` had already hit this: it declared `degraded: { kind: "reconstructed" }` under a comment saying the field is *"about the READ rather than the chain"* — the right observation, forced into an empty claim by a gate that demanded one. That entry is removed.
- **`MCP_DEGRADED_REASON` collapses into `TIER_UNAVAILABLE_REASON`** — one internal consumer, no external one, so it was a second name for a value that now lives in a shared module.
- **The two public decline reasons are cross-referenced where they are declared.** `unavailable` marks a lakehouse read; `tier_unavailable` the six proxied routes. Disjoint code paths, so no route publishes both — written down because two words for "the read failed" is how a third one appears.

## Verification

- Full suite: **955 files, 21,875 passed**
- **Patch coverage 100%** (17/17 lines+branches by diff intersection, unsharded); `test:coverage` exits 0
- `typecheck`, fresh `eslint`, `format:check`, `validate`, `validate:surface`, `validate:docs`, `validate:contract-doc-sync`, `validate:private-boundary`, `scan:public-safety`, `validate:client-sdk-sync`, `validate:artifact-budgets`, `worker:bundle:budget`, `validate:r2-sql-scan-bounds` — all pass
- Rebuilt with no artifact drift; backend-only, so no screenshots

`degraded` is added to the three route schemas behind this reader and forwarded by the two resolvers that hand-project their fields; the ownership-history node spreads its payload and already carried it.
