### PR TITLE
perf(accounts): a populated sub-millisecond store sat under the account feeds, unindexed for the only question they ask

### DIFF
--- a/migrations/neon/0032_chain_detail_account_events_by_account.sql
+++ b/migrations/neon/0032_chain_detail_account_events_by_account.sql
@@ -1,0 +1,70 @@
+-- The hot tier for the account feeds could not be read BY ACCOUNT.
+--
+-- `chain_detail_account_events` is written by the chain-detail lane and holds
+-- the head of the chain in Neon -- measured 2026-08-16, 931,486 rows spanning
+-- blocks 8,853,005..8,859,140, which is 2026-08-15T22:27Z to the head. It is
+-- indexed for the two questions the block routes ask (by `block_number`, by
+-- `observed_at`) and for neither question the ACCOUNT routes ask.
+--
+-- So the account family reads past a populated, sub-millisecond store straight
+-- into the lakehouse, where R2 SQL costs seconds per query almost regardless of
+-- what it scans. Measured the same day on `/accounts/{ss58}`: the card 12.4s,
+-- `/events?limit=5` 6.0s with its scan already floored, against 0.196s for
+-- `/blocks/{ref}`, which reads this same store through an index it does have.
+--
+-- ## What the planner actually did
+--
+-- EXPLAIN ANALYZE, production, an account with no rows in the hot window --
+-- which is the COMMON case, not the corner:
+--
+--     Limit (actual time=748.742..748.743 rows=0)
+--       -> Incremental Sort
+--            -> Index Scan Backward using idx_..._observed
+--                 Filter: ((hotkey = '5Gsb...') OR (coldkey = '5Gsb...'))
+--                 Rows Removed by Filter: 932266
+--     Execution Time: 748.769 ms
+--
+-- It walks the whole table backward through the `observed_at` index and throws
+-- away every row. The quieter the account, the more it reads to prove there is
+-- nothing -- so the cheapest answer pays the most expensive scan, which is the
+-- same shape #11425 fixed on the lakehouse side.
+--
+-- ## Two indexes, not one composite
+--
+-- The predicate is `hotkey = X OR coldkey = X`, and no single btree serves a
+-- disjunction over two columns. Two indexes let the planner take each side and
+-- combine them with a BitmapOr, which is the shape this query has had since it
+-- was written -- the same `(hotkey OR coldkey)` the lakehouse readers use,
+-- standing in for data-api's two-scan merge.
+--
+-- `observed_at DESC` as the second column, because every one of these reads is
+-- newest-first with a LIMIT. With it the index answers the ORDER BY as well as
+-- the filter and the scan stops at `limit` rows; without it the planner sorts
+-- the account's whole history to return five rows.
+--
+-- NULLS LAST matches the ORDER BY the readers emit. `coldkey` is null on every
+-- hotkey-scoped event and `hotkey` is null on `WeightsSet`, so both columns are
+-- genuinely sparse and the null placement is not academic.
+--
+-- ## Size
+--
+-- The table is pruned to a rolling window (see chain-detail-prune.ts), so these
+-- do not grow without bound. Against the 92 MB / 41 MB / 40 MB indexes 0017
+-- added on the same three tables, two more on the smallest of them is the same
+-- order of cost for a route family that currently pays 748 ms per request.
+--
+-- ## CONCURRENTLY: not in a transaction
+--
+-- As 0011, 0012 and 0017. Apply statement by statement; a failed build leaves
+-- an INVALID index to drop before retrying (`SELECT indexrelid::regclass FROM
+-- pg_index WHERE NOT indisvalid`). Every statement is IF NOT EXISTS, so a
+-- half-applied run is re-runnable -- which is what pays for having no rollback.
+-- neon:no-transaction
+
+-- 1. The hotkey side of the disjunction.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chain_detail_account_events_hotkey_observed
+  ON chain_detail_account_events (hotkey, observed_at DESC NULLS LAST);
+
+-- 2. The coldkey side. Same shape; the planner BitmapOrs the two.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chain_detail_account_events_coldkey_observed
+  ON chain_detail_account_events (coldkey, observed_at DESC NULLS LAST);

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1075,6 +1075,25 @@ export interface FeedKeyed {
   event_index?: unknown;
 }
 
+/**
+ * A row from ANY of the three producers that can answer an account feed, in the
+ * shape the page builder consumes.
+ *
+ * THREE PRODUCERS, ONE FEED. The projection publishes
+ * `AccountSummaryRecentEvent`, Neon's `chain_detail_account_events` yields
+ * `ChainDetailAccountEvents`, and the lakehouse yields `AccountEventsRow`. They
+ * describe the same events and differ in what each storage layer can promise --
+ * pg hands back numerics as strings, the lakehouse as numbers, the artifact as
+ * whatever it published -- which is exactly why `formatAccountEvent` coerces
+ * every one of them on the way out.
+ *
+ * NAMED rather than written inline as `Record<string, unknown>` at each call.
+ * The untyped-read ratchet counts that spelling in a generic position and is
+ * right to: a merge that says "any object" reads identically to a read that
+ * forgot its row type, and the two need to stay distinguishable.
+ */
+export type AccountFeedRow = FeedKeyed & Record<string, unknown>;
+
 function feedKey(row: FeedKeyed): [number, number, number] {
   return [
     Number(row.observed_at ?? 0),

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -184,6 +184,74 @@ async function resolveHotRef(
 }
 
 /** Every extrinsic in one covered block, in read order. */
+/**
+ * The oldest `observed_at` this store still holds, or null when it holds
+ * nothing / cannot be read.
+ *
+ * THE SEAM, DERIVED FROM THE STORE'S OWN FLOOR rather than pinned. The
+ * chain-detail lane prunes to a rolling window, so how far back this tier
+ * reaches is a property of the data at this instant -- a constant here would be
+ * a claim about a window someone else tunes, and it would be wrong in the
+ * direction that matters: too low, and a caller serves a page missing every
+ * event below a floor this store never had.
+ *
+ * `MIN(observed_at)` is a single descent of the index 0017 added for exactly
+ * this shape, so it costs a planner walk rather than a scan.
+ */
+export async function accountEventsHotFloorMs(
+  env: unknown,
+): Promise<number | null> {
+  const rows = await query(
+    env,
+    "SELECT MIN(observed_at) AS floor_ms FROM chain_detail_account_events",
+    [],
+  );
+  if (rows === null || rows.length === 0) return null;
+  return safeBlockNumber(rows[0]?.floor_ms);
+}
+
+/**
+ * One account's newest events from the hot store, newest first.
+ *
+ * THE READ THIS TABLE HAD NO INDEX FOR until migration 0032. It is written by
+ * the chain-detail lane and holds the head of the chain -- measured 2026-08-16,
+ * 931,486 rows spanning 2026-08-15T22:27Z to the head -- and it was indexed for
+ * the two questions the BLOCK routes ask and neither question the ACCOUNT
+ * routes ask. So the account family read past a populated, sub-millisecond
+ * store straight into the lakehouse, where R2 SQL costs seconds per query
+ * almost regardless of what it scans.
+ *
+ * Measured before and after that migration, on an account with nothing in the
+ * window -- the common case, because the quieter the account the more rows the
+ * old plan read to prove there were none:
+ *
+ *   before  748.769 ms, 24,185 buffers, "Rows Removed by Filter: 932266"
+ *   after     0.091 ms,      7 buffers, BitmapOr over the two new indexes
+ *
+ * THE SAME DISJUNCTION the lakehouse leg uses, deliberately: `hotkey = X OR
+ * coldkey = X` stands in for data-api's two-scan merge, and the two tiers
+ * answering the same question differently is the class of bug that makes a feed
+ * change shape depending on how old it is.
+ *
+ * Returns null when the store is unbound or the query fails, never a partial
+ * page: the caller falls through to the lakehouse, which is slower and whole.
+ */
+export async function loadAccountEventsHotTier(
+  env: unknown,
+  ss58: string,
+  limit: number,
+): Promise<Row[] | null> {
+  const need = safeBlockNumber(limit);
+  if (need === null || need <= 0) return null;
+  return query(
+    env,
+    `SELECT ${ACCOUNT_EVENT_COLUMNS} FROM chain_detail_account_events ` +
+      "WHERE hotkey = ? OR coldkey = ? " +
+      "ORDER BY observed_at DESC, block_number DESC, event_index DESC LIMIT ?",
+    [ss58, ss58, need],
+  );
+}
+
 export async function loadBlockExtrinsicsHotTier(
   env: unknown,
   ref: string,

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -35,6 +35,8 @@ import {
   buildSubnetEvents,
 } from "./account-events.ts";
 import {
+  accountEventsHotFloorMs,
+  loadAccountEventsHotTier,
   CHAIN_EVENT_COLUMNS,
   formatChainEvent,
   type ChainEventApi,
@@ -51,6 +53,7 @@ import {
 } from "./account-summary-projection.ts";
 import {
   mergeNewestEvents,
+  type AccountFeedRow,
   type FeedKeyed,
 } from "./account-feeds-cold-tier.ts";
 import {
@@ -168,7 +171,7 @@ async function recentEventsLeg(
      */
     query: typeof r2SqlQuery;
   },
-): Promise<AccountEventsRow[] | null> {
+): Promise<AccountFeedRow[] | null> {
   const { ss58, where, limit, network, query } = options;
   if (network !== DEFAULT_CHAIN_NETWORK) return null;
   const projected = await loadAccountSummaryProjection(env, ss58, {
@@ -177,6 +180,36 @@ async function recentEventsLeg(
   if (projected === null || projected.absent === true) return null;
   const recent = projected.recent;
   if (recent === null || recent.rows.length < limit) return null;
+
+  // THE HEAD, FROM NEON WHEN THE TWO TIERS PROVABLY MEET.
+  //
+  // `chain_detail_account_events` holds the head of the chain in Neon and is
+  // indexed by account since migration 0032: measured 0.091 ms against 748 ms
+  // before it, and against seconds for the same question in R2 SQL. The
+  // projection covers everything at or before its fold edge; this store covers
+  // everything from its own floor upward. When that floor sits at or below the
+  // fold edge the two OVERLAP and together span all of time -- so the whole
+  // page is served with NO lakehouse query at all.
+  //
+  // Measured 2026-08-16: hot floor 22:27Z against a fold edge of 00:00Z, an
+  // overlap of about ninety minutes.
+  //
+  // CHECKED, NEVER ASSUMED. Both edges move on their own schedules -- the
+  // chain-detail lane prunes to a rolling window, the producer folds on its own
+  // cadence -- so a gap is possible and a page built across one would be
+  // silently missing every event in it. `accountEventsHotFloorMs` derives the
+  // floor from the store rather than pinning it, and anything but a proven
+  // overlap falls through to the bounded R2 SQL probe below, which is slower
+  // and correct.
+  const hotFloorMs = await accountEventsHotFloorMs(env);
+  if (hotFloorMs !== null && hotFloorMs <= recent.floorMs) {
+    const hot = await loadAccountEventsHotTier(env, ss58, limit);
+    // A hot-tier failure is not a decline: it means this leg could not be
+    // served from Neon, and the R2 SQL probe below answers the same question.
+    if (hot !== null) {
+      return mergeNewestEvents<AccountFeedRow>(recent.rows, hot, limit);
+    }
+  }
 
   const head = await query<AccountEventsRow>(
     env,
@@ -210,7 +243,7 @@ async function recentEventsLeg(
   // `mergeNewestEvents` is generic over the shape both halves share, so the
   // compiler still checks that these two really do describe the same rows --
   // the job that the `as unknown as` this replaced was destroying.
-  return mergeNewestEvents<AccountEventsRow>(recent.rows, head, limit);
+  return mergeNewestEvents<AccountFeedRow>(recent.rows, head, limit);
 }
 
 export async function loadAccountEventsColdTier(

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -4,6 +4,17 @@
 // stand in for data-api's two-scan hotkey/coldkey read.
 import assert from "node:assert/strict";
 import { afterAll, beforeAll, describe, test, vi } from "vitest";
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { loadAccountEventsHotTier } from "../src/chain-detail-hot-tier.ts";
+
+// The Neon head leg reads `chain_detail_account_events` through
+// src/read-store.ts, which builds `new Client(...)` itself -- so the module is
+// the seam. See tests/helpers/pg-mock.ts for why the controller is built inside
+// vi.hoisted.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
 import {
   loadAccountEventsColdTier,
   loadBlockChainEventsColdTier,
@@ -767,47 +778,49 @@ describe("loadBlockChainEventsColdTier", () => {
  * Measured 2026-08-16: `/events?limit=5` took 6.0s with its scan already
  * floored to five days, against 174ms for the card, which issues no query.
  */
-describe("loadAccountEventsColdTier -- the projection's recent map", () => {
-  const THROUGH = "2026-08-14";
-  const FOLD_FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
-  const FIRST_OBSERVED = 1_700_000_000_010;
+// Shared by the two describes below: the projection leg and the Neon head leg
+// answer the same route and must be measured against one fixture.
+const THROUGH = "2026-08-14";
+const FOLD_FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
+const FIRST_OBSERVED = 1_700_000_000_010;
 
-  /** A published row, in the producer's shape. */
-  const recentRow = (block: number, index = 0) => ({
-    block_number: block,
-    event_index: index,
-    extrinsic_index: 1,
-    event_kind: "NeuronRegistered",
-    hotkey: ADDR,
-    coldkey: null,
-    netuid: 105,
-    uid: 242,
-    amount_tao: null,
-    alpha_amount: null,
-    observed_at: 1_700_000_000_000 + block,
+/** A published row, in the producer's shape. */
+const recentRow = (block: number, index = 0) => ({
+  block_number: block,
+  event_index: index,
+  extrinsic_index: 1,
+  event_kind: "NeuronRegistered",
+  hotkey: ADDR,
+  coldkey: null,
+  netuid: 105,
+  uid: 242,
+  amount_tao: null,
+  alpha_amount: null,
+  observed_at: 1_700_000_000_000 + block,
+});
+
+/** An archive publishing `recent` for this account, as production now does. */
+const withRecent = (rows: unknown[], recentLimit = 10) =>
+  accountSummaryArchive({
+    accounts: {
+      [ADDR]: [
+        {
+          kind: "NeuronRegistered",
+          netuid: 105,
+          count: rows.length,
+          fb: 10,
+          lb: 90,
+          fo: FIRST_OBSERVED,
+          lo: FIRST_OBSERVED,
+        },
+      ],
+    },
+    recent: { [ADDR]: rows },
+    pointer: { recent_limit: recentLimit, recent_from: "2026-07-16" },
+    through: THROUGH,
   });
 
-  /** An archive publishing `recent` for this account, as production now does. */
-  const withRecent = (rows: unknown[], recentLimit = 10) =>
-    accountSummaryArchive({
-      accounts: {
-        [ADDR]: [
-          {
-            kind: "NeuronRegistered",
-            netuid: 105,
-            count: rows.length,
-            fb: 10,
-            lb: 90,
-            fo: FIRST_OBSERVED,
-            lo: FIRST_OBSERVED,
-          },
-        ],
-      },
-      recent: { [ADDR]: rows },
-      pointer: { recent_limit: recentLimit, recent_from: "2026-07-16" },
-      through: THROUGH,
-    });
-
+describe("loadAccountEventsColdTier -- the projection's recent map", () => {
   test("SERVES THE PAGE IN ONE QUERY, not a walk", async () => {
     const q = sqlFetch([]);
     const data = await loadAccountEventsColdTier(
@@ -974,5 +987,177 @@ describe("loadAccountEventsColdTier -- the projection's recent map", () => {
       "testnet",
     );
     assert.equal(asked, 0);
+  });
+});
+
+/**
+ * The head served from NEON instead of R2 SQL, when the two tiers provably meet.
+ *
+ * `chain_detail_account_events` holds the head of the chain in Neon -- measured
+ * 2026-08-16, 931,486 rows from 2026-08-15T22:27Z to the head -- and was
+ * indexed for the two questions the BLOCK routes ask and neither question the
+ * ACCOUNT routes ask. Migration 0032 added the two it needed:
+ *
+ *   before  748.769 ms, 24,185 buffers, "Rows Removed by Filter: 932266"
+ *   after     0.091 ms,      7 buffers, BitmapOr over the new indexes
+ *
+ * The projection covers everything at or before its fold edge; this store
+ * covers everything from its own floor up. When the floor sits at or below the
+ * edge they OVERLAP and the page needs no lakehouse query at all.
+ */
+describe("loadAccountEventsColdTier -- the Neon head", () => {
+  const FOLD_FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
+
+  /** A store answering the floor probe and the per-account read. */
+  function store(floorMs: number | null, rows: Record<string, unknown>[]) {
+    const seen: string[] = [];
+    pg.control.queries.length = 0;
+    pg.control.answers = [];
+    pg.control.rows = null;
+    pg.control.failNext = null;
+    // `onQuery` is handed the RECORDED query, not a bare string -- see
+    // tests/helpers/pg-mock.ts. Reading `.text` is what lets this answer the
+    // floor probe and the per-account read differently from one double.
+    pg.control.onQuery = ({ text }) => {
+      seen.push(text);
+      pg.control.rows = text.includes("MIN(observed_at)")
+        ? floorMs === null
+          ? [{ floor_ms: null }]
+          : [{ floor_ms: floorMs }]
+        : rows;
+    };
+    return { seen, env: pgMockEnv() };
+  }
+
+  const hotRow = (block: number) => ({
+    block_number: block,
+    event_index: 0,
+    extrinsic_index: 1,
+    event_kind: "NeuronRegistered",
+    hotkey: ADDR,
+    coldkey: null,
+    netuid: 105,
+    uid: 242,
+    // A STRING, as pg hands back a numeric -- the generated row type says
+    // `amount_tao: string | null`. If the merge leaked that into the payload,
+    // the same field would change type depending on which tier answered.
+    amount_tao: "12.5",
+    alpha_amount: null,
+    observed_at: 1_700_000_000_000 + block,
+  });
+
+  test("NO LAKEHOUSE QUERY AT ALL when the tiers overlap", async () => {
+    const q = sqlFetch([]);
+    const { env } = store(FOLD_FLOOR - 90 * 60_000, [hotRow(999)]);
+    const data = await loadAccountEventsColdTier(
+      {
+        ...TOKEN,
+        ...env,
+        ...withRecent([recentRow(90), recentRow(80)]),
+      } as never,
+      ADDR,
+      { limit: 2 },
+    );
+    assert.ok(data);
+    assert.equal(q.length, 0, `expected no R2 SQL, got:\n${q.join("\n")}`);
+    assert.equal(data.events[0]!.block_number, 999, "the Neon row must lead");
+  });
+
+  test("A NUMERIC STRING from pg is coerced, not leaked", async () => {
+    // pg returns numerics as strings; the lakehouse returns numbers. The
+    // formatter normalises both, and this pins it -- a feed whose `amount_tao`
+    // is a string on recent events and a number on old ones is a contract that
+    // changes with age.
+    sqlFetch([]);
+    const { env } = store(FOLD_FLOOR - 90 * 60_000, [hotRow(999)]);
+    const data = await loadAccountEventsColdTier(
+      { ...TOKEN, ...env, ...withRecent([recentRow(90)]) } as never,
+      ADDR,
+      { limit: 1 },
+    );
+    assert.equal(typeof data!.events[0]!.amount_tao, "number");
+    assert.equal(data!.events[0]!.amount_tao, 12.5);
+  });
+
+  test("A GAP BETWEEN THE TIERS falls back to the bounded R2 SQL probe", async () => {
+    // Both edges move on their own schedules -- the chain-detail lane prunes to
+    // a rolling window, the producer folds on its own cadence -- so a gap is
+    // possible, and a page built across one is silently missing every event in
+    // it. The floor is DERIVED from the store, never assumed.
+    const q = sqlFetch([]);
+    const { env } = store(FOLD_FLOOR + 60 * 60_000, [hotRow(999)]);
+    await loadAccountEventsColdTier(
+      {
+        ...TOKEN,
+        ...env,
+        ...withRecent([recentRow(90), recentRow(80)]),
+      } as never,
+      ADDR,
+      { limit: 2 },
+    );
+    assert.equal(q.length, 1, "expected the R2 SQL probe");
+    assert.match(q[0]!, new RegExp(`observed_at >= ${FOLD_FLOOR}`));
+  });
+
+  test("A FAILING ACCOUNT READ falls back, even with a good floor", async () => {
+    // The floor probe and the per-account read are two queries and either can
+    // fail alone. A null page here means "not served from Neon", never "this
+    // account has no events" -- so the R2 SQL probe still answers.
+    const q = sqlFetch([]);
+    pg.control.queries.length = 0;
+    pg.control.answers = [];
+    pg.control.rows = null;
+    pg.control.failNext = null;
+    pg.control.onQuery = ({ text }) => {
+      if (text.includes("MIN(observed_at)")) {
+        pg.control.rows = [{ floor_ms: FOLD_FLOOR - 90 * 60_000 }];
+        return;
+      }
+      pg.control.failNext = new Error("store down");
+    };
+    const data = await loadAccountEventsColdTier(
+      {
+        ...TOKEN,
+        ...pgMockEnv(),
+        ...withRecent([recentRow(90), recentRow(80)]),
+      } as never,
+      ADDR,
+      { limit: 2 },
+    );
+    assert.ok(data, "the R2 SQL probe still answers");
+    assert.equal(q.length, 1, "expected the R2 SQL probe");
+  });
+
+  test("A NON-POSITIVE LIMIT reads nothing at all", async () => {
+    // `loadAccountEventsHotTier` is EXPORTED, so "the one caller already
+    // validated it" is a property of today's code and not of the function. A
+    // zero limit must issue no query rather than emitting `LIMIT 0`.
+    pg.control.queries.length = 0;
+    pg.control.onQuery = null;
+    for (const bad of [0, -1, Number.NaN]) {
+      assert.equal(
+        await loadAccountEventsHotTier(pgMockEnv(), ADDR, bad),
+        null,
+      );
+    }
+    assert.equal(pg.control.queries.length, 0, "an unusable limit queried");
+  });
+
+  test("AN UNREADABLE STORE falls back rather than declining", async () => {
+    // A hot-tier failure means this leg could not be served from Neon, not that
+    // the account has no events.
+    const q = sqlFetch([]);
+    const { env } = store(null, []);
+    const data = await loadAccountEventsColdTier(
+      {
+        ...TOKEN,
+        ...env,
+        ...withRecent([recentRow(90), recentRow(80)]),
+      } as never,
+      ADDR,
+      { limit: 2 },
+    );
+    assert.ok(data);
+    assert.equal(q.length, 1, "expected the R2 SQL probe");
   });
 });


### PR DESCRIPTION
## The store was already there

`chain_detail_account_events` is written by the chain-detail lane and holds the head of the chain in Neon. Measured 2026-08-16:

| | |
|---|---|
| rows | 931,486 |
| blocks | 8,853,005 → 8,859,140 |
| span | 2026-08-15T22:27Z → the head |

It is indexed for the two questions the **block** routes ask (`block_number`, `observed_at`) and for **neither** question the **account** routes ask. So the account family read past a populated, sub-millisecond store straight into the lakehouse, where R2 SQL costs seconds per query almost regardless of what it scans — while `/blocks/{ref}`, reading that same store through an index it does have, answers in **0.196 s**.

## What the planner did, before and after migration 0032

EXPLAIN ANALYZE on production, for an account with nothing in the window — the **common** case, not the corner:

```
before   Limit  (actual time=748.742..748.743 rows=0)
           ->  Index Scan Backward using idx_..._observed
                 Filter: ((hotkey = X) OR (coldkey = X))
                 Rows Removed by Filter: 932266
         Execution Time: 748.769 ms      Buffers: 24,185

after    Limit  (actual time=0.069..0.070 rows=0)
           ->  BitmapOr
                 -> Bitmap Index Scan on idx_..._hotkey_observed
                 -> Bitmap Index Scan on idx_..._coldkey_observed
         Execution Time: 0.091 ms        Buffers: 7
```

It walked the entire table backward and discarded every row. The quieter the account, the more it read to prove there was nothing — so the cheapest answer paid the most expensive scan, the same shape #11425 fixed on the lakehouse side.

**Two indexes, not one composite**: the predicate is a disjunction (`hotkey = X OR coldkey = X`, standing in for data-api's two-scan merge) and no single btree serves one. **`observed_at DESC` as the second column** because every one of these reads is newest-first with a LIMIT — with it the index answers the ORDER BY too and the scan stops at `limit`.

Applied to production through the repo's own runner, so the ledger is correct.

## The two tiers overlap, so `/events` needs no lakehouse query at all

- the **projection** covers everything at or before its fold edge
- this **store** covers everything from its own floor up

Measured the same day: hot floor **22:27Z** against a fold edge of **00:00Z** — an overlap of about ninety minutes. Together they span all of time, so the page is served from one R2 object plus one Neon index scan.

**Checked, never assumed.** Both edges move on their own schedules — the chain-detail lane prunes to a rolling window, the producer folds on its own cadence — so a gap is possible, and a page built across one would be *silently* missing every event in it. The floor is derived from the store's own `MIN(observed_at)` rather than pinned, and anything but a proven overlap falls through to the bounded R2 SQL probe. Same for a store that cannot be read, and for a per-account read that fails while the floor probe succeeds.

## The two tiers must not disagree about a row

pg hands back numerics as strings; the lakehouse hands back numbers — the generated row type says `amount_tao: string | null`. `formatAccountEvent` already coerces both, and a test now pins it: a feed whose `amount_tao` is a string on recent events and a number on older ones is a contract that changes with age.

`AccountFeedRow` names the row all three producers answer with, rather than writing `Record<string, unknown>` in a generic position — which the untyped-read ratchet counts, and is right to: a merge that says "any object" reads exactly like a read that forgot its row type.

## Verification

- **Falsified three ways**: remove the Neon leg → 2 tests fail; remove the overlap guard → the gap test fails; the non-positive-limit guard and the failing-account-read path are each pinned directly.
- **Patch coverage 12/12 lines, 14/14 branches**; full suite 21,891 passed; full CI gate 79 targets, 0 failed.
- The index plan above is the verification for the migration itself — measured on production before and after.