### PR TITLE
fix(watchdog): a container reporting an in-progress pass is not unreadable

### DIFF
--- a/src/container-lane-watchdog.ts
+++ b/src/container-lane-watchdog.ts
@@ -139,6 +139,9 @@ export interface ContainerLaneStatus {
   body: {
     checked_at?: string | null;
     updated_at?: string | null;
+    /** Published by a script reporting an IN-PROGRESS pass, where the other two
+     * spellings appear only once it finishes. */
+    started_at?: string | null;
     ok?: boolean | null;
     status?: string | null;
     detail?: string | null;
@@ -230,9 +233,29 @@ export function evaluateContainerLanes(input: {
         age_ms: null,
       };
     }
-    // Either spelling. Which word the producing script chose is not a fact
-    // about lane health, so the reader takes whichever is there.
-    const stampedAt = body.checked_at ?? body.updated_at ?? null;
+    // ANY OF THE THREE SPELLINGS. Which word the producing script chose is not
+    // a fact about lane health, so the reader takes whichever is there.
+    //
+    // `started_at` was the missing one, and its absence made a lane read
+    // `unknown` for the whole of every pass it ran. Measured 2026-08-18: the
+    // account-summary container publishes
+    //
+    //   {"phase":"scanning","started_at":"2026-08-18T07:27:19Z","ok":null,
+    //    "rows_scanned":2125318,...}
+    //
+    // mid-scan -- no `checked_at`, no `updated_at` -- so `container:account-
+    // summary` sat at "status carries no readable timestamp" while its producer
+    // was demonstrably healthy (generation 20260818T072733Z, ten minutes old).
+    // A verdict that cannot be cleared while a lane is WORKING is the opposite
+    // of what this watchdog is for.
+    //
+    // AND IT IS THE RIGHT FRESHNESS SIGNAL, not merely a third field to accept:
+    // during a pass, when that pass STARTED is exactly the age that matters --
+    // a scan still scanning three hours later is stale, and this is the field
+    // that says so. Ordered last so a script publishing both keeps reporting
+    // its most recent stamp rather than its oldest.
+    const stampedAt =
+      body.checked_at ?? body.updated_at ?? body.started_at ?? null;
     const at = stampedAt === null ? Number.NaN : Date.parse(stampedAt);
     if (!Number.isFinite(at)) {
       return {

--- a/tests/container-lane-watchdog.test.ts
+++ b/tests/container-lane-watchdog.test.ts
@@ -161,13 +161,47 @@ describe("evaluateContainerLanes", () => {
       statuses: [
         { lane: "a", body: { updated_at: FRESH, ok: true } },
         { lane: "b", body: { checked_at: FRESH, ok: true } },
+        // THE THIRD, and its absence made a lane read `unknown` for the whole
+        // of every pass. Measured 2026-08-18: account-summary publishes
+        // `{"phase":"scanning","started_at":...}` mid-scan with neither other
+        // spelling, so `container:account-summary` reported "status carries no
+        // readable timestamp" while its producer was demonstrably healthy.
+        { lane: "c", body: { started_at: FRESH, ok: null } },
       ],
       nowMs: NOW,
       thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
     });
     assert.deepEqual(
       verdict.entries.map((e) => e.verdict),
-      ["ok", "ok"],
+      ["ok", "ok", "ok"],
+    );
+  });
+
+  test("a pass that STARTED too long ago is stale, not unknown", () => {
+    // `started_at` is the right freshness signal during a pass, not merely a
+    // third field to accept: a scan still scanning long past the threshold is
+    // exactly what this watchdog exists to report, and reading it as `unknown`
+    // would file it as unreadable instead.
+    const verdict = evaluateContainerLanes({
+      statuses: [
+        {
+          lane: "slow",
+          body: {
+            started_at: new Date(
+              NOW - CONTAINER_LANE_THRESHOLD_MS * 2,
+            ).toISOString(),
+            ok: null,
+            phase: "scanning",
+          },
+        },
+      ],
+      nowMs: NOW,
+      thresholdMs: CONTAINER_LANE_THRESHOLD_MS,
+    });
+    assert.equal(verdict.entries[0]!.verdict, "stale");
+    assert.ok(
+      (verdict.entries[0]!.age_ms ?? 0) > CONTAINER_LANE_THRESHOLD_MS,
+      "the age is measured from the start, not discarded",
     );
   });
 


### PR DESCRIPTION
`container:account-summary` reads `unknown -- status carries no readable
timestamp` for the whole of every pass it runs, while its producer is
demonstrably healthy.

Measured 2026-08-18. Mid-scan the container publishes:

```json
{"phase":"scanning","started_at":"2026-08-18T07:27:19Z","ok":null,
 "rows_scanned":2125318,"groups":4627089,"peak_rss_mb":1657, ...}
```

`started_at`, and neither `checked_at` nor `updated_at` -- those appear once the
pass finishes. The reader took `body.checked_at ?? body.updated_at ?? null`, so
a lane actively doing work reported as unreadable. At the same moment the
projection was fine: generation `20260818T072733Z`, ten minutes old,
`recent_limit: 10`.

This watchdog exists because a lane nobody was thinking about went dark for 32
hours. A verdict that cannot be cleared WHILE THE LANE IS WORKING is the same
blind spot wearing the opposite sign.

## It is the right freshness signal, not just a third field to accept

The comment above this line already had the principle -- "which word the
producing script chose is not a fact about lane health, so the reader takes
whichever is there" -- and simply did not list the third spelling.

But `started_at` is also the correct age to measure during a pass: a scan still
scanning long past the threshold is precisely what this watchdog reports, and
reading it as `unknown` filed that as unreadable instead. Ordered last, so a
script publishing both keeps reporting its most recent stamp rather than its
oldest.

Two tests, both verified to fail without the change: the spelling is accepted,
and a pass whose `started_at` is twice the threshold reports `stale` with a
measured age rather than `unknown` with a null one.

Patch coverage 100%, branch-counted.