### PR TITLE
perf(accounts): the hot tier could never reach the projection's fold edge, so the fast path never fired

### DIFF
--- a/src/chain-detail-prune.ts
+++ b/src/chain-detail-prune.ts
@@ -69,6 +69,48 @@ export const CHAIN_DETAIL_MIN_RETAINED_BLOCKS = 1_800;
 /** ~24h. The ceiling on how far a stalled decoder can push retention before the
  * prune resumes and the reads start declining. */
 export const CHAIN_DETAIL_MAX_RETAINED_BLOCKS = 7_200;
+
+/**
+ * `chain_detail_account_events` keeps ~30h, and it is the ONE table that does.
+ *
+ * ## Why this table answers a second question
+ *
+ * Every other table here exists to cover one gap: chain tip minus the decoded
+ * seam, which an hourly decode lane holds to ~2h. This one is also the hot tier
+ * for the ACCOUNT family, and that family asks something different -- "does this
+ * store reach back past the projection's fold edge", the overlap
+ * `loadAccountEventsAboveFloorHotTier` checks before it serves.
+ *
+ * The two questions have different answers because the fold edge moves in DAY
+ * steps. `through` is the last COMPLETE day the producer folded, so the edge sits
+ * up to 24h behind, plus the lane's hourly cadence -- ~25h at worst in normal
+ * operation. A 6h floor cannot reach it, ever.
+ *
+ * MEASURED, not assumed. Live on 2026-08-17 the overlap was BROKEN by 6.8h:
+ * `through` 2026-08-15 put the fold edge at 2026-08-16T00:00Z against a hot
+ * floor of 06:51Z. The fast path was correct, safe, and never taken -- it had
+ * held exactly once, right after the projection recovered with an unusual
+ * `through`, which is a lucky sample rather than the steady state.
+ *
+ * ## Why only this table, and what it costs
+ *
+ * Measured live the same day: `chain_detail_account_events` plus its index is
+ * 324 MiB over 5,175 blocks -- 64.1 KiB/block, a quarter of the four tables'
+ * combined weight. Deepening it alone to 9,000 blocks costs ~451 MiB over the
+ * 6h floor, and leaves `chain_events` (410 MiB) and `extrinsics` (220 MiB) --
+ * the actual bulk -- exactly where they are. Deepening all four would have cost
+ * roughly four times as much to fix one family's reads.
+ *
+ * ## Why 30h and not more
+ *
+ * ~5h of margin over the ~25h worst case, which absorbs a missed producer pass.
+ * It does NOT absorb an outage -- the lane was dark for 33h on 2026-08-16 -- and
+ * it deliberately does not try: past this, the overlap check fails and the
+ * account routes fall back to the bounded lakehouse read, correct and slower,
+ * while the container-lane watchdog pages within 6h. Sizing retention for an
+ * outage is how a hot tier becomes the archive this one refuses to be.
+ */
+export const ACCOUNT_EVENTS_MIN_RETAINED_BLOCKS = 9_000;
 /**
  * Blocks removed per run, at most.
  *
@@ -116,6 +158,15 @@ export interface PruneWindow {
   keepFrom: number;
   /** Retained depth in blocks, after the floor/ceiling clamp. */
   retainedBlocks: number;
+  /**
+   * The same, for `chain_detail_account_events` alone -- see
+   * ACCOUNT_EVENTS_MIN_RETAINED_BLOCKS for why one table needs its own.
+   *
+   * NEVER ABOVE `keepFrom`: a deeper floor may only keep MORE rows, so an
+   * adaptive window that has already grown past it (a lagging decoder) still
+   * governs. `Math.min` states that rather than leaving it to the caller.
+   */
+  accountEventsKeepFrom: number;
 }
 
 /**
@@ -138,7 +189,19 @@ export function chainDetailPruneWindow(input: {
     CHAIN_DETAIL_MAX_RETAINED_BLOCKS,
     Math.max(CHAIN_DETAIL_MIN_RETAINED_BLOCKS, uncovered),
   );
-  return { keepFrom: head - retainedBlocks + 1, retainedBlocks };
+  const keepFrom = head - retainedBlocks + 1;
+  // The ceiling is deliberately NOT applied here. It bounds how far a stalled
+  // DECODER can push retention, which is the runaway this tier guards against;
+  // this floor is a fixed depth chosen against the producer's fold cadence and
+  // cannot run away on its own.
+  return {
+    keepFrom,
+    retainedBlocks,
+    accountEventsKeepFrom: Math.min(
+      keepFrom,
+      head - ACCOUNT_EVENTS_MIN_RETAINED_BLOCKS + 1,
+    ),
+  };
 }
 
 export interface ChainDetailPruneResult {
@@ -217,7 +280,20 @@ export async function pruneChainDetail(
       window.keepFrom,
       floor + CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN,
     );
-    const neon = await pruneChainDetailNeon(env, ctx, deletedBelow, deps);
+    // The account-events bound rides the SAME per-run cap, so a deeper floor
+    // cannot turn one run into an unbounded delete -- it only stops that table
+    // being taken as far as the others.
+    const accountEventsDeletedBelow = Math.min(
+      window.accountEventsKeepFrom,
+      floor + CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN,
+    );
+    const neon = await pruneChainDetailNeon(
+      env,
+      ctx,
+      deletedBelow,
+      deps,
+      accountEventsDeletedBelow,
+    );
     return {
       ok: true,
       keep_from: window.keepFrom,
@@ -283,6 +359,8 @@ async function pruneChainDetailNeon(
   ctx: WaitUntilLike | undefined,
   deletedBelow: number,
   deps: ChainDetailPruneDeps,
+  /** The bound for `chain_detail_account_events`, which keeps more. */
+  accountEventsDeletedBelow: number,
 ): Promise<{ neon_pruned?: boolean; neon_detail?: string }> {
   const bag = env as Record<string, unknown> | null | undefined;
   const hyperdrive = bag?.HYPERDRIVE as HyperdriveLike | undefined;
@@ -298,9 +376,14 @@ async function pruneChainDetailNeon(
   try {
     const sql = injected ?? createPgSql(hyperdrive!, ctx!);
     for (const table of PRUNE_TABLES) {
-      await sql.unsafe(`DELETE FROM ${table} WHERE block_number < $1`, [
-        deletedBelow,
-      ]);
+      // ONE table keeps more, and the bound is chosen per table rather than by
+      // running the loop twice: two DELETE passes over the same list is where a
+      // future table gets added to one and not the other.
+      const below =
+        table === "chain_detail_account_events"
+          ? accountEventsDeletedBelow
+          : deletedBelow;
+      await sql.unsafe(`DELETE FROM ${table} WHERE block_number < $1`, [below]);
     }
     return { neon_pruned: true };
   } catch (err) {

--- a/tests/chain-detail-prune.test.ts
+++ b/tests/chain-detail-prune.test.ts
@@ -33,6 +33,7 @@ import {
   CHAIN_DETAIL_PRUNE_MAX_BLOCKS_PER_RUN,
   chainDetailPruneWindow,
   pruneChainDetail,
+  ACCOUNT_EVENTS_MIN_RETAINED_BLOCKS,
 } from "../src/chain-detail-prune.ts";
 import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
 import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
@@ -153,8 +154,39 @@ describe("pruneChainDetail", () => {
       // short list rather than a decline.
       "chain_detail_blocks",
     ]);
-    for (const { values } of del.seen)
-      assert.deepEqual(values, [head - 6_000 + 120]);
+    // THREE TABLES AT ONE BOUND, and account_events at a deeper one -- see
+    // ACCOUNT_EVENTS_MIN_RETAINED_BLOCKS. It is the only table that also has to
+    // reach back past the projection's fold edge, which moves in DAY steps and
+    // so sits up to ~25h behind; the 6h floor the others use cannot reach it.
+    for (const { text, values } of del.seen) {
+      const expected = text.includes("chain_detail_account_events")
+        ? head - ACCOUNT_EVENTS_MIN_RETAINED_BLOCKS + 1
+        : head - 6_000 + 120;
+      assert.deepEqual(values, [expected], text);
+    }
+  });
+
+  test("THE DEEPER FLOOR ONLY EVER KEEPS MORE, never less", async () => {
+    // A lagging decoder pushes the adaptive window PAST the fixed floor, and
+    // when it does the window must still govern: a floor that could raise the
+    // bound would drop blocks the hot tier is expected to serve, which is the
+    // coverage hole this whole module exists to prevent.
+    const head = SEAM + 20_000;
+    const window = chainDetailPruneWindow({ head, seam: SEAM });
+    assert.ok(
+      window.accountEventsKeepFrom <= window.keepFrom,
+      `${window.accountEventsKeepFrom} > ${window.keepFrom}`,
+    );
+    // And in the normal case -- a seam close behind -- it keeps strictly more.
+    const near = chainDetailPruneWindow({ head: SEAM + 200, seam: SEAM });
+    assert.ok(
+      near.accountEventsKeepFrom < near.keepFrom,
+      "the deeper floor did not bind when the seam was close",
+    );
+    assert.equal(
+      near.keepFrom - near.accountEventsKeepFrom,
+      ACCOUNT_EVENTS_MIN_RETAINED_BLOCKS - CHAIN_DETAIL_MIN_RETAINED_BLOCKS,
+    );
   });
 
   test("a tier already inside its window deletes nothing", async () => {


### PR DESCRIPTION
## The fast path was dead code

#11437 and #11446 route the account family's post-fold probes to `chain_detail_account_events` when that store provably covers the projection's fold edge. Measured live 2026-08-17, it does not — and structurally cannot:

| | |
|---|---|
| projection `through` | 2026-08-15 |
| fold edge | **2026-08-16 00:00Z** |
| hot floor | **2026-08-16 06:51Z** |
| | **6.8 h gap** |

`through` is the last **complete** day the producer folded, so the fold edge sits up to 24 h back, plus the lane's hourly cadence — ~25 h in normal operation. The hot tier's floor is **6 h**, sized for an entirely different question: *chain tip minus the decoded seam*, which an hourly decode lane holds to ~2 h (currently 244 blocks). Six hours cannot reach twenty-five.

**The overlap held exactly once** — in the measurement that motivated #11437, taken right after the account-summary lane recovered from a 33 h outage with an unusual `through`. A lucky sample, not the steady state, and I generalised from it.

The code was correct throughout: the check failed and the routes fell back to the bounded lakehouse read. That is *why* it was invisible in every response. `Server-Timing` (#11442) is what surfaced it — `r2sql;desc="2 calls"` on a card that was supposed to issue none.

## One table, not four

Measured live the same day:

| table | data | index |
|---|---|---|
| `chain_detail_chain_events` | 410 MB | 41 MB |
| **`chain_detail_account_events`** | **292 MB** | **33 MB** |
| `chain_detail_extrinsics` | 220 MB | 4 MB |

`account_events` is 64.1 KiB/block — a quarter of the combined weight, and the only one the account family reads. Deepening it alone to 9,000 blocks (~30 h) costs **~451 MiB** over the 6 h floor and leaves the other 630 MB untouched. Deepening all four would have cost roughly 4× as much to fix one family's reads.

## Why 30 h, and what it deliberately does not cover

~5 h of margin over the ~25 h worst case, which absorbs a missed producer pass.

It does **not** absorb an outage — the lane was dark for 33 h on 2026-08-16 — and does not try. Past it the overlap check fails, the routes fall back to the bounded lakehouse read, and the container-lane watchdog (#11413) pages within 6 h. Sizing retention for an outage is how a hot tier becomes the archive this module's own header refuses to be.

## Invariants

- **The deeper floor may only ever keep MORE.** `Math.min` against the adaptive window means a lagging decoder still governs — a floor that could *raise* the bound would drop blocks the hot tier is expected to serve, which is the coverage hole the module exists to prevent. Pinned by a test at both ends: strictly deeper when the seam is close, never shallower when the seam is far.
- Both bounds ride the **same per-run delete cap**, so a deeper floor cannot turn one run into an unbounded delete.
- The bound is chosen **per table inside the existing loop**, not by running it twice — two DELETE passes over one list is where a future table gets added to one and not the other.

## Verification

- The existing "all four tables, one bound" test asserted the contract this changes; it now states the new one and checks the bound per table by name.
- **Patch coverage 7/7 lines, 2/2 branches**; full suite 957 files / 21,949 passed; full CI gate 79 targets, 0 failed.