### PR TITLE
fix(observability): two neurons sub-lanes went silent when a refactor dropped one argument

### DIFF
--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -513,6 +513,20 @@ export async function mirrorNeuronSnapshotToNeon(
       prune,
       now(),
       buffered,
+      // ONCE PER PASS (#10826), and this argument has been dropped once
+      // already. #10908 added it here; #10917 removed it four hours later
+      // while rewriting the surrounding read handles, and production's last
+      // `neon:neurons-prune` verdict is dated 2026-08-12T22:33 -- the deploy
+      // that carried it. The lane then read `unknown` for five days while the
+      // prune ran correctly every pass (0 stale rows in `neurons`, measured
+      // 2026-08-17), because a buffered success records nothing unless this
+      // says the lane cannot be recorded by anything else.
+      //
+      // It cannot: this sub-lane's statements ride under the base lane's tag,
+      // so the flush's per-lane tally never names it. The suppression in
+      // recordNeonWriteVerdict is sound only for lanes the flush will speak
+      // for later, and no flush will ever speak for this one.
+      true,
     );
   }
 
@@ -544,6 +558,10 @@ export async function mirrorNeuronSnapshotToNeon(
       verdict,
       now(),
       buffered,
+      // ONCE PER PASS -- see the prune's note above, which this lane shares
+      // verbatim: same buffered runner, same missing flush attribution, same
+      // five days of `unknown` while `neurons_passes` took a row every pass.
+      true,
     );
     results[`${NEURONS_NEON_LANE}_passes`] = verdict;
   }

--- a/tests/ledger-neon-write.test.ts
+++ b/tests/ledger-neon-write.test.ts
@@ -110,6 +110,58 @@ describe("mirrorLedgerToNeon", () => {
     ]);
   });
 
+  test("buffered: the base lane waits for the flush, the tally does NOT", async () => {
+    // THE INVARIANT THIS LANE HAD AND COULD NOT PROVE. `-pass` passes
+    // `oncePerPass: true` in src/ledger-neon-write.ts and nothing pinned it,
+    // which is exactly the position the neurons writer was in when #10917
+    // dropped the same argument during an unrelated refactor and two lanes
+    // read `unknown` for five days.
+    //
+    // The rule it encodes: a buffered success records nothing, on the
+    // assumption that the flush files an honest verdict for the lane later.
+    // That holds for the base lane, whose statements carry its name. It is
+    // false for `-pass`, which rides under the base lane's tag and so never
+    // appears in the flush's per-lane tally under any key -- so if it does not
+    // record here, nothing records it ever.
+    const spy = laneSpy();
+    const sent: unknown[] = [];
+    const ns = {
+      idFromName: (name: string) => name,
+      get: () => ({
+        async fetch(request: Request) {
+          sent.push(await request.json());
+          return new Response("{}", { status: 200 });
+        },
+      }),
+    };
+    const out = await mirrorLedgerToNeon(
+      {
+        NEON_WRITE_BUFFER_LANES: "account-balances",
+        NEON_WRITE_BUFFER: ns,
+        HYPERDRIVE: { connectionString: "postgresql://x" },
+      },
+      ctx,
+      "account-balances",
+      rows,
+      { laneHealthDb: spy.db, now: () => NOW },
+      {
+        capturedAt: NOW,
+        expectedRows: rows.length,
+        receivedRows: rows.length,
+        nowMs: NOW,
+      },
+    );
+    assert.equal(out.attempted, true);
+    assert.ok(sent.length >= 1, "statements must enqueue, not connect");
+    assert.deepEqual(
+      spy.rows.map((r) => r.lane),
+      ["neon:account-balances-pass"],
+      "the tally records at enqueue; the flush-attributed base lane does not",
+    );
+    assert.equal(spy.rows[0].verdict, "ok");
+    assert.match(String(spy.rows[0].detail), /enqueued/);
+  });
+
   // "a lane the flag does not name writes nothing" retired with the flag
   // (#10051): the write is unconditional now, and the off-arm is gone.
 

--- a/tests/neurons-neon-write.test.ts
+++ b/tests/neurons-neon-write.test.ts
@@ -167,6 +167,74 @@ describe("NEURON_MIRROR_PLANS", () => {
     assert.ok(spy.rows.every((r) => r.verdict === "ok"));
   });
 
+  test("buffered: a FULL pass records the prune and the tally too", async () => {
+    // THE REGRESSION THIS EXISTS TO CATCH, and the reason the test above could
+    // not. That one asserts an exact lane list, which looks like it would fail
+    // the moment a sub-lane stopped recording -- but it drives the shared
+    // `input`, which carries no `pass` and no `netuidMaxCapturedAt`. Both
+    // blocks are therefore skipped entirely, and an assertion that the prune
+    // and tally are absent from a run that never reached them holds no matter
+    // what their `oncePerPass` argument says.
+    //
+    // So it held through #10908 adding that argument and through #10917
+    // dropping it again four hours later, and production ran five days with
+    // `neon:neurons-prune` and `neon:neurons-pass` reading `unknown` -- two
+    // lane alarms that could never auto-close, over a prune and a tally that
+    // were both working. A pass-shaped input is what makes the list mean
+    // something.
+    const spy = laneSpy();
+    const sent: unknown[] = [];
+    const ns = {
+      idFromName: (name: string) => name,
+      get: () => ({
+        async fetch(request: Request) {
+          sent.push(await request.json());
+          return new Response("{}", { status: 200 });
+        },
+      }),
+    };
+    const out = await mirrorNeuronSnapshotToNeon(
+      {
+        NEON_WRITE_BUFFER_LANES: NEURONS_NEON_LANE,
+        NEON_WRITE_BUFFER: ns,
+        HYPERDRIVE: { connectionString: "postgresql://x" },
+      },
+      ctx,
+      {
+        ...input,
+        netuidMaxCapturedAt: new Map([[1, 5]]),
+        pass: {
+          capturedAt: NOW,
+          expectedRows: input.rows.length,
+          receivedRows: input.rows.length,
+          nowMs: NOW,
+        },
+      },
+      { laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.attempted, true);
+    assert.equal(out.prune?.ok, true);
+    assert.deepEqual(
+      spy.rows.map((r) => r.lane),
+      [
+        "neon:neuron_daily",
+        "neon:account_position_daily",
+        "neon:neurons-prune",
+        "neon:neurons-pass",
+      ],
+      "every sub-lane records at enqueue; only the flush-attributed base lane waits",
+    );
+    assert.ok(spy.rows.every((r) => r.verdict === "ok"));
+    // ENQUEUED, not landed. The rows are in the buffer at this point, and a
+    // verdict claiming Neon holds them is the overclaim #10690 refused.
+    assert.ok(
+      spy.rows.every((r) => /enqueued/.test(String(r.detail))),
+      `buffered verdicts must say enqueued -- got ${spy.rows
+        .map((r) => r.detail)
+        .join(" | ")}`,
+    );
+  });
+
   test("a failing table is reported and does not stop the others", async () => {
     // The mirror is best-effort per table. A missing `neuron_daily` must not
     // cost `account_position_daily` its refresh, and each gets its own verdict


### PR DESCRIPTION
`neon:neurons-prune` and `neon:neurons-pass` have read `unknown` since
2026-08-12T22:33 -- five days, two lane alarms that cannot auto-close, over a
prune and a tally that were both working the whole time.

A buffered write records no verdict here, because the flush is expected to file
an honest one for the lane later. That holds for a lane whose statements carry
its own name. It is false for these two sub-lanes: their statements ride under
the base lane's tag, so the flush's per-lane tally never names them and a
suppressed success is recorded by nothing, ever. `oncePerPass` is the argument
that says so.

#10908 added it to both calls. #10917 removed it four hours later while
rewriting the surrounding read handles -- the argument and its comment, with no
mention in the diff's intent -- and production's last verdict for either lane is
dated to that deploy.

The data was never affected, which is why nothing else caught it: `neurons_passes`
took a row every pass (newest 2026-08-17T21:31) and `neurons` holds 0 rows older
than their netuid's own capture, so the prune has been running correctly all
along. Only the reporting died.

WHY THE EXISTING TEST DID NOT CATCH IT. `buffered: the derived tables record at
enqueue` asserts an exact lane list, which looks like it would fail the moment a
sub-lane stopped recording. It drives the shared `input`, which carries no
`pass` and no `netuidMaxCapturedAt` -- so both blocks are skipped entirely and
the assertion holds no matter what their `oncePerPass` says. It passed before
#10908, after it, and after #10917 took it back out.

So the fix is the argument, and the guard is a pass-shaped input: a new test
drives a full pass under buffering and pins all four sub-lanes. Verified to fail
without the fix.

The same invariant is pinned for `mirrorLedgerToNeon`, which passes
`oncePerPass` correctly today and had nothing holding it there -- the position
the neurons writer was in when #10917 landed. Also verified to fail without it.

Closes #11451
Closes #11452