### PR TITLE
perf(accounts): the card's two post-fold probes asked the lakehouse for a window Neon already holds

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -111,6 +111,7 @@ import {
   accountHistoryFloorMs,
   loadAccountSummaryProjection,
 } from "./account-summary-projection.ts";
+import { loadAccountEventsAboveFloorHotTier } from "./chain-detail-hot-tier.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
 import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
@@ -1158,9 +1159,24 @@ async function headProbe(
     floorMs: number;
     limit: number;
     published: readonly Record<string, unknown>[];
+    /** The account, for the hot store's own indexed predicate. */
+    ss58: string;
   },
 ): Promise<Record<string, unknown>[] | null> {
-  const { query, where, floorMs, limit, published } = options;
+  const { query, where, floorMs, limit, published, ss58 } = options;
+  // NEON FIRST, when it provably covers this floor. Measured on the card
+  // 2026-08-16 via `Server-Timing`: the two post-fold R2 SQL probes were
+  // 3,210ms of a 3,695ms request -- 87% -- against 143ms for two Neon queries
+  // over the same window. They were not badly bounded; they asked the wrong
+  // store. See `loadAccountEventsAboveFloorHotTier` for the overlap argument.
+  const hot = await loadAccountEventsAboveFloorHotTier(
+    env,
+    ss58,
+    floorMs,
+    limit,
+  );
+  if (hot !== null) return mergeNewestEvents(published, hot, limit);
+
   const head = await query(
     env,
     `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
@@ -1192,6 +1208,47 @@ async function headProbe(
  * guessing one would either double-count or leave a hole; serving the groups
  * alone is what this did before and is at worst stale, never wrong-by-overlap.
  */
+/**
+ * Rows to (kind, netuid) groups, in the shape the SQL aggregate returns.
+ *
+ * The column names are the SQL's own aliases -- `kind`, `count`, `fb`, `lb`,
+ * `fo`, `lo` -- because the caller concatenates these onto the projection's
+ * published groups and `foldSummaryGroups` reads them by those names. Two
+ * producers of one shape is exactly where a rename goes wrong, so this mirrors
+ * the SELECT list above it rather than inventing a parallel vocabulary.
+ */
+function foldRowsToGroups(
+  rows: readonly Record<string, unknown>[],
+): Record<string, unknown>[] {
+  const groups = new Map<string, Record<string, unknown>>();
+  for (const row of rows) {
+    const kind = row.event_kind;
+    const netuid = row.netuid ?? null;
+    const key = `${String(kind)}\u0000${String(netuid)}`;
+    const block = Number(row.block_number ?? 0);
+    const observed = Number(row.observed_at ?? 0);
+    const existing = groups.get(key);
+    if (!existing) {
+      groups.set(key, {
+        kind,
+        netuid,
+        count: 1,
+        fb: block,
+        lb: block,
+        fo: observed,
+        lo: observed,
+      });
+      continue;
+    }
+    existing.count = Number(existing.count) + 1;
+    existing.fb = Math.min(Number(existing.fb), block);
+    existing.lb = Math.max(Number(existing.lb), block);
+    existing.fo = Math.min(Number(existing.fo), observed);
+    existing.lo = Math.max(Number(existing.lo), observed);
+  }
+  return [...groups.values()];
+}
+
 async function postFoldGroups(
   env: R2SqlEnv | null | undefined,
   options: {
@@ -1199,10 +1256,39 @@ async function postFoldGroups(
     scan: (bound: string) => string;
     published: Record<string, unknown>[];
     span: { foldFloorMs: number } | null;
+    /** The account, for the hot store's own indexed predicate. */
+    ss58: string;
   },
 ): Promise<Record<string, unknown>[] | null> {
-  const { query, scan, published, span } = options;
+  const { query, scan, published, span, ss58 } = options;
   if (span === null) return published;
+
+  // NEON FIRST, folded here. This aggregate reads the SAME post-fold window the
+  // head probe does, so when the hot store provably covers it the groups can be
+  // built from rows it already holds -- and `Server-Timing` on the live card
+  // (2026-08-16) put these two R2 SQL probes at 3,210ms of a 3,695ms request,
+  // ~1.6s each, against 143ms for two Neon queries over the same window.
+  //
+  // GROUPED IN JS, not in SQL, and that is not a shortcut: the aggregate is
+  // count/min/max per (kind, netuid) over at most `ACCOUNT_EVENT_SUMMARY_SCAN_CAP`
+  // rows of ONE account's recent activity. Postgres would do it faster in
+  // absolute terms and the round trip dwarfs either.
+  //
+  // A FULL PAGE MEANS THE CAP WAS REACHED, which is exactly the case the SQL
+  // version signals with `scan_capped` -- and a windowed subtotal presented as a
+  // lifetime aggregate is the self-contradicting card this whole function
+  // exists to fix. So a hot read that fills its limit falls through to the SQL
+  // path rather than publishing a total it cannot vouch for.
+  const hot = await loadAccountEventsAboveFloorHotTier(
+    env,
+    ss58,
+    span.foldFloorMs,
+    ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+  );
+  if (hot !== null && hot.length < ACCOUNT_EVENT_SUMMARY_SCAN_CAP) {
+    return [...published, ...foldRowsToGroups(hot)];
+  }
+
   const bound = ` AND observed_at >= ${Math.trunc(span.foldFloorMs)}`;
   const above = await query(
     env,
@@ -1394,6 +1480,7 @@ export async function loadAccountSummaryColdTier(
             scan,
             published: found.groups,
             span: found.span,
+            ss58,
           })
         : windowedFloorRead<Record<string, unknown>[]>(env, {
             query,
@@ -1444,6 +1531,7 @@ export async function loadAccountSummaryColdTier(
           floorMs: absentFloor,
           limit,
           published: [],
+          ss58,
         })
       : found?.recent
         ? headProbe(env, {
@@ -1452,6 +1540,7 @@ export async function loadAccountSummaryColdTier(
             floorMs: found.recent.floorMs,
             limit,
             published: found.recent.rows,
+            ss58,
           })
         : found?.span
           ? spanProbe(env, {

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -236,6 +236,59 @@ export async function accountEventsHotFloorMs(
  * Returns null when the store is unbound or the query fails, never a partial
  * page: the caller falls through to the lakehouse, which is slower and whole.
  */
+/**
+ * This account's events at or above `floorMs`, from the hot store -- or null
+ * when the store cannot prove it covers that floor.
+ *
+ * THE PRIMITIVE EVERY POST-FOLD PROBE WANTS, extracted rather than repeated.
+ * `/events` had this logic inline; the summary card, the transfer feed and the
+ * counterparty scan all ask the same question of the same window, and three
+ * copies of an overlap check is three chances for one of them to be subtly
+ * wrong about the direction of a comparison.
+ *
+ * ## Why this is worth the extraction, measured
+ *
+ * `Server-Timing` on the account card, 2026-08-16, after the projection and the
+ * hot tier were already in place:
+ *
+ *   r2;dur=87;desc="2 calls"      the projection: pointer + shard
+ *   neon;dur=143;desc="2 calls"   the hot tier
+ *   r2sql;dur=3210;desc="2 calls" the post-fold probes
+ *
+ * R2 SQL is ~1.6s PER QUERY and 87% of that request, almost regardless of what
+ * it scans -- and both of those queries ask only "what happened after the fold
+ * edge", which is the window this store holds. Nothing bounded them better;
+ * they simply asked the wrong store.
+ *
+ * ## The overlap, checked and never assumed
+ *
+ * The caller's `floorMs` is where the projection stops. This store starts at
+ * its own `MIN(observed_at)`, which the chain-detail lane's prune moves. They
+ * cover all of time together ONLY while the store's floor sits at or below the
+ * caller's -- measured that day at 22:27Z against a fold edge of 00:00Z, about
+ * ninety minutes of overlap. A page built across a gap is silently missing
+ * every event in it, so anything short of a proven overlap returns null and the
+ * caller keeps the R2 SQL probe it had.
+ *
+ * BOTH READS AT ONCE: neither the floor nor the page depends on the other's
+ * result, and issuing a page read that gets discarded when the check fails
+ * costs one indexed query (0.091 ms measured) against halving the wall clock of
+ * the path that succeeds.
+ */
+export async function loadAccountEventsAboveFloorHotTier(
+  env: unknown,
+  ss58: string,
+  floorMs: number,
+  limit: number,
+): Promise<Row[] | null> {
+  const [hotFloorMs, rows] = await Promise.all([
+    accountEventsHotFloorMs(env),
+    loadAccountEventsHotTier(env, ss58, limit),
+  ]);
+  if (hotFloorMs === null || hotFloorMs > floorMs) return null;
+  return rows;
+}
+
 export async function loadAccountEventsHotTier(
   env: unknown,
   ss58: string,

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -35,8 +35,7 @@ import {
   buildSubnetEvents,
 } from "./account-events.ts";
 import {
-  accountEventsHotFloorMs,
-  loadAccountEventsHotTier,
+  loadAccountEventsAboveFloorHotTier,
   CHAIN_EVENT_COLUMNS,
   formatChainEvent,
   type ChainEventApi,
@@ -195,49 +194,19 @@ async function recentEventsLeg(
   // the hot tier is cheapest for, which is most of them.
   if (recent === null) return null;
 
-  // THE HEAD, FROM NEON WHEN THE TWO TIERS PROVABLY MEET.
-  //
-  // `chain_detail_account_events` holds the head of the chain in Neon and is
-  // indexed by account since migration 0032: measured 0.091 ms against 748 ms
-  // before it, and against seconds for the same question in R2 SQL. The
-  // projection covers everything at or before its fold edge; this store covers
-  // everything from its own floor upward. When that floor sits at or below the
-  // fold edge the two OVERLAP and together span all of time -- so the whole
-  // page is served with NO lakehouse query at all.
-  //
-  // Measured 2026-08-16: hot floor 22:27Z against a fold edge of 00:00Z, an
-  // overlap of about ninety minutes.
-  //
-  // CHECKED, NEVER ASSUMED. Both edges move on their own schedules -- the
-  // chain-detail lane prunes to a rolling window, the producer folds on its own
-  // cadence -- so a gap is possible and a page built across one would be
-  // silently missing every event in it. `accountEventsHotFloorMs` derives the
-  // floor from the store rather than pinning it, and anything but a proven
-  // overlap falls through to the bounded R2 SQL probe below, which is slower
-  // and correct.
-  // BOTH NEON READS AT ONCE. The floor probe answers "does this store reach
-  // below the fold edge" and the page read answers "what does it hold for this
-  // account" -- neither input depends on the other's result, so issuing them in
-  // sequence spent two round trips where one wall-clock wait would do. The
-  // overlap is still CHECKED before the rows are used; running the read early
-  // costs one query that gets discarded when the check fails, against halving
-  // the latency of the path that succeeds.
-  //
-  // Not memoized, deliberately. A cached floor is only wrong when the prune has
-  // moved above the fold edge inside the TTL -- rare, small, and silent, which
-  // is the combination that makes a bug survive. Parallelism buys the same
-  // latency with none of that.
-  const [hotFloorMs, hot] = await Promise.all([
-    accountEventsHotFloorMs(env),
-    loadAccountEventsHotTier(env, ss58, limit),
-  ]);
-  if (hotFloorMs !== null && hotFloorMs <= recent.floorMs) {
-    // A hot-tier failure is not a decline: it means this leg could not be
-    // served from Neon, and the R2 SQL probe below answers the same question.
-    if (hot !== null) {
-      return mergeNewestEvents<AccountFeedRow>(recent.rows, hot, limit);
-    }
-  }
+  // THE HEAD, FROM NEON WHEN THE TWO TIERS PROVABLY MEET -- see
+  // `loadAccountEventsAboveFloorHotTier` for the overlap argument and the
+  // measurement that motivates it. A null answer means the store could not
+  // prove it covers the projection's floor, or could not be read; either way
+  // the bounded R2 SQL probe below answers the same question, slower.
+  const hot = await loadAccountEventsAboveFloorHotTier(
+    env,
+    ss58,
+    recent.floorMs,
+    limit,
+  );
+  if (hot !== null)
+    return mergeNewestEvents<AccountFeedRow>(recent.rows, hot, limit);
 
   const head = await query<AccountEventsRow>(
     env,

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -18,7 +18,17 @@ import {
   accountSummaryShardKey,
 } from "../src/account-summary-projection.ts";
 import { readFileSync } from "node:fs";
-import { describe, test, beforeEach } from "vitest";
+import { describe, test, beforeEach, vi } from "vitest";
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { accountSummaryArchive } from "./helpers/cold-tier-env.ts";
+
+// The card's post-fold probe reads `chain_detail_account_events` through
+// src/read-store.ts, which builds `new Client(...)` itself -- so the module is
+// the seam. See tests/helpers/pg-mock.ts for why the controller is hoisted.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
 import {
   foldSummaryGroups,
   loadAccountSummaryColdTier,
@@ -1318,3 +1328,293 @@ describe("mergeNewestEvents", () => {
     assert.equal(mergeNewestEvents([], [row(1, 1)], 10).length, 1);
   });
 });
+
+/**
+ * The card's post-fold probe, from Neon instead of R2 SQL.
+ *
+ * `Server-Timing` on the live card, 2026-08-16, with the projection and the
+ * pointer memo already in place:
+ *
+ *   r2;dur=87;desc="2 calls"       the projection: pointer + shard
+ *   neon;dur=143;desc="2 calls"    the hot tier
+ *   r2sql;dur=3210;desc="2 calls"  the post-fold probes
+ *
+ * R2 SQL was 87% of a 3,695ms request at ~1.6s per query. The probes were not
+ * badly bounded -- they asked the wrong store. `chain_detail_account_events`
+ * holds exactly that window and answers in milliseconds.
+ */
+/** The projection the card needs to reach its post-fold legs at all. */
+const cardArchive = () =>
+  accountSummaryArchive({
+    accounts: {
+      [SS58]: [
+        {
+          kind: "NeuronRegistered",
+          netuid: 105,
+          count: 2,
+          fb: 10,
+          lb: 90,
+          fo: 1_700_000_000_010,
+          lo: 1_700_000_000_090,
+        },
+      ],
+    },
+    // The PRODUCER's row shape, not the card's output shape:
+    // `AccountSummaryRecentEventSchema` is `.required().strict()`, so a
+    // payload missing a column is refused and the card silently takes
+    // the span branch instead -- which is what the first cut of this
+    // fixture did.
+    recent: {
+      [SS58]: [9_000_000, 8_999_999].map((block) => ({
+        block_number: block,
+        event_index: 0,
+        extrinsic_index: 1,
+        event_kind: "NeuronRegistered",
+        hotkey: SS58,
+        coldkey: null,
+        netuid: 105,
+        uid: 242,
+        amount_tao: null,
+        alpha_amount: null,
+        observed_at: Date.parse("2026-08-14T12:00:00.000Z"),
+      })),
+    },
+    pointer: { recent_limit: 10, recent_from: "2026-07-16" },
+    through: "2026-08-14",
+  });
+
+describe("the card's head probe -- Neon when the tiers overlap", () => {
+  const FOLD_FLOOR = Date.parse("2026-08-15T00:00:00.000Z");
+
+  /** A store answering the floor probe and the per-account read. */
+  function store(floorMs: number | null, rows: Record<string, unknown>[]) {
+    pg.control.queries.length = 0;
+    pg.control.answers = [];
+    pg.control.rows = null;
+    pg.control.failNext = null;
+    pg.control.onQuery = ({ text }) => {
+      pg.control.rows = text.includes("MIN(observed_at)")
+        ? floorMs === null
+          ? [{ floor_ms: null }]
+          : [{ floor_ms: floorMs }]
+        : rows;
+    };
+    return pgMockEnv();
+  }
+
+  const hotRow = (block: number) => ({
+    block_number: block,
+    event_index: 0,
+    extrinsic_index: 1,
+    event_kind: "NeuronRegistered",
+    hotkey: SS58,
+    coldkey: null,
+    netuid: 105,
+    uid: 242,
+    amount_tao: "12.5",
+    alpha_amount: null,
+    observed_at: Date.parse("2026-08-15T12:00:00.000Z"),
+  });
+
+  test("THE HEAD PROBE ASKS NEON, not the lakehouse", async () => {
+    const queries: string[] = [];
+    const probe = await headProbeForTest({
+      env: store(FOLD_FLOOR - 90 * 60_000, [hotRow(9_000_001)]),
+      queries,
+      floorMs: FOLD_FLOOR,
+    });
+    assert.ok(probe, "the probe answered");
+    assert.equal(
+      queries.length,
+      0,
+      `expected no R2 SQL:\n${queries.join("\n")}`,
+    );
+    assert.equal(probe[0]!.block_number, 9_000_001);
+  });
+
+  test("A GAP FALLS BACK to the bounded R2 SQL probe", async () => {
+    // Both edges move on their own schedules, so a gap is possible -- and a
+    // page built across one is silently missing every event in it.
+    const queries: string[] = [];
+    await headProbeForTest({
+      env: store(FOLD_FLOOR + 60 * 60_000, [hotRow(9_000_001)]),
+      queries,
+      floorMs: FOLD_FLOOR,
+    });
+    // BOTH legs fall back, not one: the aggregate and the head probe read the
+    // same post-fold window, so a gap disqualifies both.
+    assert.ok(queries.length >= 1, "expected the R2 SQL probes");
+    assert.ok(
+      queries.every((sql) => sql.includes(`observed_at >= ${FOLD_FLOOR}`)),
+      queries.join("\n"),
+    );
+  });
+
+  test("THE FOLD AGGREGATES like the SQL it replaces", async () => {
+    // FOUR rows, deliberately unordered and deliberately colliding: two share a
+    // (kind, netuid) so the merge path runs, and the second one moves BOTH ends
+    // outward so the running min and max are each exercised in both directions.
+    // One ordered pair would leave half of every comparison untaken -- the same
+    // argument the span test makes about its three groups.
+    //
+    // A NULL netuid is its own group, not a coalesced one: Transfer and Deposit
+    // are coldkey balance events with no subnet, and folding them onto a
+    // netuid-bearing kind would invent a subnet for them.
+    const at = (iso: string) => Date.parse(iso);
+    const row = (
+      kind: string,
+      netuid: number | null,
+      block: number,
+      iso: string,
+    ) => ({
+      block_number: block,
+      event_index: 0,
+      extrinsic_index: 1,
+      event_kind: kind,
+      hotkey: SS58,
+      coldkey: null,
+      netuid,
+      uid: 242,
+      amount_tao: null,
+      alpha_amount: null,
+      observed_at: at(iso),
+    });
+    const queries: string[] = [];
+    const card = await postFoldGroupsForTest({
+      env: store(FOLD_FLOOR - 90 * 60_000, [
+        row("StakeAdded", 7, 500, "2026-08-15T12:00:00.000Z"),
+        row("StakeAdded", 7, 100, "2026-08-15T20:00:00.000Z"),
+        row("StakeAdded", 9, 300, "2026-08-15T14:00:00.000Z"),
+        row("Transfer", null, 400, "2026-08-15T15:00:00.000Z"),
+      ]),
+      queries,
+    });
+    assert.equal(
+      queries.length,
+      0,
+      `expected no R2 SQL:\n${queries.join("\n")}`,
+    );
+    assert.ok("agg" in card, `the card declined: ${JSON.stringify(card)}`);
+
+    // `scanned` is `sum(count)` over the folded groups, which is the number the
+    // SQL aggregate returned. Two published events plus the four above -- and
+    // it is 6 rather than 3 only if the colliding pair was COUNTED twice while
+    // being GROUPED once, which is the whole property.
+    assert.equal(card.scanned, 6);
+
+    const byKind = new Map(card.kinds.map((k) => [String(k.kind), k]));
+    assert.deepEqual(
+      [...byKind.keys()].sort(),
+      ["NeuronRegistered", "StakeAdded", "Transfer"],
+      "a null-netuid kind is folded on its own, not onto a subnet-bearing one",
+    );
+    assert.equal(
+      Number(byKind.get("StakeAdded")!.count),
+      3,
+      "two netuid-7 rows plus one netuid-9",
+    );
+  });
+
+  test("A ROW MISSING ITS SORT COLUMNS folds without corrupting the bounds", async () => {
+    // REACHABLE for the reason `feedKey`'s own fallback is -- see "a row
+    // missing a sort column sorts LAST" above. These three columns are NOT
+    // NULL on `chain_detail_account_events`, but this fold takes
+    // `Record<string, unknown>` and the lakehouse's copy of the same table
+    // permits null in every one of them. A missing column must not throw and
+    // must not silently become NaN, which would poison every later min/max in
+    // its group.
+    const queries: string[] = [];
+    const card = await postFoldGroupsForTest({
+      env: store(FOLD_FLOOR - 90 * 60_000, [
+        {
+          event_kind: "StakeAdded",
+          netuid: 7,
+          block_number: 900,
+          observed_at: Date.parse("2026-08-15T18:00:00.000Z"),
+        },
+        // Same group, and carrying neither sort column.
+        { event_kind: "StakeAdded", netuid: 7 },
+      ]),
+      queries,
+    });
+    assert.equal(queries.length, 0);
+    assert.ok("agg" in card, "the card declined");
+    const stake = card.kinds.find((k) => k.kind === "StakeAdded");
+    assert.ok(stake, "the group survived");
+    assert.equal(Number(stake.count), 2, "both rows counted");
+    assert.ok(
+      Number.isFinite(Number(card.scanned)),
+      "a missing column must not turn the total into NaN",
+    );
+  });
+
+  test("AN UNREADABLE STORE falls back rather than declining", async () => {
+    const queries: string[] = [];
+    const probe = await headProbeForTest({
+      env: store(null, []),
+      queries,
+      floorMs: FOLD_FLOOR,
+    });
+    assert.ok(probe !== undefined);
+    assert.ok(queries.length >= 1, "expected the R2 SQL probes");
+  });
+});
+
+/** Drive the card down to its head-probe leg, recording any R2 SQL it issues. */
+async function headProbeForTest(input: {
+  env: Record<string, unknown>;
+  queries: string[];
+  floorMs: number;
+}) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    input.queries.push(String(JSON.parse(String(init.body)).query));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows: [] } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  try {
+    const out = await loadAccountSummaryColdTier(
+      {
+        ...input.env,
+        R2_SQL_TOKEN: "cfut_test",
+        // The projection is what produces the fold floor the probe bounds on;
+        // without it the card never reaches this leg at all.
+        ...cardArchive(),
+      } as never,
+      SS58,
+      { recentLimit: 2 },
+    );
+    return "recent" in out ? (out.recent ?? []) : [];
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+/** Drive the card down to its post-fold aggregate leg, returning the card. */
+async function postFoldGroupsForTest(input: {
+  env: Record<string, unknown>;
+  queries: string[];
+}) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_u: string, init: RequestInit) => {
+    input.queries.push(String(JSON.parse(String(init.body)).query));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows: [] } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  try {
+    const out = await loadAccountSummaryColdTier(
+      { ...input.env, R2_SQL_TOKEN: "cfut_test", ...cardArchive() } as never,
+      SS58,
+      { recentLimit: 2 },
+    );
+    return out;
+  } finally {
+    globalThis.fetch = original;
+  }
+}


### PR DESCRIPTION
## What the instrumentation showed

`Server-Timing` (#11442) answered the question three earlier optimisations were guessing at. The live account card, 2026-08-16:

```
server-timing: r2;dur=87;desc="2 calls",  neon;dur=143;desc="2 calls",  r2sql;dur=3210;desc="2 calls"
```

| boundary | time | share |
|---|---|---|
| R2 artifacts (pointer + shard) | 87 ms | 2% |
| Neon | 143 ms | 4% |
| **R2 SQL** | **3,210 ms** | **87%** |

~1.6 s per query. And both of those queries ask only *"what happened after the fold edge"* — which is exactly the window `chain_detail_account_events` holds, indexed by account since #11437 and answering in **0.091 ms**.

They were not badly bounded. They asked the wrong store.

Both legs now try Neon first, and the card issues **no lakehouse query at all** when the tiers overlap.

## One primitive, not three copies

`loadAccountEventsAboveFloorHotTier` is extracted rather than repeated. `/events` had this logic inline; the card's head probe and its aggregate ask the same question of the same window. Three copies of an overlap check is three chances for one of them to be subtly wrong about the direction of a comparison.

**Checked, never assumed** — in the one place. The caller's floor is where the projection stops; the store starts at its own `MIN(observed_at)`, which the prune moves. They cover all of time together only while the store's floor sits at or below the caller's — measured 22:27Z against a fold edge of 00:00Z. Anything short of a proven overlap keeps the R2 SQL probe it had, and both Neon reads are issued in parallel since neither depends on the other.

## The aggregate, folded here

`foldRowsToGroups` builds count/min/max per `(kind, netuid)` in JS over at most `ACCOUNT_EVENT_SUMMARY_SCAN_CAP` rows of one account's recent activity. Postgres would do it faster in absolute terms and the round trip dwarfs either.

**A full page means the cap was reached** — the case the SQL version signals with `scan_capped`. A windowed subtotal presented as a lifetime aggregate is the self-contradicting card `postFoldGroups` exists to fix, so a hot read that fills its limit falls through to SQL rather than publishing a total it cannot vouch for.

Group rows carry the SQL's own aliases (`kind`, `count`, `fb`, `lb`, `fo`, `lo`) because `foldSummaryGroups` reads them by those names — two producers of one shape is exactly where a rename goes wrong.

## Verification

- **Falsified during development**: before the change the same test printed 3 R2 SQL queries (the aggregate, the head probe, and a span read); after, it prints 0.
- The fold is asserted on the card's real output: four rows, two deliberately colliding and unordered so the running min *and* max are each exercised in both directions — `scanned: 6` proves the pair was **counted** twice while **grouped** once. A null `netuid` folds as its own group rather than onto a subnet-bearing kind.
- A row missing its sort columns folds without throwing or turning the total into `NaN` — reachable for the same reason `feedKey`'s own fallback is: this takes `Record<string, unknown>`, and the lakehouse's copy of the table permits null in all three.
- A gap between the tiers, and an unreadable store, each fall back to the bounded R2 SQL probes — **both** legs, since both read the same window.
- **Patch coverage 30/30 lines, 20/20 branches**; full suite 957 files; full CI gate 79 targets, 0 failed.