### PR TITLE
perf(chain-events): the latency sweep reported one draw from a 16.7x distribution

### DIFF
--- a/scripts/check-operation-latency.ts
+++ b/scripts/check-operation-latency.ts
@@ -15,11 +15,22 @@
 // rather than filled with a placeholder. Timing `/api/v1/subnets/x/ohlc` times
 // a 404 and reports the route as broken.
 //
-// ONE CALL EACH, NOT A BENCHMARK, and the report says so. A single sample
-// cannot separate a slow operation from a cold isolate or a noisy hop, which is
-// why the budget below is deliberately loose: it exists to catch the ten-second
-// operation, not to police the difference between 300ms and 500ms. Anything
-// tighter would fail on weather.
+// ONE CALL EACH, THEN THREE FOR ANYTHING THAT CROSSED THE LINE (#11420). A
+// single sample cannot separate a slow operation from a cold isolate or a noisy
+// hop, and this script used to answer that with a loose budget alone -- which
+// works only if the noise is small next to the budget. It is not. Measured
+// against production 2026-08-16, eleven COLD `/api/v1/blocks/{ref}` point
+// lookups (one query shape, distinct refs so the edge cache could not answer)
+// ran 898ms to 15,032ms: a 16.7x spread around a 3,647ms median, with draws on
+// both sides of the 5s line. No budget separates signal from noise there,
+// because the operation does not HAVE a single time.
+//
+// So the budget stays loose AND the sweep draws again: an operation over budget
+// on its first call is re-timed and scored on the median of three. That is the
+// difference between "this read is slow" and "this read was slow once", which
+// is the claim every issue filed off this sweep actually needs.
+//
+// The confirmation pass is deliberately narrow -- see `confirmOverBudget`.
 //
 // SERIAL AND SPACED, for the reason the MCP sweep records: the endpoint
 // rate-limits per client, and a parallel run turns healthy operations into
@@ -50,10 +61,24 @@ const REQUEST_TIMEOUT_MS = 45000;
  *
  * FIVE SECONDS because that is the number #9789 was filed against and the one
  * an agent's own timeout is usually set near -- past it, a caller gives up
- * rather than waits. Loose on purpose: one sample per operation cannot tell a
- * slow query from a cold start, so a tight budget would report weather.
+ * rather than waits.
+ *
+ * Still loose on purpose, but it is no longer the ONLY defence against noise:
+ * `confirmOverBudget` re-draws anything that crosses this line, so a budget
+ * that used to have to absorb a 16.7x spread now only has to sit above the
+ * median of one.
  */
 const BUDGET_MS = Number(process.env.LATENCY_BUDGET_MS ?? 5000);
+
+/**
+ * Total draws for an operation that crossed the budget on its first one.
+ *
+ * THREE, because the question a re-draw answers is "was that draw typical",
+ * and a median needs an odd count to answer it without a tie-break. Two would
+ * only tell you the two disagreed; five would spend twice the calls to move
+ * the estimate very little on a distribution this wide.
+ */
+const CONFIRM_SAMPLES = Number(process.env.LATENCY_CONFIRM_SAMPLES ?? 3);
 
 /**
  * How far under budget an operation must come in before its DECLARED entry is
@@ -160,8 +185,30 @@ type Answer = "ok" | "unaskable" | "failed";
 export interface Timing {
   surface: "rest" | "mcp" | "graphql";
   operation: string;
+  /**
+   * The operation's SCORED time -- the median of `samples`, not one draw.
+   *
+   * A single draw is what this sweep used to report, and it is not a property
+   * of the operation. Measured against production 2026-08-16, eleven COLD
+   * `/api/v1/blocks/{ref}` point lookups -- one query shape, distinct refs so
+   * the edge cache could not answer -- ran 898ms to 15,032ms, a 16.7x spread
+   * with a median of 3,647ms. Both "under budget" and "at the 15s
+   * QUERY_TIMEOUT_MS ceiling" are ordinary draws from that one distribution, so
+   * which one the sweep reported was decided by when it happened to call.
+   *
+   * That is not a budget that can be loosened into correctness: it is a
+   * distribution, and the fix is to draw from it more than once.
+   */
   ms: number;
   answer: Answer;
+  /**
+   * Every draw taken, oldest first.
+   *
+   * One element for the operations that came in under budget on the first pass
+   * -- re-timing something already fast buys nothing and costs a request
+   * against a warehouse this account has been rate-limited on (#9465).
+   */
+  samples?: number[];
 }
 
 export interface LatencyReport {
@@ -377,6 +424,8 @@ async function listLiveTools(): Promise<{ name: string; args: Row }[]> {
 
 export async function run(): Promise<LatencyReport> {
   const timings: Timing[] = [];
+  /** How to draw the same operation again, for the confirmation pass below. */
+  const retime = new Map<string, () => Promise<[number, Answer]>>();
 
   for (const route of [...API_ROUTES, ...FEED_ROUTES]) {
     // GET only. `/api/v1/ask` is the one POST route in the table, and asking it
@@ -385,14 +434,30 @@ export async function run(): Promise<LatencyReport> {
     const path = concreteRoute(route.path);
     if (path === null) continue;
     const [ms, answer] = await timeRest(path);
-    timings.push({ surface: "rest", operation: route.path, ms, answer });
+    const timing: Timing = {
+      surface: "rest",
+      operation: route.path,
+      ms,
+      answer,
+      samples: [ms],
+    };
+    timings.push(timing);
+    retime.set(key(timing), () => timeRest(path));
     process.stderr.write(`rest ${ms}ms ${answer} ${route.path}\n`);
     await sleep(CALL_SPACING_MS);
   }
 
   for (const tool of await listLiveTools()) {
     const [ms, answer] = await timeMcp(tool.name, tool.args);
-    timings.push({ surface: "mcp", operation: tool.name, ms, answer });
+    const timing: Timing = {
+      surface: "mcp",
+      operation: tool.name,
+      ms,
+      answer,
+      samples: [ms],
+    };
+    timings.push(timing);
+    retime.set(key(timing), () => timeMcp(tool.name, tool.args));
     process.stderr.write(`mcp ${ms}ms ${answer} ${tool.name}\n`);
     await sleep(CALL_SPACING_MS);
   }
@@ -400,12 +465,86 @@ export async function run(): Promise<LatencyReport> {
   const { plans } = planAll(buildSchema(SDL));
   for (const plan of plans) {
     const [ms, answer] = await timeGraphql(plan);
-    timings.push({ surface: "graphql", operation: plan.field, ms, answer });
+    const timing: Timing = {
+      surface: "graphql",
+      operation: plan.field,
+      ms,
+      answer,
+      samples: [ms],
+    };
+    timings.push(timing);
+    retime.set(key(timing), () => timeGraphql(plan));
     process.stderr.write(`graphql ${ms}ms ${answer} ${plan.field}\n`);
     await sleep(CALL_SPACING_MS);
   }
 
+  await confirmOverBudget(timings, retime);
   return summarise(timings);
+}
+
+/**
+ * Draw the over-budget operations again, and score each on its MEDIAN.
+ *
+ * WHY ONLY THESE. Re-timing all ~600 operations would triple a sweep that
+ * already runs for the better part of an hour, and it would spend those calls
+ * on the ones whose verdict is not in doubt: an operation that answered in
+ * 300ms is not one draw away from 5000ms. The operations at risk of a wrong
+ * verdict are exactly the ones that crossed the line, and there are few of them
+ * -- the 2026-08-16 run had 40 of 624, so this costs ~13% more calls, not 200%.
+ *
+ * WHY THE MEDIAN and not the minimum: the fastest draw is as unrepresentative
+ * as the slowest, and reporting it would hide real regressions behind one lucky
+ * call. The median of three is the cheapest estimator that ignores a single
+ * outlier in either direction.
+ *
+ * An operation that stops answering `ok` under re-timing keeps its FIRST
+ * answer: a 4xx on the second draw is the sweep's own subject going stale
+ * mid-run, not the operation declining, and `failed`/`unaskable` are counted
+ * elsewhere precisely so they cannot be read as slowness.
+ */
+export async function confirmOverBudget(
+  timings: Timing[],
+  retime: Map<string, () => Promise<[number, Answer]>>,
+  /** Overridable so the unit test does not sit through the real pacing. */
+  spacingMs: number = CALL_SPACING_MS,
+): Promise<void> {
+  const suspects = timings.filter(
+    (timing) => timing.answer === "ok" && timing.ms > BUDGET_MS,
+  );
+  if (suspects.length === 0) return;
+  process.stderr.write(
+    `\nconfirming ${suspects.length} over-budget call(s) with ` +
+      `${CONFIRM_SAMPLES - 1} more sample(s) each\n`,
+  );
+  for (const timing of suspects) {
+    const draw = retime.get(key(timing));
+    if (!draw) continue;
+    for (let i = 1; i < CONFIRM_SAMPLES; i++) {
+      // A zero spacing schedules NOTHING, rather than a zero-delay timer. The
+      // sweep always passes a real gap, so this is for the unit test -- and it
+      // is a correctness fix, not a convenience: the shared-registry suite runs
+      // with `isolate: false`, so a sibling file's `vi.useFakeTimers()` is still
+      // installed when this runs, and a timer that nothing advances never
+      // fires. The first version of these tests passed alone and timed out at
+      // 30s in CI for exactly that reason.
+      if (spacingMs > 0) await sleep(spacingMs);
+      const [ms, answer] = await draw();
+      if (answer !== "ok") continue;
+      timing.samples = [...(timing.samples ?? [timing.ms]), ms];
+    }
+    // The upper median, which matters only when a draw was DISCARDED above and
+    // the count came out even. On a tie this gate should prefer the slower
+    // number: half the evidence says the operation is over budget, and calling
+    // it fixed on the other half is how a real regression gets hidden by one
+    // lucky call -- the failure this whole pass exists to prevent, pointing the
+    // other way.
+    const sorted = [...(timing.samples ?? [timing.ms])].sort((a, b) => a - b);
+    timing.ms = sorted[Math.floor(sorted.length / 2)]!;
+    process.stderr.write(
+      `confirm ${timing.surface} ${timing.operation}` +
+        ` [${timing.samples?.join(", ")}] -> median ${timing.ms}ms\n`,
+    );
+  }
 }
 
 /** The verdict, split out so a recorded run can be re-scored without calling. */

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -352,24 +352,58 @@ export async function loadExtrinsicColdTier(
   network?: ChainNetworkId,
 ): Promise<ReturnType<typeof buildExtrinsic> | null> {
   let predicate: string;
+  // Hoisted out of the branch because the events read below uses them when the
+  // ref is composite -- they are the key it would otherwise wait to learn.
+  let compositeBlock: number | null = null;
+  let compositeIndex: number | null = null;
 
   const composite = /^(\d+)-(\d+)$/.exec(String(ref).trim());
   if (composite) {
-    const block = safeBlockNumber(composite[1]);
-    const index = safeBlockNumber(composite[2]);
-    if (block === null || index === null) return null;
-    predicate = `block_number = ${block} AND extrinsic_index = ${index}`;
+    compositeBlock = safeBlockNumber(composite[1]);
+    compositeIndex = safeBlockNumber(composite[2]);
+    if (compositeBlock === null || compositeIndex === null) return null;
+    predicate = `block_number = ${compositeBlock} AND extrinsic_index = ${compositeIndex}`;
   } else {
     const hash = safeHexLiteral(ref);
     if (hash === null) return null;
     predicate = `extrinsic_hash = '${hash}'`;
   }
 
-  const rows = await r2SqlQuery<ExtrinsicsRow>(
+  const extrinsicQuery = r2SqlQuery<ExtrinsicsRow>(
     env,
     `SELECT ${EXTRINSIC_COLUMNS} FROM ${chainTable("extrinsics", network)} WHERE ${predicate} LIMIT 1`,
     { rowSchema: ExtrinsicsRowSchema },
   );
+
+  // A COMPOSITE ref already names the events' key, so the second read does not
+  // depend on the first and the two go together (#11420). Measured against
+  // production 2026-08-16, `/extrinsics/8760000-1` reported
+  // `server-timing: r2sql;dur=10768;desc="2 calls"` -- two serial reads of a
+  // warehouse whose own per-query spread is 16.7x, so the route was paying that
+  // tail twice for keys it held before the first query was sent.
+  //
+  // A HASH ref cannot do this: `block_number`/`extrinsic_index` are what the
+  // first read is FOR, so that form stays serial rather than guessing a key.
+  //
+  // The cost of being wrong is bounded and one-sided: on a ref that matches no
+  // extrinsic the events read was issued for nothing. It is concurrent, so it
+  // costs the caller no wall-clock, and a point ref naming a block-index pair
+  // that does not exist is not a shape real traffic produces.
+  //
+  // NO `.catch` HERE, deliberately. The two paths below return before awaiting
+  // this promise, so a rejection would be unhandled -- but `r2SqlQuery` cannot
+  // reject. Verified 2026-08-16 rather than assumed: a fetch that throws and a
+  // body over `R2_SQL_MAX_BODY_BYTES` both come back as `null`, because the
+  // one `throw` inside it (`R2SqlBodyTooLargeError`) is re-caught before the
+  // function returns. A catch here would be a guard nothing can fire, and the
+  // test written to cover it passed with the catch REMOVED -- which is how it
+  // was caught.
+  const eventsQuery =
+    composite && compositeBlock !== null && compositeIndex !== null
+      ? embeddedEvents(env, compositeBlock, compositeIndex, network)
+      : null;
+
+  const rows = await extrinsicQuery;
   if (rows === null) return null;
   const row = rows[0];
   // A confirmed absence is an ANSWER, and the same schema-stable payload the
@@ -378,19 +412,34 @@ export async function loadExtrinsicColdTier(
 
   const block = safeBlockNumber(row.block_number);
   const index = safeBlockNumber(row.extrinsic_index);
-  let events: unknown[] = [];
-  if (block !== null && index !== null) {
-    const found = await r2SqlQuery<AccountEventsRow>(
-      env,
-      `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} ` +
-        `WHERE block_number = ${block} AND extrinsic_index = ${index} ` +
-        `ORDER BY event_index LIMIT ${MAX_EMBEDDED_EVENTS}`,
-      { rowSchema: AccountEventsRowSchema },
-    );
-    // Events failing is NOT a reason to withhold the extrinsic: the Postgres
-    // tier serves an empty event list for pre-migration rows too, so an empty
-    // list here is a shape the caller already handles.
-    events = (found ?? []).map(formatAccountEvent).filter(Boolean);
-  }
-  return buildExtrinsic(row, ref, events);
+  const events =
+    eventsQuery ??
+    (block !== null && index !== null
+      ? embeddedEvents(env, block, index, network)
+      : Promise.resolve([]));
+  return buildExtrinsic(row, ref, await events);
+}
+
+/**
+ * The account_events this extrinsic emitted, embedded exactly as the Postgres
+ * tier embeds them.
+ *
+ * Events failing is NOT a reason to withhold the extrinsic: the Postgres tier
+ * serves an empty event list for pre-migration rows too, so an empty list here
+ * is a shape the caller already handles.
+ */
+async function embeddedEvents(
+  env: R2SqlEnv | null | undefined,
+  block: number,
+  index: number,
+  network?: ChainNetworkId,
+): Promise<unknown[]> {
+  const found = await r2SqlQuery<AccountEventsRow>(
+    env,
+    `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} ` +
+      `WHERE block_number = ${block} AND extrinsic_index = ${index} ` +
+      `ORDER BY event_index LIMIT ${MAX_EMBEDDED_EVENTS}`,
+    { rowSchema: AccountEventsRowSchema },
+  );
+  return (found ?? []).map(formatAccountEvent).filter(Boolean);
 }

--- a/tests/extrinsics-cold-tier.test.ts
+++ b/tests/extrinsics-cold-tier.test.ts
@@ -13,7 +13,7 @@ import {
   loadExtrinsicColdTier,
   loadExtrinsicFeedColdTier,
 } from "../src/extrinsics-cold-tier.ts";
-import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { R2_SQL_TOKEN_ENV, r2SqlQuery } from "../src/r2-sql.ts";
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 const SIGNER = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
@@ -381,6 +381,103 @@ describe("loadAccountExtrinsicsColdTier", () => {
 });
 
 describe("loadExtrinsicColdTier", () => {
+  /**
+   * Issue every query but HOLD the extrinsic read open, so "was the events read
+   * dispatched yet?" is answerable. A serial implementation cannot have issued
+   * it -- it is still awaiting the row that names its key.
+   */
+  function gatedFetch() {
+    const issued: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      const sql = String(JSON.parse(String(init.body)).query);
+      issued.push(sql);
+      const events = sql.includes("account_events");
+      if (!events) await gate;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: { rows: events ? [] : [row(500, 3)] },
+        }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return { issued, release: () => release() };
+  }
+
+  test("a composite ref issues BOTH reads at once (#11420)", async () => {
+    // Measured against production 2026-08-16, this route reported
+    // `r2sql;dur=10768;desc="2 calls"` -- two SERIAL reads of a warehouse whose
+    // per-query spread is 16.7x, for a key the ref already named.
+    const { issued, release } = gatedFetch();
+    const pending = loadExtrinsicColdTier(TOKEN as never, "500-3");
+    await new Promise((r) => setTimeout(r, 0));
+    assert.equal(
+      issued.length,
+      2,
+      "both reads must be in flight while the first is still unresolved",
+    );
+    assert.ok(
+      issued.some((q) => q.includes("account_events")),
+      "the events read is the one that must not wait",
+    );
+    release();
+    assert.ok(await pending);
+  });
+
+  test("a HASH ref stays serial -- its key is what the first read is FOR", async () => {
+    // The counterpart control: without it, "issue both" could be implemented by
+    // guessing a key, and this test is what makes that impossible to ship.
+    const { issued, release } = gatedFetch();
+    const pending = loadExtrinsicColdTier(
+      TOKEN as never,
+      `0x${"ab".repeat(32)}`,
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    assert.equal(
+      issued.length,
+      1,
+      "the events read cannot be issued before the row names its block/index",
+    );
+    release();
+    assert.ok(await pending);
+  });
+
+  test("r2SqlQuery DECLINES rather than rejecting, so no catch is owed", async () => {
+    // Why `loadExtrinsicColdTier` starts the events read without a `.catch`
+    // even though two paths return before awaiting it. This is the fact that
+    // makes a floating promise safe, and it is asserted rather than assumed --
+    // the first version of this test went through the loader instead and
+    // passed with the catch REMOVED, proving nothing.
+    const big = JSON.stringify({
+      success: true,
+      result: { rows: [{ padding: "x".repeat(4000) }] },
+    });
+    for (const [label, stub] of [
+      [
+        "a fetch that throws",
+        async () => {
+          throw new Error("network down");
+        },
+      ],
+      ["a body over the cap", async () => new Response(big, { status: 200 })],
+    ] as const) {
+      globalThis.fetch = stub as unknown as typeof fetch;
+      assert.equal(
+        await r2SqlQuery(
+          { ...TOKEN, R2_SQL_MAX_BODY_BYTES: 128 } as never,
+          "SELECT 1",
+        ),
+        null,
+        `${label} must decline, not reject`,
+      );
+    }
+  });
+
   test("resolves a composite <block>-<index> id and embeds its events", async () => {
     const q = sqlFetch(
       [row(500, 3)],

--- a/tests/operation-latency-verdict.test.ts
+++ b/tests/operation-latency-verdict.test.ts
@@ -13,6 +13,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  confirmOverBudget,
   family,
   summarise,
   type Timing,
@@ -169,5 +170,115 @@ describe("a read is one entry, not three", () => {
       family({ surface: "mcp", operation: "get_subnet_snapshot" }),
       "mcp:get_subnet_snapshot",
     );
+  });
+});
+
+// The confirmation pass (#11420). The sweep's verdict used to rest on ONE draw
+// per operation, and the distribution it draws from is 16.7x wide: measured
+// against production 2026-08-16, eleven cold `/api/v1/blocks/{ref}` point
+// lookups ran 898ms to 15,032ms around a 3,647ms median. Both "under budget"
+// and "at the 15s ceiling" are ordinary draws from that, so a single sample
+// decided the verdict by when the sweep happened to call.
+describe("confirming an over-budget draw before believing it", () => {
+  /** A retime map whose draws are scripted, and which counts what it served. */
+  function draws(script: Record<string, number[]>) {
+    const calls: string[] = [];
+    const map = new Map<string, () => Promise<[number, "ok"]>>();
+    for (const [key, values] of Object.entries(script)) {
+      let i = 0;
+      map.set(key, async () => {
+        calls.push(key);
+        return [values[Math.min(i++, values.length - 1)]!, "ok"];
+      });
+    }
+    return { map, calls };
+  }
+
+  test("an operation that was slow ONCE is scored on its median, not that draw", async () => {
+    const timing: Timing = {
+      surface: "rest",
+      operation: "/api/v1/blocks/{ref}",
+      ms: 15032,
+      answer: "ok",
+      samples: [15032],
+    };
+    const { map, calls } = draws({ "rest:/api/v1/blocks/{ref}": [898, 3647] });
+    await confirmOverBudget([timing], map, 0);
+    assert.deepEqual(timing.samples, [15032, 898, 3647]);
+    assert.equal(
+      timing.ms,
+      3647,
+      "the median of the three, not the first draw",
+    );
+    assert.equal(calls.length, 2, "two MORE draws, for three total");
+    // And the verdict that follows from it: no longer over budget.
+    assert.deepEqual(summarise([timing]).overBudget, []);
+  });
+
+  test("an operation that is genuinely slow stays over budget", async () => {
+    // The control. Without it, "score on the median" could be satisfied by
+    // anything that lowers the number, and a real regression would vanish.
+    const timing: Timing = {
+      surface: "rest",
+      operation: "/api/v1/blocks/{ref}",
+      ms: 12000,
+      answer: "ok",
+      samples: [12000],
+    };
+    const { map } = draws({ "rest:/api/v1/blocks/{ref}": [11500, 13000] });
+    await confirmOverBudget([timing], map, 0);
+    assert.equal(timing.ms, 12000);
+    assert.equal(summarise([timing]).overBudget.length, 1);
+  });
+
+  test("an operation UNDER budget is never re-drawn", async () => {
+    // The cost control: re-timing all ~600 operations would triple a sweep that
+    // already runs the better part of an hour, against a warehouse this account
+    // has been rate-limited on (#9465).
+    const timing: Timing = {
+      surface: "rest",
+      operation: "/api/v1/subnets",
+      ms: 300,
+      answer: "ok",
+      samples: [300],
+    };
+    const { map, calls } = draws({ "rest:/api/v1/subnets": [9000, 9000] });
+    await confirmOverBudget([timing], map, 0);
+    assert.deepEqual(calls, [], "no confirmation calls for a fast operation");
+    assert.equal(timing.ms, 300);
+  });
+
+  test("a re-draw that stops answering `ok` does not become a sample", async () => {
+    // A 4xx on the second draw is the sweep's own subject going stale mid-run.
+    // Counting it as a time would let an unaskable call decide a latency
+    // verdict -- the exact conflation `answer` exists to prevent.
+    const timing: Timing = {
+      surface: "rest",
+      operation: "/api/v1/blocks/{ref}",
+      ms: 9000,
+      answer: "ok",
+      samples: [9000],
+    };
+    const calls: string[] = [];
+    const map = new Map<string, () => Promise<[number, "ok" | "unaskable"]>>([
+      [
+        "rest:/api/v1/blocks/{ref}",
+        async () => {
+          calls.push("x");
+          return calls.length === 1 ? [12, "unaskable"] : [8000, "ok"];
+        },
+      ],
+    ]);
+    await confirmOverBudget([timing], map, 0);
+    assert.deepEqual(
+      timing.samples,
+      [9000, 8000],
+      "the 12ms 4xx is not a time",
+    );
+    // Discarding a draw leaves an EVEN count, and on a tie this gate takes the
+    // slower number: half the evidence still says over budget, and calling it
+    // fixed on the other half is how a regression hides behind one lucky call.
+    assert.equal(timing.ms, 9000, "the upper median, conservatively");
+    assert.equal(summarise([timing]).overBudget.length, 1);
   });
 });


### PR DESCRIPTION
## What the measurement actually says

#11420 records three point lookups at 9.2–15.1 s, from the scheduled sweep's **one serial sample** per operation. Measured against production 2026-08-16 using `Server-Timing` (#11442), with **distinct subjects** so every read is a genuine cache miss:

| route | min | **median** | max | r2sql calls |
|---|---|---|---|---|
| `/api/v1/blocks/{ref}` | 898 | **3,647** | 15,032 | 1 |
| `/api/v1/chain-events` | 730 | **5,287** | 9,431 | 1 |
| `/api/v1/extrinsics/{ref}` | 2,987 | **9,956** | 15,340 | **2** |

Eleven cold `/blocks/{ref}` lookups — *one* query shape, distinct refs — ran 898 ms to 15,032 ms with **no relationship to block height**: 8,100,000 answered in 898 ms while 7,200,000 hit the 15 s `QUERY_TIMEOUT_MS` ceiling. Both are ordinary draws from one distribution whose median is *under* the 5 s budget.

So `/blocks/{ref}`'s place in that list was decided by when the sweep happened to call. `Server-Timing` also attributes the cost: r2sql 8,370 ms against neon 76 ms — the lakehouse, not the store.

## The sweep draws again before believing a draw

An operation over budget on its first call is re-timed and scored on the **median of three**. Narrow on purpose: an operation that answered in 300 ms is not one draw away from 5,000 ms, and re-timing all ~600 would triple a sweep that already runs the better part of an hour against a warehouse this account has been rate-limited on (#9465). The 2026-08-16 run had 40 of 624 over budget — ~13% more calls, not 200%.

The header's *"ONE CALL EACH … which is why the budget is deliberately loose"* is updated with it. A loose budget only absorbs noise that is small next to the budget, and 16.7× is not.

On an **even** sample count — which happens when a re-draw comes back `unaskable` and is discarded — the *upper* median wins. Half the evidence still says over budget, and calling it fixed on the other half is how a regression hides behind one lucky call.

## The one read genuinely doing too much

`loadExtrinsicColdTier` issued two **serial** lakehouse reads. For a composite `<block>-<index>` ref the second read's key is named by the ref itself, so it waited on a query whose answer it already held — paying that 16.7× tail twice. Those now go together. A **hash** ref stays serial, because its key is what the first read is *for*, and a test asserts that difference so "issue both" cannot be satisfied by guessing a key.

## Not included, and why

- `/api/v1/extrinsics/{hash}` — the form the sweep times — is the serial one, so this does **not** speed it up.
- `/chain-events`' median (5,287 ms) is still over budget on a single read.

Both stay open on #11420 rather than being declared fixed by a change that didn't fix them. I also did **not** add these routes to `DECLARED`: an exemption for something that may be fine is the quietly-growing list that file warns about.

## A guard I wrote, tested, and deleted

I added a `.catch` on the concurrent read, and a test for it. The test passed with the catch **removed** — so it asserted nothing. Calling `r2SqlQuery` directly showed why: neither a throwing fetch nor a body over `R2_SQL_MAX_BODY_BYTES` rejects; both decline to `null`. The catch was a guard that could not fire. It's gone, and the replacement test asserts that fact directly, which is what its absence now rests on.

## Verification

- Full suite **957 files / 21,996 passed**; all **57** CI validators pass
- **Patch coverage 100%** by diff intersection
- `tsc`, `lint`, `format:check` clean; build produces no drift
- Rebased onto `0693897c6` and re-verified
