### PR TITLE
fix(watchdog): pure churn is a measurement, and `stale` is this enum's word for a fault

### DIFF
--- a/src/axon-announcement-watchdog.ts
+++ b/src/axon-announcement-watchdog.ts
@@ -583,7 +583,30 @@ export async function runAxonAnnouncementWatchdog(
     // `stale` is the vocabulary `lane_health` has for "this lane has a finding";
     // there is no `finding` verdict, and inventing one would drift from the
     // published enum every other reader shares.
-    verdict: findings.length > 0 ? "stale" : "ok",
+    //
+    // PURE CHURN IS NOT ONE OF THEM (#11367). The paging decision above already
+    // concluded that churn-only means "nobody went dark, and there is nobody to
+    // go looking for" -- and `stale` is not a neutral word for that, it is this
+    // enum's assertion of a FAULT. Writing it for a measured non-event made two
+    // components disagree: the watchdog decided not to page, and `src/lane-alarm.ts`
+    // raised anyway, because its finding set is `Exclude<LaneVerdict, "ok">` and
+    // it never sees the paging decision.
+    //
+    // The cost of that disagreement is an issue that cannot close. lane-alarm
+    // closes on the first `ok`, so a lane held at `stale` by ordinary
+    // deregistration churn keeps its alarm open for as long as the churn lasts
+    // -- #11367 has been open since 2026-08-15 on exactly this. A verdict that
+    // cannot be cleared is not a health signal; the neurons sub-lanes were the
+    // same shape (#11466).
+    //
+    // THE FINDING IS NOT SUPPRESSED, which is the point the block above makes
+    // and this keeps: `detail` still carries the subnet, the ratio, the
+    // mechanism and the counts, on /self-health and in history, exactly as
+    // before. What changes is only whether that record asserts a fault. A
+    // withdrawal, a fleet-wide flag, an unread mechanism or any MIXED set are
+    // all still `stale` -- `churnOnly` is the same `every` bar the page uses,
+    // so one non-churn finding restores it.
+    verdict: findings.length > 0 && !churnOnly ? "stale" : "ok",
     age_ms: null,
     detail,
     checked_at: now(),

--- a/tests/axon-announcement-watchdog.test.ts
+++ b/tests/axon-announcement-watchdog.test.ts
@@ -922,6 +922,15 @@ describe("the tick reports the mechanism it measured", () => {
     return String(insert.values[3]);
   };
 
+  /** The VERDICT column, where `verdict()` above returns the detail. */
+  const verdictValue = () => {
+    const insert = pg.control.queries.find((q) =>
+      q.text.includes("INSERT INTO lane_health"),
+    );
+    assert.ok(insert);
+    return String(insert.values[1]);
+  };
+
   test("PURE CHURN records its verdict and does NOT page (#11386)", async () => {
     // SN25's real shape. Churn means the announcing miners were deregistered
     // and their UIDs reused by miners that never served -- nobody went dark and
@@ -953,6 +962,47 @@ describe("the tick reports the mechanism it measured", () => {
     assert.equal(result.flagged, true);
     assert.equal(result.churn_only, true);
     assert.match(verdict(), /churn-replaced: 67 of 67/);
+    // AND THE VERDICT MATCHES THE PAGING DECISION (#11367). `stale` is this
+    // enum's word for a fault, and the block above just concluded there is no
+    // fault and nobody to go looking for. Writing it anyway made lane-alarm --
+    // whose finding set is `Exclude<LaneVerdict, "ok">` and which never sees
+    // the paging decision -- open an issue that then could not close, because
+    // it closes on the first `ok` and churn keeps the lane off it.
+    assert.equal(verdictValue(), "ok");
+  });
+
+  test("CHURN MIXED WITH A WITHDRAWAL is still stale, and still pages", async () => {
+    // The bar that keeps #11367's change from suppressing a real fault. Churn
+    // clears the verdict only when it is ALL of it -- `every`, the same bar the
+    // page uses -- so one subnet whose miners actually went dark restores both
+    // the exception and the `stale` verdict, even alongside a churning one.
+    //
+    // Without this, "no page for churn" would quietly become "no page whenever
+    // any churn is present", which is the opposite reading.
+    answer(
+      [
+        ...rowsFor(25, then(flat(8, 80), [14, 256])),
+        ...rowsFor(101, then(flat(8, 223), [129, 256])),
+      ],
+      [
+        { netuid: 25, via_reuse: 67, same_hotkey: 0 },
+        { netuid: 101, via_reuse: 0, same_hotkey: 94 },
+      ],
+    );
+    let captured: Record<string, unknown> | null = null;
+    const result = (await runAxonAnnouncementWatchdog(pgMockEnv(), {
+      now: () => Date.parse("2026-08-16T00:00:00Z"),
+      recordException: (async (_e: unknown, ev: Record<string, unknown>) => {
+        captured = ev;
+        return true;
+      }) as never,
+    })) as { alerted: boolean; churn_only: boolean; flagged: boolean };
+
+    assert.equal(result.flagged, true);
+    assert.equal(result.churn_only, false, "one non-churn finding is enough");
+    assert.equal(result.alerted, true, "the withdrawal still pages");
+    assert.ok(captured, "and still records an exception");
+    assert.equal(verdictValue(), "stale");
   });
 
   test("SN126's REAL shape: moved to an unroutable address, not gone dark", async () => {


### PR DESCRIPTION
`axon-announcement` has held `stale` since 2026-08-15 and #11367 has been open
that whole time, over a finding the watchdog itself decided is not worth paging
anyone about:

```
axon-announcement  stale  SN25 14/21 axons (67%, churn-replaced: 67 of 67 losses were deregistrations)
```

`churn-replaced` means the announcing miners were DEREGISTERED and their UIDs
reused by miners that never served. The paging block above the verdict already
draws the conclusion in those words -- "nobody went dark, and there is nobody to
go looking for" -- and suppresses the exception. It then wrote `stale` anyway.

## Two components disagreeing, and what the disagreement costs

`src/lane-alarm.ts` never sees the paging decision. Its finding set is
`Exclude<LaneVerdict, "ok">`, so it raises on the verdict alone -- and it closes
an alarm on the first `ok`. A lane held off `ok` by ordinary deregistration
churn therefore keeps its issue open for as long as the churn lasts, which for
SN25 is until its baseline decays below the floor.

That is the same shape as the neurons sub-lanes in #11466: a verdict that cannot
be cleared is not a health signal. Here it is worse in one way, because the
system had already decided there was nothing to clear.

## What changes, and what deliberately does not

`churnOnly` now clears the verdict as well as the page. It is the same `every`
bar, so the two cannot drift: a withdrawal, a fleet-wide flag, an unread
mechanism, or any MIXED set are all still `stale` and still page. One non-churn
finding restores both.

THE FINDING IS NOT SUPPRESSED. `detail` still carries the subnet, the ratio, the
mechanism and the counts, on `/self-health` and in `lane_health` history,
byte-identical to before -- which is the point the paging block already makes
("suppressing the page is not suppressing the finding"). What changes is only
whether that record asserts a fault, and for a measured non-event it should not.

`stale_lane_count` stops counting it too, which is the honest arithmetic: three
stale lanes today, one of which is the network's ordinary state.

Two tests. The pure-churn one now pins the verdict as well as the detail and
fails without the change. The mixed-set one is the guard that matters more --
it passes in both states, so "no page for churn" cannot quietly become "no page
whenever any churn is present".

Patch coverage 100%, branch-counted, on all four branches of the new condition.

Closes #11367