### PR TITLE
fix(accounts): the hot tier rejected the quiet accounts it is cheapest for

### DIFF
--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -179,7 +179,21 @@ async function recentEventsLeg(
   });
   if (projected === null || projected.absent === true) return null;
   const recent = projected.recent;
-  if (recent === null || recent.rows.length < limit) return null;
+  // NO LENGTH CHECK, and the first version of this had one -- `rows.length <
+  // limit` -- which was both redundant and WRONG IN THE DIRECTION THAT MATTERS.
+  //
+  // `readRecent` returns a list only when two things already hold: the pointer
+  // publishes at least `limit` events per account (it declines when
+  // `recent_limit < need`), and the list is COMPLETE for this account (it
+  // declines when the list is shorter than `min(published, lifetime)`). So a
+  // list that arrives here is the newest `min(published, lifetime)` events --
+  // every event the account has, when it has fewer than the limit asked for.
+  //
+  // Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC, whose whole history is two
+  // events: `?limit=5` saw a two-row list, read it as "not enough", and walked
+  // the lakehouse anyway -- 13.4s. The check rejected exactly the quiet accounts
+  // the hot tier is cheapest for, which is most of them.
+  if (recent === null) return null;
 
   // THE HEAD, FROM NEON WHEN THE TWO TIERS PROVABLY MEET.
   //

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -943,18 +943,39 @@ describe("loadAccountEventsColdTier -- the projection's recent map", () => {
     }
   });
 
-  test("DECLINES when the caller wants more rows than the list holds", async () => {
-    // A short list is indistinguishable from a short account, so asking for
-    // more than it holds cannot be answered from it.
+  test("A SHORT BUT COMPLETE LIST IS SERVED, not treated as insufficient", async () => {
+    // The bug the first version of this shipped. `readRecent` returns a list
+    // only when the pointer publishes at least `limit` per account AND the list
+    // is complete for this account -- so two rows for an account with two
+    // lifetime events IS the answer to `?limit=5`, not a short page.
     //
-    // ASSERTED ON THE BOUND, NOT THE QUERY COUNT. Since #11431 the walk clamps
-    // to the projection's floor and can also finish in one query, so counting
-    // them no longer tells the two tiers apart. The bound does: the hot probe
-    // starts at the generation's fold edge, the walk at this account's own
-    // first observed event.
+    // Measured 2026-08-16 on 5EEmaGFE...5oM3qDSC, whose whole history is two
+    // events: a `rows.length < limit` check read that as "not enough" and
+    // walked the lakehouse anyway, 13.4s. It rejected exactly the quiet
+    // accounts the hot tier is cheapest for, which is most of them.
+    const q = sqlFetch([]);
+    const data = await loadAccountEventsColdTier(
+      { ...TOKEN, ...withRecent([recentRow(90), recentRow(80)]) } as never,
+      ADDR,
+      { limit: 5 },
+    );
+    assert.ok(data);
+    assert.equal(data.events.length, 2, "both published events are served");
+    assert.equal(q.length, 1, `expected one head probe:\n${q.join("\n")}`);
+    assert.match(q[0]!, new RegExp(`observed_at >= ${FOLD_FLOOR}`));
+  });
+
+  test("DECLINES when the POINTER publishes fewer than the limit asks", async () => {
+    // The real insufficiency, and the only one the artifact can express: a
+    // generation publishing ten per account cannot answer a request for twenty,
+    // because the eleventh through twentieth were never written. That is a fact
+    // about the producer, not about the account.
     const q = sqlFetch([]);
     await loadAccountEventsColdTier(
-      { ...TOKEN, ...withRecent([recentRow(90), recentRow(80)]) } as never,
+      {
+        ...TOKEN,
+        ...withRecent([recentRow(90), recentRow(80)], 2),
+      } as never,
       ADDR,
       { limit: 5 },
     );


### PR DESCRIPTION
#11435 shipped `recent.rows.length < limit` as a guard on the projection leg. It is **redundant** and **wrong in the direction that matters**.

## Why it is redundant

`readRecent` returns a list only when two things already hold:

1. the pointer publishes at least `limit` events per account — it declines when `recent_limit < need`
2. the list is **complete** for this account — it declines when the list is shorter than `min(published, lifetime)`

So a list that arrives at the caller *is* the newest `min(published, lifetime)` events. For an account with fewer events than the limit asked for, that is **every event it has**.

## Why it was harmful

Measured 2026-08-16 on `5EEmaGFEAtAWCviYezuMbutPummVsk9zMXJzcnNo5oM3qDSC`, whose entire history is two events:

```
/events?limit=5   →  a two-row list, read as "not enough"  →  walked the lakehouse  →  13.4s
```

against the sub-second answer the projection plus the Neon head (#11437) can give. The check rejected exactly the quiet accounts the hot tier is cheapest for — which is most of them. It was the reason #11435 and #11437 measured no better than before in production.

## The real insufficiency

The only one the artifact can express, and `readRecent` already enforces it: a generation publishing ten events per account cannot answer a request for twenty, because the eleventh through twentieth were never written. That is a fact about the **producer**, not about the account.

The test that asserted the old behaviour pinned the bug; it now states that contract instead, and a second test pins the short-but-complete case.

## Verification

- **Falsified**: restoring the old guard fails the new test.
- Patch coverage 1/1 lines, 2/2 branches; full CI gate 79 targets, 0 failed.