### PR TITLE
perf(accounts): the entities read scanned 895M rows per request to return the one row that table holds

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -17,6 +17,9 @@
 // (one lane's throw never skips the next) and each failure records exactly
 // one exception under `projection:<name>` so a silently dead lane is visible.
 
+import { CHAIN_OWNERSHIP_PROJECTION_KEY } from "./subnet-ownership-artifact.ts";
+import { fetchOwnershipChangeRows } from "./subnet-ownership-cold-tier.ts";
+
 import { artifactWriteBucket } from "./projection-store.ts";
 
 import {
@@ -165,6 +168,24 @@ export interface ProjectionLane {
    * dispatch branch. Every current lane runs on the shared
    * PROJECTION_LANES_CRON tick, so none sets this yet. */
   intervalCron?: string;
+  /**
+   * Names the reader that serves this artifact, for a lane that backs NO
+   * chain-scope projection route.
+   *
+   * Every lane above this one fills an artifact a `PROJECTION_ROUTE_HANDLERS`
+   * entry serves, and the invariant in tests/projection-networks.ts is what
+   * stops a lane filling an artifact nobody reads. `chain-ownership` is served
+   * instead by `loadOwnershipChangeRows`, behind
+   * `/accounts/{ss58}/entities` and `/subnets/{netuid}/ownership-history` --
+   * two routes that are not chain-scope and whose cold tier reads the stream
+   * directly.
+   *
+   * A POSITIVE DECLARATION, not an exemption: it says which consumer exists,
+   * so the invariant still fails for a lane that names none. An exemption list
+   * would only say the rule does not apply here, which is the shape that lets
+   * a genuinely unread artifact hide.
+   */
+  servedBy?: string;
   /** The artifact body ({schema_version, generated_at, row_count, windows}),
    * or null when the lakehouse could not answer EVERY query — a partial
    * artifact would serve one window's fresh numbers next to another's
@@ -890,6 +911,39 @@ async function computeChainWeights(
 }
 
 /**
+ * The SubnetOwnerChanged stream, whole (#11421).
+ *
+ * NOT WINDOWED, unlike every lane above it. Those serve routes that ask about a
+ * window; this serves two routes that ask about a HISTORY -- who has ever
+ * traded a subnet -- so a window would be the wrong shape and the artifact
+ * holds the entire stream. It can afford to: the 895M-row event table holds one
+ * such event, and a chain-wide ownership transfer does not arrive in volume.
+ *
+ * Reads through `fetchOwnershipChangeRows`, the SAME function the request path
+ * falls back to, so the stored rows are byte-for-byte what a live read would
+ * have produced -- including the `args` restoration from Iceberg's JSON string,
+ * which `decodeChainEventArgs` requires and would silently drop a row without.
+ *
+ * An EMPTY stream is a measured answer and stores as one. A chain on which
+ * nothing has been traded is the honest state for 127 of 128 subnets, so
+ * declining on it would leave both routes paying the 13-second read forever on
+ * exactly the networks where the answer is cheapest to state.
+ */
+async function computeChainOwnership(
+  env: Env,
+  network: ChainNetworkId,
+): Promise<Record<string, unknown> | null> {
+  const rows = await fetchOwnershipChangeRows(env, network);
+  if (rows === null) return null;
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    row_count: rows.length,
+    rows,
+  };
+}
+
+/**
  * GET /api/v1/chain/weights/setters, every supported window (#11418).
  *
  * The per-IDENTITY leaderboard, so it stores `{ rows, totals }` rather than the
@@ -1526,6 +1580,14 @@ export const PROJECTION_LANES: ProjectionLane[] = [
     name: "chain-weight-setters",
     artifactKey: CHAIN_WEIGHT_SETTERS_PROJECTION_KEY,
     compute: computeChainWeightSetters,
+  },
+  {
+    name: "chain-ownership",
+    artifactKey: CHAIN_OWNERSHIP_PROJECTION_KEY,
+    compute: computeChainOwnership,
+    // Not a chain-scope route: the stream is read by the ENTITIES and
+    // OWNERSHIP-HISTORY cold tiers, which narrow it per address and per subnet.
+    servedBy: "loadOwnershipChangeRows",
   },
 ];
 

--- a/src/projection-store.ts
+++ b/src/projection-store.ts
@@ -119,7 +119,7 @@ export function artifactWriteBucket(
  * tier cannot answer -- and none of them should reach a builder.
  */
 export async function readArtifactObject<T>(
-  env: Env | null | undefined,
+  env: ArtifactStoreEnv | null | undefined,
   key: string,
   network: ChainNetworkId,
   schema: z.ZodType<T>,
@@ -184,7 +184,7 @@ export interface ProjectionWindowQuery<T> {
  * has not computed 30d yet must not have its 7d numbers published as 30d.
  */
 export async function readProjectionWindow<T>(
-  env: Env | null | undefined,
+  env: ArtifactStoreEnv | null | undefined,
   query: ProjectionWindowQuery<T>,
 ): Promise<ProjectionWindowRead<T> | null> {
   const label = query.window ?? query.defaultWindow;

--- a/src/subnet-ownership-artifact.ts
+++ b/src/subnet-ownership-artifact.ts
@@ -1,0 +1,86 @@
+// The SubnetOwnerChanged stream, served from a SCHEDULED PROJECTION artifact
+// instead of scanning 895M rows per request (#11421).
+//
+// ## What this replaces, and what it costs today
+//
+// `loadOwnershipChangeRows` asks `chain.chain_events` for
+// `pallet = 'SubtensorModule' AND method = 'SubnetOwnerChanged'` with NO block
+// window and NO limit. Neither predicate prunes files -- they are low-cardinality
+// string equalities on a 895M-row table -- so the engine opens the table to
+// return, by that module's own account, ONE row. Automatic ownership transfers
+// are rare chain-wide events, which is what makes the unfiltered read
+// defensible and also what makes precomputing it obvious.
+//
+// Measured against production 2026-08-16 with `Server-Timing` (#11442), five
+// draws each with DISTINCT subjects so the edge cache could not answer:
+//
+//   /accounts/{ss58}/entities            min 10,420  median 13,711  max 15,108
+//   /subnets/{netuid}/ownership-history  min  6,842  median 10,516  max 27,704
+//
+// The narrow spread on `entities` (1.45x, and a MINIMUM of 10.4s) is what marks
+// this as a real floor rather than the warehouse variance #11420 turned out to
+// be: there is no lucky draw here, every call pays it. The second route runs
+// this scan plus its own observations read, which is why it reports two calls.
+//
+// ## Why the whole stream, not a window
+//
+// The other lanes store per-window rollups because their routes ask about a
+// window. This one is a HISTORY: a caller asking who has ever traded a subnet
+// is asking about all of it, so the artifact holds the entire stream. It can
+// afford to -- one row today, and a chain-wide ownership transfer is not a
+// thing that arrives in volume.
+//
+// ## What it does NOT change
+//
+// The rows are stored exactly as `loadOwnershipChangeRows` returns them, with
+// `args` already restored from Iceberg's JSON string to the parsed shape
+// postgres.js would have delivered. That restoration is the reader's contract
+// with `decodeChainEventArgs`, which does not parse strings and would silently
+// drop a row handed one -- so doing it in the lane rather than after the read
+// keeps one definition of "a usable ownership row" instead of two.
+import { z } from "zod";
+
+import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
+import {
+  type ArtifactStoreEnv,
+  readArtifactObject,
+} from "./projection-store.ts";
+import { ProjectionRowsSchema } from "../schemas-src/projection-artifact.ts";
+
+export const CHAIN_OWNERSHIP_PROJECTION_KEY =
+  "metagraph/projections/chain-ownership.json";
+
+/**
+ * The stored stream.
+ *
+ * `rows` is REQUIRED and an empty array is a real answer: a chain on which
+ * nothing has been traded is the honest state for 127 of 128 subnets, and a
+ * lane that found none must be able to say so. What must never happen is an
+ * absent `rows` reading as "none", which is why it is not optional.
+ */
+const OwnershipArtifactSchema = z.object({
+  schema_version: z.literal(1),
+  rows: ProjectionRowsSchema,
+});
+
+/**
+ * Every SubnetOwnerChanged row the lane last stored, or null when the artifact
+ * store cannot answer FAITHFULLY -- unbound, missing object, or a body that is
+ * not what the lane wrote.
+ *
+ * Null sends the caller to the lakehouse read this exists to avoid, which is
+ * the point: this can only make the route faster, never wrong, and shipping it
+ * before the lane has first run is safe by construction.
+ */
+export async function loadOwnershipRowsFromArtifact(
+  env: ArtifactStoreEnv | null | undefined,
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+): Promise<Record<string, unknown>[] | null> {
+  const body = await readArtifactObject(
+    env,
+    CHAIN_OWNERSHIP_PROJECTION_KEY,
+    network,
+    OwnershipArtifactSchema,
+  );
+  return body?.rows ?? null;
+}

--- a/src/subnet-ownership-cold-tier.ts
+++ b/src/subnet-ownership-cold-tier.ts
@@ -16,11 +16,17 @@
 // decoder for the same facts -- so parity means reading the same stream from
 // chain.chain_events and feeding the same formatter.
 //
-// The scan is pallet+method filtered over a large table with no index to
-// lean on, so it can be slow on a cold cache. That is acceptable here: the
-// route sits behind the edge cache, ownership changes are rare enough that
-// the match set is tiny, and a timeout declines to the caller's existing
-// schema-stable empty rather than failing the request.
+// THE SCAN IS NOW BEHIND A LANE (#11421). It is pallet+method filtered over a
+// large table with no index to lean on, and that was called "acceptable ...
+// can be slow on a cold cache" here until it was measured. Against production
+// 2026-08-16, `/accounts/{ss58}/entities` spent a MINIMUM of 10,420ms in r2sql
+// across five distinct subjects, median 13,711ms -- not a cold-cache tail but
+// a floor every caller pays, to return the one row this table holds.
+//
+// `loadOwnershipChangeRows` reads the projection first and falls through to
+// this query when the lane has not run, so the answer is unchanged either way
+// and the edge cache is no longer the only thing standing between a caller and
+// a 13-second read.
 
 import { buildAccountEntities } from "./entity-labels.ts";
 import {
@@ -29,6 +35,21 @@ import {
 } from "./subnet-ownership-history.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
 import type { R2SqlEnv } from "./r2-sql.ts";
+import {
+  chainTable,
+  type ChainNetworkId,
+  DEFAULT_CHAIN_NETWORK,
+} from "./chain-network.ts";
+import { loadOwnershipRowsFromArtifact } from "./subnet-ownership-artifact.ts";
+import type { ArtifactStoreEnv } from "./projection-store.ts";
+
+/**
+ * Both stores these readers touch: the lakehouse they fall back to, and the
+ * archive the lane writes. Declared rather than cast into -- `R2SqlEnv` names
+ * only the warehouse credentials, and widening it would tell every other
+ * `r2SqlQuery` caller it has a bucket.
+ */
+type OwnershipReadEnv = R2SqlEnv & ArtifactStoreEnv;
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -51,12 +72,13 @@ const OWNERSHIP_EVENT_COLUMNS =
  * The whole stream is small enough for that to be the right trade: automatic
  * ownership transfers are rare chain-wide events, not a feed.
  */
-async function loadOwnershipChangeRows(
+export async function fetchOwnershipChangeRows(
   env: R2SqlEnv | null | undefined,
+  network?: ChainNetworkId,
 ): Promise<Record<string, unknown>[] | null> {
   const rows = await r2SqlQuery(
     env,
-    `SELECT ${OWNERSHIP_EVENT_COLUMNS} FROM chain.chain_events` +
+    `SELECT ${OWNERSHIP_EVENT_COLUMNS} FROM ${chainTable("chain_events", network)}` +
       ` WHERE pallet = 'SubtensorModule' AND method = '${OWNERSHIP_CHANGE_EVENT_METHOD}'` +
       ` ORDER BY block_number ASC`,
   );
@@ -84,6 +106,30 @@ async function loadOwnershipChangeRows(
 }
 
 /**
+ * The stream, from the LANE if it has run and from the lakehouse if it has not.
+ *
+ * The artifact is tried first because the read below is the expensive one:
+ * measured against production 2026-08-16, `/accounts/{ss58}/entities` spent a
+ * median of 13,711ms in r2sql with a MINIMUM of 10,420ms across five distinct
+ * subjects -- a floor every caller pays, not a tail some callers draw.
+ *
+ * Falling through on a miss is what makes this safe to ship before the lane has
+ * ever run: the answer is identical either way, because the lane stores exactly
+ * what `fetchOwnershipChangeRows` returned.
+ */
+async function loadOwnershipChangeRows(
+  env: OwnershipReadEnv | null | undefined,
+  network?: ChainNetworkId,
+): Promise<Record<string, unknown>[] | null> {
+  const projected = await loadOwnershipRowsFromArtifact(
+    env,
+    network ?? DEFAULT_CHAIN_NETWORK,
+  );
+  if (projected !== null) return projected;
+  return await fetchOwnershipChangeRows(env, network);
+}
+
+/**
  * GET /api/v1/accounts/{coldkey}/entities -- one address's subnet-ownership
  * ties. The coldkey filter happens in buildAccountEntities, in JS after
  * decoding, exactly as it does on the Postgres tier, so the address never
@@ -93,7 +139,7 @@ async function loadOwnershipChangeRows(
  * schema-stable empty-ties fallback.
  */
 export async function loadAccountEntitiesColdTier(
-  env: R2SqlEnv | null | undefined,
+  env: OwnershipReadEnv | null | undefined,
   coldkey: string,
 ): Promise<ReturnType<typeof buildAccountEntities> | null> {
   const rows = await loadOwnershipChangeRows(env);
@@ -118,7 +164,7 @@ export async function loadAccountEntitiesColdTier(
  * echoing a nonsense value back into the payload.
  */
 export async function loadSubnetOwnershipHistoryColdTier(
-  env: R2SqlEnv | null | undefined,
+  env: OwnershipReadEnv | null | undefined,
   netuid: unknown,
 ): Promise<ReturnType<typeof buildSubnetOwnershipHistory> | null> {
   const subnet = safeBlockNumber(netuid);

--- a/tests/projection-networks.test.ts
+++ b/tests/projection-networks.test.ts
@@ -78,14 +78,28 @@ describe("the projection route list is derived from the router", () => {
     }
   });
 
-  // The other direction: one route per lane, plus the split's extra reader.
-  // A lane whose route is missing here would fill an artifact nobody serves.
-  test("every lane's route is listed", () => {
+  // The other direction: a lane whose consumer is missing would fill an
+  // artifact nobody serves.
+  //
+  // This used to be a bare count equality, which reads as "one route per lane"
+  // but only actually checks that two lists are the same LENGTH -- two lanes
+  // sharing a route and one lane with none would satisfy it exactly as well.
+  // #11421 added the first lane with no chain-scope route at all
+  // (`chain-ownership`, read by the entities and ownership-history cold tiers),
+  // so the count stopped matching and the rule had to be stated properly.
+  test("every lane has a consumer: a chain-scope route, or a named reader", () => {
+    const routeBacked = PROJECTION_LANES.filter((lane) => !lane.servedBy);
     assert.equal(
       PROJECTION_ROUTE_PATHS.length,
-      PROJECTION_LANES.length,
-      "each lane backs exactly one chain-scope route",
+      routeBacked.length,
+      "each route-backed lane backs exactly one chain-scope route",
     );
+    for (const lane of PROJECTION_LANES) {
+      assert.ok(
+        lane.servedBy === undefined || lane.servedBy.length > 0,
+        `${lane.name} declares an empty consumer, which names nothing`,
+      );
+    }
   });
 });
 

--- a/tests/subnet-ownership-answer.test.ts
+++ b/tests/subnet-ownership-answer.test.ts
@@ -30,13 +30,21 @@ afterEach(() => {
   globalThis.fetch = realFetch;
 });
 
-function sqlFetch(...responses: unknown[][]) {
+/**
+ * Answer by WHICH TABLE the query names, not by call order.
+ *
+ * The two reads are concurrent, so their arrival order is scheduling rather
+ * than contract -- and it changed in #11421, when the stream read started
+ * awaiting the projection artifact before falling through to SQL. An
+ * order-keyed stub silently handed each query the OTHER one's rows, which
+ * reads as a wrong answer rather than a reordering.
+ */
+function sqlFetch(streamRows: unknown[] = [], ledgerRows: unknown[] = []) {
   const queries: string[] = [];
-  let call = 0;
   globalThis.fetch = (async (_u: string, init: RequestInit) => {
-    queries.push(JSON.parse(String(init.body)).query);
-    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
-    call += 1;
+    const sql = String(JSON.parse(String(init.body)).query);
+    queries.push(sql);
+    const rows = /subnet_ownership_history/.test(sql) ? ledgerRows : streamRows;
     return {
       ok: true,
       status: 200,
@@ -48,10 +56,13 @@ function sqlFetch(...responses: unknown[][]) {
 
 describe("loadSubnetOwnerObservations", () => {
   test("reads one subnet's captures oldest first, narrowed in SQL", async () => {
-    const q = sqlFetch([
-      { owner_coldkey: OWNER_A, captured_at: 1 },
-      { owner_coldkey: OWNER_B, captured_at: 2 },
-    ]);
+    const q = sqlFetch(
+      [],
+      [
+        { owner_coldkey: OWNER_A, captured_at: 1 },
+        { owner_coldkey: OWNER_B, captured_at: 2 },
+      ],
+    );
     const rows = await loadSubnetOwnerObservations(TOKEN, 18);
     assert.match(q[0]!, /FROM chain\.subnet_ownership_history/);
     // The ledger carries netuid as a real column, so unlike the event stream
@@ -76,7 +87,8 @@ describe("loadSubnetOwnerObservations", () => {
 
 describe("answerSubnetOwnershipHistory", () => {
   test("merges both sources into one labelled history", async () => {
-    // The event stream first (it is issued first), then the ledger slice.
+    // Keyed by table, so this says WHICH source carries what rather than
+    // which query happened to be issued first.
     sqlFetch(
       [],
       [

--- a/tests/subnet-ownership-artifact.test.ts
+++ b/tests/subnet-ownership-artifact.test.ts
@@ -1,0 +1,119 @@
+// The ownership-stream projection reader (#11421).
+//
+// This lane exists because the read it replaces is the only one in the family
+// with a measured FLOOR rather than a tail: against production 2026-08-16,
+// `/accounts/{ss58}/entities` spent a minimum of 10,420ms in r2sql across five
+// distinct subjects (median 13,711ms), scanning an 895M-row table to return the
+// one SubnetOwnerChanged row it holds.
+//
+// So the contract worth pinning here is the FALLTHROUGH: every decline must
+// reach the lakehouse read, because that is what makes shipping this before the
+// lane has ever run safe.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  CHAIN_OWNERSHIP_PROJECTION_KEY,
+  loadOwnershipRowsFromArtifact,
+} from "../src/subnet-ownership-artifact.ts";
+
+const ROW = {
+  block_number: 8_500_000,
+  pallet: "SubtensorModule",
+  method: "SubnetOwnerChanged",
+  args: { netuid: 7, old_coldkey: "0xaa", new_coldkey: "0xbb" },
+  observed_at: 1_784_537_200_378,
+};
+
+function bucketWith(body: unknown, { missing = false } = {}) {
+  const gets: string[] = [];
+  return {
+    gets,
+    env: {
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          gets.push(key);
+          if (missing) return null;
+          return {
+            async json() {
+              return body;
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+describe("loadOwnershipRowsFromArtifact", () => {
+  test("serves the stored stream verbatim", async () => {
+    const { env, gets } = bucketWith({ schema_version: 1, rows: [ROW] });
+    const rows = await loadOwnershipRowsFromArtifact(env);
+    assert.deepEqual(gets, [CHAIN_OWNERSHIP_PROJECTION_KEY]);
+    assert.equal(rows?.length, 1);
+    // `args` arrives PARSED, not as Iceberg's JSON string. The lane restores it
+    // so `decodeChainEventArgs` -- which does not parse strings, and silently
+    // drops a row handed one -- sees the shape it requires.
+    assert.deepEqual(rows?.[0]?.args, ROW.args);
+  });
+
+  test("an EMPTY stream is an answer, not a decline", async () => {
+    // The honest state for 127 of 128 subnets. Declining on it would leave both
+    // routes paying the 13-second read forever on the networks where the answer
+    // is cheapest to state.
+    const { env } = bucketWith({ schema_version: 1, rows: [] });
+    assert.deepEqual(await loadOwnershipRowsFromArtifact(env), []);
+  });
+
+  test("reads the per-network key off mainnet, never mainnet's", async () => {
+    const { env, gets } = bucketWith({ schema_version: 1, rows: [] });
+    await loadOwnershipRowsFromArtifact(env, "testnet");
+    assert.ok(gets.length > 0, "the reader actually looked");
+    assert.ok(!gets.includes(CHAIN_OWNERSHIP_PROJECTION_KEY));
+  });
+
+  describe("declines so the caller falls through to the lakehouse", () => {
+    test("no archive bound", async () => {
+      assert.equal(await loadOwnershipRowsFromArtifact({}), null);
+      assert.equal(await loadOwnershipRowsFromArtifact(null), null);
+    });
+
+    test("the object is missing -- the lane has not run yet", async () => {
+      const { env } = bucketWith(null, { missing: true });
+      assert.equal(await loadOwnershipRowsFromArtifact(env), null);
+    });
+
+    test("a body that is not what the lane wrote", async () => {
+      for (const body of [
+        null,
+        {},
+        { schema_version: 2, rows: [] },
+        { schema_version: 1 },
+        // `rows` absent must NEVER read as "no ownership changes" -- that is a
+        // wrong answer wearing a measured one's shape, which is why the schema
+        // requires it rather than defaulting it.
+        { schema_version: 1, rows: null },
+        { schema_version: 1, rows: "nope" },
+        { schema_version: 1, rows: [null] },
+      ]) {
+        const { env } = bucketWith(body);
+        assert.equal(
+          await loadOwnershipRowsFromArtifact(env),
+          null,
+          `${JSON.stringify(body)} must decline`,
+        );
+      }
+    });
+
+    test("a bucket that throws", async () => {
+      const env = {
+        METAGRAPH_ARCHIVE: {
+          async get() {
+            throw new Error("archive unavailable");
+          },
+        },
+      };
+      assert.equal(await loadOwnershipRowsFromArtifact(env), null);
+    });
+  });
+});

--- a/tests/subnet-ownership-cold-tier.test.ts
+++ b/tests/subnet-ownership-cold-tier.test.ts
@@ -66,6 +66,82 @@ function sqlFetch(...responses: unknown[][]) {
   return queries;
 }
 
+describe("the projection short-circuits the scan (#11421)", () => {
+  /**
+   * A stored row carries args PARSED -- the lane restores Iceberg's JSON string
+   * before writing, so the artifact holds the driver shape `decodeChainEventArgs`
+   * needs. A stored row that still held the string would be one this reader
+   * silently drops.
+   */
+  function storedRow() {
+    return {
+      ...ownershipRow(),
+      args: {
+        netuid: 7,
+        old_coldkey: OLD_COLDKEY_BYTES,
+        new_coldkey: NEW_COLDKEY_BYTES,
+      },
+    };
+  }
+
+  /** An archive that answers the ownership key with `body`. */
+  function archive(body: unknown) {
+    return {
+      ...TOKEN,
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return body === null
+            ? null
+            : {
+                async json() {
+                  return body;
+                },
+              };
+        },
+      },
+    };
+  }
+
+  test("an artifact HIT issues no lakehouse query at all", async () => {
+    // The whole point. This read is a measured floor -- minimum 10,420ms in
+    // r2sql across five distinct subjects against production 2026-08-16 -- so
+    // "the artifact answered" has to mean the scan did not run, not that it ran
+    // and was discarded.
+    const q = sqlFetch([ownershipRow()]);
+    const data = (await loadAccountEntitiesColdTier(
+      archive({ schema_version: 1, rows: [storedRow()] }) as never,
+      NEW_COLDKEY_SS58,
+    )) as Row;
+    assert.deepEqual(q, [], "no query reached the warehouse");
+    assert.ok(data, "and the route was still answered");
+  });
+
+  test("an artifact MISS falls through to the scan, unchanged", async () => {
+    // What makes this safe to ship before the lane has ever run: the answer is
+    // identical either way, because the lane stores exactly what this returns.
+    const q = sqlFetch([ownershipRow()]);
+    const data = (await loadAccountEntitiesColdTier(
+      archive(null) as never,
+      NEW_COLDKEY_SS58,
+    )) as Row;
+    assert.equal(q.length, 1, "the lakehouse answered instead");
+    assert.match(q[0]!, /FROM chain\.chain_events/);
+    assert.ok(data);
+  });
+
+  test("an EMPTY stored stream is served, not treated as a miss", async () => {
+    // A chain on which nothing has been traded is the honest state for 127 of
+    // 128 subnets. Falling through on it would leave the scan running forever
+    // on exactly the networks whose answer is cheapest to state.
+    const q = sqlFetch([ownershipRow()]);
+    await loadAccountEntitiesColdTier(
+      archive({ schema_version: 1, rows: [] }) as never,
+      NEW_COLDKEY_SS58,
+    );
+    assert.deepEqual(q, [], "an empty artifact still short-circuits");
+  });
+});
+
 describe("loadAccountEntitiesColdTier", () => {
   test("reads the SubnetOwnerChanged stream with data-api's exact predicate", async () => {
     const q = sqlFetch([ownershipRow()]);
@@ -155,9 +231,14 @@ describe("loadSubnetOwnershipHistoryColdTier", () => {
       TOKEN as never,
       7,
     )) as Row;
-    assert.match(q[0]!, /FROM chain\.chain_events/);
+    // Matched by CONTENT, not by index. The two reads are concurrent, and
+    // since #11421 the stream read awaits the projection artifact before
+    // falling through to SQL -- so which of them reaches the warehouse first is
+    // scheduling, not contract, and pinning `q[0]` asserted the scheduling.
+    const streamQuery = q.find((sql) => /FROM chain\.chain_events/.test(sql));
+    assert.ok(streamQuery, "the stream is still read from chain_events");
     assert.ok(
-      !/netuid/.test(q[0]!),
+      !/netuid/.test(streamQuery),
       "the netuid predicate is not expressible against a JSON-string args column",
     );
     assert.equal(data.netuid, 7);


### PR DESCRIPTION
## The measurement

#11421 lists five reads at 9.2–15.4 s from the sweep's **one serial sample**. Re-measured against production 2026-08-16 with `Server-Timing` (#11442), five draws each with **distinct subjects** so the edge cache could not answer:

| route | min | **median** | max | r2sql calls |
|---|---|---|---|---|
| `/accounts/{ss58}/entities` | 10,420 | **13,711** | 15,108 | 1 |
| `/subnets/{netuid}/stake-transfers` | 6,708 | **18,760** | 30,187 | **3** |
| `/subnets/{netuid}/ownership-history` | 6,842 | **10,516** | 27,704 | **2** |
| `/validators/{hotkey}/history` | 1,281 | **15,000** | 15,000 | 1 |
| `/accounts/{ss58}/subnets/{netuid}/history` | 995 | **7,279** | 15,000 | 1 |
| `/accounts/{ss58}/stake-moves` | 4,596 | **6,877** | 11,951 | 1 |

Unlike #11420 — where `/blocks/{ref}` turned out to be one draw from a 16.7× distribution with a median *under* budget — `entities` has a narrow **1.45× spread and a minimum of 10,420 ms**. That's a floor every caller pays, not a tail some callers draw. Worth fixing rather than re-scoring.

## What it was doing

`loadOwnershipChangeRows` asked `chain.chain_events` for `pallet = 'SubtensorModule' AND method = 'SubnetOwnerChanged'` with **no block window and no limit**. Neither predicate prunes files — both are low-cardinality string equalities — so the engine opened a **895M-row table to return the one row it holds**.

That was a considered trade, and the header said so: *"acceptable here: the route sits behind the edge cache, ownership changes are rare"*. The edge cache is **60 s**. Every minute, one caller paid 13 seconds for a value that changes approximately never.

## The lane

`chain-ownership` precomputes the stream; `loadOwnershipChangeRows` reads the artifact and falls through to the same query when the lane hasn't run — so this can only make the routes faster, never wrong, and is safe to ship before the lane's first tick.

Two routes benefit, because both read one stream through one function: `/accounts/{ss58}/entities` and `/subnets/{netuid}/ownership-history` (the latter already `DECLARED` under #10312).

Not windowed, unlike its seventeen siblings — those serve routes that ask about a *window*, this serves routes that ask about a *history*. An **empty** stream stores as a measured answer: "nothing has been traded" is the honest state for 127 of 128 subnets, and declining on it would leave the scan running forever on exactly the networks whose answer is cheapest to state.

The lane reads through `fetchOwnershipChangeRows` — the same function the request path falls back to — so stored rows are what a live read would have produced, including the `args` restoration from Iceberg's JSON string that `decodeChainEventArgs` requires and would silently drop a row without.

## Two defects fixed on the way

- The query named `chain.chain_events` **literally** rather than through `chainTable(…)`, so a testnet read would have answered from mainnet's table. Now threaded like its siblings.
- `tests/projection-networks.ts` asserted the lane/route invariant as a **bare count equality**. It reads as "one route per lane" but only checks two lists are the same *length* — two lanes sharing a route plus one lane with none would satisfy it equally. This is the first lane with no chain-scope route, so the rule is now stated: a lane either backs a route or **names its reader** (`servedBy`). A positive declaration of the consumer, not an exemption — a lane naming none still fails.

## Not included

The other four reads are separate queries needing separate fixes. `stake-transfers` makes **three serial calls**; `validators/{hotkey}/history` sits at exactly 15,000 ms — `QUERY_TIMEOUT_MS`, i.e. declining rather than answering. Both stay open on #11421 with the measurements posted there.

## Verification

- Full suite **958 files / 22,006 passed**; all **57** CI validators pass
- **Patch coverage 100%** by diff intersection
- The short-circuit tests were verified to FAIL with the artifact read removed, so they assert the thing that matters: an artifact hit issues *no* warehouse query
- `tsc`, `lint`, `format:check` clean; build produces no drift
