### PR TITLE
feat(observability): Server-Timing from the three storage boundaries, because optimising these routes meant guessing

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -60,6 +60,7 @@ import {
 import type { R2SqlEnv } from "./r2-sql.ts";
 import { z } from "zod";
 import { registerModuleStateReset } from "./module-state-registry.ts";
+import { timed, TIMING_R2 } from "./request-timing.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 
 /** Objects the producer writes, one per shard. Contract with
@@ -209,6 +210,13 @@ interface ArtifactBucket {
 }
 
 async function readJson(
+  bucket: ArtifactBucket,
+  key: string,
+): Promise<Record<string, unknown> | null> {
+  return timed(TIMING_R2, () => readJsonOnce(bucket, key));
+}
+
+async function readJsonOnce(
   bucket: ArtifactBucket,
   key: string,
 ): Promise<Record<string, unknown> | null> {

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -39,6 +39,7 @@ import { z } from "zod";
 import { recordExceptionEvent, type TelemetryEnv } from "./usage-telemetry.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { LAKEHOUSE_ROW_SCHEMAS } from "../schemas-src/lakehouse.ts";
+import { timed, TIMING_R2_SQL } from "./request-timing.ts";
 import { LAKEHOUSE_NAMESPACES } from "./chain-network.ts";
 import { R2SqlBodySchema } from "../schemas-src/r2-sql-envelope.ts";
 import type { R2SqlMetrics } from "../schemas-src/r2-sql-envelope.ts";
@@ -700,6 +701,16 @@ export type R2SqlReader = (
 ) => Promise<Record<string, unknown>[] | null>;
 
 export async function r2SqlQuery<Row = Record<string, unknown>>(
+  env: R2SqlEnv | null | undefined,
+  sql: string,
+  deps: R2SqlDeps = {},
+): Promise<Row[] | null> {
+  return timed(TIMING_R2_SQL, () => r2SqlQueryOnce<Row>(env, sql, deps));
+}
+
+/** The query itself. Split from the timed wrapper above so the boundary is
+ * measured in ONE place rather than at each of this function's ~20 returns. */
+async function r2SqlQueryOnce<Row = Record<string, unknown>>(
   env: R2SqlEnv | null | undefined,
   sql: string,
   deps: R2SqlDeps = {},

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -35,6 +35,7 @@
 // answer, which is the failure mode this whole migration keeps having to
 // design against.
 import { Client } from "pg";
+import { timed, TIMING_NEON } from "./request-timing.ts";
 import { toPositionalPlaceholders } from "./pg-sql.ts";
 
 /** The minimal pg client this needs, so a test can hand it a fake. */
@@ -310,7 +311,9 @@ export function pgReadStore(
   connectionString: string,
   deps: ReadStoreDeps = {},
 ): ReadStoreDb {
-  const run = async (text: string, values: unknown[]) => {
+  const run = async (text: string, values: unknown[]) =>
+    timed(TIMING_NEON, () => runOnce(text, values));
+  const runOnce = async (text: string, values: unknown[]) => {
     const client =
       deps.clientFactory?.(connectionString) ??
       new Client({ connectionString });

--- a/src/request-timing.ts
+++ b/src/request-timing.ts
@@ -1,0 +1,137 @@
+// Where a request's milliseconds actually went, as `Server-Timing`.
+//
+// ## Why this exists
+//
+// Optimising these routes on 2026-08-16 meant guessing. `/accounts/{ss58}`
+// issues 28 requests across three storage layers -- an R2 artifact, Neon, and
+// R2 SQL over Iceberg -- and NOTHING said which one a given millisecond
+// belonged to. The same request measured 1.8s and 8.8s twenty minutes apart,
+// and the tell that it was not the code came from a route nobody had touched:
+// `/blocks/{ref}` moved 0.196s -> 4.65s in the same window, because the shared
+// Neon compute was contended. Three separate optimisations were made against
+// end-to-end numbers that could not distinguish any of that.
+//
+// A cache hit is 0.12s and a cold read is seconds; between those two facts sit
+// three storage layers and no measurement. This is the measurement.
+//
+// ## Why the BOUNDARIES and not the routes
+//
+// Instrumenting handlers would mean touching every one of them and remembering
+// to on the next -- the same argument `withEdgeCache`, `dataRouteRateLimit` and
+// `labelDegradedResponse` all make for living at the dispatch point. There are
+// exactly three places a request can spend real time here, and each has ONE
+// function in front of it:
+//
+//   neon    `pgReadStore`'s runner      src/read-store.ts
+//   r2sql   `r2SqlQuery`                src/r2-sql.ts
+//   r2      the projection's `readJson` src/account-summary-projection.ts
+//
+// Instrument those and every route -- including ones written next year -- is
+// covered without its author doing anything.
+//
+// The tier that answered falls out of the same data rather than needing a
+// mechanism of its own: `r2sql;count=0` beside `neon;count=2` IS "served from
+// the hot tier", and no separate header can disagree with it.
+//
+// ## AsyncLocalStorage, and why it is safe here
+//
+// `nodejs_compat` is on, so the store is native. It is what lets a counter deep
+// in `r2SqlQuery` attribute to the right request without threading a context
+// through forty call sites -- the exact cost src/tracing.ts's header cites as
+// its reason for NOT nesting spans.
+//
+// The alternative in this repo is `degradedSnapshot`'s module-global
+// counter-and-diff, which documents that a concurrent request can label this
+// one. That trade is defensible for a boolean that errs safe; it is not
+// defensible for a number, where cross-request bleed does not degrade the
+// answer, it invents one.
+//
+// ## Cost when nobody is looking
+//
+// `mark` outside a request scope is a map lookup returning undefined, and
+// `timed` still awaits its callback. No allocation per call, no header emitted
+// when nothing was measured.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** One boundary's tally for one request. */
+export interface TimingMark {
+  /** Total wall time across every call, in milliseconds. */
+  durationMs: number;
+  /** How many calls -- the number that names the TIER that answered. */
+  count: number;
+}
+
+const store = new AsyncLocalStorage<Map<string, TimingMark>>();
+
+/**
+ * Run `fn` with a fresh timing scope.
+ *
+ * Nested calls REUSE the outer scope rather than shadowing it, so a handler
+ * that wraps itself does not silently drop the marks its caller collected.
+ */
+export function withRequestTiming<T>(fn: () => Promise<T>): Promise<T> {
+  if (store.getStore()) return fn();
+  return store.run(new Map(), fn);
+}
+
+/** Add `ms` to a boundary's tally. A no-op outside a request scope. */
+export function mark(name: string, ms: number): void {
+  const marks = store.getStore();
+  if (!marks) return;
+  const existing = marks.get(name);
+  if (existing) {
+    existing.durationMs += ms;
+    existing.count += 1;
+    return;
+  }
+  marks.set(name, { durationMs: ms, count: 1 });
+}
+
+/**
+ * Time `fn` under `name`, whatever it does.
+ *
+ * THE TIMER RUNS ON THE FAILURE PATH TOO. A boundary that threw still spent the
+ * time, and a request whose slowness came from a read that timed out is exactly
+ * the one worth measuring -- dropping it would make the header quietest about
+ * the requests it exists for.
+ */
+export async function timed<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  if (!store.getStore()) return fn();
+  const started = Date.now();
+  try {
+    return await fn();
+  } finally {
+    mark(name, Date.now() - started);
+  }
+}
+
+/** The marks collected so far, or null outside a request scope. */
+export function requestTimings(): ReadonlyMap<string, TimingMark> | null {
+  return store.getStore() ?? null;
+}
+
+/**
+ * The `Server-Timing` value for this request, or null when nothing was
+ * measured -- an empty header is noise on the ~40 routes that touch no store.
+ *
+ * `dur` and `desc` are the standard's own fields; `count` rides in `desc`
+ * because the standard has no field for it and inventing a key would put this
+ * outside what a browser's devtools panel will render. That panel is most of
+ * the value: it is where somebody debugging a slow page will actually look.
+ */
+export function serverTimingHeader(
+  marks: ReadonlyMap<string, TimingMark> | null = requestTimings(),
+): string | null {
+  if (!marks || marks.size === 0) return null;
+  return [...marks.entries()]
+    .map(
+      ([name, { durationMs, count }]) =>
+        `${name};dur=${durationMs};desc="${count} call${count === 1 ? "" : "s"}"`,
+    )
+    .join(", ");
+}
+
+/** The boundary names, so a reader and a writer cannot drift. */
+export const TIMING_NEON = "neon";
+export const TIMING_R2_SQL = "r2sql";
+export const TIMING_R2 = "r2";

--- a/tests/account-edge-cache.test.ts
+++ b/tests/account-edge-cache.test.ts
@@ -343,3 +343,54 @@ describe("the account edge cache", () => {
     assert.equal(cache.putKeys.length, 1, "the HEAD stored its own entry");
   });
 });
+
+/**
+ * `Server-Timing`, from the three storage boundaries.
+ *
+ * The header exists because optimising these routes meant guessing: the same
+ * request measured 1.8s and 8.8s twenty minutes apart, and a route nobody had
+ * touched moved 0.196s -> 4.65s in the same window because the shared Neon
+ * compute was contended. Nothing said which layer a millisecond belonged to.
+ */
+describe("server-timing", () => {
+  test("NAMES THE BOUNDARY THAT SPENT THE TIME", async () => {
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    const res = await get(EVENTS, envAt(8_800_000));
+    const timing = res.headers.get("server-timing");
+    assert.ok(timing, "no server-timing header at all");
+    // The lakehouse leg ran, so it must be named -- and named with a count,
+    // which is what makes `r2sql;desc="0 calls"` unrepresentable rather than
+    // ambiguous: a boundary that did not run simply is not there.
+    assert.match(timing, /r2sql;dur=\d+;desc="\d+ calls?"/, timing);
+    assert.match(timing, /r2;dur=\d+;desc="\d+ calls?"/, timing);
+  });
+
+  test("A ROUTE THAT TOUCHES NO STORE emits nothing", async () => {
+    // ~40 routes read no store at all. An empty header on those is noise.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/networks"),
+      envAt(8_800_000),
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("server-timing"), null);
+  });
+
+  test("IT IS EXPOSED, or a browser cannot read it", async () => {
+    // The UI is served from metagraph.sh and calls api.metagraph.sh, so an
+    // unexposed timing header is a timing header nobody uses.
+    const cache = mockCaches();
+    cache.install();
+    countLakehouse();
+    const res = await get(EVENTS, envAt(8_800_000));
+    assert.match(
+      res.headers.get("access-control-expose-headers") ?? "",
+      /\bserver-timing\b/,
+    );
+  });
+});

--- a/tests/request-timing.test.ts
+++ b/tests/request-timing.test.ts
@@ -1,0 +1,132 @@
+// Where a request's milliseconds went, as `Server-Timing`.
+//
+// Optimising the account routes on 2026-08-16 meant guessing: the same request
+// measured 1.8s and 8.8s twenty minutes apart, and the tell that it was not the
+// code came from a route nobody had touched -- `/blocks/{ref}` moved
+// 0.196s -> 4.65s in the same window, because the shared Neon compute was
+// contended. Three optimisations were made against numbers that could not
+// distinguish any of that.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  mark,
+  requestTimings,
+  serverTimingHeader,
+  timed,
+  TIMING_NEON,
+  TIMING_R2,
+  TIMING_R2_SQL,
+  withRequestTiming,
+} from "../src/request-timing.ts";
+
+describe("request timing", () => {
+  test("MARKS FROM CONCURRENT REQUESTS DO NOT MIX", async () => {
+    // The property that decides the whole design. The repo's other
+    // collect-from-deep mechanism (`degradedSnapshot`) is a module global and
+    // documents that a concurrent request can label this one -- defensible for
+    // a boolean that errs safe, indefensible for a number, where bleed does not
+    // degrade the answer, it invents one.
+    const seen: (string | null)[] = [];
+    await Promise.all([
+      withRequestTiming(async () => {
+        mark(TIMING_NEON, 10);
+        // Yield, so the other request runs inside this one's scope.
+        await Promise.resolve();
+        mark(TIMING_NEON, 10);
+        seen.push(serverTimingHeader());
+      }),
+      withRequestTiming(async () => {
+        mark(TIMING_R2_SQL, 500);
+        await Promise.resolve();
+        seen.push(serverTimingHeader());
+      }),
+    ]);
+    assert.deepEqual(seen.sort(), [
+      `neon;dur=20;desc="2 calls"`,
+      `r2sql;dur=500;desc="1 call"`,
+    ]);
+  });
+
+  test("THE CALL COUNT IS WHAT NAMES THE TIER", async () => {
+    // `r2sql;count=0` beside `neon;count=2` IS "served from the hot tier", so
+    // no separate header can disagree with it. That is why the count rides
+    // along rather than the duration alone.
+    const header = await withRequestTiming(async () => {
+      mark(TIMING_R2, 40);
+      mark(TIMING_R2, 35);
+      mark(TIMING_NEON, 3);
+      return serverTimingHeader();
+    });
+    assert.equal(
+      header,
+      `r2;dur=75;desc="2 calls"`.concat(`, neon;dur=3;desc="1 call"`),
+    );
+  });
+
+  test("NOTHING MEASURED EMITS NO HEADER", async () => {
+    // ~40 routes touch no store at all. An empty header on those is noise.
+    assert.equal(
+      await withRequestTiming(async () => serverTimingHeader()),
+      null,
+    );
+  });
+
+  test("OUTSIDE A REQUEST SCOPE every entry point is inert", () => {
+    // Cron ticks, queue consumers and direct unit calls all reach these
+    // boundaries. They must cost a map lookup, not an allocation.
+    assert.equal(requestTimings(), null);
+    mark(TIMING_NEON, 99);
+    assert.equal(serverTimingHeader(), null);
+  });
+
+  test("`timed` STILL RUNS ITS CALLBACK outside a scope", async () => {
+    // The boundaries call it unconditionally; a version that skipped the work
+    // when unscoped would break every cron that reads a store.
+    let ran = false;
+    const out = await timed(TIMING_NEON, async () => {
+      ran = true;
+      return 7;
+    });
+    assert.equal(out, 7);
+    assert.equal(ran, true);
+  });
+
+  test("A THROWING BOUNDARY IS STILL MEASURED", async () => {
+    // A boundary that threw still spent the time, and a request whose slowness
+    // came from a read that timed out is exactly the one worth measuring --
+    // dropping it would make this quietest about the requests it exists for.
+    const header = await withRequestTiming(async () => {
+      await timed(TIMING_R2_SQL, async () => {
+        throw new Error("query aborted");
+      }).catch(() => null);
+      return serverTimingHeader();
+    });
+    assert.match(header ?? "", /^r2sql;dur=\d+;desc="1 call"$/);
+  });
+
+  test("A NESTED SCOPE REUSES THE OUTER ONE", async () => {
+    // A handler that wraps itself must not silently drop what its caller
+    // collected.
+    const header = await withRequestTiming(async () => {
+      mark(TIMING_NEON, 5);
+      await withRequestTiming(async () => {
+        mark(TIMING_NEON, 5);
+      });
+      return serverTimingHeader();
+    });
+    assert.equal(header, `neon;dur=10;desc="2 calls"`);
+  });
+
+  test("the header PARSES as the standard's own grammar", async () => {
+    // The browser devtools panel is most of the value here, and it renders
+    // `name;dur=<number>;desc="<string>"` -- anything else is dropped silently.
+    const header = await withRequestTiming(async () => {
+      mark(TIMING_NEON, 1);
+      mark(TIMING_R2_SQL, 2);
+      return serverTimingHeader();
+    });
+    for (const entry of (header ?? "").split(", ")) {
+      assert.match(entry, /^[a-z0-9]+;dur=\d+(?:\.\d+)?;desc="[^"]*"$/, entry);
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -299,6 +299,10 @@ import {
 } from "./account-edge-cache.ts";
 import { parseRouteQuery, routeQuery, routeText } from "../src/route-query.ts";
 import {
+  serverTimingHeader,
+  withRequestTiming,
+} from "../src/request-timing.ts";
+import {
   handleSubnetMetagraph,
   handleNeuron,
   handleSubnetHyperparams,
@@ -6056,10 +6060,31 @@ async function handleChainFirehoseIngest(request: Request, env: Env) {
  * unforgettable rather than 40 more places to remember.
  */
 export async function handleRequest(request: Request, env: Env, ctx: Ctx = {}) {
-  const before = degradedSnapshot();
-  const response = await dispatchCached(request, env, ctx);
-  labelDegradedResponse(response, before);
-  return response;
+  return withRequestTiming(async () => {
+    const before = degradedSnapshot();
+    const response = await dispatchCached(request, env, ctx);
+    labelDegradedResponse(response, before);
+    // WHERE THE MILLISECONDS WENT, as the standard header a browser's devtools
+    // panel already renders. Set here for the same reason the degraded label is
+    // -- one point every route passes -- and built from marks collected at the
+    // three storage boundaries rather than by instrumenting handlers, so a
+    // route written next year is covered without its author doing anything.
+    //
+    // IN PLACE, swallowing an immutable-headers throw, exactly as
+    // `labelDegradedResponse` documents. The one response class with immutable
+    // headers is a body read back out of the edge cache, whose timings belong
+    // to the request that STORED it -- losing the header there is correct,
+    // because this request spent none of that time.
+    const timing = serverTimingHeader();
+    if (timing !== null) {
+      try {
+        response.headers.set("server-timing", timing);
+      } catch {
+        // A cached body; see above.
+      }
+    }
+    return response;
+  });
 }
 
 /**

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -57,6 +57,13 @@ const EXPOSED_RESPONSE_HEADERS = [
   // initialize, must be readable by a browser-based MCP client to send back
   // on subsequent requests.
   "mcp-session-id",
+  // Where the request's milliseconds went, per storage boundary. EXPOSED for
+  // the same reason `x-metagraph-degraded` is: the UI is served from
+  // metagraph.sh and calls api.metagraph.sh, so without this a browser cannot
+  // read it at all -- and a timing header the page cannot see is a timing
+  // header nobody uses. `Timing-Allow-Origin` governs the Performance API's
+  // own view; this governs `fetch`'s.
+  "server-timing",
 ];
 
 // Pre-joined value, for builders that emit plain header objects (the MCP server).


### PR DESCRIPTION
## Why

Three optimisations landed today against end-to-end numbers that could not distinguish where a millisecond went. `/accounts/{ss58}` crosses an R2 artifact, Neon, and R2 SQL over Iceberg, and nothing said which layer owned which part of the wall clock.

The tell that it was never the code came from a route nobody had touched:

| route | earlier | later | touched? |
|---|---|---|---|
| `/blocks/{ref}` | 0.196 s | **4.65 s** | **no** |
| `/accounts/{ss58}/events` | 1.8 s | 8.8 s | yes |

Same twenty minutes. The shared Neon compute was contended. A cache hit is 0.12 s and a cold read is seconds; between those two facts sit three storage layers and, until now, no measurement.

## What it emits

```
server-timing: r2;dur=740;desc="2 calls", neon;dur=3;desc="2 calls"
```

Two R2 artifact reads took 740 ms, two Neon queries took 3 ms, and **no lakehouse query ran** — which is precisely "served from the hot tier". The tier falls out of the same data rather than needing a mechanism of its own, so no second header can disagree with it.

## Boundaries, not routes

Three places a request can spend real time, one function in front of each:

| mark | boundary |
|---|---|
| `neon` | `pgReadStore`'s runner — `src/read-store.ts` |
| `r2sql` | `r2SqlQuery` — `src/r2-sql.ts` |
| `r2` | the projection's `readJson` — `src/account-summary-projection.ts` |

One edit each, and every route — including ones written next year — is covered without its author doing anything. The same argument `withEdgeCache`, `dataRouteRateLimit` and `labelDegradedResponse` all make for living at the dispatch point.

`r2SqlQuery` is split into a timed wrapper and the query itself so the boundary is measured in one place rather than at each of its ~20 returns.

## Not PostHog, and not instead of it

`src/tracing.ts` sends sampled OTLP spans for aggregate analysis, with a rate that defaults to zero for reasons its own header sets out. This is unsampled, costs no network call, and answers a different question — *where did this request's eight seconds go* — on the request in front of you. They're complements.

## AsyncLocalStorage

`nodejs_compat` is already on. The repo's other collect-from-deep mechanism is `degradedSnapshot`'s module global, which explicitly documents that a concurrent request can label this one. Defensible for a boolean that errs safe; indefensible for a number, where cross-request bleed doesn't degrade the answer — it invents one. **A test fires two concurrent requests and asserts their marks stay separate.**

## Cost when unused

`mark` outside a request scope is a map lookup returning undefined. No header is emitted when nothing was measured, so the ~40 routes that touch no store are byte-identical. Exposed via CORS for the same reason `x-metagraph-degraded` is — the UI is cross-origin, and a header the page can't read is a header nobody uses.

## Verification

- **Falsified**: drop the header and the end-to-end test fails.
- Pinned: concurrent isolation, throwing boundaries still measured, nested scopes reuse the outer one, inert outside a scope, no header when nothing ran, CORS exposure, and that the output parses as the standard's own grammar (anything else is silently dropped by devtools).
- **Patch coverage 20/20 lines, 11/11 branches**; full suite 956 files / 21,915 passed; full CI gate 79 targets, 0 failed.