### PR TITLE
fix(docs): get_more_tools reports a gap, it does not page in more tools

### DIFF
--- a/apps/ui/content/docs/mcp.mdx
+++ b/apps/ui/content/docs/mcp.mdx
@@ -22,10 +22,15 @@ https://api.metagraph.sh/mcp/core   streamable HTTP — core profile, 23 tools
 | Pick it when         | context is cheap (subagents, offline tooling) | context is model context — most agents |
 
 <Callout title="A context diet, not an authorization boundary">
-  A session connected to `/mcp/core` can still `tools/call` every one of the 240 tools. When a thin
-  session needs more, `get_more_tools` pages additional tool definitions in on demand, and `ask`
-  answers whole questions without any further tools at all — a core session is never stranded.
+  A session connected to `/mcp/core` can still `tools/call` every one of the 240 tools — listing
+  filters, calls don't. When a thin session needs one the core profile never listed, it calls it by
+  name, and `ask` answers whole questions without any further tools at all — a core session is never
+  stranded.
 </Callout>
+
+`get_more_tools` is not part of that: it reports a capability this server lacks. Call it when nothing
+in the catalogue does what you need, and describe the goal in `context` — it records the gap and
+returns an acknowledgement, not data or additional tools.
 
 ## Authentication
 


### PR DESCRIPTION
Closes #11444

## The contradiction

`/docs/mcp` told readers that a thin `/mcp/core` session reaches the rest of the catalogue via `get_more_tools`. The tool's own description, live on both endpoints, says the opposite.

**Docs**, `apps/ui/content/docs/mcp.mdx:26`:

> When a thin session needs more, `get_more_tools` pages additional tool definitions in on demand […]

**`tools/list`**, verified against `https://api.metagraph.sh/mcp` and `/mcp/core`:

> **This tool returns no data and unlocks no additional tools; it records the gap so the capability can be built.** Do not call it as a discovery step: the full catalogue is already in `tools/list`.

## The tool description is right

`get_more_tools` is the `reportMissing` virtual tool — the capability-gap report:

- `src/mcp-server.ts:5543` — `export const MCP_MISSING_CAPABILITY_TOOL = "get_more_tools";`
- `src/mcp-tool-exposures.ts:70` — *"Reports a capability this server lacks; it reads no data and has no REST equivalent, because the caller is an MCP agent telling us what the catalogue is missing rather than asking for anything."*
- `schemas-src/mcp-tools/missing-capability.ts` — input `z.object({}).strict()`, output a fixed `{ acknowledged, … }`; the header states *"The tool answers a fixed, contentless acknowledgement by design."*

## What changed

The callout's point never depended on the false clause — both surviving mechanisms are true as written. A core session can `tools/call` all 240 tools because listing filters and calls don't, and `ask` answers whole questions with no further tools. So the clause is dropped rather than reworded, and the "never stranded" claim now rests only on things that are actually true.

Adds a short paragraph naming what `get_more_tools` actually does, so a reader who meets it in `tools/list` — it is the first tool in both profiles — is not left guessing.

## Why it is worth a PR

It targets exactly the readers we most want on the recommended default endpoint. An agent that trusts the page believes `/mcp/core` has a paging escape hatch it does not have. The wrong description also propagates: it had already been copied into a third-party directory listing of this server, sourced from this page.

## Scope

One file, prose only. No component, route, or schema change — so no contract regeneration and no screenshot table (consistent with #11234 and #11259, both docs-content PRs merged without one).

## Validation

```
npx prettier --check apps/ui/content/docs/mcp.mdx    clean before and after the edit
npm run build --workspace=apps/ui                    ✓ built in 18.69s
git diff --check                                     clean
git diff --stat                                      1 file, +8 / -3
```

## Explicitly not in scope

`metagraph.sh/mcp` returning 404 is **not** a bug and is not touched here. Docs-only topics live at `/docs/<name>`; `/badges` and `/feeds` 404 at the root identically. Recording it so it does not get bundled in as a follow-up.
