### PR TITLE
perf(accounts): a rotated generation sent the card to the lakehouse instead of the shard beside it

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -301,6 +301,31 @@ async function resolvePointer(
   return resolved;
 }
 
+/**
+ * The current pointer, or null unless it is one this reader may serve from.
+ *
+ * EXTRACTED SO THE RETRY CANNOT SKIP A CHECK. The rotation retry below resolves
+ * a second pointer and reads a second shard from it, so every rule that
+ * qualified the first one -- the schema version it declares, a `generated_at`
+ * that is a real date, and the staleness bound -- has to hold for the second
+ * one too. Inlining them once and trusting the retry to be "the same pointer,
+ * just newer" is how a stale or wrong-versioned generation gets served by the
+ * path that exists to recover from a missing one.
+ */
+async function usablePointer(
+  bucket: ArtifactObjectStore,
+  now: () => number,
+  maxAgeMs: number,
+): Promise<z.infer<typeof AccountSummaryPointerSchema> | null> {
+  const pointer = await resolvePointer(bucket, now);
+  if (pointer === null) return null;
+  if (pointer.schema_version !== ACCOUNT_SUMMARY_SCHEMA_VERSION) return null;
+  const generated = Date.parse(pointer.generated_at);
+  if (!Number.isFinite(generated)) return null;
+  if (maxAgeMs > 0 && now() - generated > maxAgeMs) return null;
+  return pointer;
+}
+
 export async function loadAccountSummaryProjection(
   env: (R2SqlEnv & ArtifactStoreEnv) | null | undefined,
   account: string,
@@ -337,33 +362,63 @@ export async function loadAccountSummaryProjection(
   // Worker costs ~370 ms (`/api/v1/coverage`, which does exactly one), and the
   // projection does two in sequence -- the pointer, then the shard it names --
   // so the pointer alone was a third of the wall clock on the fast path.
-  const pointer = await resolvePointer(bucket, now);
-  if (pointer === null) return null;
-  if (pointer.schema_version !== ACCOUNT_SUMMARY_SCHEMA_VERSION) return null;
-  const shards = pointer.shard_count;
-  const generation = pointer.generation;
-  const generated = Date.parse(pointer.generated_at);
-  if (!Number.isFinite(generated)) return null;
-  if (maxAgeMs > 0 && now() - generated > maxAgeMs) return null;
+  const first = await usablePointer(bucket, now, maxAgeMs);
+  if (first === null) return null;
 
-  const payload = await readJson(
+  let pointer = first;
+  let payload = await readJson(
     bucket,
-    accountSummaryShardKey(account, shards, generation),
+    accountSummaryShardKey(account, first.shard_count, first.generation),
   );
+
   // A MISS INVALIDATES THE MEMO, and that is what makes memoizing the pointer
   // safe. The producer deletes a generation's shards once the next one is live,
   // so a memoized pointer can name a generation that no longer exists -- and
   // without this every account request would decline for the rest of the TTL,
   // turning a 370 ms saving into a multi-minute outage once an hour.
   //
-  // Dropping it here means the NEXT request re-reads the pointer and succeeds,
-  // so the window is one request rather than one TTL. This request still
-  // declines, which is correct: it has no shard to answer from, and the caller
-  // falls back to the lakehouse exactly as it did before the projection existed.
+  // AND THEN IT RE-READS, rather than declining this request. Dropping the memo
+  // fixes the NEXT request on THIS isolate, which is a much weaker guarantee
+  // than it reads as: the memo is isolate-local, so every isolate that survives
+  // a rotation pays its own declining request, and the thing a decline costs
+  // here is not a slow read -- it is the caller's unbounded lakehouse walk.
+  //
+  // Measured on production 2026-08-17, six accounts whose shards all existed and
+  // whose payloads all parsed: three answered in 0.64-0.89s from the projection
+  // (`neon` only, no `r2sql`), and the rest took 19.2s, 25.7s and 30.8s with
+  // FIVE `r2sql` calls -- the `windowedRowRead` walk -- and the route 503s at
+  // the 15s ceiling when that walk overruns. Every generation but the current
+  // one is deleted (verified: three prior generations return no object), so the
+  // only thing separating those two outcomes was which generation the isolate
+  // had memoized.
+  //
+  // ONE RETRY, AND ONLY ON A NEW GENERATION. A fresh pointer naming the SAME
+  // generation means the shard is genuinely absent -- a partial publish, or an
+  // account whose shard the producer never wrote -- and re-reading the identical
+  // key would just buy the same miss twice. So the retry is conditioned on the
+  // generation actually having moved, which is exactly the rotation this exists
+  // to survive, and costs one pointer GET (~250 ms) against a walk that costs
+  // twenty to thirty seconds.
   if (!payload) {
     resetAccountSummaryPointerCache();
-    return null;
+    const fresh = await usablePointer(bucket, now, maxAgeMs);
+    if (fresh !== null && fresh.generation !== first.generation) {
+      pointer = fresh;
+      payload = await readJson(
+        bucket,
+        accountSummaryShardKey(account, fresh.shard_count, fresh.generation),
+      );
+    }
+    // A MISS STILL LEAVES NO MEMO BEHIND, which is the invariant the retry must
+    // not spend. `usablePointer` re-memoizes whatever it resolved, so without
+    // this a request that failed to find its shard would hand the next one a
+    // pointer it had just proven unusable -- the exact stale-pointer state
+    // dropping the memo exists to prevent, restored by the code meant to
+    // recover from it. Success keeps its memo: that pointer is the fresh one,
+    // and it just answered.
+    if (!payload) resetAccountSummaryPointerCache();
   }
+  if (!payload) return null;
   const accounts = payload["accounts"];
   if (!accounts || typeof accounts !== "object") return null;
 

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -1200,6 +1200,82 @@ describe("the pointer memo", () => {
     );
   });
 
+  test("A ROTATION IS SERVED, not declined and left to the lakehouse", async () => {
+    // THE COST OF DECLINING, which the memo-drop above does not pay back. It
+    // repairs the NEXT request on THIS isolate; the memo is isolate-local, so
+    // every isolate alive across a rotation still has one request that finds no
+    // shard -- and that request does not merely go slow, it falls through to
+    // the caller's unbounded `windowedRowRead` walk of chain.account_events.
+    //
+    // Measured on production 2026-08-17: six accounts whose shards all existed
+    // and whose payloads all parsed, three answered in 0.64-0.89s from the
+    // projection while the others took 19.2s, 25.7s and 30.8s with five r2sql
+    // calls, and /accounts/{ss58} 503s when that walk overruns the 15s ceiling.
+    // Every generation but the current one is deleted, so the only difference
+    // between those two outcomes was which generation the isolate had memoized.
+    const NEXT = "20260814T110000Z";
+    const rotated = archive({
+      // The pointer the producer has already advanced...
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer({
+        generation: NEXT,
+        generated_at: "2026-08-14T11:00:00Z",
+      }),
+      // ...and only the new generation's shard, because the old one is deleted.
+      [accountSummaryShardKey(HOT, SHARDS, NEXT)]: {
+        schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
+        generated_at: "2026-08-14T11:00:00Z",
+        shard_count: SHARDS,
+        accounts: { [HOT]: [group()] },
+      },
+    });
+
+    // Warm the memo onto the OLD generation, exactly as an isolate that served
+    // a request before the rotation would hold it.
+    const stale = archive(published({ [HOT]: [group()] }));
+    await readFound(stale.env, HOT, FRESH);
+
+    // Now the same isolate takes a request after the producer rotated.
+    const found = await readFound(rotated.env, HOT, FRESH);
+    assert.equal(
+      found.groups.length,
+      1,
+      "the rotation must be re-resolved and served, not declined",
+    );
+    assert.deepEqual(
+      rotated.asked,
+      [
+        accountSummaryShardKey(HOT, SHARDS, GEN),
+        ACCOUNT_SUMMARY_POINTER_KEY,
+        accountSummaryShardKey(HOT, SHARDS, NEXT),
+      ],
+      "the miss on the memoized generation re-reads the pointer, then the shard it now names",
+    );
+  });
+
+  test("a shard absent under the CURRENT generation is not re-read", async () => {
+    // The retry is for a rotation, and a fresh pointer naming the SAME
+    // generation is not one: the shard is genuinely absent -- a partial
+    // publish, or an account the producer never wrote -- and asking for the
+    // identical key a second time buys the same miss twice. So this declines on
+    // one shard GET plus the pointer re-read that proved nothing had moved.
+    const gone = archive({
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer(),
+    });
+    assert.equal(
+      await loadAccountSummaryProjection(gone.env, HOT, FRESH),
+      null,
+    );
+    assert.deepEqual(
+      gone.asked,
+      [
+        ACCOUNT_SUMMARY_POINTER_KEY,
+        accountSummaryShardKey(HOT, SHARDS, GEN),
+        ACCOUNT_SUMMARY_POINTER_KEY,
+      ],
+      "one shard read, never two for the same key",
+    );
+  });
+
   test("AN UNREADABLE POINTER IS NOT MEMOIZED for the TTL", async () => {
     // A transient R2 blip must cost one request, not five minutes of declines.
     const broken = archive({ [ACCOUNT_SUMMARY_POINTER_KEY]: { nope: 1 } });


### PR DESCRIPTION
`/api/v1/accounts/{ss58}` answers in 0.64-0.89s when it reads the account-summary
projection, and takes 19-31s with five `r2sql` calls when it does not -- 503ing
when that walk overruns the 15s ceiling. Measured on production 2026-08-17 across
six accounts whose shards all existed and whose payloads all parsed, three of
them landed on each side of that split.

The only thing separating the two was which generation the isolate had memoized.

The producer publishes a generation and DELETES the previous one's 16,384 shards
-- verified: three prior generations return no object, the current one returns
the shard. The pointer naming it is memoized per isolate for five minutes. So
every isolate alive across a rotation issues one shard GET for a generation that
no longer exists, and that miss returned null.

Null is not a slow path here. `loadAccountSummaryColdTier` reads the projection
to decide which arm to take, and without one BOTH legs fall to
`windowedRowRead` -- the unbounded scattered scan of `chain.account_events` that
#11222 is about. So a rotation did not cost the card its hot tier for one
request; it cost the request twenty to thirty seconds, or a 503.

Dropping the memo on a miss was already there, and it repairs the NEXT request on
THIS isolate. That is a weaker guarantee than it reads as: the memo is
isolate-local, so the repair never arrives before the damage, and it arrives once
per isolate per rotation.

So the miss is re-resolved instead of declined. A fresh pointer naming a
DIFFERENT generation is a rotation, and the shard it now names is read -- one
pointer GET, ~250ms, against a twenty-second walk. A fresh pointer naming the
SAME generation is not a rotation: the shard is genuinely absent (a partial
publish, or an account the producer never wrote), so re-reading the identical key
would buy the same miss twice, and this declines exactly as before.

Two invariants are kept rather than assumed:

  * A MISS STILL LEAVES NO MEMO. `usablePointer` re-memoizes whatever it
    resolved, so a failed retry would hand the next request a pointer it had just
    proven unusable -- the stale-pointer state the drop exists to prevent,
    restored by the code meant to recover from it. Only a success keeps its memo.
  * THE RETRY REVALIDATES. Schema version, a parseable `generated_at`, and the
    staleness bound are extracted into `usablePointer` so the second pointer
    clears every rule the first one did. A retry that assumed "same pointer, just
    newer" is how a stale or wrong-versioned generation reaches the reader.

Both new tests fail without the change. Patch coverage 100%, branch-counted.

Closes #11222