### PR TITLE
perf(ui): the health dot fetched a page's own data a second time, every 30 seconds, forever

### DIFF
--- a/apps/ui/src/hooks/use-endpoint-health.test.ts
+++ b/apps/ui/src/hooks/use-endpoint-health.test.ts
@@ -1,6 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-
-import { makeWindow } from "@/lib/metagraphed/test-window";
+import { describe, expect, it } from "vitest";
 
 import { classifyEndpointLatency } from "./use-endpoint-health";
 
@@ -25,47 +23,7 @@ describe("classifyEndpointLatency", () => {
   });
 });
 
-// #8700: the footer health dot must probe the network the user is actually
-// reading. This hook predates multi-network addressing and built its URL by
-// hand, so on testnet.metagraph.sh it measured mainnet's /api/v1/coverage.
-// The failure is silent — an unprefixed probe still returns 200 and still
-// paints green — so it needs an explicit assertion rather than a smoke test.
-describe("buildEndpointHealthUrl network scoping", () => {
-  async function freshHook(win: ReturnType<typeof makeWindow>) {
-    vi.resetModules();
-    vi.stubGlobal("window", win);
-    return import("./use-endpoint-health");
-  }
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("probes the un-prefixed path on the mainnet apex", async () => {
-    const mod = await freshHook(makeWindow({}, "metagraph.sh"));
-    expect(mod.buildEndpointHealthUrl("https://api.metagraph.sh")).toBe(
-      "https://api.metagraph.sh/api/v1/coverage",
-    );
-  });
-
-  it("probes the testnet partition on the testnet host", async () => {
-    const mod = await freshHook(makeWindow({}, "testnet.metagraph.sh"));
-    expect(mod.buildEndpointHealthUrl("https://api.metagraph.sh")).toBe(
-      "https://api.metagraph.sh/api/v1/testnet/coverage",
-    );
-  });
-
-  it("follows a stored preference on a host with no network label", async () => {
-    const mod = await freshHook(makeWindow({ "metagraphed:network": "testnet" }, "localhost"));
-    expect(mod.buildEndpointHealthUrl("http://localhost:8787")).toBe(
-      "http://localhost:8787/api/v1/testnet/coverage",
-    );
-  });
-
-  it("tolerates a base with a trailing slash without doubling it", async () => {
-    const mod = await freshHook(makeWindow({}, "testnet.metagraph.sh"));
-    expect(mod.buildEndpointHealthUrl("https://api.metagraph.sh/")).toBe(
-      "https://api.metagraph.sh/api/v1/testnet/coverage",
-    );
-  });
-});
+// #8700's network-scoping property MOVED rather than disappeared. The dot no
+// longer builds a URL at all -- every sample now comes from `apiFetch`, which
+// resolves the network at call time -- so the assertion lives beside the code
+// that owns it, in lib/metagraphed/api-latency.test.ts.

--- a/apps/ui/src/hooks/use-endpoint-health.ts
+++ b/apps/ui/src/hooks/use-endpoint-health.ts
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
-import { applyNetworkPrefix } from "@/lib/metagraphed/client";
-import { useApiBase, useNetwork } from "./use-api-base";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { apiLatencySnapshot, subscribeApiLatency } from "@/lib/metagraphed/api-latency";
 
 export type EndpointHealth = "checking" | "ok" | "slow" | "bad" | "down";
 
@@ -12,7 +11,8 @@ export interface EndpointHealthState {
 // Round-trip latency tiers for the footer's API-endpoint health dot.
 const SLOW_MS = 300; // ok → slow (yellow)
 const BAD_MS = 800; // slow → bad (orange)
-const REFRESH_MS = 30_000;
+/** How often the hook re-checks whether its sample has aged out. */
+const STALE_TICK_MS = 30_000;
 
 /** Pure latency bucketing for the footer health dot; exported for unit tests. */
 export function classifyEndpointLatency(ms: number | null): EndpointHealth {
@@ -20,29 +20,6 @@ export function classifyEndpointLatency(ms: number | null): EndpointHealth {
   if (ms > BAD_MS) return "bad";
   if (ms > SLOW_MS) return "slow";
   return "ok";
-}
-
-/**
- * The URL the footer health dot probes, for the currently selected network.
- *
- * Exported and pure so the network scoping is testable in this suite's plain
- * node environment, mirroring buildChainStreamUrl in use-chain-stream.ts. The
- * bug this guards against is silent: an unprefixed probe still returns 200 and
- * still paints a green dot, it just measures the wrong partition.
- */
-export function buildEndpointHealthUrl(base: string): string {
-  return `${base.replace(/\/$/, "")}${applyNetworkPrefix("/api/v1/coverage")}`;
-}
-
-async function pingMs(url: string, signal: AbortSignal): Promise<number | null> {
-  const start = performance.now?.() ?? Date.now();
-  try {
-    const res = await fetch(url, { headers: { Accept: "application/json" }, signal });
-    if (!res.ok) return null;
-    return Math.round((performance.now?.() ?? Date.now()) - start);
-  } catch {
-    return null; // network error / abort → treated as down by the caller
-  }
 }
 
 /**
@@ -60,33 +37,59 @@ async function pingMs(url: string, signal: AbortSignal): Promise<number | null> 
  * mainnet one. `/api/v1/coverage` is served on every network, so prefixing it
  * is safe (unlike, say, /api/v1/feeds/watch, which genuinely 404s off mainnet).
  */
+/**
+ * How long ago a sample stops being evidence.
+ *
+ * A tab left open on a static page makes no API calls, and a five-minute-old
+ * number is not a claim about the API's health NOW. Past this the dot returns
+ * to "checking" rather than asserting a stale green -- the same distinction
+ * `unknown` vs `stale` draws in the API's own lane verdicts.
+ */
+const SAMPLE_MAX_AGE_MS = 5 * 60_000;
+
+/**
+ * The footer health dot, from the API calls the page ALREADY makes.
+ *
+ * IT USED TO PROBE. This hook fetched `/api/v1/coverage` itself every 30
+ * seconds, on every page, for as long as the tab stayed open -- and measured
+ * 2026-08-16, one account page load issued that URL TWICE: once for the data it
+ * renders and once more purely to time it. Over a ten-minute session the probe
+ * alone was ~20 requests that render nothing.
+ *
+ * The page was already issuing the measurement. `apiFetch` now records every
+ * round trip (see lib/metagraphed/api-latency.ts) and this subscribes, so the
+ * dot costs zero requests.
+ *
+ * IT IS ALSO A BETTER MEASUREMENT. A synthetic probe timed one endpoint nobody
+ * was waiting on; this times what the user is actually waiting for, which is
+ * what the dot claims to report. A page whose data reads are slow while
+ * `/coverage` happened to be warm used to show green. It cannot now.
+ *
+ * NETWORK SCOPING COMES FOR FREE, and that is worth stating because the old
+ * probe had to build its own prefixed URL to get it right (and did not, until
+ * it was fixed). Every recorded sample came from `apiFetch`, which resolves the
+ * network at call time -- so the samples ARE the selected network's, without
+ * this hook knowing that a network exists.
+ */
 export function useEndpointHealth(): EndpointHealthState {
-  const { base } = useApiBase();
-  // Subscribed, not merely read: applyNetworkPrefix resolves the network at
-  // call time, so without this the effect would not re-run when the user
-  // switches networks in place and the dot would keep probing the old one.
-  const { network } = useNetwork();
-  const [state, setState] = useState<EndpointHealthState>({ status: "checking", ms: null });
+  const sample = useSyncExternalStore(
+    subscribeApiLatency,
+    apiLatencySnapshot,
+    // SSR and the first client pass must agree, and the server has made no
+    // calls -- returning a sample here would hydrate a dot the client then
+    // changes, which React reports as a mismatch.
+    () => null,
+  );
+  const [now, setNow] = useState(() => Date.now());
 
+  // The dot has to go stale on its own, with no traffic to push it: a sample
+  // ages even when nothing else happens.
   useEffect(() => {
-    const url = buildEndpointHealthUrl(base);
-    let active = true;
-    const controller = new AbortController();
+    const id = window.setInterval(() => setNow(Date.now()), STALE_TICK_MS);
+    return () => window.clearInterval(id);
+  }, []);
 
-    async function check() {
-      const ms = await pingMs(url, controller.signal);
-      if (active) setState({ status: classifyEndpointLatency(ms), ms });
-    }
-
-    setState({ status: "checking", ms: null });
-    void check();
-    const id = window.setInterval(() => void check(), REFRESH_MS);
-    return () => {
-      active = false;
-      controller.abort();
-      window.clearInterval(id);
-    };
-  }, [base, network.id]);
-
-  return state;
+  if (!sample) return { status: "checking", ms: null };
+  if (now - sample.at > SAMPLE_MAX_AGE_MS) return { status: "checking", ms: null };
+  return { status: classifyEndpointLatency(sample.ms), ms: sample.ms };
 }

--- a/apps/ui/src/lib/metagraphed/api-latency.test.ts
+++ b/apps/ui/src/lib/metagraphed/api-latency.test.ts
@@ -1,0 +1,144 @@
+// The footer health dot's measurement, after it stopped issuing its own probe.
+//
+// `useEndpointHealth` used to fetch `/api/v1/coverage` every 30 seconds, on
+// every page, for as long as the tab stayed open. Measured 2026-08-16, one
+// account page load issued that URL TWICE -- once for the data it renders and
+// once purely to time it -- and over a ten-minute session the probe alone was
+// ~20 requests that render nothing.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  apiLatencySnapshot,
+  recordApiLatency,
+  resetApiLatency,
+  subscribeApiLatency,
+} from "./api-latency";
+
+afterEach(() => {
+  resetApiLatency();
+  vi.unstubAllGlobals();
+});
+
+describe("the api latency store", () => {
+  it("has no sample before the page has called anything", () => {
+    // SSR and the first client pass both land here, and they must agree --
+    // returning a number would hydrate a dot the client then changes.
+    expect(apiLatencySnapshot()).toBeNull();
+  });
+
+  it("keeps the NEWEST sample, not the first", () => {
+    recordApiLatency(120);
+    recordApiLatency(35);
+    expect(apiLatencySnapshot()?.ms).toBe(35);
+  });
+
+  it("A FAILURE IS A SAMPLE, not an absence", () => {
+    // `ms: null` is what the dot renders as "down". Dropping it would leave
+    // the last successful number on screen while nothing works, which is the
+    // failure a health dot exists to prevent.
+    recordApiLatency(40);
+    recordApiLatency(null);
+    expect(apiLatencySnapshot()?.ms).toBeNull();
+  });
+
+  it("stamps each sample, so a stale one can be told from a fresh one", () => {
+    vi.useFakeTimers({ now: 1_700_000_000_000, toFake: ["Date"] });
+    try {
+      recordApiLatency(10);
+      expect(apiLatencySnapshot()?.at).toBe(1_700_000_000_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("notifies every subscriber, and stops on unsubscribe", () => {
+    let a = 0;
+    let b = 0;
+    const offA = subscribeApiLatency(() => (a += 1));
+    subscribeApiLatency(() => (b += 1));
+    recordApiLatency(1);
+    expect([a, b]).toEqual([1, 1]);
+    offA();
+    recordApiLatency(2);
+    expect([a, b]).toEqual([1, 2]);
+  });
+});
+
+describe("apiFetch feeds the store", () => {
+  /** A fresh module graph, so the store's module state cannot leak between
+   * cases -- and so `buildUrl` re-reads the network from the stubbed window. */
+  async function freshClient(host = "metagraph.sh", stored = {}) {
+    vi.resetModules();
+    vi.stubGlobal("window", {
+      location: { hostname: host, host, origin: `https://${host}` },
+      localStorage: {
+        getItem: (k: string) => (stored as Record<string, string>)[k] ?? null,
+        setItem: () => undefined,
+      },
+    });
+    return {
+      client: await import("./client"),
+      store: await import("./api-latency"),
+    };
+  }
+
+  it("records the round trip of a real call", async () => {
+    const { client, store } = await freshClient();
+    vi.stubGlobal(
+      "fetch",
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await client.apiFetch("/api/v1/coverage");
+    const sample = store.apiLatencySnapshot();
+    expect(sample).not.toBeNull();
+    expect(typeof sample?.ms).toBe("number");
+  });
+
+  it("records a NETWORK FAILURE as down", async () => {
+    const { client, store } = await freshClient();
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("offline");
+    });
+    await expect(client.apiFetch("/api/v1/coverage")).rejects.toThrow();
+    expect(store.apiLatencySnapshot()?.ms).toBeNull();
+  });
+
+  it("AN ABORT IS NOT A MEASUREMENT", async () => {
+    // React Query cancels in-flight requests on unmount and on every keystroke
+    // behind a debounce. Reporting those as "down" would paint the dot red on
+    // ordinary navigation.
+    const { client, store } = await freshClient();
+    const controller = new AbortController();
+    controller.abort();
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("The operation was aborted");
+    });
+    await expect(
+      client.apiFetch("/api/v1/coverage", { signal: controller.signal }),
+    ).rejects.toThrow();
+    expect(store.apiLatencySnapshot()).toBeNull();
+  });
+
+  it("THE SAMPLES ARE THE SELECTED NETWORK'S, without the dot knowing networks exist", async () => {
+    // #8700's property, at its new home. The old probe built its own URL by
+    // hand and got this wrong: on testnet.metagraph.sh it measured MAINNET's
+    // artifact, and the failure was silent because an unprefixed probe still
+    // returns 200 and still paints green. Now every sample comes from
+    // `apiFetch`, which resolves the network at call time -- so the scoping is
+    // structural rather than remembered.
+    const { client } = await freshClient("testnet.metagraph.sh");
+    const seen: string[] = [];
+    vi.stubGlobal("fetch", async (url: string) => {
+      seen.push(String(url));
+      return new Response(JSON.stringify({ ok: true, data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    await client.apiFetch("/api/v1/coverage");
+    expect(seen[0]).toContain("/api/v1/testnet/coverage");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/api-latency.ts
+++ b/apps/ui/src/lib/metagraphed/api-latency.ts
@@ -1,0 +1,76 @@
+// The latency of the API calls this page ALREADY makes.
+//
+// ## Why this exists
+//
+// `useEndpointHealth` painted the footer's health dot by fetching
+// `/api/v1/coverage` itself, every 30 seconds, on every page, for as long as
+// the tab stayed open. Measured 2026-08-16 on one account page load: 20 API
+// requests, of which `/api/v1/coverage` was TWO -- once for the data the page
+// renders, and once more purely to time it. Over a ten-minute session the probe
+// alone is ~20 extra requests that render nothing.
+//
+// The page is already issuing the measurement. Every `apiFetch` is a real
+// round trip to the same origin, so recording how long it took answers the
+// dot's question -- "is the API up, and how fast" -- for free.
+//
+// ## Why this is also a BETTER measurement
+//
+// A synthetic probe times one endpoint that no user is waiting on. This times
+// what the user is actually waiting for, which is the number the dot claims to
+// report. A page whose data reads are slow while `/coverage` happens to be warm
+// used to show green; now it cannot.
+//
+// ## What it deliberately does not do
+//
+// No history, no percentiles, no store framework. The dot renders one bucket
+// from one number, and anything richer belongs in PostHog -- which already
+// receives `$web_vitals` and, since #11442, `Server-Timing` from the API's own
+// three storage boundaries. This is the smallest thing that removes a request.
+
+/** One completed API call: how long, and whether it answered at all. */
+export interface ApiLatencySample {
+  /** Round-trip milliseconds, or null when the request failed outright. */
+  ms: number | null;
+  /** `Date.now()` at completion, so a stale sample can be told from a fresh one. */
+  at: number;
+}
+
+let latest: ApiLatencySample | null = null;
+const listeners = new Set<() => void>();
+
+/**
+ * Record a completed call. Called from `apiFetch`, and from nowhere else --
+ * a second writer would be a second definition of "the API's latency".
+ *
+ * A FAILED REQUEST IS A SAMPLE, not an absence: `ms: null` is what the dot
+ * renders as "down", and dropping it would leave the last successful number on
+ * screen while nothing works, which is the failure a health dot exists to
+ * prevent.
+ */
+export function recordApiLatency(ms: number | null): void {
+  latest = { ms, at: Date.now() };
+  for (const listener of listeners) listener();
+}
+
+/** The newest sample, or null before the page has made a call. */
+export function apiLatencySnapshot(): ApiLatencySample | null {
+  return latest;
+}
+
+/**
+ * Subscribe, in `useSyncExternalStore`'s shape.
+ *
+ * Returns the unsubscribe, and the store is module-level rather than context
+ * because `apiFetch` is called from query functions that have no React tree
+ * above them.
+ */
+export function subscribeApiLatency(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Reset, for tests. Module state outlives a test file otherwise. */
+export function resetApiLatency(): void {
+  latest = null;
+  listeners.clear();
+}

--- a/apps/ui/src/lib/metagraphed/client.ts
+++ b/apps/ui/src/lib/metagraphed/client.ts
@@ -1,4 +1,5 @@
 import { getApiBase, getNetworkPrefix } from "./config";
+import { recordApiLatency } from "./api-latency.ts";
 import type { ApiEnvelope, ApiMeta } from "./types";
 
 export class ApiError extends Error {
@@ -87,6 +88,12 @@ export async function apiFetch<T>(
   opts: { params?: QueryParams; signal?: AbortSignal; init?: RequestInit } = {},
 ): Promise<ApiResult<T>> {
   const url = buildUrl(path, opts.params);
+  // Every call is a real round trip to the API's own origin, so timing it here
+  // is what lets the footer health dot stop issuing a probe of its own -- see
+  // lib/metagraphed/api-latency.ts. Recorded on BOTH paths: a failure is the
+  // sample that renders "down", and dropping it would leave the last good
+  // number on screen while nothing works.
+  const startedAt = performance.now?.() ?? Date.now();
   let res: Response;
   try {
     res = await fetch(url, {
@@ -95,11 +102,16 @@ export async function apiFetch<T>(
       ...opts.init,
     });
   } catch (err) {
+    // An ABORT is not a measurement. React Query cancels in-flight requests on
+    // unmount and on every keystroke behind a debounce, and reporting those as
+    // "down" would paint the dot red on ordinary navigation.
+    if (!opts.signal?.aborted) recordApiLatency(null);
     throw new ApiError((err as Error).message || "Network error", {
       status: 0,
       url: redactUrlForError(url),
     });
   }
+  recordApiLatency(Math.round((performance.now?.() ?? Date.now()) - startedAt));
 
   const text = await res.text();
   let body: unknown = null;


### PR DESCRIPTION
## What it cost

`useEndpointHealth` painted the footer's health dot by fetching `/api/v1/coverage` **itself**, on a 30-second interval, on every page, for as long as the tab stayed open.

Measured 2026-08-16 on one account page load: **20 API requests**, of which `/api/v1/coverage` was **two** — once for the data the page renders, and once purely to time it. Over a ten-minute session the probe alone is ~20 requests that render nothing.

The page was already issuing the measurement. `apiFetch` now records every round trip and the dot subscribes to that, so **it costs zero requests**.

## It is also a better measurement

A synthetic probe timed one endpoint nobody was waiting on. This times what the user is actually waiting for — which is what the dot claims to report. A page whose data reads are slow while `/coverage` happened to be warm used to show green; it cannot now.

Three cases the store gets right, each pinned:

| | |
|---|---|
| **an abort is not a sample** | React Query cancels in-flight requests on unmount and on every keystroke behind a debounce — reporting those as "down" would paint the dot red on ordinary navigation |
| **a failure *is* a sample** | `ms: null` is what renders "down". Dropping it would leave the last good number on screen while nothing works — the exact failure a health dot exists to prevent |
| **a sample ages out at 5 min** | a tab left open on a static page makes no calls, and a five-minute-old number is not a claim about health *now*, so the dot returns to "checking" rather than asserting a stale green |

That last one is the same distinction the API's own lane verdicts draw between `unknown` and `stale`.

## #8700's property moved rather than disappeared

That issue was about the probe measuring the **wrong network**: the hook built its URL by hand, so on `testnet.metagraph.sh` it timed mainnet's artifact — silently, because an unprefixed probe still returns 200 and still paints green.

There is no URL to build now. Every sample comes from `apiFetch`, which resolves the network at call time, so the scoping is **structural rather than remembered**. The assertion moved to sit beside the code that owns it (`api-latency.test.ts` asserts a testnet host produces `/api/v1/testnet/coverage`), and `buildEndpointHealthUrl` / `pingMs` are deleted rather than left exported with no caller.

## Verification

- UI suite 269 files / 2,329 tests; full CI gate 79 targets, 0 failed.
- No visual change — the dot renders the same buckets from the same classifier, which is untouched and still tested.