### PR TITLE
fix(deploy): a PostHog outage stopped three Workers from deploying at all

### DIFF
--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -109,6 +109,39 @@ if [[ "$POSTHOG_ENABLED" == "true" ]] &&
   POSTHOG_ENABLED=false
 fi
 
+# ...AND IT HAS TO REACH POSTHOG (#11421). The rule above is right and was
+# applied to only half the ways this step fails: a MISSING cli skipped, but a
+# cli that ran and could not reach the API took the deploy down with it, under
+# `set -e`.
+#
+# That is not hypothetical. On 2026-08-17 every Workers Build in the account
+# began failing at `posthog-cli sourcemap inject` with
+#
+#   WARN posthog_cli::api::releases: failed to get release from hash:
+#     Request error: error sending request for url (https://us.i.posthog.com/...)
+#   Failed: error occurred while running deploy command
+#
+# after a 30s timeout -- on three Workers, on unrelated branches (a renovate
+# bump and a perf branch), and identically on a retrigger ten minutes later.
+# The wrangler build had already SUCCEEDED in every one of them; the bytes were
+# ready to ship. A third-party observability endpoint being unreachable had
+# become an estate-wide deploy outage.
+#
+# So the same trade is applied to the same failure: run the two posthog phases
+# tolerantly, and on ANY failure fall through to the plain deploy below. That
+# path rebuilds from source, so a bundle half-injected by a failed `inject` is
+# never what ships -- and no chunk id is stamped without a map behind it, which
+# is the one outcome worse than no symbolication at all.
+posthog_phase() {
+  if "$@"; then
+    return 0
+  fi
+  echo "warning: $1 failed (see #11421); deploying WITHOUT sourcemap" \
+    "injection or upload. A Worker deployed without symbolication is a small" \
+    "observability loss; a Worker that did not deploy is an outage." >&2
+  return 1
+}
+
 if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # Phase 0: start from an empty $OUTDIR. `wrangler --outdir` writes into the
   # directory without clearing it, so anything left there from an earlier run
@@ -148,10 +181,15 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # (metagraphed-data-api, 2026-07-31). posthog-cli's own help says these are
   # "strongly recommended to be set explicitly during release CD workflows",
   # and this is why: they are what makes the 3 Workers x 2 modes distinct.
-  npx @posthog/cli sourcemap inject \
+  if ! posthog_phase npx @posthog/cli sourcemap inject \
     --directory "$OUTDIR" \
     --release-name "$RELEASE_NAME" \
-    --release-version "$RELEASE_VERSION"
+    --release-version "$RELEASE_VERSION"; then
+    POSTHOG_ENABLED=false
+  fi
+fi
+
+if [[ "$POSTHOG_ENABLED" == "true" ]]; then
 
   # Phases 3-4 below: upload the sourcemap, then ship the EXACT injected
   # file -- --no-bundle skips wrangler's
@@ -187,11 +225,15 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # live on 2026-08-02's deploys. Uploading first is safe: the map + chunk
   # id are fully determined by phase 2's inject, and an upload for a deploy
   # that subsequently fails is inert (its chunk id never serves traffic).
-  npx @posthog/cli sourcemap upload \
+  if ! posthog_phase npx @posthog/cli sourcemap upload \
     --directory "$OUTDIR" \
     --release-name "$RELEASE_NAME" \
-    --release-version "$RELEASE_VERSION"
+    --release-version "$RELEASE_VERSION"; then
+    POSTHOG_ENABLED=false
+  fi
+fi
 
+if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # Phase 4: ship the EXACT injected bundle the map above describes.
   npx wrangler "${WRANGLER_SUBCOMMAND[@]}" \
     "$ENTRY_JS" \

--- a/tests/deploy-worker-sourcemaps.test.ts
+++ b/tests/deploy-worker-sourcemaps.test.ts
@@ -1,0 +1,186 @@
+// The Worker deploy script's FAILURE POSTURE (#11421).
+//
+// `scripts/deploy-worker-with-sourcemaps.sh` ships three production Workers,
+// and it had no test. On 2026-08-17 every Workers Build in the account failed
+// at `posthog-cli sourcemap inject` -- a 30s network timeout to
+// `us.i.posthog.com` -- on three Workers and unrelated branches, identically on
+// retrigger. The wrangler build had SUCCEEDED in every one; the bytes were
+// ready to ship. A third-party observability endpoint being unreachable had
+// become an estate-wide deploy outage.
+//
+// The script's own header already had the rule, written for #10916 when the
+// cli could be MISSING: "A Worker deployed without symbolication is a small
+// observability loss; a Worker that did not deploy is an outage." It simply
+// was not applied to the cli FAILING. These tests pin both halves, plus the one
+// failure that must stay fatal.
+//
+// Driven through a stubbed PATH rather than mocked internals: the thing under
+// test is a bash script's control flow under `set -euo pipefail`, and the only
+// honest way to exercise that is to run it.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "vitest";
+
+const SCRIPT = join(
+  import.meta.dirname,
+  "..",
+  "scripts",
+  "deploy-worker-with-sourcemaps.sh",
+);
+
+/**
+ * A sandbox whose `npx` and `git` are shell stubs that log every invocation.
+ *
+ * `failInject`/`failUpload` make the matching posthog phase exit non-zero,
+ * which is exactly what the live outage did.
+ */
+function sandbox({
+  failInject = false,
+  failUpload = false,
+  emitBundles = 1,
+} = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "deploy-sourcemaps-"));
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  const log = join(dir, "calls.log");
+
+  writeFileSync(
+    join(bin, "npx"),
+    `#!/usr/bin/env bash
+echo "npx $*" >> ${JSON.stringify(log)}
+args="$*"
+case "$args" in
+  *"--no-install @posthog/cli --version"*) exit 0 ;;
+  *"sourcemap inject"*) exit ${failInject ? 1 : 0} ;;
+  *"sourcemap upload"*) exit ${failUpload ? 1 : 0} ;;
+  *"--dry-run"*)
+    # wrangler's build phase: write the bundle(s) the script then globs for.
+    outdir=""
+    prev=""
+    for a in $args; do
+      if [ "$prev" = "--outdir" ]; then outdir="$a"; fi
+      prev="$a"
+    done
+    mkdir -p "$outdir"
+    for i in $(seq 1 ${emitBundles}); do echo "// bundle" > "$outdir/entry$i.js"; done
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  chmodSync(join(bin, "npx"), 0o755);
+
+  writeFileSync(
+    join(bin, "git"),
+    `#!/usr/bin/env bash
+echo "0000000000000000000000000000000000000000"
+`,
+    { mode: 0o755 },
+  );
+  chmodSync(join(bin, "git"), 0o755);
+
+  return { dir, bin, log };
+}
+
+function run(
+  opts: Parameters<typeof sandbox>[0] & { preview?: boolean } = {},
+): { calls: string[]; failed: boolean } {
+  const { dir, bin, log } = sandbox(opts);
+  const args = ["fake.jsonc", ...(opts.preview ? ["--preview"] : [])];
+  let failed = false;
+  try {
+    execFileSync("bash", [SCRIPT, ...args], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        POSTHOG_CLI_API_KEY: "phc_test",
+        POSTHOG_CLI_PROJECT_ID: "220683",
+      },
+      stdio: "pipe",
+    });
+  } catch {
+    failed = true;
+  }
+  // The log is absent only if the script died before its first stub call --
+  // itself a result worth reporting as "no calls" rather than a throw here.
+  let calls: string[];
+  try {
+    calls = readFileSync(log, "utf8").trim().split("\n").filter(Boolean);
+  } catch {
+    calls = [];
+  }
+  return { calls, failed };
+}
+
+/** Did a wrangler call that actually SHIPS (not `--dry-run`) happen? */
+const shipped = (calls: string[]) =>
+  calls.some((c) => c.includes("wrangler") && !c.includes("--dry-run"));
+
+describe("the deploy survives PostHog being unreachable (#11421)", () => {
+  test("a healthy run injects, uploads, and ships the injected bundle", () => {
+    const { calls, failed } = run();
+    assert.equal(failed, false);
+    assert.ok(calls.some((c) => c.includes("sourcemap inject")));
+    assert.ok(calls.some((c) => c.includes("sourcemap upload")));
+    // The injected file is shipped with --no-bundle, or wrangler's esbuild
+    // would rebuild from source and discard the chunk marker.
+    assert.ok(
+      calls.some((c) => c.includes("--no-bundle")),
+      "the exact injected bundle is what ships",
+    );
+  });
+
+  test("a failing INJECT still deploys, without symbolication", () => {
+    const { calls, failed } = run({ failInject: true });
+    assert.equal(failed, false, "a posthog outage is not a deploy outage");
+    assert.ok(shipped(calls), "the Worker still shipped");
+    assert.ok(
+      !calls.some((c) => c.includes("sourcemap upload")),
+      "and did not try to upload a map for a bundle it never injected",
+    );
+    assert.ok(
+      !calls.some((c) => c.includes("--no-bundle")),
+      "the fallback rebuilds from source rather than shipping a half-injected file",
+    );
+  });
+
+  test("a failing UPLOAD still deploys, and ships no orphan chunk id", () => {
+    // The subtler half. `inject` succeeded, so the bundle in $OUTDIR carries a
+    // chunk marker -- but its map never landed. Shipping THAT file would leave
+    // PostHog resolving traces against a chunk id it has no map for. The
+    // fallback rebuilds from source, so the marker never reaches production.
+    const { calls, failed } = run({ failUpload: true });
+    assert.equal(failed, false);
+    assert.ok(shipped(calls), "the Worker still shipped");
+    assert.ok(
+      !calls.some((c) => c.includes("--no-bundle")),
+      "the marked bundle is NOT what ships when its map failed to upload",
+    );
+  });
+
+  test("an ambiguous bundle glob still FAILS -- that one is ours", () => {
+    // The control that stops "tolerate failures" becoming "tolerate anything".
+    // Two .js files means wrangler emitted something this script cannot reason
+    // about, and shipping the wrong one mis-symbolicates silently. A third
+    // party being down is not our bug; this is.
+    const { failed } = run({ emitBundles: 2 });
+    assert.equal(failed, true);
+  });
+
+  test("the preview mode takes the same posture", () => {
+    const { calls, failed } = run({ failInject: true, preview: true });
+    assert.equal(failed, false);
+    assert.ok(calls.some((c) => c.includes("versions upload")));
+  });
+});


### PR DESCRIPTION
## Every deploy in the account failed for ~90 minutes today

**Status: PostHog recovered on its own at ~17:13Z, so this PR's own Workers Builds are green via the HAPPY path, not the fallback.** The build log shows `injecting done` / `Uploaded metagraphed-data-api`. The fix is therefore proven by its tests, not by this run — see below.

Not a build error — the wrangler build **succeeds** in each one, and the deploy command then dies at `posthog-cli sourcemap inject` after a 30 s timeout:

```
WARN  posthog_cli::api::releases: failed to get release from hash:
      Request error: error sending request for url (https://us.i.posthog.com/…)
ERROR posthog_cli::commands: msg="Oops! Request error: …"
Failed: error occurred while running deploy command
```

Three Workers (`data-api`, `registry-sync-api`, `wss-lb`), on unrelated branches — a renovate bump and a perf branch — and **identically on a manual retrigger ten minutes later**. Green at 09:40Z, failing 16:49Z–17:01Z, recovered by 17:13Z. Any production deploy from `main` in that window would have failed the same way, and nothing in the pipeline would have survived it.

## The rule was already written — and applied to only half the cases

The script's own header states it, from #10916 when the CLI could be *missing*:

> **SKIP, NEVER FAIL.** A Worker deployed without symbolication is a small observability loss; a Worker that did not deploy is an outage.

That covered `@posthog/cli` being **absent**. It did not cover the CLI **running and failing**, which under `set -euo pipefail` takes the deploy with it. Both posthog phases now run tolerantly and fall through to the plain deploy.

## Why the fallback rebuilds rather than shipping what it has

A failed `upload` is the subtle case: `inject` has already stamped a chunk id into the bundle, and shipping *that* file would leave PostHog resolving traces against a chunk id whose map never landed. The fallback rebuilds from source, so the marker never reaches production — no symbolication is a small loss; a marker with no map behind it is a worse one.

## What stays fatal

The "exactly one `.js` in `$OUTDIR`" assertion. Two bundles means wrangler emitted something this script cannot reason about, and shipping the wrong one mis-symbolicates **silently** — the failure mode that reads as working. A third party being down is not our bug; that is.

## A test, where there was none

This script ships three production Workers and had zero coverage. It's now driven through a **stubbed PATH** — the thing under test is bash control flow under `set -e`, and the only honest way to exercise that is to run it.

**Three of the five tests fail against the previous script**; the healthy-run and must-stay-fatal cases pass against both, so the suite discriminates rather than just going green.

## Verification

- Full suite **958 files / 22,001 passed**; all **57** CI validators pass
- `tsc`, `lint`, `format:check` clean; build produces no drift
- Failure diagnosed from the Cloudflare Builds API (build UUIDs `9a3a1672…`, `ad3a516f…`, and retrigger `9a275b43…`), not inferred
