### PR TITLE
perf(revenue-coverage): the GraphQL and MCP surfaces had the same loop

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,4 +1,5 @@
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
+import { mapLimit } from "./health-probe-core.ts";
 import { asJsonObject } from "../schemas-src/json-request.ts";
 
 import { observationsReadDb } from "./observations-read-runner.ts";
@@ -943,9 +944,10 @@ import type {
 } from "../generated/graphql/types.ts";
 import { readStore } from "./read-store.ts";
 import {
+  REVENUE_COVERAGE_SURFACE_READS,
+  SUBNET_REVENUE_FIELD_SOURCES,
   loadSubnetRevenue,
   revenueWindowDays,
-  SUBNET_REVENUE_FIELD_SOURCES,
 } from "./revenue-load.ts";
 import { loadRevenueObservations } from "./revenue-observations.ts";
 import { REVENUE_OBSERVATION_TABLES } from "./read-store-tables.ts";
@@ -7551,8 +7553,24 @@ const rootValue = {
       readStore(context.env, REVENUE_OBSERVATION_TABLES),
       null,
     );
+    // THE SAME ARGUMENT THE OBSERVATIONS READ ABOVE MAKES (#11422). The surface
+    // read was left inside the loop, so this field paid 129 artifact reads in
+    // series -- measured 6.6s and 7.5s live, against a 5s budget, while the
+    // REST route serving identical data had just been fixed to 1.7s. Hoisted
+    // onto the same bounded pool, from the same constant, so the three surfaces
+    // cannot drift again.
+    const surfacesByRow = await mapLimit(
+      rows as Row[],
+      REVENUE_COVERAGE_SURFACE_READS,
+      async (row: Row) => {
+        const netuid = Number(row?.netuid);
+        if (!Number.isInteger(netuid)) return null;
+        return surfacesForNetuid(context, netuid);
+      },
+    );
+
     const subnets = [];
-    for (const row of rows as Row[]) {
+    for (const [index, row] of (rows as Row[]).entries()) {
       const netuid = Number(row?.netuid);
       if (!Number.isInteger(netuid)) continue;
       subnets.push(
@@ -7560,7 +7578,7 @@ const rootValue = {
           netuid,
           window_days: windowDays,
           economics: row,
-          surfaces: await surfacesForNetuid(context, netuid),
+          surfaces: surfacesByRow[index] ?? null,
           usd_per_tao: usd,
           observations: observations ?? null,
         }),

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
 import { asJsonObject } from "../schemas-src/json-request.ts";
+import { mapLimit } from "./health-probe-core.ts";
 
 import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
 import { GraphqlResponsePayloadSchema } from "../schemas-src/internal-wire.ts";
@@ -1713,6 +1714,7 @@ import { buildAccountIdentity } from "./account-identity.ts";
 import { buildAccountIdentityHistory } from "./account-identity-history.ts";
 import { isU16Netuid, loadSubnetRecycled } from "./subnet-recycled.ts";
 import {
+  REVENUE_COVERAGE_SURFACE_READS,
   SUBNET_REVENUE_FIELD_SOURCES,
   loadSubnetRevenue,
   revenueWindowDays,
@@ -9848,8 +9850,22 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ),
       );
       const allObservations = await mcpRevenueObservations(ctx, null);
+      // AND THE SURFACE READ TOO (#11422). The comment above says "ONE read for
+      // every subnet, matching the REST handler" -- it matched the REST handler
+      // in the defect as well, awaiting one artifact per subnet inside the
+      // loop. Same bounded pool, same constant, so all three surfaces move
+      // together.
+      const surfacesByRow = await mapLimit(
+        rows,
+        REVENUE_COVERAGE_SURFACE_READS,
+        async (row: Record<string, unknown>) => {
+          const netuid = Number(row?.netuid);
+          if (!Number.isInteger(netuid)) return null;
+          return mcpSubnetSurfaces(ctx, netuid);
+        },
+      );
       const subnets = [];
-      for (const row of rows) {
+      for (const [index, row] of rows.entries()) {
         const netuid = Number(row?.netuid);
         if (!Number.isInteger(netuid)) continue;
         subnets.push(
@@ -9857,7 +9873,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             netuid,
             window_days: windowDays,
             economics: row,
-            surfaces: await mcpSubnetSurfaces(ctx, netuid),
+            surfaces: surfacesByRow[index] ?? null,
             usd_per_tao: usd,
             observations: allObservations,
           }),

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -81,6 +81,23 @@ export function taoTotalPerBlock(economics: Row | null): number {
  * series is src/revenue-serving.ts's job, because that is where the grain and
  * `supersedes` rules live.
  */
+/**
+ * How many subnet artifacts a network-wide revenue read fetches at once.
+ *
+ * DECLARED HERE because all three surfaces compose the same answer -- REST's
+ * `handleChainRevenueCoverage`, GraphQL's `chain_revenue_coverage` and the MCP
+ * tool -- and each one had its own `await` inside its own loop. Fixing one and
+ * leaving two is how the REST route ended up eight times faster than the field
+ * serving the identical data (#11422).
+ *
+ * SIXTEEN, against 129 subnets: eight waves rather than one burst. `mapLimit`
+ * rather than `Promise.all` for the reason the cron prober uses it -- to
+ * respect the runtime's simultaneous-connection cap. Firing every read at once
+ * to fix a latency problem is how a rate limit becomes the next one, and this
+ * account has been rate-limited before (#9465).
+ */
+export const REVENUE_COVERAGE_SURFACE_READS = 16;
+
 export function revenueSourcesFor(
   surfaces: Row[] | null | undefined,
 ): RevenueSourceRow[] {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -432,6 +432,7 @@ import { mapLimit } from "../../src/health-probe-core.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
 import {
+  REVENUE_COVERAGE_SURFACE_READS,
   SUBNET_REVENUE_FIELD_SOURCES,
   loadSubnetRevenue,
 } from "../../src/revenue-load.ts";
@@ -7713,19 +7714,6 @@ export async function handleSubnetRevenue(
 /** Every subnet's coverage in one response. Subnets with no observed revenue
  * are INCLUDED with null ratios rather than dropped: omitting them would make
  * the covered set look like the whole network. */
-/**
- * How many subnet artifacts the revenue-coverage route reads at once.
- *
- * SIXTEEN, against 129 subnets: eight waves rather than one burst. The cron
- * prober's own pool runs at eight and it talks to third-party origins; these
- * are first-party artifact GETs, so a wider pool is fair, and the ceiling that
- * matters is the runtime's simultaneous-connection cap rather than any per-read
- * cost. Sized to collapse the wall clock without ever being the thing that
- * trips a limit -- the account has been rate-limited before (#9465), and a
- * latency fix that trades one failure mode for another is not a fix.
- */
-const REVENUE_COVERAGE_SURFACE_READS = 16;
-
 export async function handleChainRevenueCoverage(
   request: Request,
   env: Env,


### PR DESCRIPTION
#11477 fixed the REST route and left two thirds of the defect in place. The
identical `await` sits inside the identical loop in `chain_revenue_coverage`
(src/graphql.ts) and the MCP tool (src/mcp-server.ts), each under a comment
making the very argument it violates:

    // ONE observation read for the whole network rather than one per subnet:
    // 129 round trips would price this field out of existence.
    ...
    surfaces: await surfacesForNetuid(context, netuid),   // 129 round trips

    // ONE read for every subnet, matching the REST handler
    ...
    surfaces: await mcpSubnetSurfaces(ctx, netuid),       // matched it in the defect too

Measured live before this change: GraphQL `chain_revenue_coverage` 6.6s and
7.5s, against a 5,000ms budget, while REST served the identical data in 1.7s.
Found by sweeping for the pattern rather than by assuming the fix was whole --
30 sequential-await-in-loop sites across the tree, of which these two are the
ones composing a network-wide answer per request.

## Single-sourced, so the three cannot drift again

`REVENUE_COVERAGE_SURFACE_READS` moves to src/revenue-load.ts, beside
`loadSubnetRevenue` -- the function all three surfaces call. It was declared in
the REST handler by #11477, which is exactly the shape that let one surface be
fixed and two forgotten. One declaration now, imported three times; the grep for
`= 16` returns one line.

Same bounded `mapLimit` pool in all three, same input-order indexing.

No behaviour change beyond sequencing: identical reads, identical shapes,
identical payloads.

Patch coverage 100%, branch-counted.

Refs #11422