### PR TITLE
perf(accounts): the newest events were published in an object we already fetched, and only the card read them

### DIFF
--- a/schemas-src/artifacts/account-summary-projection.ts
+++ b/schemas-src/artifacts/account-summary-projection.ts
@@ -45,34 +45,84 @@ import { AccountEventsRowSchema } from "../lakehouse.ts";
  * not consult it; declaring it here is what stops it being an undeclared field
  * on a published object, which is the defect #9831 was filed about.
  */
-export const AccountSummaryPointerSchema = z
-  .object({
-    schema_version: z.number().int(),
-    generation: z.string().min(1),
-    shard_count: z.number().int().positive(),
-    generated_at: z.string().min(1),
-    account_count: z.number().int().nonnegative(),
-    through: z.string().min(1).optional(),
-    /**
-     * How many events per account the shards carry in their `recent` map
-     * (metagraphed-infra#575), when they carry one at all.
-     *
-     * THE LIMIT TRAVELS WITH THE DATA. `ACCOUNT_SUMMARY_RECENT_LIMIT` lives in
-     * this repository and the producer lives in another, so a reader that
-     * assumed the published N matched its own would serve a short feed the
-     * moment the two diverged -- and no CI here could see it. Declaring the N
-     * actually written lets the reader DECLINE when the artifact carries fewer
-     * than it needs, exactly as `shard_count` already travels rather than being
-     * agreed by convention.
-     *
-     * OPTIONAL, because every generation published before #575 lacks it, and
-     * those pointers are still valid to read for their aggregate leg. Absent
-     * means "no recent map" -- not "some unknown number" -- so the reader falls
-     * back to the lakehouse for that leg alone.
-     */
-    recent_limit: z.number().int().positive().optional(),
-  })
-  .strict();
+export const AccountSummaryPointerSchema = z.object({
+  schema_version: z.number().int(),
+  generation: z.string().min(1),
+  shard_count: z.number().int().positive(),
+  generated_at: z.string().min(1),
+  account_count: z.number().int().nonnegative(),
+  through: z.string().min(1).optional(),
+  /**
+   * How many events per account the shards carry in their `recent` map
+   * (metagraphed-infra#575), when they carry one at all.
+   *
+   * THE LIMIT TRAVELS WITH THE DATA. `ACCOUNT_SUMMARY_RECENT_LIMIT` lives in
+   * this repository and the producer lives in another, so a reader that
+   * assumed the published N matched its own would serve a short feed the
+   * moment the two diverged -- and no CI here could see it. Declaring the N
+   * actually written lets the reader DECLINE when the artifact carries fewer
+   * than it needs, exactly as `shard_count` already travels rather than being
+   * agreed by convention.
+   *
+   * OPTIONAL, because every generation published before #575 lacks it, and
+   * those pointers are still valid to read for their aggregate leg. Absent
+   * means "no recent map" -- not "some unknown number" -- so the reader falls
+   * back to the lakehouse for that leg alone.
+   */
+  recent_limit: z.number().int().positive().optional(),
+  /**
+   * The earliest day the recent lists cover, as the producer states it.
+   *
+   * DECLARED BECAUSE IT IS PUBLISHED, which is #9831's rule -- but it was
+   * declared LATE, and the cost is the whole reason `.strict()` is gone from
+   * this object. See below.
+   *
+   * The producer seeds the lists by walking history backward, so at any
+   * moment they describe a suffix of time; this names where that suffix
+   * starts. The reader does not consult it -- `readRecent` settles
+   * completeness per account against the groups' lifetime count, which is
+   * exact where a global watermark is conservative.
+   */
+  recent_from: z.string().min(1).optional(),
+});
+
+/**
+ * WHY THIS ONE OBJECT IS NOT `.strict()`, unlike everything around it.
+ *
+ * It was, and on 2026-08-16T17:30Z that took the entire account family's hot
+ * tier down in production, silently. The account-summary lane recovered after
+ * two days out (metagraphed-infra#599, #601) and its first generation published
+ * a field this schema did not declare:
+ *
+ *   {"generation":"20260816T173020Z", ... ,"recent_limit":10,
+ *    "recent_from":"2026-07-16","through":"2026-08-15"}
+ *
+ * `.strict()` rejected the whole pointer over `recent_from`. Not the field --
+ * the POINTER. `loadAccountSummaryProjection` returned null for every account,
+ * so the card lost its projection, `readRecent` never ran, and
+ * `accountHistoryFloorMs` returned null -- which made every scan floor #11425
+ * had just added INERT. Measured: `/events?limit=5` back to 21s. Nothing
+ * failed; every route quietly took its slow path.
+ *
+ * THE PRODUCER IS IN ANOTHER REPOSITORY AND DEPLOYS INDEPENDENTLY. That is the
+ * whole argument, and it is the same one `container-lane-status.ts` makes for
+ * the five status objects. Weigh the two failure modes:
+ *
+ *   strict + a field the producer ADDED  -> total, silent loss of the hot tier
+ *                                           for every account. Happened.
+ *   strip  + a field the producer TYPO'D -> that one field reads as absent, the
+ *                                           reader declines that leg alone and
+ *                                           falls back. Slow, and correct.
+ *
+ * The second is strictly better, and this reader is built for it: every
+ * optional field's absence already means "fall back to the lakehouse", so
+ * stripping degrades along a path that is tested rather than into a hole.
+ *
+ * NOT `.passthrough()`, which the no-passthrough gate bans and which would be
+ * the wrong tool anyway: zod's default STRIPS what it does not describe rather
+ * than carrying it onward, so nothing undeclared reaches a caller. The
+ * declared fields are validated exactly as strictly as before.
+ */
 
 /**
  * One group row inside a shard: an account's events of one kind on one subnet.

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1059,7 +1059,23 @@ export type AccountSummaryColdTierResult =
  * query returned. Sorting on `observed_at` alone would reorder events inside a
  * block, and the cursor token the other tier issues encodes all three.
  */
-function feedKey(row: Record<string, unknown>): [number, number, number] {
+/**
+ * The three columns the account feed orders and de-duplicates on.
+ *
+ * DECLARED AS A SHAPE rather than taking `Record<string, unknown>`, so the two
+ * row types that meet here -- the lakehouse's parsed row and the projection's
+ * stricter `AccountSummaryRecentEvent` -- can both satisfy it without either
+ * being erased through `unknown`. That erasure is what the double-assertion
+ * ratchet sits at zero for: it would have let a merge of the wrong two row
+ * types compile.
+ */
+export interface FeedKeyed {
+  observed_at?: unknown;
+  block_number?: unknown;
+  event_index?: unknown;
+}
+
+function feedKey(row: FeedKeyed): [number, number, number] {
   return [
     Number(row.observed_at ?? 0),
     Number(row.block_number ?? 0),
@@ -1082,13 +1098,13 @@ function feedKey(row: Record<string, unknown>): [number, number, number] {
  * row in a card is a visible wrong answer, while the cost of the check is a Set
  * over at most twenty rows.
  */
-export function mergeNewestEvents(
-  published: readonly Record<string, unknown>[],
-  head: readonly Record<string, unknown>[],
+export function mergeNewestEvents<Row extends FeedKeyed>(
+  published: readonly Row[],
+  head: readonly Row[],
   limit: number,
-): Record<string, unknown>[] {
+): Row[] {
   const seen = new Set<string>();
-  const merged: Record<string, unknown>[] = [];
+  const merged: Row[] = [];
   for (const row of [...head, ...published]) {
     const id = `${String(row.block_number)}:${String(row.event_index)}`;
     if (seen.has(id)) continue;

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -40,8 +40,19 @@ import {
   type ChainEventApi,
 } from "./chain-detail-hot-tier.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
-import { type ChainNetworkId, chainTable } from "./chain-network.ts";
-import { accountHistoryFloorMs } from "./account-summary-projection.ts";
+import {
+  type ChainNetworkId,
+  DEFAULT_CHAIN_NETWORK,
+  chainTable,
+} from "./chain-network.ts";
+import {
+  accountHistoryFloorMs,
+  loadAccountSummaryProjection,
+} from "./account-summary-projection.ts";
+import {
+  mergeNewestEvents,
+  type FeedKeyed,
+} from "./account-feeds-cold-tier.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -86,6 +97,122 @@ export interface AccountEventsQuery {
  * when the lakehouse cannot answer faithfully, so the caller keeps its
  * existing fallback.
  */
+/**
+ * The account's newest events, served from the projection instead of the walk.
+ *
+ * THE HOT TIER THIS FAMILY ALREADY HAD AND DID NOT USE. metagraphed-infra#575
+ * publishes each account's newest N events as COMPLETE ROWS -- block_number,
+ * event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao,
+ * alpha_amount, observed_at -- and generation 20260816T173020Z is the first to
+ * carry them (`recent_limit: 10`, `recent_from: 2026-07-16`, 814,072 accounts).
+ * `readRecent` had exactly ONE consumer: the summary card. A request for the
+ * newest five events walked the lakehouse while the newest ten sat in a 63 KB
+ * object the same page load had already fetched.
+ *
+ * ## Why this is a latency fix and the bounds were a cost fix
+ *
+ * R2 SQL costs seconds per query almost regardless of what it scans -- measured
+ * 2026-08-16, `/events?limit=5` on 5EEmaGFE...5oM3qDSC took 6.0s AFTER its scan
+ * was floored to five days, while the card answered in 174ms because it issues
+ * no query at all. #11425 and #11431 cut bytes and query count, which is real
+ * money; neither can get under the per-query floor. Not querying does.
+ *
+ * ONE PROBE REMAINS, and it is not optional: the projection describes events at
+ * or before its fold edge, so anything newer is missing from it. `floorMs` is
+ * where the producer stopped, so a single bounded read covers exactly the gap
+ * -- against the walk's two-to-three reads over the account's whole span.
+ *
+ * ## What makes serving it EXACT rather than approximately right
+ *
+ * `readRecent` only returns a list when that list IS the newest
+ * `min(published, lifetime)` events -- it declines a short one rather than
+ * handing back a truncated page. So the first `limit` of it are the newest
+ * `limit` overall, and `mergeNewestEvents` re-sorts them with the head probe on
+ * the feed's own three-part key. The page is byte-identical to the walk's,
+ * which is what lets the caller's cursor stay unchanged.
+ *
+ * ## Every reason this DECLINES, and why each has to
+ *
+ *   any filter      `kind`, `netuid`, `blockStart`, `blockEnd`. The published
+ *                   list is the newest N UNFILTERED; the newest N matching a
+ *                   filter are not a subset of it -- an account whose ten
+ *                   newest are all one kind has none of another in the list
+ *                   while having plenty in the chain. Filtering here would
+ *                   answer "none" with total confidence.
+ *   a cursor        the list is page 1 by construction. A seek token asks for
+ *                   rows below a point the projection may not reach.
+ *   an offset       same argument: `offset` skips into a region the list does
+ *                   not describe.
+ *   limit > rows    the list holds `min(recent_limit, lifetime)` rows. Asking
+ *                   for more than it holds cannot be answered from it, because
+ *                   a short list here is indistinguishable from a short account.
+ *   another network the projection is mainnet's.
+ *
+ * A decline costs one R2 GET of an object the card has usually warmed, and
+ * falls through to exactly the walk that ran before this existed.
+ */
+async function recentEventsLeg(
+  env: R2SqlEnv | null | undefined,
+  options: {
+    ss58: string;
+    where: readonly string[];
+    limit: number;
+    network: ChainNetworkId;
+    /**
+     * The generic reader, not `R2SqlReader`. `r2SqlQuery` derives the catalog
+     * schema from the table named in the SQL and refuses any row that violates
+     * it, so naming the row type here is "validated, then named" -- which is
+     * what `validate:untyped-db-reads` sits at a ceiling of zero to require.
+     * `R2SqlReader` erases that to `Record<string, unknown>` and would count
+     * against it.
+     */
+    query: typeof r2SqlQuery;
+  },
+): Promise<AccountEventsRow[] | null> {
+  const { ss58, where, limit, network, query } = options;
+  if (network !== DEFAULT_CHAIN_NETWORK) return null;
+  const projected = await loadAccountSummaryProjection(env, ss58, {
+    recentLimit: limit,
+  });
+  if (projected === null || projected.absent === true) return null;
+  const recent = projected.recent;
+  if (recent === null || recent.rows.length < limit) return null;
+
+  const head = await query<AccountEventsRow>(
+    env,
+    `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} ` +
+      `WHERE ${where.join(" AND ")} ` +
+      `AND observed_at >= ${Math.trunc(recent.floorMs)}` +
+      ` ORDER BY observed_at DESC, block_number DESC, event_index DESC` +
+      ` LIMIT ${limit}`,
+  );
+  // A FAILED PROBE FAILS THE LEG rather than serving the published half alone.
+  // The missing rows would be the NEWEST ones -- the top of the feed -- and the
+  // payload carries nothing that could say they were dropped. Returning null
+  // falls through to the walk, which is slower and complete.
+  if (head === null) return null;
+
+  // BOTH HALVES ARE ALREADY VALIDATED, each by the reader that owns it, and
+  // neither is cast into place:
+  //
+  //   published  `AccountSummaryRecentSchema` inside `readRecent` -- required
+  //              and `.strict()`, because a published artifact writes whole
+  //              rows and a missing column there is a producer bug
+  //   probe      `r2SqlQuery` itself, which derives the catalog schema from the
+  //              table named in the SQL and refuses any row that violates it
+  //              (src/r2-sql.ts) -- returning null, which is the branch above
+  //
+  // A second `safeParse` here was the first version of this, and it was
+  // DUPLICATED VALIDATION: the same rows checked twice against the same
+  // generated schema, with a second decline path to keep in step with the
+  // first. One owner per boundary.
+  //
+  // `mergeNewestEvents` is generic over the shape both halves share, so the
+  // compiler still checks that these two really do describe the same rows --
+  // the job that the `as unknown as` this replaced was destroying.
+  return mergeNewestEvents<AccountEventsRow>(recent.rows, head, limit);
+}
+
 export async function loadAccountEventsColdTier(
   env: R2SqlEnv | null | undefined,
   ss58: string,
@@ -155,6 +282,32 @@ export async function loadAccountEventsColdTier(
 
   // Cursor pages never carry an offset, mirroring data-api.
   const paged = cursor ? 0 : offset;
+
+  // THE HOT TIER FIRST, when the request is one the projection can answer
+  // exactly -- see `recentEventsLeg` for every reason it declines. Placed after
+  // `where` is assembled so the head probe carries the identical predicate, and
+  // gated on the absence of every narrowing the published list cannot express.
+  if (
+    cursor === null &&
+    paged === 0 &&
+    query.kind == null &&
+    query.netuid == null &&
+    query.blockStart == null &&
+    query.blockEnd == null
+  ) {
+    const hot = await recentEventsLeg(env, {
+      ss58,
+      where,
+      limit,
+      network: network ?? DEFAULT_CHAIN_NETWORK,
+      query: r2SqlQuery,
+    });
+    // `paged` is 0 here by the guard above -- the hot tier only ever serves an
+    // unpaged first page -- and passing it explicitly keeps that visible at the
+    // call site rather than relying on the reader to re-derive it.
+    if (hot !== null) return pageOf(hot, ss58, limit, offset, 0);
+  }
+
   const rows = await windowedRowRead<AccountEventsRow>(env, {
     table: chainTable("account_events", network),
     columns: EVENT_COLUMNS,
@@ -168,7 +321,26 @@ export async function loadAccountEventsColdTier(
     floorMs,
   });
   if (rows === null) return null;
+  return pageOf(rows, ss58, limit, offset, paged);
+}
 
+/**
+ * One page and its seek token, from rows either tier produced.
+ *
+ * SHARED SO THE TWO TIERS CANNOT DIVERGE. The cursor is built from the last row
+ * of the page, so a hot-tier page that paginated differently from the walk's
+ * would hand the caller a token that skips or repeats rows on page 2 -- and
+ * page 2 always goes to the walk, because a cursor makes the request
+ * hot-tier-ineligible. The rows are identical by construction; this makes the
+ * token identical by construction too.
+ */
+function pageOf<Row extends FeedKeyed & Record<string, unknown>>(
+  rows: Row[],
+  ss58: string,
+  limit: number,
+  offset: number,
+  paged: number,
+): ReturnType<typeof buildAccountEvents> {
   const page = paged > 0 ? rows.slice(paged) : rows;
   const last = page.length === limit ? page[page.length - 1] : null;
   const nextCursor = last

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -22,6 +22,7 @@ import {
   foldSummaryGroups,
   loadAccountSummaryColdTier,
   mergeNewestEvents,
+  type FeedKeyed,
 } from "../src/account-feeds-cold-tier.ts";
 import {
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
@@ -1273,7 +1274,12 @@ describe("mergeNewestEvents", () => {
     // columns is nullable on `chain.account_events`. A missing key must not
     // throw and must not sort ABOVE a real event -- the card's top row is the
     // most visible thing on it.
-    const merged = mergeNewestEvents(
+    // The type argument is explicit because the fixtures below are DELIBERATELY
+    // partial -- one row per nullable sort column -- and left to infer, TS
+    // narrows `Row` to a union of those exact literal shapes and then refuses
+    // the complete row in the published half. `FeedKeyed` is the shape the
+    // merge actually needs, which is what these rows are testing against.
+    const merged = mergeNewestEvents<FeedKeyed>(
       [{ observed_at: 50, block_number: 1, event_index: 3 }],
       [
         // One row per nullable sort column, each with an identity of its own so

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -606,11 +606,22 @@ describe("the pointer is PARSED, not indexed (metagraphed-infra#580)", () => {
     }
   });
 
-  test("an undeclared field is refused", () => {
-    assert.equal(
-      AccountSummaryPointerSchema.safeParse(pointer({ surprise: 1 })).success,
-      false,
+  test("an undeclared field is STRIPPED, not refused", () => {
+    // THIS ASSERTION USED TO READ `false`, and it pinned the assumption that
+    // caused an outage. On 2026-08-16T17:30Z the producer -- which lives in
+    // another repository and deploys on its own schedule -- published
+    // `recent_from`, and `.strict()` rejected the whole pointer over it. Every
+    // account lost its projection silently; see the dedicated describe block at
+    // the end of this file for the full account.
+    //
+    // The field is dropped rather than carried onward, which is the difference
+    // from `.passthrough()` (banned by the no-passthrough gate) and the reason
+    // nothing undeclared can reach a caller.
+    const parsed = AccountSummaryPointerSchema.safeParse(
+      pointer({ surprise: 1 }),
     );
+    assert.equal(parsed.success, true);
+    assert.ok(parsed.data && !("surprise" in parsed.data));
   });
 
   test("a pointer that fails the schema declines the tier rather than throwing", async () => {
@@ -951,10 +962,10 @@ describe("AccountSummaryRecentEventSchema", () => {
  * `span` alone would silently take no floor on exactly the accounts whose
  * unbounded walk is most expensive.
  */
-describe("accountHistoryFloorMs", () => {
-  /** A pointer stamped now, so the freshness check is not a clock race. */
-  const nowIso = () => new Date().toISOString();
+/** A pointer stamped now, so a freshness check is not a clock race. */
+const nowIso = () => new Date().toISOString();
 
+describe("accountHistoryFloorMs", () => {
   test("a PRESENT account floors at its earliest folded event", async () => {
     const store = archive(
       published(
@@ -1024,5 +1035,94 @@ describe("accountHistoryFloorMs", () => {
       await accountHistoryFloorMs(store.env, HOT, DEFAULT_CHAIN_NETWORK),
       4_242,
     );
+  });
+});
+
+/**
+ * The pointer must survive a producer that publishes MORE than this declares.
+ *
+ * 2026-08-16T17:30Z, production: the account-summary lane recovered after two
+ * days out (metagraphed-infra#599, #601) and its first generation published a
+ * field this schema did not declare. `.strict()` rejected the whole pointer
+ * over it -- not the field, the POINTER -- so `loadAccountSummaryProjection`
+ * returned null for every account. The card lost its projection, `readRecent`
+ * never ran, and `accountHistoryFloorMs` returned null, which made every scan
+ * floor #11425 had just added INERT. `/events?limit=5` went back to 21s.
+ *
+ * Nothing failed. Every route quietly took its slow path.
+ */
+describe("the pointer, against a producer that deploys independently", () => {
+  /** The exact bytes production published at 2026-08-16T17:30:20Z. */
+  const LIVE = {
+    schema_version: 1,
+    generation: "20260816T173020Z",
+    shard_count: 16384,
+    generated_at: "2026-08-16T17:30:20Z",
+    account_count: 814072,
+    recent_limit: 10,
+    recent_from: "2026-07-16",
+    through: "2026-08-15",
+  };
+
+  test("THE LIVE POINTER PARSES", () => {
+    const parsed = AccountSummaryPointerSchema.safeParse(LIVE);
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues));
+    assert.equal(parsed.data.recent_limit, 10);
+    assert.equal(parsed.data.recent_from, "2026-07-16");
+  });
+
+  test("A FIELD THIS SCHEMA HAS NEVER SEEN is stripped, not fatal", () => {
+    // The next `recent_from`. The producer is in another repository and ships
+    // on its own schedule, so this WILL happen again -- and the cost of being
+    // wrong is total and silent, where the cost of stripping is that one
+    // unknown field is ignored.
+    const parsed = AccountSummaryPointerSchema.safeParse({
+      ...LIVE,
+      some_field_added_next_quarter: { nested: true },
+    });
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues));
+    assert.equal(parsed.data.generation, "20260816T173020Z");
+    assert.ok(
+      !("some_field_added_next_quarter" in parsed.data),
+      "stripped, not carried onward -- this is not passthrough",
+    );
+  });
+
+  test("A DECLARED FIELD IS STILL VALIDATED EXACTLY AS STRICTLY", () => {
+    // Dropping `.strict()` loosens what the object may CONTAIN, never what a
+    // declared field may BE. A producer that starts writing a string count is
+    // still refused.
+    for (const bad of [
+      { ...LIVE, shard_count: "16384" },
+      { ...LIVE, shard_count: 0 },
+      { ...LIVE, generation: "" },
+      { ...LIVE, recent_limit: 0 },
+      { ...LIVE, account_count: -1 },
+    ]) {
+      assert.equal(
+        AccountSummaryPointerSchema.safeParse(bad).success,
+        false,
+        JSON.stringify(bad).slice(0, 90),
+      );
+    }
+  });
+
+  test("THE WHOLE READ SURVIVES an unknown pointer field, end to end", async () => {
+    // The unit above is the rule; this is the property that broke. A pointer
+    // that parses but a read that still declines would be the same outage.
+    const store = archive(
+      published(
+        { [HOT]: [group()] },
+        {
+          through: "2026-08-13",
+          generated_at: nowIso(),
+          recent_from: "2026-07-16",
+          a_field_from_the_future: 1,
+        },
+      ),
+    );
+    const found = await readFound(store.env, HOT, FRESH);
+    assert.equal(found.groups.length, 1);
+    assert.ok(found.span, "the floor every account route depends on");
   });
 });

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -11,6 +11,7 @@ import {
   loadSubnetEventsColdTier,
 } from "../src/events-cold-tier.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { encodeCursor } from "../src/cursor.ts";
 import { accountSummaryArchive } from "./helpers/cold-tier-env.ts";
 import { visibleInWindow } from "./helpers/scan-window.ts";
 import { OFFSET_EMULATION_CAP } from "../src/r2-sql-blocks.ts";
@@ -750,5 +751,228 @@ describe("loadBlockChainEventsColdTier", () => {
     sqlFetch([]);
     const data = await loadBlockChainEventsColdTier(TOKEN as never, "8500000");
     assert.deepEqual(data, { block_number: 8_500_000, count: 0, events: [] });
+  });
+});
+
+/**
+ * `/events` served from the projection instead of the walk.
+ *
+ * metagraphed-infra#575 publishes each account's newest N events as COMPLETE
+ * rows, and generation 20260816T173020Z is the first to carry them
+ * (`recent_limit: 10`, 814,072 accounts). `readRecent` had exactly one
+ * consumer -- the summary card -- so a request for the newest five events
+ * walked the lakehouse while the newest ten sat in an object the same page load
+ * had already fetched.
+ *
+ * Measured 2026-08-16: `/events?limit=5` took 6.0s with its scan already
+ * floored to five days, against 174ms for the card, which issues no query.
+ */
+describe("loadAccountEventsColdTier -- the projection's recent map", () => {
+  const THROUGH = "2026-08-14";
+  const FOLD_FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
+  const FIRST_OBSERVED = 1_700_000_000_010;
+
+  /** A published row, in the producer's shape. */
+  const recentRow = (block: number, index = 0) => ({
+    block_number: block,
+    event_index: index,
+    extrinsic_index: 1,
+    event_kind: "NeuronRegistered",
+    hotkey: ADDR,
+    coldkey: null,
+    netuid: 105,
+    uid: 242,
+    amount_tao: null,
+    alpha_amount: null,
+    observed_at: 1_700_000_000_000 + block,
+  });
+
+  /** An archive publishing `recent` for this account, as production now does. */
+  const withRecent = (rows: unknown[], recentLimit = 10) =>
+    accountSummaryArchive({
+      accounts: {
+        [ADDR]: [
+          {
+            kind: "NeuronRegistered",
+            netuid: 105,
+            count: rows.length,
+            fb: 10,
+            lb: 90,
+            fo: FIRST_OBSERVED,
+            lo: FIRST_OBSERVED,
+          },
+        ],
+      },
+      recent: { [ADDR]: rows },
+      pointer: { recent_limit: recentLimit, recent_from: "2026-07-16" },
+      through: THROUGH,
+    });
+
+  test("SERVES THE PAGE IN ONE QUERY, not a walk", async () => {
+    const q = sqlFetch([]);
+    const data = await loadAccountEventsColdTier(
+      {
+        ...TOKEN,
+        ...withRecent([recentRow(90), recentRow(80), recentRow(70)]),
+      } as never,
+      ADDR,
+      { limit: 3 },
+    );
+    assert.ok(data);
+    assert.equal(data.events.length, 3);
+    assert.equal(q.length, 1, `expected one head probe, got:\n${q.join("\n")}`);
+    assert.match(q[0]!, new RegExp(`observed_at >= ${FOLD_FLOOR}`));
+  });
+
+  test("THE PAGE IS BYTE-IDENTICAL to the walk's", async () => {
+    // The property that makes this safe to switch on. A hot page that differed
+    // would also hand back a different cursor, and page 2 always goes to the
+    // walk -- so a divergence here skips or repeats rows on the next page.
+    const rows = [recentRow(90), recentRow(80), recentRow(70)];
+    sqlFetch([]);
+    const hot = await loadAccountEventsColdTier(
+      { ...TOKEN, ...withRecent(rows) } as never,
+      ADDR,
+      { limit: 3 },
+    );
+    sqlFetch(rows);
+    const cold = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 3,
+    });
+    assert.deepEqual(hot, cold);
+  });
+
+  test("THE HEAD PROBE WINS -- a post-fold event is not missed", async () => {
+    // The projection describes events at or before its fold edge. Anything
+    // newer is missing from it, which is why the probe is not optional.
+    const fresh = recentRow(999);
+    const q = sqlFetch([fresh]);
+    const data = await loadAccountEventsColdTier(
+      { ...TOKEN, ...withRecent([recentRow(90), recentRow(80)]) } as never,
+      ADDR,
+      { limit: 2 },
+    );
+    assert.ok(data);
+    assert.equal(q.length, 1);
+    assert.equal(data.events[0]!.block_number, 999, "the newest row must lead");
+  });
+
+  test("A FAILED PROBE FALLS THROUGH to the walk, never serves a partial", async () => {
+    // The missing rows would be the NEWEST -- the top of the feed -- and the
+    // payload carries nothing that could say they were dropped.
+    let call = 0;
+    globalThis.fetch = (async () => {
+      call += 1;
+      if (call === 1) throw new Error("probe down");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const data = await loadAccountEventsColdTier(
+      { ...TOKEN, ...withRecent([recentRow(90), recentRow(80)]) } as never,
+      ADDR,
+      { limit: 2 },
+    );
+    assert.ok(data, "the walk still answers");
+    assert.ok(call > 1, "it fell through rather than declining");
+  });
+
+  test("A ROW THE CATALOG REFUSES declines the route, on BOTH tiers", async () => {
+    // Neither half of this merge is validated here, and that is deliberate:
+    // the published half is parsed by `AccountSummaryRecentSchema` inside
+    // `readRecent`, and the probe half by `r2SqlQuery`, which derives the
+    // catalog schema from the table named in the SQL. A second `safeParse` in
+    // the leg was the first version of this and was duplicated validation.
+    //
+    // The end-to-end contract is what matters: a row the catalog refuses makes
+    // the probe null, the hot leg falls through, and the walk -- reading the
+    // same table through the same guard -- declines too. The route answers
+    // null, which the caller turns into a decline. It never serves the row.
+    const q = sqlFetch([{ ...recentRow(999), block_number: "not a number" }]);
+    const data = await loadAccountEventsColdTier(
+      { ...TOKEN, ...withRecent([recentRow(90), recentRow(80)]) } as never,
+      ADDR,
+      { limit: 2 },
+    );
+    assert.equal(data, null, "a malformed row must never be served");
+    assert.ok(
+      q.length > 1,
+      `expected a fall-through to the walk, got:\n${q.join("\n")}`,
+    );
+  });
+
+  test("DECLINES on every narrowing the published list cannot express", async () => {
+    // The list is the newest N UNFILTERED. The newest N matching a filter are
+    // not a subset of it: an account whose ten newest are all one kind has none
+    // of another in the list while having plenty in the chain.
+    const rows = [recentRow(90), recentRow(80), recentRow(70)];
+    for (const [label, extra] of [
+      ["kind", { kind: "Transfer" }],
+      ["netuid", { netuid: 7 }],
+      ["blockStart", { blockStart: 10 }],
+      ["blockEnd", { blockEnd: 99 }],
+      ["offset", { offset: 1 }],
+      ["cursor", { cursor: encodeCursor([1, 2, 3]) }],
+    ] as [string, Record<string, unknown>][]) {
+      const q = sqlFetch(rows);
+      await loadAccountEventsColdTier(
+        { ...TOKEN, ...withRecent(rows) } as never,
+        ADDR,
+        { limit: 2, ...extra },
+      );
+      assert.ok(q.length >= 1, `${label}: no read at all`);
+      assert.ok(
+        !q.every((sql) => sql.includes(`observed_at >= ${FOLD_FLOOR}`)),
+        `${label} was served from the projection`,
+      );
+    }
+  });
+
+  test("DECLINES when the caller wants more rows than the list holds", async () => {
+    // A short list is indistinguishable from a short account, so asking for
+    // more than it holds cannot be answered from it.
+    //
+    // ASSERTED ON THE BOUND, NOT THE QUERY COUNT. Since #11431 the walk clamps
+    // to the projection's floor and can also finish in one query, so counting
+    // them no longer tells the two tiers apart. The bound does: the hot probe
+    // starts at the generation's fold edge, the walk at this account's own
+    // first observed event.
+    const q = sqlFetch([]);
+    await loadAccountEventsColdTier(
+      { ...TOKEN, ...withRecent([recentRow(90), recentRow(80)]) } as never,
+      ADDR,
+      { limit: 5 },
+    );
+    assert.ok(q.length >= 1, "premise: a read was issued");
+    assert.ok(
+      q.every((sql) => !sql.includes(`observed_at >= ${FOLD_FLOOR}`)),
+      `served from the projection: ${q[0]}`,
+    );
+    assert.ok(
+      q.some((sql) => sql.includes(`observed_at >= ${FIRST_OBSERVED}`)),
+      `the walk must floor at the account's own span: ${q[0]}`,
+    );
+  });
+
+  test("A NON-DEFAULT NETWORK reads no projection at all", async () => {
+    let asked = 0;
+    const bucket = {
+      METAGRAPH_ARCHIVE: {
+        get: async () => {
+          asked += 1;
+          return null;
+        },
+      },
+    };
+    sqlFetch([]);
+    await loadAccountEventsColdTier(
+      { ...TOKEN, ...bucket } as never,
+      ADDR,
+      { limit: 2 },
+      "testnet",
+    );
+    assert.equal(asked, 0);
   });
 });

--- a/tests/helpers/cold-tier-env.ts
+++ b/tests/helpers/cold-tier-env.ts
@@ -176,6 +176,17 @@ export function forbiddenDataApi() {
  */
 export function accountSummaryArchive(input: {
   accounts: Record<string, unknown>;
+  /**
+   * The producer's newest-N event map, keyed by account (infra#575).
+   *
+   * SEPARATE FROM `accounts` because it is separate in the artifact: a
+   * generation can carry groups and no map at all, which is what every
+   * generation before 20260816T173020Z did, and the reader has to decline that
+   * case rather than read an empty list as "no events".
+   */
+  recent?: Record<string, unknown>;
+  /** Extra pointer fields -- `recent_limit`, `recent_from`. */
+  pointer?: Record<string, unknown>;
   through?: string;
   generation?: string;
   shards?: number;
@@ -183,6 +194,8 @@ export function accountSummaryArchive(input: {
 }): ArchiveDouble {
   const {
     accounts,
+    recent = null,
+    pointer = {},
     through = "2026-08-14",
     generation = "20260815T000000Z",
     shards = 16384,
@@ -198,6 +211,14 @@ export function accountSummaryArchive(input: {
     if (entry !== null) bucket[account] = entry;
     byShard.set(shard, bucket);
   }
+  /** The same split for the recent map, which rides in the same shard object. */
+  const recentByShard = new Map<number, Record<string, unknown>>();
+  for (const [account, rows] of Object.entries(recent ?? {})) {
+    const shard = accountShard(account, shards);
+    const bucket = recentByShard.get(shard) ?? {};
+    bucket[account] = rows;
+    recentByShard.set(shard, bucket);
+  }
   return archiveEnv((key) => {
     if (key === pointerKey) {
       return {
@@ -207,13 +228,22 @@ export function accountSummaryArchive(input: {
         generated_at: generatedAt,
         account_count: Object.keys(accounts).length,
         through,
+        ...pointer,
       };
     }
     if (key.startsWith(prefix) && key.endsWith(".json")) {
       const shard = Number(key.slice(prefix.length, -".json".length));
       const bucket = byShard.get(shard);
       if (bucket === undefined) return null;
-      return { schema_version: 1, shard_count: shards, accounts: bucket };
+      return {
+        schema_version: 1,
+        shard_count: shards,
+        accounts: bucket,
+        // Omitted entirely when the fixture declares none, matching a
+        // pre-#575 generation -- an empty object would be a DIFFERENT claim
+        // ("folded, nothing recent") from the absence the reader must decline.
+        ...(recent === null ? {} : { recent: recentByShard.get(shard) ?? {} }),
+      };
     }
     return null;
   });


### PR DESCRIPTION
Two things, and the second is why the first had no effect in production.

## The pointer rejected itself, and every account route went quiet

`AccountSummaryPointerSchema` was `.strict()`. On **2026-08-16T17:30Z** the account-summary lane recovered after two days out (metagraphed-infra#599, #601) and its first generation published a field this repo did not declare:

```json
{"schema_version":1,"generation":"20260816T173020Z","shard_count":16384,
 "generated_at":"2026-08-16T17:30:20Z","account_count":814072,
 "recent_limit":10,"recent_from":"2026-07-16","through":"2026-08-15"}
```

`.strict()` rejected the whole pointer over `recent_from`. Not the field — the **pointer**. So `loadAccountSummaryProjection` returned null for every account:

- the card lost its projection
- `readRecent` never ran
- `accountHistoryFloorMs` returned null, which made **every scan floor #11425 had just added inert**

Measured: `/events?limit=5` back to 21s. Nothing failed. Every route quietly took its slow path.

**The producer is in another repository and deploys independently**, so weigh the two failure modes:

| | |
|---|---|
| strict + a field the producer **added** | total, silent loss of the hot tier for every account — happened |
| strip + a field the producer **typo'd** | that one field reads as absent, that leg declines, fall back is slow and correct |

The second is strictly better, and this reader is built for it: every optional field's absence already means "fall back to the lakehouse", so stripping degrades along a path that is tested rather than into a hole. `recent_from` is declared as well, because it is published and #9831's rule stands.

Not `.passthrough()` — the gate bans it and it is the wrong tool anyway: zod's default **strips** what it does not describe rather than carrying it onward, so nothing undeclared reaches a caller, and declared fields are validated exactly as strictly as before (pinned by a test).

An existing test asserted `an undeclared field is refused`. It pinned the assumption that caused the outage; it now states the corrected contract.

## `/events` answers from the projection

The map has been published since that generation, and `readRecent` had exactly **one** consumer: the summary card. A request for the newest five events walked the lakehouse while the newest ten sat in a 63 KB object the same page load had already fetched:

```json
{"block_number":8850439,"event_index":164,"event_kind":"NeuronRegistered",
 "hotkey":"5EEma…","netuid":105,"uid":242,"observed_at":1786802028000}
```

**This is a latency fix where the bounds were a cost fix.** R2 SQL costs seconds per query almost regardless of what it scans — `/events?limit=5` took 6.0s with its scan already floored to five days, against 174ms for the card, which issues no query at all. #11425 and #11431 cut bytes and query count, which is real money; neither gets under the per-query floor. Not querying does.

**One probe remains and is not optional**: the projection describes events at or before its fold edge, so anything newer is missing from it. `floorMs` is where the producer stopped, so a single bounded read covers exactly the gap — against the walk's reads over the account's whole span.

### Every reason it declines

| | |
|---|---|
| any filter | the list is the newest N **unfiltered**; the newest N matching a filter are not a subset of it. An account whose ten newest are all one kind has none of another in the list while having plenty in the chain — filtering here would answer "none" with total confidence |
| a cursor | the list is page 1 by construction |
| an offset | skips into a region the list does not describe |
| `limit` > rows held | a short list is indistinguishable from a short account |
| another network | the projection is mainnet's |

A decline costs one R2 GET of an object the card has usually warmed, and falls through to exactly the walk that ran before.

## No casts, and no second validation

`mergeNewestEvents` is now generic over `FeedKeyed` — the shape both row types share — which removed the two `as unknown as` hops the first version needed. The boundary ratchet is at zero for a reason: that erasure would have let a merge of the wrong two row types compile.

A `safeParse` on the probe rows was also removed as **duplicated validation**: `r2SqlQuery` already derives the catalog schema from the table named in the SQL and refuses any row that violates it. One owner per boundary. The row type is named at that validated call rather than erased to `Record<string, unknown>`, which is what `validate:untyped-db-reads` sits at zero to require.

## Verification

- **Falsified both**: with the hot leg short-circuited, 3 tests fail; with `.strict()` restored, 3 fail.
- The page is asserted **byte-identical to the walk's** — a hot page that differed would hand back a different cursor, and page 2 always goes to the walk.
- A row the catalog refuses is asserted to decline the route on **both** tiers rather than be served.
- Tests discriminate the tiers **by the bound**, not the query count: since #11431 the walk clamps to the projection floor and can also finish in one query.
- **Patch coverage 14/14 lines, 24/24 branches**; full suite 21,887 passed; full CI gate 79 targets, 0 failed.