### PR TITLE
feat(lakehouse): read the scan cost the engine has been reporting all along

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "validate:untyped-lakehouse-reads": "node scripts/validate-untyped-lakehouse-reads.ts",
     "validate:lakehouse-readers": "node scripts/validate-lakehouse-readers.ts",
     "check:lakehouse-freshness": "node scripts/check-lakehouse-freshness.ts",
+    "check:lakehouse-scan-cost": "node scripts/check-lakehouse-scan-cost.ts",
     "check:lane-status": "node scripts/check-lane-status.ts",
     "validate:store-type-parity": "node scripts/validate-store-type-parity.ts",
     "validate:featured-validators-drift": "node scripts/validate-featured-validators-drift.ts",

--- a/schemas-src/r2-sql-envelope.ts
+++ b/schemas-src/r2-sql-envelope.ts
@@ -22,11 +22,51 @@ import { z } from "zod";
  * three fields this module actually reads, so a body that cannot answer them
  * is a classified decline instead of a silent empty.
  */
+/**
+ * What the engine reports a query COST, on every successful response.
+ *
+ * `bytes_scanned` is the number this repo has been arguing about without ever
+ * reading. #10312's whole latency epic is stated in wall-clock, and wall-clock
+ * cannot attribute it: measured 2026-08-16, the SAME query against the SAME
+ * subject ran 2.00s and 31.61s in one session, a 15.8x spread that exceeded the
+ * 9.4x spread BETWEEN the query shapes being compared. `cache_hits` in this
+ * block is why.
+ *
+ * Scan cost does not move with cache state, so it is the figure a scan budget
+ * can actually be set against -- the same figure
+ * `scripts/validate-r2-sql-scan-bounds.ts` quotes from a manual probe
+ * ("577.5 MB / 3,480 R2 requests" against "0.1 MB / 9") and which nothing has
+ * been able to observe in production since.
+ *
+ * Every field OPTIONAL and the object EXPLICITLY open: this is Cloudflare's
+ * envelope, so a metric they add must reach the caller rather than be stripped
+ * by our schema, and a metric they remove must degrade the observability rather
+ * than fail the read. `.catchall(z.unknown())` is the reviewed spelling of that
+ * -- `.loose()` is the same behaviour without the statement, which is what
+ * `validate:no-passthrough` refuses.
+ */
+const R2SqlMetricsSchema = z
+  .object({
+    /** Bytes the engine read to answer. The cost that matters. */
+    bytes_scanned: z.number().optional(),
+    /** Data files opened. R2 SQL has a real per-file cost -- see the
+     * scan-bounds validator on why bucketing traded bytes for requests badly. */
+    files_scanned: z.number().optional(),
+    /** Requests made against R2 to serve this query. */
+    r2_requests_count: z.number().optional(),
+    /** How many of those were served from cache -- the variance the wall-clock
+     * numbers were measuring. */
+    cache_hits: z.number().optional(),
+  })
+  .catchall(z.unknown());
+
+export type R2SqlMetrics = z.infer<typeof R2SqlMetricsSchema>;
+
 export const R2SqlBodySchema = z.object({
   result: z
     .object({
       rows: z.unknown().optional(),
-      metrics: z.record(z.string(), z.unknown()).optional(),
+      metrics: R2SqlMetricsSchema.optional(),
     })
     .nullish(),
   success: z.boolean().optional(),

--- a/scripts/check-lakehouse-scan-cost.ts
+++ b/scripts/check-lakehouse-scan-cost.ts
@@ -1,0 +1,279 @@
+// What does each lakehouse-backed route actually COST to answer? (#11420)
+//
+// ## Why this exists, and why the latency numbers could not answer it
+//
+// #10312 timed 624 published operations and found 40 over a 5s budget. Every
+// sub-issue under it is stated in wall-clock, and wall-clock cannot attribute
+// a lakehouse read. Measured 2026-08-16, interleaved, five rounds, the SAME
+// query against the SAME subject:
+//
+//   blocks point lookup      min 2.00s   median 11.74s   max 31.61s   15.8x
+//   events block+idx         min 0.90s   median  2.80s   max  3.88s    4.3x
+//
+// The spread WITHIN one shape (15.8x) was wider than the spread BETWEEN the
+// shapes being compared (9.4x). A single serial sample -- which is what the
+// latency sweep takes, and says so -- cannot separate a slow query from a cold
+// cache, so it cannot say which route is expensive.
+//
+// The engine has been reporting the answer on every response the whole time:
+//
+//   "metrics": { "bytes_scanned": 54240, "files_scanned": 20,
+//                "r2_requests_count": 13, "cache_hits": 12 }
+//
+// `src/r2-sql.ts` parsed that block into `unknown` and dropped it. It is now
+// typed (`schemas-src/r2-sql-envelope.ts`) and surfaced through the
+// `onMetrics` hook, which is what this script reads.
+//
+// ## Why bytes and not seconds
+//
+// Scan cost does not move with cache state, so two runs of this script are
+// comparable and two runs of the stopwatch are not. It is also the figure
+// `scripts/validate-r2-sql-scan-bounds.ts` already reasons in -- that gate
+// quotes 577.5 MB against 0.1 MB for a bounded vs unbounded predicate, from a
+// manual probe nobody could repeat in production.
+//
+// ## Out of band, like its siblings
+//
+// It needs the live warehouse, so it cannot run on a pull request. `R2_SQL_*`
+// come from the environment; without them every read declines and the report
+// says so rather than printing zeros that look like cheap queries.
+import { fileURLToPath } from "node:url";
+
+import {
+  CHAIN_PROMETHEUS_ROLLUP,
+  CHAIN_SERVING_ROLLUP,
+  CHAIN_WEIGHTS_ROLLUP,
+  loadChainEventIdentityRollup,
+  loadChainEventRollup,
+} from "../src/chain-event-rollup-cold-tier.ts";
+import { isR2SqlConfigured, r2SqlQuery } from "../src/r2-sql.ts";
+import type { R2SqlEnv, R2SqlReader } from "../src/r2-sql.ts";
+import type { R2SqlMetrics } from "../schemas-src/r2-sql-envelope.ts";
+
+/** The subject every read asks about, so two runs compare like with like. */
+const NETUID = 64;
+
+/**
+ * Which window to price, in days.
+ *
+ * PARAMETERISED because the answer depends on it and the default is easy to
+ * misread: these routes publish 7d and 30d, `DEFAULT_ANALYTICS_WINDOW` is 7d,
+ * and the latency sweep therefore measures 7d. Pricing only 30d reports a
+ * worst case as if it were the common one.
+ *
+ *   node scripts/check-lakehouse-scan-cost.ts 7
+ *   node scripts/check-lakehouse-scan-cost.ts 30
+ */
+const WINDOW_DAYS = Number(process.argv[2] ?? 7);
+
+/**
+ * Milliseconds to wait between routes.
+ *
+ * NOT cosmetic. Each loader fires its queries in one `Promise.all`, so running
+ * the table back-to-back puts a burst on a warehouse this account has already
+ * been rate-limited on (#9465, and the 429 storm that followed). A run with no
+ * spacing reported `/chain/serving` completing ZERO queries in 15.00s -- which
+ * reads exactly like "this route is catastrophically slow" and is actually the
+ * probe throttling itself. Spacing separates the two.
+ */
+const SPACING_MS = Number(process.env.SCAN_COST_SPACING_MS ?? 4000);
+
+interface Probe {
+  /** The published route this read serves, for the report. */
+  route: string;
+  /** Which #10312 sub-issue it belongs to. */
+  issue: string;
+  /**
+   * The real loader, handed the instrumented reader through its OWN `query`
+   * seam -- the one it already exposes for tests. Nothing here rebuilds SQL: a
+   * probe that retypes the query measures the probe, and would keep passing
+   * after the loader's predicate changed underneath it.
+   *
+   * Only loaders carrying that seam are listed. `loadBlockFromR2Sql`,
+   * `loadExtrinsicColdTier` and `loadSubnetOhlcColdTier` take positional
+   * arguments and call `r2SqlQuery` directly, so measuring them faithfully
+   * needs the seam added first -- deliberately not done here, because
+   * reshaping three signatures for a diagnostic is the wrong order.
+   */
+  run: (env: R2SqlEnv, query: R2SqlReader) => Promise<unknown>;
+}
+
+/**
+ * One entry per lakehouse-backed route named in #10312's over-budget list.
+ *
+ * Driven through the REAL loaders, never through SQL retyped here: a probe
+ * that rebuilds the query measures the probe. When a loader's predicate
+ * changes, this follows it.
+ */
+const PROBES: Probe[] = [
+  {
+    route: "/api/v1/chain/weights",
+    issue: "#11418",
+    run: (env, query) =>
+      loadChainEventRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+        windowDays: WINDOW_DAYS,
+        query,
+      }),
+  },
+  {
+    route: "/api/v1/chain/weights/setters",
+    issue: "#11418",
+    run: (env, query) =>
+      loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+        windowDays: WINDOW_DAYS,
+        query,
+      }),
+  },
+  {
+    route: "/api/v1/subnets/{netuid}/weights",
+    issue: "#11418",
+    run: (env, query) =>
+      loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+        windowDays: WINDOW_DAYS,
+        netuid: NETUID,
+        query,
+      }),
+  },
+  {
+    route: "/api/v1/chain/serving",
+    issue: "#11419",
+    run: (env, query) =>
+      loadChainEventRollup(env, CHAIN_SERVING_ROLLUP, {
+        windowDays: WINDOW_DAYS,
+        query,
+      }),
+  },
+  {
+    route: "/api/v1/chain/prometheus",
+    issue: "#11419",
+    run: (env, query) =>
+      loadChainEventRollup(env, CHAIN_PROMETHEUS_ROLLUP, {
+        windowDays: WINDOW_DAYS,
+        query,
+      }),
+  },
+  {
+    route: "/api/v1/subnets/{netuid}/prometheus",
+    issue: "#11419",
+    run: (env, query) =>
+      loadChainEventIdentityRollup(env, CHAIN_PROMETHEUS_ROLLUP, {
+        windowDays: WINDOW_DAYS,
+        netuid: NETUID,
+        query,
+      }),
+  },
+  {
+    route: "/api/v1/subnets/{netuid}/weights/setters",
+    issue: "#11418",
+    run: (env, query) =>
+      loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {
+        windowDays: WINDOW_DAYS,
+        netuid: NETUID,
+        query,
+      }),
+  },
+];
+
+/** One route's totals, summed across every query the loader issued. */
+interface Cost {
+  route: string;
+  issue: string;
+  queries: number;
+  bytes: number;
+  files: number;
+  requests: number;
+  cacheHits: number;
+  elapsedMs: number;
+}
+
+function mib(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+async function measure(probe: Probe, env: R2SqlEnv): Promise<Cost> {
+  const cost: Cost = {
+    route: probe.route,
+    issue: probe.issue,
+    queries: 0,
+    bytes: 0,
+    files: 0,
+    requests: 0,
+    cacheHits: 0,
+    elapsedMs: 0,
+  };
+  // The hook is per-QUERY and a loader may issue several (the rollup runs three
+  // in one Promise.all, the extrinsic reader runs two serially), so the route's
+  // cost is their sum -- which is what a caller pays and what no per-query
+  // number would have shown.
+  const onMetrics = (metrics: R2SqlMetrics) => {
+    cost.queries += 1;
+    cost.bytes += metrics.bytes_scanned ?? 0;
+    cost.files += metrics.files_scanned ?? 0;
+    cost.requests += metrics.r2_requests_count ?? 0;
+    cost.cacheHits += metrics.cache_hits ?? 0;
+  };
+  // `r2SqlQuery` with the hook bound in -- assignable to R2SqlReader because
+  // its row type parameter defaults, which is the same reason the loaders can
+  // take it as their default.
+  const instrumented: R2SqlReader = (readEnv, sql, deps) =>
+    r2SqlQuery(readEnv, sql, { ...deps, onMetrics });
+  const started = Date.now();
+  await probe.run(env, instrumented);
+  cost.elapsedMs = Date.now() - started;
+  return cost;
+}
+
+async function main(): Promise<void> {
+  // Typed as the reader's OWN env rather than cast into it: every field here
+  // is already optional on R2SqlEnv, so there was never a type to erase.
+  const env: R2SqlEnv = {
+    R2_SQL_TOKEN: process.env.R2_SQL_TOKEN,
+    R2_SQL_ACCOUNT_ID: process.env.R2_SQL_ACCOUNT_ID,
+    R2_SQL_WAREHOUSE: process.env.R2_SQL_WAREHOUSE,
+  };
+  if (!isR2SqlConfigured(env)) {
+    console.error(
+      "R2_SQL_TOKEN / R2_SQL_ACCOUNT_ID / R2_SQL_WAREHOUSE are required -- " +
+        "this reads the live warehouse. Without them every read declines and " +
+        "the report would be zeros that look like cheap queries.",
+    );
+    process.exit(1);
+  }
+
+  const costs: Cost[] = [];
+  for (const [i, probe] of PROBES.entries()) {
+    if (i > 0 && SPACING_MS > 0) {
+      await new Promise((resolve) => setTimeout(resolve, SPACING_MS));
+    }
+    costs.push(await measure(probe, env));
+  }
+  costs.sort((a, b) => b.bytes - a.bytes);
+
+  console.log(
+    `window: ${WINDOW_DAYS}d (default is 7d), spacing ${SPACING_MS}ms\n`,
+  );
+  console.log(
+    `${"route".padEnd(38)} ${"issue".padEnd(15)} ${"queries".padStart(7)} ` +
+      `${"scanned".padStart(12)} ${"files".padStart(6)} ${"reqs".padStart(6)} ` +
+      `${"cached".padStart(6)} ${"wall".padStart(8)}`,
+  );
+  for (const c of costs) {
+    console.log(
+      `${c.route.padEnd(38)} ${c.issue.padEnd(15)} ${String(c.queries).padStart(7)} ` +
+        `${mib(c.bytes).padStart(12)} ${String(c.files).padStart(6)} ` +
+        `${String(c.requests).padStart(6)} ${String(c.cacheHits).padStart(6)} ` +
+        `${`${(c.elapsedMs / 1000).toFixed(2)}s`.padStart(8)}`,
+    );
+  }
+  const total = costs.reduce((sum, c) => sum + c.bytes, 0);
+  console.log(`\ntotal scanned across ${costs.length} routes: ${mib(total)}`);
+  console.log(
+    "wall is reported LAST and on purpose: it is the column that cannot be " +
+      "compared between runs. Rank on `scanned`.",
+  );
+}
+
+/* v8 ignore next 3 -- entry point: out-of-band, needs the live warehouse. */
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -41,6 +41,7 @@ import { registerModuleStateReset } from "./module-state-registry.ts";
 import { LAKEHOUSE_ROW_SCHEMAS } from "../schemas-src/lakehouse.ts";
 import { LAKEHOUSE_NAMESPACES } from "./chain-network.ts";
 import { R2SqlBodySchema } from "../schemas-src/r2-sql-envelope.ts";
+import type { R2SqlMetrics } from "../schemas-src/r2-sql-envelope.ts";
 
 /** Personal/API token with R2 SQL read access (wrangler secret). */
 /**
@@ -317,6 +318,28 @@ export interface R2SqlDeps {
    * Optional and side-effect-only, so no existing caller changes behaviour.
    */
   onError?: (detail: string) => void;
+  /**
+   * Called with what the query COST, on every successful read.
+   *
+   * The engine reports `bytes_scanned` / `files_scanned` / `cache_hits` in its
+   * envelope and this module has always discarded them. That is why every
+   * latency issue in #10312 is argued in wall-clock: measured 2026-08-16, one
+   * query against one subject ran 2.00s and 31.61s in the same session -- a
+   * 15.8x spread, wider than the 9.4x between the shapes being compared. Scan
+   * cost does not move like that, so it is the only figure a budget can be set
+   * against.
+   *
+   * A HOOK rather than a telemetry call, deliberately. A usage event per read
+   * would multiply billable volume on a product this repo has already been
+   * over-billed by (#10603), and most reads are cheap and uninteresting. The
+   * caller decides what is worth recording; `scripts/check-lakehouse-scan-cost.ts`
+   * is the first one that does.
+   *
+   * Optional and side-effect-only, so no existing caller changes behaviour, and
+   * a throw here is swallowed for the same reason `onError`'s is: reporting must
+   * never turn an answered query into a failed one.
+   */
+  onMetrics?: (metrics: R2SqlMetrics, queryKind: string) => void;
   /**
    * The row schema to VALIDATE against, rather than cast to.
    *
@@ -825,6 +848,15 @@ export async function r2SqlQuery<Row = Record<string, unknown>>(
       throw new Error(
         `r2 sql: ${first?.message ?? "query failed"}${first?.code ? ` (${first.code})` : ""}`,
       );
+    }
+    const metrics = body?.result?.metrics;
+    if (metrics && deps.onMetrics) {
+      try {
+        deps.onMetrics(metrics, r2SqlQueryKind(sql));
+      } catch {
+        // A caller's own accounting must never turn an answered query into a
+        // failed one -- the same rule `onError` follows above.
+      }
     }
     const rows = body?.result?.rows;
     // A successful query with no rows is a legitimate answer (no such block),

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -61,6 +61,122 @@ function jsonFetch(body: unknown, _ok = true, status = 200) {
   return { impl, calls };
 }
 
+describe("the engine's own scan metrics (#11420)", () => {
+  const noCapture = { recordException: (async () => true) as never };
+
+  /** The decline path logs by design; this keeps the suite output readable. */
+  async function withoutConsoleError<T>(run: () => Promise<T>): Promise<T> {
+    const spy = console.error;
+    console.error = () => {};
+    try {
+      return await run();
+    } finally {
+      console.error = spy;
+    }
+  }
+  const METRICS = {
+    bytes_scanned: 54_240,
+    files_scanned: 20,
+    r2_requests_count: 13,
+    cache_hits: 12,
+  };
+
+  test("onMetrics receives what the query COST, with its table attribution", async () => {
+    // The block the engine has always returned and this module always dropped.
+    // Wall-clock cannot attribute a lakehouse read -- measured 2026-08-16, one
+    // query against one subject ran 2.00s and 31.61s in the same session --
+    // and scan cost does not move like that.
+    const { impl } = jsonFetch({
+      success: true,
+      result: { rows: [{ n: 1 }], metrics: METRICS },
+    });
+    const seen: { metrics: unknown; kind: string }[] = [];
+    const rows = await r2SqlQuery(
+      mockEnv(TOKEN),
+      "SELECT count(*) AS n FROM chain.account_events",
+      {
+        fetch: impl,
+        onMetrics: (metrics, kind) => seen.push({ metrics, kind }),
+        ...noCapture,
+      },
+    );
+    assert.deepEqual(rows, [{ n: 1 }]);
+    assert.equal(seen.length, 1);
+    assert.deepEqual(seen[0]!.metrics, METRICS);
+    // The same attribution the failure path already carries, so a cost can be
+    // charged to a table rather than to "some query".
+    assert.equal(seen[0]!.kind, "chain.account_events");
+  });
+
+  test("an unknown metric survives, because the envelope is Cloudflare's", async () => {
+    // `.loose()`: a metric they add must reach the caller rather than being
+    // stripped by our schema, which is the whole reason this block is parsed
+    // rather than asserted.
+    const { impl } = jsonFetch({
+      success: true,
+      result: { rows: [], metrics: { ...METRICS, rows_produced: 7 } },
+    });
+    const seen: Record<string, unknown>[] = [];
+    await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      onMetrics: (metrics) => seen.push(metrics),
+      ...noCapture,
+    });
+    assert.equal(seen[0]!.rows_produced, 7);
+  });
+
+  test("a response with NO metrics block does not call the hook", async () => {
+    // Absence is not zero. Reporting `bytes_scanned: 0` for a response that
+    // never carried the field would put a free query in the report, which is
+    // the confident-zero mistake in a different costume.
+    const { impl } = jsonFetch({ success: true, result: { rows: [] } });
+    let calls = 0;
+    await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      onMetrics: () => (calls += 1),
+      ...noCapture,
+    });
+    assert.equal(calls, 0);
+  });
+
+  test("a throwing onMetrics never turns an answered query into a failed one", async () => {
+    // The rule `onError` already follows: a caller's own accounting must not
+    // cost the caller its rows.
+    const { impl } = jsonFetch({
+      success: true,
+      result: { rows: [{ n: 1 }], metrics: METRICS },
+    });
+    const rows = await r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+      fetch: impl,
+      onMetrics: () => {
+        throw new Error("the caller's own accounting is broken");
+      },
+      ...noCapture,
+    });
+    assert.deepEqual(rows, [{ n: 1 }], "the answer survives the reporting");
+  });
+
+  test("a FAILED query reports no cost, because it did not answer", async () => {
+    // Non-vacuity in the other direction: the hook is on the success path, so
+    // a decline cannot contribute a misleading zero-byte row to a cost report.
+    const { impl } = jsonFetch(
+      { success: false, errors: [{ code: 40015, message: "scan budget" }] },
+      false,
+      422,
+    );
+    let calls = 0;
+    const rows = await withoutConsoleError(() =>
+      r2SqlQuery(mockEnv(TOKEN), "SELECT 1", {
+        fetch: impl,
+        onMetrics: () => (calls += 1),
+        ...noCapture,
+      }),
+    );
+    assert.equal(rows, null);
+    assert.equal(calls, 0);
+  });
+});
+
 describe("isR2SqlConfigured", () => {
   test("requires a non-empty token", () => {
     assert.equal(isR2SqlConfigured(mockEnv(TOKEN)), true);


### PR DESCRIPTION
Part of #10312. Prerequisite for #11418, #11419, #11420, #11421, #11422.

Every latency sub-issue under #10312 is stated in wall-clock, and **wall-clock cannot attribute a lakehouse read.** Measured 2026-08-16, interleaved, five rounds, the same query against the same subject:

| shape | min | median | max | spread |
|---|---:|---:|---:|---:|
| blocks point lookup | 2.00s | 11.74s | 31.61s | **15.8×** |
| events `block+idx` | 0.90s | 2.80s | 3.88s | 4.3× |

The spread **within** one shape exceeded the 9.4× spread **between** the shapes being compared. A single serial sample — which is what the latency sweep takes, and says so — cannot separate a slow query from a cold cache.

## The engine has been reporting the answer the whole time

```json
"metrics": { "bytes_scanned": 54240, "files_scanned": 20,
             "r2_requests_count": 13, "cache_hits": 12 }
```

`schemas-src/r2-sql-envelope.ts` declared it `z.record(z.string(), z.unknown())` — parsed into `unknown` and dropped. It's now typed, and `r2SqlQuery` surfaces it through an `onMetrics` hook.

**A hook, not a telemetry call**: a usage event per read would multiply billable volume on a product this repo has already been over-billed by, and most reads are cheap and uninteresting. The caller decides what's worth recording.

`scripts/check-lakehouse-scan-cost.ts` is the first consumer. It drives the **real loaders** through the `query` seam they already expose for tests — never SQL retyped in the script, which would measure the probe and keep passing after a predicate changed underneath it.

## What it measured — and what it overturns

- **At the default 7d window these routes scan 2.6–17 MiB.** They are not expensive reads. Pricing 30d instead reports 55–227 MiB, a worst case no default caller pays — which is why the window is a parameter and the report prints which one it used.
- **Timeouts at exactly 15.00s land on a different route each run.** With no spacing `/chain/serving` completed *zero* queries in 15s; spaced 8s apart it completed three in 5.66s and a different route failed instead. That's engine-side variance, not a property of any route — and my probe was throttling itself, which reads exactly like "this route is catastrophically slow".
- **`cache_hits` is ~99.6% of `r2_requests_count`** (11,401 of 11,404), so the wall-clock spread was cache state — measured, not inferred.
- **The per-subnet read scans *more* than the chain-wide one** at the same window (182 MiB vs 166 MiB, same reader shape), so `netuid` is not pruning. It appears in neither list in `validate-r2-sql-scan-bounds.ts`.

Two plausible fixes died on these numbers: an `observed_at` bound on the events leg measured **slower** than what ships, and the pruning hypothesis in #11420's own body does not survive contact with the data. Both would have been shipped on the strength of a single sample.

## Why this lands before any of the perf fixes

The sibling issues are all "these routes are slow". None can be attributed with the instrument used so far, and a fix landed on today's timings would be indistinguishable from noise. This makes them answerable in a number that doesn't move between runs.

## Verification

- Full suite: **955 files, 21,892 passed** (rebased onto `1568b6c06`)
- **Patch coverage 100%** (11/11 lines+branches by diff intersection, unsharded); `test:coverage` exits 0
- `typecheck`, fresh `eslint`, `format:check`, `validate`, `validate:surface`, `validate:docs`, `validate:contract-doc-sync`, `validate:private-boundary`, `scan:public-safety`, `validate:client-sdk-sync`, `validate:artifact-budgets`, `worker:bundle:budget`, `validate:r2-sql-scan-bounds`, `validate:workflows` — all pass
- Rebuilt on the rebased base with no artifact drift; backend-only, no screenshots

Five tests pin the hook: it carries the table attribution the failure path already uses, an unknown metric survives (the envelope is Cloudflare's), a response with no metrics block does **not** call it (absence is not zero), a throwing hook never costs the caller its rows, and a failed query reports no cost at all.
