### PR TITLE
perf(accounts): the pointer was fetched on every request for an object that changes once an hour

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -58,6 +58,8 @@ import {
   AccountSummaryRecentSchema,
 } from "../schemas-src/artifacts/account-summary-projection.ts";
 import type { R2SqlEnv } from "./r2-sql.ts";
+import { z } from "zod";
+import { registerModuleStateReset } from "./module-state-registry.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 
 /** Objects the producer writes, one per shard. Contract with
@@ -240,6 +242,56 @@ async function readJson(
  * lifetime total and publishing it would be a better number -- but a route
  * whose meaning depends on its tier is worse than either.
  */
+/**
+ * How long a resolved pointer is reused inside one isolate.
+ *
+ * FIVE MINUTES against an hourly producer, the same ratio
+ * `resolveDecodeWatermark` uses and for the same reason: it bounds the visible
+ * lag at ~8% of the producer's own cadence, which is well inside the freshness
+ * this artifact already claims (`ACCOUNT_SUMMARY_MAX_AGE_MS` is three days).
+ */
+export const ACCOUNT_SUMMARY_POINTER_TTL_MS = 5 * 60_000;
+
+/** The resolved pointer and when it expires. The PROMISE is memoized, not the
+ * value, so concurrent requests on a cold isolate share one R2 GET instead of
+ * racing to issue several. */
+let pointerMemo: {
+  expiresAt: number;
+  value: Promise<z.infer<typeof AccountSummaryPointerSchema> | null>;
+} | null = null;
+
+registerModuleStateReset("src/account-summary-projection.ts", () => {
+  pointerMemo = null;
+});
+
+/** Drop the memo so the next resolve re-reads R2. Exported for tests, and
+ * called on a shard miss -- see the call site for why that is what makes
+ * memoizing safe at all. */
+export function resetAccountSummaryPointerCache(): void {
+  pointerMemo = null;
+}
+
+async function resolvePointer(
+  bucket: ArtifactBucket,
+  now: () => number,
+): Promise<z.infer<typeof AccountSummaryPointerSchema> | null> {
+  const at = now();
+  if (pointerMemo && pointerMemo.expiresAt > at) return pointerMemo.value;
+  const value = (async () => {
+    const parsed = AccountSummaryPointerSchema.safeParse(
+      await readJson(bucket, ACCOUNT_SUMMARY_POINTER_KEY),
+    );
+    return parsed.success ? parsed.data : null;
+  })();
+  // A FAILED READ IS NOT MEMOIZED for the TTL: it is stored so concurrent
+  // callers share the in-flight request, then cleared, so a transient R2 blip
+  // costs one request rather than five minutes of declines.
+  pointerMemo = { expiresAt: at + ACCOUNT_SUMMARY_POINTER_TTL_MS, value };
+  const resolved = await value;
+  if (resolved === null) pointerMemo = null;
+  return resolved;
+}
+
 export async function loadAccountSummaryProjection(
   env: R2SqlEnv | null | undefined,
   account: string,
@@ -271,11 +323,14 @@ export async function loadAccountSummaryProjection(
   // `generated_at`, a POSITIVE INTEGER `shard_count`) are the two the previous
   // hand-rolled checks existed to enforce. See the schema's header for why each
   // one is load-bearing.
-  const parsedPointer = AccountSummaryPointerSchema.safeParse(
-    await readJson(bucket, ACCOUNT_SUMMARY_POINTER_KEY),
-  );
-  if (!parsedPointer.success) return null;
-  const pointer = parsedPointer.data;
+  //
+  // MEMOIZED, because this object changes once an hour and was being fetched on
+  // EVERY account request. Measured 2026-08-16, an R2 artifact read from this
+  // Worker costs ~370 ms (`/api/v1/coverage`, which does exactly one), and the
+  // projection does two in sequence -- the pointer, then the shard it names --
+  // so the pointer alone was a third of the wall clock on the fast path.
+  const pointer = await resolvePointer(bucket, now);
+  if (pointer === null) return null;
   if (pointer.schema_version !== ACCOUNT_SUMMARY_SCHEMA_VERSION) return null;
   const shards = pointer.shard_count;
   const generation = pointer.generation;
@@ -287,7 +342,20 @@ export async function loadAccountSummaryProjection(
     bucket,
     accountSummaryShardKey(account, shards, generation),
   );
-  if (!payload) return null;
+  // A MISS INVALIDATES THE MEMO, and that is what makes memoizing the pointer
+  // safe. The producer deletes a generation's shards once the next one is live,
+  // so a memoized pointer can name a generation that no longer exists -- and
+  // without this every account request would decline for the rest of the TTL,
+  // turning a 370 ms saving into a multi-minute outage once an hour.
+  //
+  // Dropping it here means the NEXT request re-reads the pointer and succeeds,
+  // so the window is one request rather than one TTL. This request still
+  // declines, which is correct: it has no shard to answer from, and the caller
+  // falls back to the lakehouse exactly as it did before the projection existed.
+  if (!payload) {
+    resetAccountSummaryPointerCache();
+    return null;
+  }
   const accounts = payload["accounts"];
   if (!accounts || typeof accounts !== "object") return null;
 

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -215,9 +215,23 @@ async function recentEventsLeg(
   // floor from the store rather than pinning it, and anything but a proven
   // overlap falls through to the bounded R2 SQL probe below, which is slower
   // and correct.
-  const hotFloorMs = await accountEventsHotFloorMs(env);
+  // BOTH NEON READS AT ONCE. The floor probe answers "does this store reach
+  // below the fold edge" and the page read answers "what does it hold for this
+  // account" -- neither input depends on the other's result, so issuing them in
+  // sequence spent two round trips where one wall-clock wait would do. The
+  // overlap is still CHECKED before the rows are used; running the read early
+  // costs one query that gets discarded when the check fails, against halving
+  // the latency of the path that succeeds.
+  //
+  // Not memoized, deliberately. A cached floor is only wrong when the prune has
+  // moved above the fold edge inside the TTL -- rare, small, and silent, which
+  // is the combination that makes a bug survive. Parallelism buys the same
+  // latency with none of that.
+  const [hotFloorMs, hot] = await Promise.all([
+    accountEventsHotFloorMs(env),
+    loadAccountEventsHotTier(env, ss58, limit),
+  ]);
   if (hotFloorMs !== null && hotFloorMs <= recent.floorMs) {
-    const hot = await loadAccountEventsHotTier(env, ss58, limit);
     // A hot-tier failure is not a decline: it means this leg could not be
     // served from Neon, and the R2 SQL probe below answers the same question.
     if (hot !== null) {

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -11,13 +11,14 @@
 // capped-scan boundary must survive the probe that used to answer it being
 // folded into the aggregate (it was the query that aborted -- see "two reads").
 import assert from "node:assert/strict";
+import { resetAccountSummaryPointerCache } from "../src/account-summary-projection.ts";
 import { visibleInWindow } from "./helpers/scan-window.ts";
 import {
   ACCOUNT_SUMMARY_POINTER_KEY,
   accountSummaryShardKey,
 } from "../src/account-summary-projection.ts";
 import { readFileSync } from "node:fs";
-import { describe, test } from "vitest";
+import { describe, test, beforeEach } from "vitest";
 import {
   foldSummaryGroups,
   loadAccountSummaryColdTier,
@@ -31,6 +32,12 @@ import {
 } from "../src/account-events.ts";
 
 type Row = Record<string, unknown>;
+
+// The pointer memo is module-level and reset only between test FILES, so
+// whichever test resolved it first would decide every later test's generation.
+// Same reasoning as `resetDecodeWatermarkCache` in
+// tests/analytics-edge-cache.test.ts.
+beforeEach(() => resetAccountSummaryPointerCache());
 
 const SS58 = "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
 

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -6,7 +6,7 @@
 // the other direction: reading a HALF-PUBLISHED generation, or accepting a
 // payload it should have refused.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, beforeEach } from "vitest";
 import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "../src/account-events.ts";
 import {
   AccountSummaryPointerSchema,
@@ -23,8 +23,17 @@ import {
   type AccountSummaryProjectionRead,
   recentFloorMs,
   accountHistoryFloorMs,
+  ACCOUNT_SUMMARY_POINTER_TTL_MS,
 } from "../src/account-summary-projection.ts";
 import { DEFAULT_CHAIN_NETWORK } from "../src/chain-network.ts";
+import { resetAccountSummaryPointerCache } from "../src/account-summary-projection.ts";
+
+// The pointer memo is module-level and reset only between test FILES, so
+// whichever test resolved it first would decide every later test's generation.
+// Same reasoning as `resetDecodeWatermarkCache` in
+// tests/analytics-edge-cache.test.ts: a file that varies the artifact per test
+// has to own the memo that would otherwise answer from the previous one.
+beforeEach(() => resetAccountSummaryPointerCache());
 
 const HOT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 const COLD = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
@@ -1124,5 +1133,92 @@ describe("the pointer, against a producer that deploys independently", () => {
     const found = await readFound(store.env, HOT, FRESH);
     assert.equal(found.groups.length, 1);
     assert.ok(found.span, "the floor every account route depends on");
+  });
+});
+
+/**
+ * The pointer memo, and the miss that makes it safe.
+ *
+ * Measured 2026-08-16: an R2 artifact read from this Worker costs ~370 ms
+ * (`/api/v1/coverage`, which does exactly one), and the projection does two in
+ * sequence -- the pointer, then the shard it names. The pointer changes once an
+ * hour and was being fetched on EVERY account request.
+ */
+describe("the pointer memo", () => {
+  const FRESH_POINTER = () => ({ generated_at: nowIso() });
+
+  test("ONE R2 READ across many callers, not one each", async () => {
+    const store = archive(published({ [HOT]: [group()] }, FRESH_POINTER()));
+    for (let i = 0; i < 4; i += 1) {
+      await loadAccountSummaryProjection(store.env, HOT);
+    }
+    const pointerReads = store.asked.filter(
+      (key) => key === ACCOUNT_SUMMARY_POINTER_KEY,
+    ).length;
+    assert.equal(pointerReads, 1, store.asked.join("\n"));
+    assert.equal(
+      store.asked.length,
+      5,
+      "one pointer read plus one shard read per caller",
+    );
+  });
+
+  test("CONCURRENT CALLERS SHARE ONE IN-FLIGHT READ", async () => {
+    // The PROMISE is memoized, not the value, so a cold isolate taking four
+    // simultaneous requests issues one R2 GET rather than racing four.
+    const store = archive(published({ [HOT]: [group()] }, FRESH_POINTER()));
+    await Promise.all(
+      [0, 1, 2, 3].map(() => loadAccountSummaryProjection(store.env, HOT)),
+    );
+    assert.equal(
+      store.asked.filter((key) => key === ACCOUNT_SUMMARY_POINTER_KEY).length,
+      1,
+    );
+  });
+
+  test("A SHARD MISS DROPS THE MEMO, so the next request re-reads", async () => {
+    // THE THING THAT MAKES MEMOIZING SAFE AT ALL. The producer deletes a
+    // generation's shards once the next one is live, so a memoized pointer can
+    // name a generation that no longer exists. Without this, every account
+    // request would decline for the rest of the TTL -- turning a 370 ms saving
+    // into a multi-minute outage once an hour.
+    const gone = archive({
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer(FRESH_POINTER()),
+    });
+    assert.equal(await loadAccountSummaryProjection(gone.env, HOT), null);
+
+    const live = archive(published({ [HOT]: [group()] }, FRESH_POINTER()));
+    const found = await readFound(live.env, HOT, FRESH);
+    assert.equal(
+      found.groups.length,
+      1,
+      "the next request re-read the pointer",
+    );
+    assert.ok(
+      live.asked.includes(ACCOUNT_SUMMARY_POINTER_KEY),
+      "it must not have answered from the dropped memo",
+    );
+  });
+
+  test("AN UNREADABLE POINTER IS NOT MEMOIZED for the TTL", async () => {
+    // A transient R2 blip must cost one request, not five minutes of declines.
+    const broken = archive({ [ACCOUNT_SUMMARY_POINTER_KEY]: { nope: 1 } });
+    assert.equal(await loadAccountSummaryProjection(broken.env, HOT), null);
+
+    const live = archive(published({ [HOT]: [group()] }, FRESH_POINTER()));
+    const found = await readFound(live.env, HOT, FRESH);
+    assert.equal(found.groups.length, 1);
+  });
+
+  test("THE MEMO EXPIRES, so a new generation is picked up", async () => {
+    const first = archive(published({ [HOT]: [group()] }, FRESH_POINTER()));
+    await loadAccountSummaryProjection(first.env, HOT);
+    const later = () => Date.now() + ACCOUNT_SUMMARY_POINTER_TTL_MS + 1;
+    const second = archive(published({ [HOT]: [group()] }, FRESH_POINTER()));
+    await loadAccountSummaryProjection(second.env, HOT, { now: later });
+    assert.ok(
+      second.asked.includes(ACCOUNT_SUMMARY_POINTER_KEY),
+      "past the TTL the pointer must be re-read",
+    );
   });
 });

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -3,7 +3,7 @@
 // one equivalence specific to this module: the single OR disjunction must
 // stand in for data-api's two-scan hotkey/coldkey read.
 import assert from "node:assert/strict";
-import { afterAll, beforeAll, describe, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, test, vi, beforeEach } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 import { loadAccountEventsHotTier } from "../src/chain-detail-hot-tier.ts";
 
@@ -24,8 +24,16 @@ import {
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import { encodeCursor } from "../src/cursor.ts";
 import { accountSummaryArchive } from "./helpers/cold-tier-env.ts";
+import { resetAccountSummaryPointerCache } from "../src/account-summary-projection.ts";
 import { visibleInWindow } from "./helpers/scan-window.ts";
 import { OFFSET_EMULATION_CAP } from "../src/r2-sql-blocks.ts";
+
+// The pointer memo is module-level and reset only between test FILES, so
+// whichever test resolved it first would decide every later test's generation.
+// Same reasoning as `resetDecodeWatermarkCache` in
+// tests/analytics-edge-cache.test.ts: a file that varies the artifact per test
+// has to own the memo that would otherwise answer from the previous one.
+beforeEach(() => resetAccountSummaryPointerCache());
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 const ADDR = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";


### PR DESCRIPTION
## The cost

Measured 2026-08-16: an R2 artifact read from this Worker costs **~370 ms** (`/api/v1/coverage` does exactly one), and the projection does **two in sequence** — the pointer, then the shard it names.

The pointer is a single object for the whole fleet, republished once per producer pass. Every account request was fetching it. That was roughly a third of the wall clock on the fast path.

Memoized per isolate, **5 minutes against an hourly producer** — the same ratio `resolveDecodeWatermark` uses, bounding visible lag at ~8% of the producer's cadence and far inside the three days this artifact's own freshness ceiling allows. The **promise** is memoized rather than the value, so a cold isolate taking four simultaneous requests issues one R2 GET instead of racing four.

## The miss is what makes it safe

The producer deletes a generation's shards once the next one is live — verified by hand: generation `20260816T173020Z`'s shard 12350 was already gone while `20260816T183102Z`'s was serving.

So a memoized pointer **can** name a generation that no longer exists. Without a way out, every account request would decline for the rest of the TTL — converting a 370 ms saving into a multi-minute outage once an hour, which is worse than the problem it solves.

A shard miss therefore **drops the memo**. This request still declines (it has no shard to answer from, and the caller falls back to the lakehouse exactly as before the projection existed), but the next one re-reads the pointer and succeeds. The window is one request rather than one TTL.

An unreadable pointer isn't memoized either, for the same reason at smaller scale: a transient R2 blip must cost one request, not five minutes of declines.

## Both Neon reads at once

`accountEventsHotFloorMs` and `loadAccountEventsHotTier` answer different questions — *does this store reach below the fold edge*, and *what does it hold for this account* — and neither input depends on the other's result. They ran in sequence.

The overlap is still **checked** before the rows are used; issuing the read early costs one query that gets discarded when the check fails, against halving the wall clock of the path that succeeds.

Deliberately **not** a memo on the floor: a cached floor is wrong exactly when the prune has moved above the fold edge inside the TTL — rare, small, and silent, which is the combination that lets a bug survive. Parallelism buys the same latency with none of it.

## Verification

- **Falsified three ways**: remove the memo → 2 tests fail; remove the miss-invalidation → the stale-generation test fails; the TTL expiry, the concurrent-share and the unreadable-pointer paths are each pinned.
- Three test files now reset the memo per test, for the reason `analytics-edge-cache.test.ts` states about the decode watermark: module state is reset between *files*, so a file that varies the artifact per test must own the memo that would otherwise answer from the previous one.
- **Patch coverage 20/20 lines, 12/12 branches**; full suite 955 files / 21,904 passed; full CI gate 79 targets, 0 failed.