### PR TITLE
fix(blocks): chain-walk nav was dead on the tier that answers the route

### DIFF
--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -282,26 +282,135 @@ export async function loadBlockFromR2Sql(
   const asNumber = safeBlockNumber(ref);
   const asHash = asNumber === null ? safeHexLiteral(ref) : null;
   if (asNumber === null && asHash === null) return null;
-  const predicate =
-    asNumber !== null
-      ? `block_number = ${asNumber}`
-      : `block_hash = '${asHash}'`;
+  const table = chainTable("blocks", network);
+
+  // CHAIN-WALK NAV, AT NO EXTRA QUERY (#11462). This tier served
+  // `prev_block_number`/`next_block_number` as permanently null, so #1853's
+  // navigation was structurally present and dead on the tier that answers this
+  // route -- a client walking the chain got null and stopped, with nothing in
+  // the payload saying the tier simply did not populate them.
+  //
+  // The Postgres tier gets them from a SECOND query for its nearest stored
+  // neighbours, and copying that here was the option this was parked on: one
+  // more warehouse query per read, on a route measured at a 3,647ms median
+  // against an account that has been rate-limited before (#9465).
+  //
+  // It does not need one. The ref IS the height, so the block and both
+  // neighbours are three adjacent values of the column this table is ordered
+  // by -- widening `= N` to `N-1 .. N+1` returns all three in the SAME query.
+  // R2 SQL prunes columns well and files poorly (src/r2-sql.ts), and a
+  // three-height range opens exactly the parts the point lookup already did.
+  //
+  // PRESENCE, NOT ARITHMETIC. A neighbour is reported only when this tier
+  // actually holds it, so nav never links to a block the API cannot then
+  // serve. That is the Postgres tier's own rule -- nearest STORED neighbour --
+  // narrowed to +/-1, which is the same answer on a contiguous chain and an
+  // honest null at a coverage edge instead of a link into a gap.
+  if (asNumber !== null) {
+    const rows = await r2SqlQuery<BlocksRow>(
+      env,
+      `SELECT ${BLOCK_COLUMNS} FROM ${table} ` +
+        `WHERE block_number >= ${Math.max(asNumber - 1, 0)} ` +
+        `AND block_number <= ${asNumber + 1} ` +
+        `ORDER BY block_number ASC LIMIT 3`,
+    );
+    // A CONFIGURED lakehouse that could not answer is a decline, not "no such
+    // block" (#11424). This route was measured at 15,085ms -- AT the 15s
+    // `QUERY_TIMEOUT_MS` -- on 2026-08-16, and the bare null reached the caller
+    // as the same payload a confirmed absence produces, which is the one
+    // distinction the comment below already insists on. With NO lakehouse bound
+    // the null stands: there is nothing to read and the caller's own floor is
+    // correct.
+    if (rows === null) {
+      return isR2SqlConfigured(env) ? declineBlock(ref) : null;
+    }
+    // A confirmed absence is an ANSWER: buildBlock(undefined, ref) is the same
+    // "no such block" payload the Postgres tier produces, and returning it here
+    // (rather than null) stops the caller re-deriving it.
+    return buildBlock(
+      recordOrNull(rows.find((row) => blockHeight(row) === asNumber)),
+      ref,
+      neighboursOf(rows, asNumber),
+    );
+  }
+
   const rows = await r2SqlQuery<BlocksRow>(
     env,
-    `SELECT ${BLOCK_COLUMNS} FROM ${chainTable("blocks", network)} WHERE ${predicate} LIMIT 1`,
+    `SELECT ${BLOCK_COLUMNS} FROM ${table} WHERE block_hash = '${asHash}' LIMIT 1`,
   );
-  // A CONFIGURED lakehouse that could not answer is a decline, not "no such
-  // block" (#11424). This route was measured at 15,085ms -- AT the 15s
-  // `QUERY_TIMEOUT_MS` -- on 2026-08-16, and the bare null reached the caller
-  // as the same payload a confirmed absence produces, which is the one
-  // distinction the comment below already insists on. With NO lakehouse bound
-  // the null stands: there is nothing to read and the caller's own floor is
-  // correct.
   if (rows === null) {
     return isR2SqlConfigured(env) ? declineBlock(ref) : null;
   }
-  // A confirmed absence is an ANSWER: buildBlock(undefined, ref) is the same
-  // "no such block" payload the Postgres tier produces, and returning it here
-  // (rather than null) stops the caller re-deriving it.
-  return buildBlock(recordOrNull(rows[0]), ref);
+  const row = recordOrNull(rows[0]);
+  // From the ROW, not from `recordOrNull`'s widened copy: `blockHeight` reads a
+  // typed column, and going through `Record<string, unknown>` would put this
+  // back on the untyped-read ratchet the generated catalog types exist to keep
+  // at zero.
+  const height = blockHeight(rows[0]);
+  if (row === null || height === null) return buildBlock(row, ref);
+
+  // A HASH REF CANNOT FOLD ITS NEIGHBOURS IN, because the height is not known
+  // until the row comes back -- so this is the one path that pays a second
+  // query, and it pays it for parity rather than leaving nav null on half the
+  // ref forms. Intermittent nav is worse than none: it reads as data rather
+  // than as a tier limit.
+  //
+  // ONE COLUMN over three heights, which is the cheapest shape this engine
+  // has, and it lands on a route the edge already holds for 600s (#11016), so
+  // it is paid on a cache miss by a minority ref form.
+  //
+  // A FAILED NEIGHBOUR READ STILL SERVES THE BLOCK. Nav is a hint; the block
+  // is the answer. Declining the whole payload because a navigation aid could
+  // not be read would trade the thing the caller asked for against the thing
+  // it did not.
+  const neighbours = await r2SqlQuery<BlocksRow>(
+    env,
+    `SELECT block_number FROM ${table} ` +
+      `WHERE block_number >= ${Math.max(height - 1, 0)} ` +
+      `AND block_number <= ${height + 1} ` +
+      `ORDER BY block_number ASC LIMIT 3`,
+  );
+  return buildBlock(
+    row,
+    ref,
+    neighbours === null ? undefined : neighboursOf(neighbours, height),
+  );
+}
+
+/**
+ * One row's height, coerced -- the engine can hand back a numeric string.
+ *
+ * Takes a ROW, not `unknown`, and carries no shape guard: `r2SqlQuery`
+ * validates every row against the catalog schema and throws on one that does
+ * not match, so a non-object can never arrive here. A `typeof row === "object"`
+ * check would be an unreachable branch, which is not safety -- the same reading
+ * src/account-feeds-cold-tier.ts applies to its own `?? 0`.
+ *
+ * The null it DOES return is reachable and load-bearing: every catalog column is
+ * nullable, so `block_number` can legitimately arrive null.
+ */
+function blockHeight(row: BlocksRow | undefined): number | null {
+  return safeBlockNumber(row?.block_number);
+}
+
+/**
+ * `prev`/`next` from the heights actually returned, never from `height +/- 1`.
+ *
+ * The distinction is the whole point of reading the range: arithmetic would
+ * advertise a neighbour at a coverage edge that this tier cannot serve, and a
+ * chain-walk link into a gap is worse than a null that says "the walk stops
+ * here". Genesis has no prev and the head has no next, and both fall out of
+ * presence without being special-cased.
+ */
+function neighboursOf(
+  rows: readonly BlocksRow[],
+  height: number,
+): { prev: number | null; next: number | null } {
+  const heights = new Set(
+    rows.map(blockHeight).filter((n): n is number => n !== null),
+  );
+  return {
+    prev: heights.has(height - 1) ? height - 1 : null,
+    next: heights.has(height + 1) ? height + 1 : null,
+  };
 }

--- a/tests/blocks-cold-tier.test.ts
+++ b/tests/blocks-cold-tier.test.ts
@@ -197,7 +197,10 @@ describe("the resolved seam actually routes the request", () => {
       String(above),
     );
     assert.deepEqual(sql, [], "D1 must not be asked for a decoded block");
-    assert.match(queries[0]!, new RegExp(`block_number = ${above}`));
+    // The range #11462 widened the point lookup to -- the block and both
+    // neighbours in one query. Matched on the lower bound so this keeps
+    // asserting WHICH height was asked for, which is what this test is about.
+    assert.match(queries[0]!, new RegExp(`block_number >= ${above - 1}`));
     assert.equal(data!.block!.author, lakeRow(above).author);
   });
 
@@ -603,7 +606,7 @@ describe("loadBlockColdTier", () => {
     );
     assert.equal(data!.block!.block_number, SEAM);
     assert.equal(sql.length, 0, "D1 cannot own this height, so is not asked");
-    assert.match(queries[0]!, new RegExp(`block_number = ${SEAM}`));
+    assert.match(queries[0]!, new RegExp(`block_number >= ${SEAM - 1}`));
   });
 
   test("a height above the seam that D1 lacks is a real absence, not a scan", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -5705,7 +5705,9 @@ describe("graphql — blocks / block (#5575, lakehouse feed)", () => {
       assert.equal(body.data.block.ref, "123");
       assert.equal(body.data.block.block.block_number, 123);
       assert.equal(body.data.block.block.spec_version, 200);
-      assert.match(lake.queries[0], /block_number = 123/);
+      // #11462 widened this to the block plus its two neighbours, so the
+      // chain-walk fields are populated from the same read.
+      assert.match(lake.queries[0], /block_number >= 122/);
     } finally {
       lake.restore();
     }

--- a/tests/r2-sql-blocks.test.ts
+++ b/tests/r2-sql-blocks.test.ts
@@ -50,6 +50,31 @@ function sqlFetch(rows: unknown[]) {
   return { impl, queries };
 }
 
+/**
+ * `sqlFetch` for a loader that issues MORE THAN ONE query.
+ *
+ * The shared helper replays one row set for every query, which cannot express
+ * "the resolve returned this and the neighbour read returned that" -- and a
+ * double that replays the same answer would let a two-query path pass while
+ * reading the wrong result for the second. `null` in the sequence is a failed
+ * query (a non-2xx), so the degradation path is reachable too.
+ */
+function sqlFetchSeq(responses: readonly (unknown[] | null)[]) {
+  const queries: string[] = [];
+  const impl = (async (_u: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query);
+    const rows = responses[queries.length - 1];
+    if (rows === null || rows === undefined) {
+      return new Response("upstream said no", { status: 500 });
+    }
+    return new Response(JSON.stringify({ success: true, result: { rows } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { impl, queries };
+}
+
 describe("safeAuthorLiteral", () => {
   test("accepts an SS58 address, refuses anything else", () => {
     assert.equal(safeAuthorLiteral(AUTHOR), AUTHOR);
@@ -301,12 +326,63 @@ describe("loadBlockFeedFromR2Sql", () => {
 });
 
 describe("loadBlockFromR2Sql", () => {
-  test("resolves by height", async () => {
-    const { impl, queries } = sqlFetch([row(8755000)]);
+  test("resolves by height, and its neighbours ride the SAME query", async () => {
+    // #11462. `prev_block_number`/`next_block_number` were permanently null on
+    // this tier, so #1853's chain-walk nav was structurally present and dead on
+    // the tier that answers the route. The Postgres tier gets them from a
+    // second query; here the ref IS the height, so widening `= N` to
+    // `N-1 .. N+1` returns the block and both neighbours in one read -- no
+    // extra warehouse query on a route that has been rate-limited before.
+    const { impl, queries } = sqlFetch([
+      row(8754999),
+      row(8755000),
+      row(8755001),
+    ]);
     globalThis.fetch = impl;
     const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "8755000");
-    assert.match(queries[0]!, /block_number = 8755000/);
-    assert.equal(data!.block!.block_number, 8755000);
+    assert.equal(queries.length, 1, "one query, not two");
+    assert.match(
+      queries[0]!,
+      /block_number >= 8754999 AND block_number <= 8755001/,
+    );
+    assert.equal(data!.block!.block_number, 8755000, "the asked-for height");
+    assert.equal(data!.prev_block_number, 8754999);
+    assert.equal(data!.next_block_number, 8755001);
+  });
+
+  test("a neighbour this tier does NOT hold is null, not arithmetic", async () => {
+    // PRESENCE, never `height +/- 1`. Arithmetic would advertise a block at a
+    // coverage edge that the API cannot then serve, and a chain-walk link into
+    // a gap is worse than a null saying the walk stops here. The head has no
+    // next and genesis no prev, and both fall out of the same rule.
+    const { impl } = sqlFetch([row(8754999), row(8755000)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "8755000");
+    assert.equal(data!.prev_block_number, 8754999);
+    assert.equal(data!.next_block_number, null, "absent means null");
+  });
+
+  test("the range never asks for a negative height at genesis", async () => {
+    const { impl, queries } = sqlFetch([row(0)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "0");
+    assert.match(queries[0]!, /block_number >= 0 AND block_number <= 1/);
+    assert.equal(data!.prev_block_number, null);
+  });
+
+  test("a range that does NOT contain the asked height is still an absence", async () => {
+    // The neighbours can come back without the block itself -- a gap at exactly
+    // N. Picking `rows[0]` would then serve block N-1 under a ref for N, which
+    // is a wrong answer rather than a missing one.
+    const { impl } = sqlFetch([row(8754999), row(8755001)]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "8755000");
+    assert.equal(data!.block, null, "no row for N is no block");
+    assert.equal(
+      data!.prev_block_number,
+      null,
+      "and buildBlock withholds nav without a block to walk from",
+    );
   });
 
   test("resolves by hash, lowercased", async () => {
@@ -314,6 +390,55 @@ describe("loadBlockFromR2Sql", () => {
     globalThis.fetch = impl;
     await loadBlockFromR2Sql(mockEnv(TOKEN), "0xABCDEF");
     assert.match(queries[0]!, /block_hash = '0xabcdef'/);
+  });
+
+  test("a hash ref gets nav too, from a second read of its heights", async () => {
+    // The one path that cannot fold the neighbours in: the height is unknown
+    // until the row returns. It pays the extra query rather than leaving nav
+    // null on half the ref forms -- intermittent nav reads as data rather than
+    // as a tier limit, which is worse than none.
+    const { impl, queries } = sqlFetchSeq([
+      [row(42)],
+      [{ block_number: 41 }, { block_number: 42 }, { block_number: 43 }],
+    ]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "0xABCDEF");
+    assert.equal(queries.length, 2);
+    assert.match(queries[1]!, /block_number >= 41 AND block_number <= 43/);
+    assert.match(
+      queries[1]!,
+      /SELECT block_number FROM/,
+      "one column, the cheapest shape this engine has",
+    );
+    assert.equal(data!.block!.block_number, 42);
+    assert.equal(data!.prev_block_number, 41);
+    assert.equal(data!.next_block_number, 43);
+  });
+
+  test("a hash row with an unusable height serves the block and asks no more", async () => {
+    // The height is what the neighbour read is keyed on, so an unreadable one
+    // means there is nothing to ask for. Issuing the second query anyway would
+    // spend a warehouse read to bound a range around NaN.
+    const { impl, queries } = sqlFetchSeq([
+      [{ ...row(42), block_number: null }],
+    ]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "0xABCDEF");
+    assert.equal(queries.length, 1, "no neighbour read without a height");
+    assert.equal(data!.prev_block_number, null);
+    assert.equal(data!.next_block_number, null);
+  });
+
+  test("a failed neighbour read still serves the block", async () => {
+    // Nav is a hint; the block is the answer. Declining the whole payload
+    // because a navigation aid could not be read would trade the thing the
+    // caller asked for against the thing it did not.
+    const { impl } = sqlFetchSeq([[row(42)], null]);
+    globalThis.fetch = impl;
+    const data = await loadBlockFromR2Sql(mockEnv(TOKEN), "0xABCDEF");
+    assert.equal(data!.block!.block_number, 42, "the block still lands");
+    assert.equal(data!.prev_block_number, null);
+    assert.equal(data!.next_block_number, null);
   });
 
   test("a confirmed absence is the shared no-such-block payload, not null", async () => {


### PR DESCRIPTION
`/api/v1/blocks/{ref}` served `prev_block_number` and `next_block_number` as
permanently null on the lakehouse tier. Verified live 2026-08-17 on a mid-chain
block well below head:

```
GET /api/v1/blocks/8760000
  "block_number": 8760000
  "prev_block_number": null
  "next_block_number": null
```

So #1853's navigation was structurally present and dead on the tier that now
answers this route: a client walking the chain got null and stopped, with
nothing in the payload saying the tier simply did not populate them.

## Why it was parked, and why that objection does not survive

The Postgres tier gets the fields from a SECOND query for its nearest stored
neighbours, and copying that shape here was the option this was parked on: one
more warehouse query per read, on a route measured at a 3,647ms median with a
16.7x spread, against an account that has been rate-limited before (#9465).

It does not need one. The ref IS the height, so the block and both neighbours
are three adjacent values of the column the table is ordered by -- widening
`block_number = N` to `N-1 .. N+1` returns all three in the SAME query. R2 SQL
prunes columns well and files poorly (src/r2-sql.ts), so a three-height range
opens exactly the parts the point lookup already opened. Zero extra queries,
which is better than the best option the issue listed.

## Presence, never arithmetic

A neighbour is reported only when this tier actually holds it. `height +/- 1`
would advertise a block at a coverage edge that the API cannot then serve, and a
chain-walk link into a gap is worse than a null saying the walk stops here. That
is the Postgres tier's own rule -- nearest STORED neighbour -- narrowed to +/-1,
which is the same answer on a contiguous chain and an honest null at an edge.
Genesis has no prev and the head no next, and both fall out of presence without
being special-cased.

A hash ref is the one path that cannot fold its neighbours in, because the
height is unknown until the row returns. It pays a second query rather than
leaving nav null on half the ref forms -- intermittent nav reads as data rather
than as a tier limit, which is worse than none. That read is one column over
three heights, the cheapest shape this engine has, on a route the edge already
holds for 600s (#11016). A failed neighbour read still serves the block: nav is
a hint, the block is the answer.

`blockHeight` carries no `typeof row === "object"` guard. `r2SqlQuery` validates
every row against the catalog schema and throws on one that does not match, so a
non-object cannot arrive -- the guard would be an unreachable branch, which is
not safety. The null it does return is reachable and load-bearing: every catalog
column is nullable, so `block_number` can legitimately arrive null.

Three tests in tests/blocks-cold-tier.test.ts and tests/graphql.test.ts pinned
the old `block_number = N` predicate while testing ROUTING; they now match the
range's lower bound, which is still the assertion they were making. The new
tests fail without the change. Patch coverage 100%, branch-counted.

Closes #11462