### PR TITLE
feat(lane-health): publish the coverage counts on a healthy tick too

### DIFF
--- a/src/lane-verdict-detail.ts
+++ b/src/lane-verdict-detail.ts
@@ -32,20 +32,54 @@
 // an unmeasured mechanism (#11381).
 
 /**
- * `reason (key=value, ...)`, or the bare reason when nothing is measurable.
+ * `reason (key=value, ...)`, the bare reason when nothing is measurable, or the
+ * bare facts when there is no reason.
  *
- * Returns null for a healthy lane, matching the `detail` column's existing
- * meaning -- an `ok` verdict has no reason and gains no facts.
+ * ## A HEALTHY LANE PUBLISHES ITS COUNTS TOO (#11390)
+ *
+ * This used to return null the moment `reason` was absent, on the reading that
+ * "an `ok` verdict has no reason and gains no facts". The first half is right;
+ * the second turned out to be the thing blocking its own sibling issue.
+ *
+ * #11384 published these counts so a verdict could be triaged from the durable
+ * record. #11390 then wants to replace `NOMINATOR_POSITIONS_EXPECTED_COLDKEYS`
+ * -- a pinned constant that has gone stale three times -- with a floor derived
+ * from a trailing median of the lane's own coverage, and named these counts as
+ * "the only place a trailing baseline can come from".
+ *
+ * They could not be. Measured 2026-08-18: of 658 `nominator-positions-staleness`
+ * verdicts only 20 carried counts, spanning 27 hours and then stopping -- not
+ * because the lane stopped ticking, but because it RECOVERED. A baseline
+ * sampled only while a lane is unhealthy is a median of bad passes, which is
+ * the same error as the pinned constant approached from the other side.
+ *
+ * The pass-tally table is not a substitute either: `received_rows` counts rows
+ * POSTED, and `nominator_positions` upserts on `(coldkey, hotkey, netuid)`, so
+ * a pass posting 108,306 rows lands 95,086 -- 12% of the posted rows are
+ * duplicate keys collapsing. It cannot be compared against a count read from
+ * the table.
+ *
+ * So the facts are published whether or not there is a reason, and the baseline
+ * exists by construction from the next tick onward.
+ *
+ * ## What did not change
+ *
+ * A verdict with neither a reason nor a measurable fact is still null -- the
+ * column's meaning for "nothing to say" is unchanged, and every lane with no
+ * coverage leg keeps writing null exactly as before.
  */
 export function laneVerdictDetail(
   reason: string | null | undefined,
   facts: Readonly<Record<string, number | null | undefined>> = {},
 ): string | null {
-  if (typeof reason !== "string" || reason === "") return null;
+  const named = typeof reason === "string" && reason !== "" ? reason : null;
   const parts: string[] = [];
   for (const [key, value] of Object.entries(facts ?? {})) {
     if (typeof value !== "number" || !Number.isFinite(value)) continue;
     parts.push(`${key}=${value}`);
   }
-  return parts.length === 0 ? reason : `${reason} (${parts.join(", ")})`;
+  if (parts.length === 0) return named;
+  // Bare, without an empty `()` in front of them: a healthy lane's detail reads
+  // as the measurement it is, not as a reason that went missing.
+  return named === null ? parts.join(", ") : `${named} (${parts.join(", ")})`;
 }

--- a/tests/lane-verdict-detail.test.ts
+++ b/tests/lane-verdict-detail.test.ts
@@ -4,6 +4,35 @@ import assert from "node:assert/strict";
 import { laneVerdictDetail } from "../src/lane-verdict-detail.ts";
 
 describe("laneVerdictDetail — the counts the verdict was decided on (#11384)", () => {
+  test("A HEALTHY LANE PUBLISHES ITS COUNTS (#11390)", () => {
+    // The change that unblocks deriving a coverage floor from history. These
+    // counts used to be dropped the moment `reason` was absent, so they were
+    // recorded ONLY while a lane was unhealthy -- measured 2026-08-18, 20 of
+    // 658 `nominator-positions-staleness` verdicts carried them, and they
+    // stopped the moment the lane recovered. A trailing median over that is a
+    // median of bad passes.
+    //
+    // Bare, with no empty `()` in front: a healthy lane's detail reads as the
+    // measurement it is.
+    assert.equal(
+      laneVerdictDetail(null, { covered: 19851, total: 19873, floor: 17010 }),
+      "covered=19851, total=19873, floor=17010",
+    );
+    // And a reason still wins the prefix when there is one.
+    assert.equal(
+      laneVerdictDetail("partial", { covered: 16988, total: 19873 }),
+      "partial (covered=16988, total=19873)",
+    );
+  });
+
+  test("nothing to say is still null", () => {
+    // The column's meaning for "no reason and nothing measurable" is unchanged,
+    // so every lane with no coverage leg keeps writing null exactly as before.
+    assert.equal(laneVerdictDetail(null, {}), null);
+    assert.equal(laneVerdictDetail(null, { covered: undefined }), null);
+    assert.equal(laneVerdictDetail(null, { covered: Number.NaN }), null);
+  });
+
   test("a healthy lane has no detail", () => {
     // `ok` verdicts pass `reason: null`, and the column's existing meaning for
     // that is null rather than an empty string.


### PR DESCRIPTION
#11390 wants `NOMINATOR_POSITIONS_EXPECTED_COLDKEYS` -- a pinned constant that
has gone stale three times -- replaced by a floor derived from a trailing median
of the lane's own coverage, and names the counts #11385 publishes as "the only
place a trailing baseline can come from".

They could not be. `laneVerdictDetail` returned null the moment `reason` was
absent, so the counts were recorded ONLY while a lane was unhealthy.

Measured 2026-08-18: of 658 `nominator-positions-staleness` verdicts, **20**
carried counts. They span 27 hours and then stop -- not because the lane stopped
ticking, it writes every 30 minutes, but because it RECOVERED. A trailing median
over that sample is a median of bad passes, which is the pinned constant's error
approached from the other side.

## The pass tally is not a substitute, which is worth writing down

`nominator_positions_passes` looks like the missing history -- 30 passes over 10
days. It cannot serve as the denominator for a numerator read from the table:
`received_rows` counts rows POSTED, and `nominator_positions` upserts on
`(coldkey, hotkey, netuid)`. For the newest pass, 108,306 posted rows land as
95,086, and `count(*) = count(DISTINCT (coldkey, hotkey, netuid))` at that
stamp, so the 12.2% gap is duplicate keys collapsing on upsert rather than rows
going missing. Comparing a post count against a table count would put the floor
12% out.

That leaves `lane_health` as the only per-tick record of what the watchdog
actually measured, so it has to record it on every tick.

## The change

Facts publish whether or not there is a reason:

    reason + facts -> "partial (covered=16988, total=19873)"    unchanged
    facts only     -> "covered=19851, total=19873, floor=17010" new
    reason only    -> "partial"                                 unchanged
    neither        -> null                                      unchanged

Bare rather than `(...)` with nothing in front, so a healthy lane's detail reads
as the measurement it is. The seven watchdogs sharing this formatter all gain
their counts on healthy ticks; a lane with no coverage leg still writes null.

This reverses the "an `ok` verdict has no reason and gains no facts" half of
#11384's docstring, deliberately -- the other half, that the durable record
should carry what the transient notification did, is what this serves.

#11390 stays open: its seven-day window starts now rather than having silently
never started, and the derivation itself is still its own change.

Patch coverage 100%, branch-counted. Verified to fail without the change.