### PR TITLE
perf(accounts): the card declined the complete history to serve a truncated one, slowly

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -6159,7 +6159,7 @@ type AccountSummary {
   last_seen_at: String
 
   """
-  True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null.
+  True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. False means the totals are the account's complete history, at any magnitude: when the account-summary projection answers, the counts are running totals folded over the whole history rather than a scan of the newest N, so a large event_count here is exact rather than truncated.
   """
   event_scan_capped: Boolean
   event_kinds: [AccountEventKind!]

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -654,7 +654,7 @@ export type AccountSummary = {
   activity?: Maybe<AccountActivity>;
   event_count: Scalars['Int']['output'];
   event_kinds?: Maybe<Array<AccountEventKind>>;
-  /** True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. */
+  /** True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. False means the totals are the account's complete history, at any magnitude: when the account-summary projection answers, the counts are running totals folded over the whole history rather than a scan of the newest N, so a large event_count here is exact rather than truncated. */
   event_scan_capped?: Maybe<Scalars['Boolean']['output']>;
   first_block?: Maybe<Scalars['Int']['output']>;
   first_seen_at?: Maybe<Scalars['String']['output']>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5837,7 +5837,7 @@ export interface components {
                 count: number;
                 kind: string;
             }[];
-            /** @description True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. */
+            /** @description True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. False means the totals are the account's complete history, at any magnitude: when the account-summary projection answers, the counts are running totals folded over the whole history rather than a scan of the newest N, so a large event_count here is exact rather than truncated. */
             event_scan_capped?: boolean;
             first_block?: number | null;
             first_seen_at?: string | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -17776,7 +17776,7 @@
             "type": "array"
           },
           "event_scan_capped": {
-            "description": "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null.",
+            "description": "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. False means the totals are the account's complete history, at any magnitude: when the account-summary projection answers, the counts are running totals folded over the whole history rather than a scan of the newest N, so a large event_count here is exact rather than truncated.",
             "type": "boolean"
           },
           "first_block": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5837,7 +5837,7 @@ export interface components {
                 count: number;
                 kind: string;
             }[];
-            /** @description True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. */
+            /** @description True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. False means the totals are the account's complete history, at any magnitude: when the account-summary projection answers, the counts are running totals folded over the whole history rather than a scan of the newest N, so a large event_count here is exact rather than truncated. */
             event_scan_capped?: boolean;
             first_block?: number | null;
             first_seen_at?: string | null;

--- a/schemas-src/routes/account-summary.ts
+++ b/schemas-src/routes/account-summary.ts
@@ -99,7 +99,7 @@ export const AccountSummaryArtifactSchema = z
       .boolean()
       .optional()
       .describe(
-        "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null.",
+        "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. False means the totals are the account's complete history, at any magnitude: when the account-summary projection answers, the counts are running totals folded over the whole history rather than a scan of the newest N, so a large event_count here is exact rather than truncated.",
       ),
     event_kinds: z.array(AccountEventKindCountSchema).optional(),
     registrations: z

--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -388,6 +388,7 @@ export function buildAccountSummary(
     agg,
     kinds,
     scanned,
+    complete,
     registrations,
     recent,
     activity,
@@ -396,6 +397,22 @@ export function buildAccountSummary(
     agg?: Record<string, unknown> | null;
     kinds?: Array<Record<string, unknown>> | null;
     scanned?: unknown;
+    /**
+     * Whether the aggregate covers the account's whole history (#11468).
+     *
+     * The reader that built it says so, rather than this function inferring it
+     * from `scanned > CAP`. That inference was a proxy for "the lakehouse probe
+     * stopped at CAP + 1" and it stopped holding when the projection began
+     * answering above the cap: its totals are running sums folded forward from
+     * a 2020 floor, so a large one is EXACT, and treating size as evidence of
+     * truncation nulled `first_block`/`first_seen_at` on exactly the accounts
+     * whose full history was known.
+     *
+     * Defaults to `undefined`, which keeps the old inference for every caller
+     * that has no better evidence -- a bare `buildAccountSummary` over lakehouse
+     * rows still reports `event_scan_capped` the way it always did.
+     */
+    complete?: boolean;
     registrations?: Array<Record<string, unknown>> | null;
     recent?: Array<Record<string, unknown>> | null;
     activity?: Record<string, unknown> | null;
@@ -406,15 +423,24 @@ export function buildAccountSummary(
   const eventCount = toBlockNumber(a.c) ?? 0;
   const scannedCount =
     scanned != null ? (toBlockNumber(scanned) ?? 0) : eventCount;
-  // event_count / subnet_count / event_kinds are aggregated over exactly the
-  // account's newest ACCOUNT_EVENT_SUMMARY_SCAN_CAP events. `scanned` is a probe
-  // COUNT over CAP+1: when it exceeds CAP the account has more events than that
-  // window, so those totals are a lower bound and the window's MIN(block_number) /
-  // MIN(observed_at) are its floor, not the account's all-time first — flag it and
-  // null first_*. `> CAP` (not `>=`) means an account with EXACTLY CAP events is
-  // complete (the probe found no extra row), so its totals + first_* stay exact.
-  // last_* stay exact regardless (the newest events include the latest).
-  const eventScanCapped = scannedCount > ACCOUNT_EVENT_SUMMARY_SCAN_CAP;
+  // event_count / subnet_count / event_kinds are aggregated over the account's
+  // newest ACCOUNT_EVENT_SUMMARY_SCAN_CAP events when a lakehouse probe answered,
+  // and over its WHOLE history when the projection did. `scanned` is a probe
+  // COUNT over CAP+1 in the first case: when it exceeds CAP the account has more
+  // events than that window, so those totals are a lower bound and the window's
+  // MIN(block_number) / MIN(observed_at) are its floor, not the account's all-time
+  // first — flag it and null first_*. `> CAP` (not `>=`) means an account with
+  // EXACTLY CAP events is complete (the probe found no extra row), so its totals +
+  // first_* stay exact. last_* stay exact regardless (the newest events include
+  // the latest).
+  //
+  // `complete` OVERRIDES THE SIZE TEST when the caller knows (#11468). The
+  // projection's totals are exact at any magnitude, so a 208,423-event account is
+  // not capped — it is fully counted, and its first_* are its real first event
+  // rather than a window floor. Inferring truncation from the count alone would
+  // discard the complete history on precisely the accounts that have one.
+  const eventScanCapped =
+    complete === true ? false : scannedCount > ACCOUNT_EVENT_SUMMARY_SCAN_CAP;
   return {
     schema_version: 1,
     ss58,

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1047,10 +1047,53 @@ export type AccountSummaryColdTierResult =
       agg: Record<string, unknown>;
       kinds: Array<Record<string, unknown>>;
       scanned: number;
+      /**
+       * Whether `scanned` is the account's LIFETIME event count rather than a
+       * probe's lower bound (#11468).
+       *
+       * The distinction the card used to infer from `scanned > CAP` alone, which
+       * was only ever a proxy for "the lakehouse probe stopped at CAP + 1". It
+       * stopped being a valid proxy once the projection could answer above the
+       * cap: those totals are running sums folded forward from a 2020 floor, so
+       * a large one is exact rather than truncated, and inferring truncation
+       * from its SIZE nulls `first_block`/`first_seen_at` on the very accounts
+       * whose full history the projection actually knows.
+       *
+       * So the reader that assembled the aggregate says whether it is whole,
+       * instead of the formatter guessing from a number.
+       */
+      complete: boolean;
       recent: Array<Record<string, unknown>>;
       declined?: undefined;
     }
   | { declined: string[] };
+
+/**
+ * The post-fold aggregate, and whether anything was truncated building it.
+ *
+ * Two fields rather than a bare array because the two halves have different
+ * evidentiary weight: the projection's published groups are lifetime totals and
+ * cannot be short, while the post-fold probe reads CAP + 1 rows and can be. A
+ * caller handed only the concatenation cannot tell which it has.
+ */
+interface PostFoldGroups {
+  groups: Record<string, unknown>[];
+  complete: boolean;
+}
+
+/**
+ * A pure lakehouse aggregate, and whether its own probe overflowed.
+ *
+ * The CTE behind both callers reads `ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1` rows,
+ * so a sum at or above the cap means the account has more events than the probe
+ * looked at and every total here is a lower bound. That is the ONLY thing the
+ * cap decides now, and it is decided in one place so the two lakehouse arms
+ * cannot answer it differently.
+ */
+function withScanCompleteness(rows: Record<string, unknown>[]): PostFoldGroups {
+  const scanned = rows.reduce((n, row) => n + Number(row.count), 0);
+  return { groups: rows, complete: scanned <= ACCOUNT_EVENT_SUMMARY_SCAN_CAP };
+}
 
 /**
  * The feed's own sort key, as a comparable tuple.
@@ -1259,9 +1302,11 @@ async function postFoldGroups(
     /** The account, for the hot store's own indexed predicate. */
     ss58: string;
   },
-): Promise<Record<string, unknown>[] | null> {
+): Promise<PostFoldGroups | null> {
   const { query, scan, published, span, ss58 } = options;
-  if (span === null) return published;
+  // No fold edge, so there is nothing to add and nothing that could have been
+  // truncated: the published totals stand on their own and they are lifetime.
+  if (span === null) return { groups: published, complete: true };
 
   // NEON FIRST, folded here. This aggregate reads the SAME post-fold window the
   // head probe does, so when the hot store provably covers it the groups can be
@@ -1286,7 +1331,9 @@ async function postFoldGroups(
     ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   );
   if (hot !== null && hot.length < ACCOUNT_EVENT_SUMMARY_SCAN_CAP) {
-    return [...published, ...foldRowsToGroups(hot)];
+    // COMPLETE: the published half is lifetime by construction and the hot half
+    // did not fill its limit, so nothing was truncated at either end.
+    return { groups: [...published, ...foldRowsToGroups(hot)], complete: true };
   }
 
   const bound = ` AND observed_at >= ${Math.trunc(span.foldFloorMs)}`;
@@ -1301,7 +1348,17 @@ async function postFoldGroups(
   // caller would publish the same self-contradicting card this exists to fix,
   // and it would do it silently.
   if (!above) return null;
-  return [...published, ...above];
+  // THE DELTA IS THE ONLY THING THAT CAN BE SHORT HERE. `scan` reads CAP + 1
+  // rows of the POST-FOLD window, so a delta at or above the cap means that
+  // window alone overflowed the probe and its totals are a lower bound -- which
+  // makes the sum a lower bound too, however exact the published half is.
+  // Counted over the delta rather than the total for exactly that reason: the
+  // published half is lifetime and is not evidence of truncation at any size.
+  const delta = above.reduce((n, row) => n + Number(row.count), 0);
+  return {
+    groups: [...published, ...above],
+    complete: delta <= ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+  };
 }
 
 /**
@@ -1465,14 +1522,17 @@ export async function loadAccountSummaryColdTier(
 
   const [groupRows, recentRows] = await Promise.all([
     absentFloor !== null
-      ? query(
+      ? // The projection PROVED there is nothing at or before the fold edge, so
+        // this bounded read sees the account's entire history -- complete
+        // unless the read itself overflowed CAP + 1.
+        query(
           env,
           `WITH scan AS (${scan(absentBound)}) SELECT event_kind AS kind, netuid AS netuid, ` +
             `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
             `min(observed_at) AS fo, max(observed_at) AS lo ` +
             `FROM scan GROUP BY event_kind, netuid`,
           { onError: track("summary-groups-bounded") },
-        )
+        ).then((rows) => (rows === null ? null : withScanCompleteness(rows)))
       : found
         ? postFoldGroups(env, {
             query: (e, sql) =>
@@ -1504,7 +1564,9 @@ export async function loadAccountSummaryColdTier(
             satisfied: (rows) =>
               rows.reduce((n, row) => n + Number(row.count), 0) >
               ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
-          }),
+          }).then((rows) =>
+            rows === null ? null : withScanCompleteness(rows),
+          ),
     // THE FEED LEG, and the read that actually times this route out
     // (#11222). `windowedRowRead` probes `now-2d` then `now-8d` and then reads
     // the WHOLE remainder -- and 95.8% of accounts are past both probes, so
@@ -1567,9 +1629,11 @@ export async function loadAccountSummaryColdTier(
   if (!groupRows || !recentRows) {
     return { declined: failures };
   }
-  const folded = foldSummaryGroups(groupRows);
+  const folded = foldSummaryGroups(groupRows.groups);
 
-  // The CTE read CAP + 1, so this is min(total, CAP + 1) -- the probe's number.
+  // The CTE read CAP + 1, so this is min(total, CAP + 1) -- the probe's number
+  // -- on a lakehouse read, and the account's true lifetime total on a
+  // projection-backed one. `groupRows.complete` is which.
   //
   // No `?? 0`: foldSummaryGroups starts `count` at 0 and only ever adds a
   // finite rowCount, so `agg.c` is always a number and the nullish half is a
@@ -1578,16 +1642,24 @@ export async function loadAccountSummaryColdTier(
   const scanned = Number(folded.agg.c);
 
   return {
-    // Clamped back to the PUBLISHED window so the payload is unchanged: an
-    // uncapped account (total <= CAP) is already below the clamp and untouched,
-    // and a capped one reported CAP before and still does. The extra row exists
-    // to answer the capped question, not to widen what is served.
+    // CLAMPED ONLY WHEN THE COUNT IS A PROBE'S. Clamping exists because the
+    // lakehouse CTE reads CAP + 1 and `sum(count)` over it is therefore
+    // min(total, CAP + 1) -- a number that means "at least this many", and
+    // publishing CAP + 1 of it would be publishing a scan artefact.
+    //
+    // A complete aggregate has no such artefact to hide: it is the account's
+    // lifetime total, and clamping it to 5,000 would replace a true 208,423
+    // with a smaller wrong one on precisely the accounts whose whole history
+    // this tier can now prove.
     agg: {
       ...folded.agg,
-      c: Math.min(scanned, ACCOUNT_EVENT_SUMMARY_SCAN_CAP),
+      c: groupRows.complete
+        ? scanned
+        : Math.min(scanned, ACCOUNT_EVENT_SUMMARY_SCAN_CAP),
     },
     kinds: folded.kinds,
     scanned,
+    complete: groupRows.complete,
     recent: recentRows,
   };
 }

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -57,7 +57,11 @@ import {
   artifactBucket,
 } from "./projection-store.ts";
 
-import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "./account-events.ts";
+// ACCOUNT_EVENT_SUMMARY_SCAN_CAP is deliberately NOT imported here (#11468).
+// The cap is a statement about what a lakehouse probe managed to read, and this
+// module reads an artifact whose totals are exact at any size -- so nothing here
+// has a decision to make with it. It moved to the caller, which owns the reads
+// it can actually bound: see `complete` in src/account-feeds-cold-tier.ts.
 import {
   type AccountSummaryRecentEvent,
   AccountSummaryGroupsSchema,
@@ -245,11 +249,15 @@ async function readJsonOnce(
  * generation too old to trust, a shard that will not parse, or an account the
  * projection has not seen.
  *
- * THE CAP KEEPS ITS MEANING. The caller derives `scanned` from the summed group
- * counts and clamps it, so an account over the cap reports `event_scan_capped`
- * and null `first_*` whichever tier answered. The projection knows the true
- * lifetime total and publishing it would be a better number -- but a route
- * whose meaning depends on its tier is worse than either.
+ * THE CAP IS THE CALLER'S, NOT THIS READER'S (#11468). `scanned` is the summed
+ * group counts -- the account's true lifetime total, because the producer folds
+ * running totals forward rather than sampling a window -- and it is published
+ * as such. What the cap decides is whether a LAKEHOUSE read may be described as
+ * complete, which is a claim about that read and not about this artifact; see
+ * `complete` in src/account-feeds-cold-tier.ts. This reader used to decline
+ * above the cap so both tiers would answer alike, which held the route to the
+ * degraded answer (clamped `event_count`, nulled `first_*`) and cost every
+ * over-cap account an unbounded scan to get it.
  */
 /**
  * How long a resolved pointer is reused inside one isolate.
@@ -476,24 +484,41 @@ export async function loadAccountSummaryProjection(
   // reads the lakehouse rather than publishing an empty card from a shard.
   if (!groups.length) return null;
 
-  // AN ACCOUNT OVER THE CAP IS NOT THIS TIER'S TO ANSWER.
+  // AN ACCOUNT OVER THE CAP IS EXACTLY THE ONE THIS TIER SHOULD ANSWER, and
+  // until #11468 this line declined it.
   //
-  // The projection aggregates an account's WHOLE history. The live path
-  // aggregates the newest ACCOUNT_EVENT_SUMMARY_SCAN_CAP events. Below the cap
-  // those are the same set, so the answers are identical -- above it they are
-  // not, and the difference is invisible in `event_count` (both clamp to CAP)
-  // while `event_kinds` and `subnet_count` silently widen to lifetime.
+  // The reasoning it replaced was about DISAGREEMENT, and that half was right:
+  // the projection aggregates an account's whole history, the live path
+  // aggregates the newest ACCOUNT_EVENT_SUMMARY_SCAN_CAP events, and above the
+  // cap those are different sets. Measured on 5Fv5t8frGG3MKt..., the live path
+  // reported 4 kinds across 2 subnets and the projection 10 across 3. One route
+  // must not answer two ways.
   //
-  // Measured on 5Fv5t8frGG3MKt...: the live path reports 4 kinds across 2
-  // subnets, the projection 10 across 3. Same route, different answer depending
-  // on which tier served it, which is worse than either answer alone.
+  // WHAT IT GOT BACKWARDS IS WHICH ANSWER TO KEEP. The capped one is not a
+  // second opinion, it is a DEGRADED one: `event_count` clamps to 5,000,
+  // `first_block` and `first_seen_at` are nulled outright because the window's
+  // floor is not the account's first event, and `event_kinds`/`subnet_count`
+  // are lower bounds. The projection's is the account's real history --
+  // persisted running totals folded forward from 2020-01-01, associatively, so
+  // it is exact rather than approximate (metagraphed-infra's
+  // account_summary_r2.py: "the card's aggregate is a lifetime question and no
+  // window answers it"). This is a block explorer; the complete history is the
+  // answer users come for.
   //
-  // So this declines above the cap and the lakehouse answers, exactly as it did
-  // before the projection existed. That is a small minority of accounts -- the
-  // cap is 5,000 lifetime events -- and it costs them nothing they were not
-  // already paying.
+  // AND DECLINING WAS NOT FREE, which the old comment's "it costs them nothing
+  // they were not already paying" assumed. A null here is not a slow path: it
+  // is the signal `loadAccountSummaryColdTier` reads to choose its arms, so
+  // declining sent BOTH legs to unbounded scattered scans. Measured on
+  // production 2026-08-17 across 16 accounts from the top 40 by stake, over-cap
+  // correlated with slow 16 of 16: under the cap 0.63-1.07s with no `r2sql` at
+  // all, over it 6.7-22.8s with 3-4 `r2sql` calls and 503s at the 15s ceiling.
+  // Seven of those sixteen were over the cap -- ~0.55% of all accounts by
+  // metagraphed-infra#575's sampling, but 44% of the ones people actually open.
+  //
+  // So the cap no longer decides whether this tier answers. It decides what the
+  // CALLER may claim about a lakehouse read, which is where it always belonged
+  // -- see `complete` in src/account-feeds-cold-tier.ts.
   const scanned = groups.reduce((n, g) => n + Number(g.count), 0);
-  if (scanned > ACCOUNT_EVENT_SUMMARY_SCAN_CAP) return null;
 
   return {
     groups,

--- a/tests/account-events.test.ts
+++ b/tests/account-events.test.ts
@@ -953,6 +953,50 @@ test("buildAccountSummary nulls all-time first_* when the event scan is capped",
   assert.ok(full.first_seen_at);
 });
 
+test("a COMPLETE aggregate is not capped, however large it is", () => {
+  // #11468. `scanned > CAP` was only ever a proxy for "the lakehouse probe
+  // stopped at CAP + 1", and it stopped holding when the projection began
+  // answering above the cap: those totals are running sums folded forward
+  // associatively from a 2020 floor, so a 208,423-event account is EXACT rather
+  // than truncated.
+  //
+  // Inferring truncation from size would null `first_block`/`first_seen_at` on
+  // precisely the accounts whose whole history is known -- a block explorer
+  // reporting "first seen: unknown" for an account it has fully counted.
+  const complete = buildAccountSummary("5Hk", {
+    agg: { c: 208_423, sc: 42, fb: 100, lb: 900, fo: 1000, lo: 9000 },
+    scanned: 208_423,
+    complete: true,
+  });
+  assert.equal(complete.event_scan_capped, false);
+  assert.equal(
+    complete.event_count,
+    208_423,
+    "the lifetime total is published, not clamped to the cap",
+  );
+  assert.equal(complete.subnet_count, 42);
+  assert.equal(complete.first_block, 100, "the real first event, not a floor");
+  assert.ok(complete.first_seen_at);
+
+  // The SAME numbers without the claim keep the old reading: a caller with no
+  // evidence of completeness still gets the conservative answer.
+  const unclaimed = buildAccountSummary("5Hk", {
+    agg: { c: 208_423, sc: 42, fb: 100, lb: 900, fo: 1000, lo: 9000 },
+    scanned: 208_423,
+  });
+  assert.equal(unclaimed.event_scan_capped, true);
+  assert.equal(unclaimed.first_block, null);
+
+  // And `complete: false` is not a way to CLEAR a cap the probe really hit.
+  const stillCapped = buildAccountSummary("5Hk", {
+    agg: { c: ACCOUNT_EVENT_SUMMARY_SCAN_CAP, sc: 3, fb: 100, fo: 1000 },
+    scanned: ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1,
+    complete: false,
+  });
+  assert.equal(stillCapped.event_scan_capped, true);
+  assert.equal(stillCapped.first_block, null);
+});
+
 test("buildSubnetEventSummary groups event kinds into coarse categories", () => {
   const out = buildSubnetEventSummary(
     [

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -775,15 +775,21 @@ describe("the projection short-circuits the aggregate leg (#11131)", () => {
     assert.equal(buildAccountSummary(SS58, cold as never).event_count, 6);
   });
 
-  test("AN OVER-CAP ACCOUNT FALLS BACK -- the tiers must not disagree", async () => {
-    // I shipped this wrong and production caught it. The projection aggregates
-    // an account's WHOLE history; this leg aggregates the newest CAP events.
-    // `event_count` clamps to CAP either way, so the divergence hides there --
-    // but `event_kinds` and `subnet_count` widen to lifetime. Measured live:
-    // 4 kinds / 2 subnets from the lakehouse against 10 / 3 from the shard.
+  test("AN OVER-CAP ACCOUNT IS SERVED WHOLE, not sent to the lakehouse", async () => {
+    // THE INVERSION (#11468), and the previous version of this test asserted the
+    // opposite. Its premise -- one route must not have two answers -- still
+    // holds; what it got wrong is which answer to keep.
     //
-    // So above the cap the projection declines and this leg runs, which is what
-    // keeps one route from having two answers.
+    // The lakehouse's is the DEGRADED one: `event_count` clamped to 5,000,
+    // `first_block`/`first_seen_at` nulled because a window floor is not the
+    // account's first event, `event_kinds`/`subnet_count` lower bounds. The
+    // shard's is the account's real history, folded forward associatively from a
+    // 2020 floor. For a block explorer that is not a tie.
+    //
+    // And declining was never free: null is the signal this reader uses to pick
+    // its arms, so it sent BOTH legs to unbounded scans. Measured on production
+    // 2026-08-17, over-cap correlated with slow 16 of 16 -- 0.63-1.07s under the
+    // cap with no r2sql at all, 6.7-22.8s and 503s over it.
     const engine = fakeEngine();
     const cold = await loadAccountSummaryColdTier(
       archive([
@@ -800,13 +806,72 @@ describe("the projection short-circuits the aggregate leg (#11131)", () => {
       SS58,
       { query: engine.query as never },
     );
-    assert.ok(
+    assert.equal(
       engine.seen.some((s) => s.includes("GROUP BY event_kind, netuid")),
-      "the lakehouse leg must answer for an account the shard cannot",
+      false,
+      "the aggregate leg must NOT reach the lakehouse for an account the shard describes",
     );
     const card = buildAccountSummary(SS58, cold as never);
-    assert.equal(card.event_count, 6);
-    assert.equal(card.event_scan_capped, false);
+    assert.equal(
+      card.event_count,
+      ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 500,
+      "the lifetime total is published rather than clamped to the cap",
+    );
+    assert.equal(
+      card.event_scan_capped,
+      false,
+      "nothing was truncated, so nothing may claim it was",
+    );
+    assert.equal(
+      card.first_block,
+      1,
+      "and the account's real first event survives, instead of being nulled",
+    );
+  });
+
+  test("an ABSENT account whose bounded aggregate FAILS declines", async () => {
+    // The other arm that has to report completeness (#11468), and its failure
+    // path. Absence is a positive answer -- the shard exists and does not list
+    // this account, so there is provably nothing at or before the fold edge and
+    // the bounded read covers the account's whole history. When that read fails
+    // there is no history to describe, and the reader must DECLINE rather than
+    // publish a zero card: `event_count: 0` for an account that has events is
+    // the confidently-wrong outcome this family refuses.
+    const stamp = new Date().toISOString();
+    const absent = {
+      METAGRAPH_ARCHIVE: {
+        get: async (key: string) => {
+          if (key === ACCOUNT_SUMMARY_POINTER_KEY) {
+            return {
+              json: async () => ({
+                schema_version: 1,
+                generation: GEN,
+                shard_count: SHARDS,
+                generated_at: stamp,
+                account_count: 0,
+                // Needed for the floor -- without it absence cannot be bounded
+                // and the reader declines earlier, on a different path.
+                through: "2026-08-14",
+              }),
+            };
+          }
+          if (key === SHARD_KEY) {
+            return {
+              json: async () => ({ schema_version: 1, accounts: {} }),
+            };
+          }
+          return null;
+        },
+      },
+    } as never;
+    const engine = fakeEngine({ groups: null });
+    const cold = await loadAccountSummaryColdTier(absent, SS58, {
+      query: engine.query as never,
+    });
+    assert.ok(
+      cold.declined,
+      "a failed aggregate is a decline, not a zero card",
+    );
   });
 });
 

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -515,15 +515,25 @@ describe("loadAccountSummaryProjection", () => {
     }
   });
 
-  test("AN ACCOUNT OVER THE CAP DECLINES -- the two tiers would disagree", async () => {
-    // The defect this exists for, caught in production before it was trusted.
-    // The projection aggregates an account's WHOLE history; the live path
-    // aggregates the newest CAP events. `event_count` clamps to CAP either way,
-    // so the difference hides there -- but `event_kinds` and `subnet_count`
-    // silently widen to lifetime.
+  test("AN ACCOUNT OVER THE CAP IS ANSWERED -- with the history it really has", async () => {
+    // THE DECLINE THIS USED TO ASSERT, and why it inverted (#11468).
     //
-    // Measured on a real account: live reported 4 kinds across 2 subnets, the
-    // projection 10 across 3. Same route, different answer by tier.
+    // The disagreement it was built on is real: the projection aggregates an
+    // account's WHOLE history, the live path aggregates the newest CAP events,
+    // and above the cap `event_kinds`/`subnet_count` differ. Measured on a real
+    // account, live reported 4 kinds across 2 subnets and the projection 10
+    // across 3. One route must not answer two ways.
+    //
+    // What declining got wrong is WHICH answer to keep. The capped one is the
+    // degraded one -- `event_count` clamped to 5,000, `first_block` and
+    // `first_seen_at` nulled outright -- while the projection's is the account's
+    // real history, folded forward associatively from a 2020 floor. Declining
+    // held the route to the worse answer AND made it slow: null is the signal
+    // the caller reads to pick its arms, so it sent both legs to unbounded
+    // scans. Measured on production 2026-08-17, over-cap correlated with slow
+    // 16/16 -- 0.63-1.07s under the cap, 6.7-22.8s and 503s over it.
+    //
+    // So an over-cap account is now ANSWERED, with the totals it really has.
     const over = [
       group({
         kind: "AxonServed",
@@ -533,9 +543,16 @@ describe("loadAccountSummaryProjection", () => {
       group({ kind: "Transfer", netuid: null, count: 1 }),
     ];
     const store = archive(published({ [HOT]: over }));
+    const found = await readFound(store.env, HOT, FRESH);
     assert.equal(
-      await loadAccountSummaryProjection(store.env, HOT, FRESH),
-      null,
+      found.groups.length,
+      2,
+      "the over-cap account is served, not declined",
+    );
+    assert.equal(
+      found.groups.reduce((n, g) => n + Number(g.count), 0),
+      ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1,
+      "and its lifetime total is published rather than clamped",
     );
   });
 


### PR DESCRIPTION
`/api/v1/accounts/{ss58}` answers in 0.63-1.07s for an account under the
event-scan cap and 6.7-22.8s for one over it, 503ing at the 15s ceiling. Measured
on production 2026-08-17 across 16 accounts from the top 40 by stake, over-cap
correlated with slow **16 of 16**: under the cap `Server-Timing` shows `neon`
only and no `r2sql` at all, over it 3-4 `r2sql` calls.

`loadAccountSummaryProjection` ended with `if (scanned > CAP) return null`. Null
is not a slow path here -- it is the signal `loadAccountSummaryColdTier` reads to
choose its arms -- so declining sent BOTH legs to unbounded scattered scans of
chain.account_events.

## Why it declined, and what that got backwards

The disagreement it was built on is real: the projection aggregates an account's
whole history, the live path aggregates the newest CAP events, and above the cap
`event_kinds`/`subnet_count` differ. Measured on 5Fv5t8frGG3MKt..., live reported
4 kinds across 2 subnets and the projection 10 across 3. One route must not
answer two ways.

Which answer to keep is where it went wrong. The capped one is not a second
opinion, it is a DEGRADED one: `event_count` clamped to 5,000, `first_block` and
`first_seen_at` nulled outright because a window floor is not the account's first
event, `event_kinds`/`subnet_count` lower bounds. The projection's is the
account's real history -- metagraphed-infra's account_summary_r2.py persists
running totals and folds days forward from a 2020 floor, and the aggregates are
associative, so folding day 3 into days 1-2 equals grouping days 1-3. Exact, at
any magnitude. Its own header: "the card's aggregate is a lifetime question and
no window answers it."

This is a block explorer. The complete history is the answer.

So the projection now answers above the cap, and the tiers still agree, because
the lakehouse only answers when the projection cannot.

## The cap moves to where it belongs

It was never a property of an account -- it is what a lakehouse probe managed to
read. `scanned > CAP` was a proxy for "the CTE stopped at CAP + 1", and that
proxy failed the moment an exact total could exceed the cap: it would null
`first_*` on precisely the accounts whose whole history is known.

So the reader that assembles the aggregate reports whether it is whole, and the
formatter stops guessing from a number:

  * `postFoldGroups` returns `{ groups, complete }`. The published half is
    lifetime and cannot be short; only the post-fold delta can be, so
    completeness is counted over the DELTA rather than the total.
  * The two lakehouse arms share `withScanCompleteness`, so they cannot answer
    the cap question differently.
  * `buildAccountSummary` takes `complete`. It defaults to undefined and keeps
    the old size inference for every caller with no better evidence.
  * `agg.c` is clamped only when the count is a probe's. Clamping a complete
    208,423 to 5,000 would replace a true number with a smaller wrong one.

`event_scan_capped: false` now means what it says -- the totals are the account's
complete history -- and the published description says so.

Four tests, each verified to fail without the change. Patch coverage 100%,
branch-counted.