### PR TITLE
fix(chain-events): the explorer's own event feed timed out and served an empty list

### DIFF
--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -417,6 +417,89 @@ export function formatChainEvent(
 
 /** Every chain event in one covered block, in read order. The payload shape is
  * the one `/api/v1/blocks/{n}/chain-events` has always published. */
+/**
+ * The newest chain events at or below `ceiling`, from the hot store.
+ *
+ * ## The route this exists for was serving NOTHING
+ *
+ * Measured live 2026-08-17, `/api/v1/chain-events?limit=5` -- the explorer's
+ * "what is happening on chain" feed:
+ *
+ *   16.9s, 0 rows, x-metagraph-degraded: tier_unavailable
+ *   server-timing: r2sql;dur=15030;desc="1 call"
+ *
+ * 15,030ms is the lakehouse query ceiling. The read is already block-windowed
+ * (5,000 blocks, 18.6 MB measured) and still could not finish, so the feed
+ * answered an empty list with a degraded header on every request.
+ *
+ * The same rows are in Neon. `chain_detail_chain_events` carries every column
+ * the feed formats -- pallet, method, args, phase, extrinsic_index,
+ * observed_at -- and its PRIMARY KEY is `(block_number, event_index)`, which is
+ * this feed's exact sort order. No new index was needed:
+ *
+ *   Limit (actual time=0.018..0.020 rows=5)
+ *     -> Index Scan Backward using chain_detail_chain_events_pkey
+ *   Execution Time: 0.030 ms      Buffers: shared hit=4
+ *
+ * 0.030ms against a 15s timeout, and the answer is NEWER: this store tracks the
+ * chain head (37s behind, measured), while the lakehouse ceiling this feed read
+ * down from is the decode seam, ~50 minutes back.
+ *
+ * ## A SHORT PAGE MEANS THE ANSWER SPANS THE SEAM
+ *
+ * This store is contiguous from its own floor to the head, so a FULL page taken
+ * from it is provably the newest `limit` at or below the ceiling. A short one is
+ * not: the remainder lies below the floor, in the lakehouse. The caller must
+ * fall through in that case rather than publish a truncated feed -- which is
+ * also what keeps pagination honest, because the cursor a full page emits is
+ * the same three-part token the lakehouse leg reads, so the walk continues
+ * across the seam instead of stopping at it.
+ *
+ * `pallet`/`method` are applied here rather than filtered afterwards, for the
+ * same reason: a filter applied to a page already cut to `limit` would return
+ * fewer than the caller asked for while more matches existed.
+ */
+export async function loadChainEventsHeadHotTier(
+  env: unknown,
+  options: {
+    limit: number;
+    /** Read at or below this block; null starts at the head. */
+    ceiling: number | null;
+    pallet?: string | null;
+    method?: string | null;
+  },
+): Promise<Row[] | null> {
+  const need = safeBlockNumber(options.limit);
+  if (need === null || need <= 0) return null;
+  const where: string[] = [];
+  const params: unknown[] = [];
+  if (options.ceiling !== null) {
+    const ceiling = safeBlockNumber(options.ceiling);
+    if (ceiling === null) return null;
+    where.push("block_number <= ?");
+    params.push(ceiling);
+  }
+  for (const [value, column] of [
+    [options.pallet, "pallet"],
+    [options.method, "method"],
+  ] as [unknown, string][]) {
+    if (value == null) continue;
+    if (typeof value !== "string" || value === "") return null;
+    // BOUND, not interpolated: this store speaks parameters, unlike R2 SQL --
+    // see `safeNameLiteral`'s existence on the lakehouse side for what the
+    // absence of them costs.
+    where.push(`${column} = ?`);
+    params.push(value);
+  }
+  return query(
+    env,
+    `SELECT ${CHAIN_EVENT_COLUMNS} FROM chain_detail_chain_events` +
+      (where.length ? ` WHERE ${where.join(" AND ")}` : "") +
+      " ORDER BY block_number DESC, event_index DESC LIMIT ?",
+    [...params, need],
+  );
+}
+
 export async function loadBlockChainEventsHotTier(
   env: unknown,
   height: number,

--- a/src/chain-events-cold-tier.ts
+++ b/src/chain-events-cold-tier.ts
@@ -36,9 +36,16 @@
 // `block=` needs no window at all: it is a single-block lookup and already
 // cheap, so it is passed straight through and stays exact.
 
-import { formatChainEvent } from "./chain-detail-hot-tier.ts";
+import {
+  formatChainEvent,
+  loadChainEventsHeadHotTier,
+} from "./chain-detail-hot-tier.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
-import { type ChainNetworkId, chainTable } from "./chain-network.ts";
+import {
+  type ChainNetworkId,
+  DEFAULT_CHAIN_NETWORK,
+  chainTable,
+} from "./chain-network.ts";
 import { r2SqlQuery, safeBlockNumber, safeNameLiteral } from "./r2-sql.ts";
 import { CHAIN_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { ChainEventsRow } from "../generated/lakehouse/types.ts";
@@ -215,6 +222,55 @@ export async function loadChainEventsColdTier(
     if (cursor) {
       // Within the ceiling block, resume strictly after the cursor's event.
       where.push(`(block_number < ${cursor[1]} OR event_index < ${cursor[2]})`);
+    }
+  }
+
+  // THE HOT STORE FIRST, and it answers this feed's common case entirely.
+  //
+  // Measured live 2026-08-17 before this: `?limit=5` took 16.9s, returned ZERO
+  // rows and set `x-metagraph-degraded` -- the lakehouse read hit its 15s
+  // ceiling even though it was already windowed to 5,000 blocks. The same rows
+  // in Neon answer in 0.030ms off the primary key, and they are NEWER: that
+  // store tracks the chain head while the ceiling above is the decode seam,
+  // ~50 minutes back.
+  //
+  // A SHORT PAGE FALLS THROUGH. The hot store is contiguous from its floor to
+  // the head, so a FULL page is provably the newest `limit` at or below the
+  // ceiling; a short one means the rest lies below that floor and only the
+  // lakehouse has it. Serving the short page would truncate the feed silently,
+  // and would also break the walk -- the cursor below is the same three-part
+  // token this function's own pages emit, so falling through is what lets
+  // pagination cross the seam instead of stopping at it.
+  //
+  // Only for the DEFAULT NETWORK: `chain_detail_*` is mainnet's hot tier and
+  // carries no network column, so another chain's feed must not read it.
+  if (
+    block === null &&
+    (network === undefined || network === DEFAULT_CHAIN_NETWORK)
+  ) {
+    const hot = await loadChainEventsHeadHotTier(env, {
+      limit,
+      ceiling: cursor
+        ? (cursor[1] as number)
+        : before !== null
+          ? before - 1
+          : null,
+      pallet: typeof query.pallet === "string" ? query.pallet : null,
+      method: typeof query.method === "string" ? query.method : null,
+    });
+    if (hot !== null && hot.length === limit) {
+      const page = hot as ChainEventsRow[];
+      const tail = page[page.length - 1]!;
+      return {
+        count: page.length,
+        next_before: safeBlockNumber(tail.block_number),
+        next_cursor: encodeCursor([
+          safeBlockNumber(tail.observed_at),
+          safeBlockNumber(tail.block_number),
+          safeBlockNumber(tail.event_index),
+        ]),
+        events: formatEvents(page),
+      };
     }
   }
 

--- a/tests/chain-events-cold-tier.test.ts
+++ b/tests/chain-events-cold-tier.test.ts
@@ -8,7 +8,17 @@
 // That case gets its own tests.
 
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { loadChainEventsHeadHotTier } from "../src/chain-detail-hot-tier.ts";
+
+// The head leg reads `chain_detail_chain_events` through src/read-store.ts,
+// which builds `new Client(...)` itself -- so the module is the seam. See
+// tests/helpers/pg-mock.ts for why the controller is hoisted.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
 import {
   CHAIN_EVENTS_BLOCK_WINDOW,
   CHAIN_EVENTS_STATS_BLOCKS_DEFAULT,
@@ -600,5 +610,167 @@ describe("an unformattable row is passed through, never dropped", () => {
     sqlFetch([null as unknown as Record<string, unknown>]);
     const page = await loadChainEventsColdTier(TOKEN, { limit: 50 });
     assert.equal(page, null, "a corrupt row declines, never half-serves");
+  });
+});
+
+/**
+ * The head of this feed, from Neon instead of the lakehouse.
+ *
+ * Measured live 2026-08-17, `/api/v1/chain-events?limit=5` -- the explorer's
+ * "what is happening on chain" feed:
+ *
+ *   16.9s, 0 rows, x-metagraph-degraded: tier_unavailable
+ *   server-timing: r2sql;dur=15030;desc="1 call"
+ *
+ * 15,030ms is the lakehouse query ceiling. The read was already windowed to
+ * 5,000 blocks and still could not finish, so the feed served an empty list
+ * with a degraded header on every request. The same rows answer in 0.030ms off
+ * `chain_detail_chain_events`'s primary key, which IS this feed's sort order.
+ */
+describe("loadChainEventsColdTier -- the Neon head", () => {
+  const hotRow = (block: number, index = 0, pallet = "SubtensorModule") => ({
+    block_number: block,
+    event_index: index,
+    pallet,
+    method: "NeuronRegistered",
+    args: "{}",
+    phase: "ApplyExtrinsic",
+    extrinsic_index: 1,
+    observed_at: 1_700_000_000_000 + block,
+  });
+
+  /** A store answering the head read with `rows`. */
+  function store(rows: Record<string, unknown>[]) {
+    const seen: string[] = [];
+    pg.control.queries.length = 0;
+    pg.control.answers = [];
+    pg.control.rows = null;
+    pg.control.failNext = null;
+    pg.control.onQuery = ({ text }) => {
+      seen.push(text);
+      pg.control.rows = rows;
+    };
+    return { seen, env: { ...TOKEN, ...pgMockEnv() } as unknown as Env };
+  }
+
+  test("A FULL PAGE COMES FROM NEON, with no lakehouse query at all", async () => {
+    const q = sqlFetch([]);
+    const { seen, env } = store([hotRow(900), hotRow(899), hotRow(898)]);
+    const page = await loadChainEventsColdTier(env, { limit: 3 });
+    assert.ok(page);
+    assert.equal(page.count, 3);
+    assert.equal(q.length, 0, `expected no R2 SQL:\n${q.join("\n")}`);
+    assert.equal(page.events[0]!.block_number, 900, "newest first");
+    assert.match(seen[0]!, /ORDER BY block_number DESC, event_index DESC/);
+  });
+
+  test("A SHORT PAGE FALLS THROUGH -- it does not truncate the feed", async () => {
+    // The hot store is contiguous from its floor to the head, so a FULL page is
+    // provably the newest N; a short one means the rest lies below that floor,
+    // where only the lakehouse has it. Serving the short page would silently
+    // truncate the feed AND break the walk.
+    const q = sqlFetch([]);
+    const { env } = store([hotRow(900)]);
+    await loadChainEventsColdTier(env, { limit: 5 });
+    assert.ok(q.length > 0, "expected the lakehouse read");
+  });
+
+  test("THE CURSOR IS THE SAME TOKEN the lakehouse leg reads", async () => {
+    // What lets the walk cross the seam: page 1 from Neon, page 2 from
+    // whichever tier holds the next rows. A cursor of a different shape would
+    // strand the caller at the boundary.
+    const { env } = store([hotRow(900), hotRow(899)]);
+    sqlFetch([]);
+    const page = await loadChainEventsColdTier(env, { limit: 2 });
+    assert.ok(page?.next_cursor, "a full page must paginate");
+    assert.equal(page.next_before, 899);
+
+    // Feed it back: the ceiling now comes from the cursor, not the head.
+    const second = store([hotRow(898), hotRow(897)]);
+    sqlFetch([]);
+    const next = await loadChainEventsColdTier(second.env, {
+      limit: 2,
+      cursor: page.next_cursor,
+    });
+    assert.ok(next);
+    // `$1`, not `?`: `toPositionalPlaceholders` rewrites the placeholders on
+    // the way to pg, so the recorded text is the converted form.
+    assert.match(second.seen[0]!, /block_number <= \$\d/);
+  });
+
+  test("A PALLET FILTER IS APPLIED IN THE QUERY, not to a cut page", async () => {
+    // A filter applied after the page was already cut to `limit` would return
+    // fewer than the caller asked for while more matches existed.
+    const { seen, env } = store([hotRow(900, 0, "Balances")]);
+    sqlFetch([]);
+    await loadChainEventsColdTier(env, { limit: 1, pallet: "Balances" });
+    assert.match(seen[0]!, /pallet = \$\d/);
+  });
+
+  test("A SINGLE-BLOCK LOOKUP still goes to the lakehouse", async () => {
+    // `?block=` is exact and already cheap, and the hot store holds only a
+    // rolling window -- answering a historical block from it would 404 a block
+    // the lakehouse has.
+    const q = sqlFetch([]);
+    const { env } = store([hotRow(900)]);
+    await loadChainEventsColdTier(env, { limit: 5, block: 900 });
+    assert.ok(q.length > 0, "expected the lakehouse read");
+  });
+
+  test("ANOTHER NETWORK never reads mainnet's hot store", async () => {
+    // `chain_detail_*` carries no network column.
+    sqlFetch([]);
+    const { seen, env } = store([hotRow(900), hotRow(899)]);
+    await loadChainEventsColdTier(env, { limit: 2 }, "testnet");
+    // The hot store is never touched -- that is the whole assertion. Whether
+    // the lakehouse leg then answers or declines is that tier's business (with
+    // no resolvable testnet head it declines), and asserting on it here would
+    // pin an unrelated contract.
+    assert.equal(seen.length, 0, "mainnet's hot store was asked for testnet");
+  });
+
+  test("AN UNUSABLE ARGUMENT REFUSES, and issues no query", async () => {
+    // `loadChainEventsHeadHotTier` is EXPORTED, so "the one caller already
+    // validated it" is a property of today's code and not of the function. A
+    // bad argument must refuse rather than emit `LIMIT 0`, an unbounded read,
+    // or a `pallet = ''` that quietly matches nothing.
+    pg.control.queries.length = 0;
+    pg.control.onQuery = () => {
+      pg.control.rows = [];
+    };
+    const env = pgMockEnv();
+    for (const [label, opts] of [
+      ["zero limit", { limit: 0, ceiling: null }],
+      ["negative limit", { limit: -1, ceiling: null }],
+      ["NaN limit", { limit: Number.NaN, ceiling: null }],
+      ["unusable ceiling", { limit: 5, ceiling: Number.NaN }],
+      ["empty pallet", { limit: 5, ceiling: null, pallet: "" }],
+      ["non-string method", { limit: 5, ceiling: null, method: 7 as never }],
+    ] as [string, Parameters<typeof loadChainEventsHeadHotTier>[1]][]) {
+      assert.equal(
+        await loadChainEventsHeadHotTier(env, opts),
+        null,
+        `${label} must be refused`,
+      );
+    }
+    assert.equal(
+      pg.control.queries.length,
+      0,
+      "an unusable argument reached the store",
+    );
+  });
+
+  test("AN UNREADABLE STORE falls through rather than declining", async () => {
+    const q = sqlFetch([]);
+    pg.control.queries.length = 0;
+    pg.control.onQuery = () => {
+      pg.control.failNext = new Error("store down");
+    };
+    const page = await loadChainEventsColdTier(
+      { ...TOKEN, ...pgMockEnv() } as unknown as Env,
+      { limit: 2 },
+    );
+    assert.ok(page, "the lakehouse still answers");
+    assert.ok(q.length > 0);
   });
 });


### PR DESCRIPTION
## The feed was serving nothing

Measured live 2026-08-17 — `/api/v1/chain-events?limit=5`, the explorer's "what is happening on chain" feed:

```
http=200  time=16.9s  rows=0  x-metagraph-degraded: tier_unavailable
server-timing: r2sql;dur=15030;desc="1 call"
```

**15,030 ms is the lakehouse query ceiling.** The read was already windowed to 5,000 blocks (18.6 MB measured) and still could not finish, so this feed answered an empty list with a degraded header on every request.

`Server-Timing` (#11442) is what surfaced it. A 200 with zero rows is indistinguishable from a quiet chain in the payload.

## The rows were in Neon the whole time

`chain_detail_chain_events` carries every column the feed formats — `pallet`, `method`, `args`, `phase`, `extrinsic_index`, `observed_at` — and its **primary key is `(block_number, event_index)`**, which is this feed's exact sort order. No new index was needed:

```
Limit  (actual time=0.018..0.020 rows=5)
  ->  Index Scan Backward using chain_detail_chain_events_pkey
Execution Time: 0.030 ms      Buffers: shared hit=4
```

**0.030 ms against a 15 s timeout** — and the answer is *newer*: that store tracks the chain head (37 s behind, measured) while the ceiling this feed read down from is the decode seam, ~50 minutes back.

## A short page falls through, and that keeps pagination honest

The hot store is contiguous from its own floor to the head, so a **full** page taken from it is provably the newest `limit` at or below the ceiling. A short one is not — the remainder lies below that floor, where only the lakehouse has it — so serving it would truncate the feed silently.

It would also strand the walk. The cursor a full page emits is the **same three-part token the lakehouse leg reads**, so page 2 is answered by whichever tier holds the next rows and the walk crosses the seam instead of stopping at it. There's a test that pages across it.

## The other guards

| | |
|---|---|
| `pallet` / `method` | applied **in** the query, not to a page already cut to `limit` — otherwise a filter returns fewer matches than asked for while more exist. Bound parameters, not interpolated: this store speaks parameters, unlike R2 SQL, where `safeNameLiteral` exists precisely because it doesn't |
| `?block=` | still goes to the lakehouse — exact, already cheap, and the hot store's rolling window would 404 a historical block the lakehouse has |
| another network | never touches it — `chain_detail_*` is mainnet's and carries no network column |
| unusable arguments | refuse and issue no query; the function is exported, so "the caller validated it" is a property of today's code, not of the function |

## Verification

- **Falsified both ways**: remove the hot leg → 2 tests fail; remove the short-page guard → the truncation test fails.
- **Patch coverage 21/21 lines, 33/33 branches**; full suite 958 files / 22,008 passed; full CI gate 82 targets (now including `apps/ui`'s own lint/tsc/test), 0 failed.