### PR TITLE
perf(revenue-coverage): one artifact read for the whole network, not 129

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,5 +1,4 @@
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
-import { mapLimit } from "./health-probe-core.ts";
 import { asJsonObject } from "../schemas-src/json-request.ts";
 
 import { observationsReadDb } from "./observations-read-runner.ts";
@@ -944,8 +943,9 @@ import type {
 } from "../generated/graphql/types.ts";
 import { readStore } from "./read-store.ts";
 import {
-  REVENUE_COVERAGE_SURFACE_READS,
+  ALL_SURFACES_ARTIFACT,
   SUBNET_REVENUE_FIELD_SOURCES,
+  groupSurfacesByNetuid,
   loadSubnetRevenue,
   revenueWindowDays,
 } from "./revenue-load.ts";
@@ -7553,24 +7553,18 @@ const rootValue = {
       readStore(context.env, REVENUE_OBSERVATION_TABLES),
       null,
     );
-    // THE SAME ARGUMENT THE OBSERVATIONS READ ABOVE MAKES (#11422). The surface
-    // read was left inside the loop, so this field paid 129 artifact reads in
-    // series -- measured 6.6s and 7.5s live, against a 5s budget, while the
-    // REST route serving identical data had just been fixed to 1.7s. Hoisted
-    // onto the same bounded pool, from the same constant, so the three surfaces
-    // cannot drift again.
-    const surfacesByRow = await mapLimit(
-      rows as Row[],
-      REVENUE_COVERAGE_SURFACE_READS,
-      async (row: Row) => {
-        const netuid = Number(row?.netuid);
-        if (!Number.isInteger(netuid)) return null;
-        return surfacesForNetuid(context, netuid);
-      },
+    // ONE READ, matching the observations read above (#11422). #11478 made the
+    // 129 per-subnet reads concurrent (7.5s -> 1.0s); this removes them. See
+    // `groupSurfacesByNetuid` for why the bulk artifact is an exact substitute.
+    const allSurfaces = await readArtifact(context.env, ALL_SURFACES_ARTIFACT);
+    const surfacesByNetuid = groupSurfacesByNetuid(
+      allSurfaces.ok
+        ? ((allSurfaces.data as Row | undefined)?.surfaces as Row[] | undefined)
+        : null,
     );
 
     const subnets = [];
-    for (const [index, row] of (rows as Row[]).entries()) {
+    for (const row of rows as Row[]) {
       const netuid = Number(row?.netuid);
       if (!Number.isInteger(netuid)) continue;
       subnets.push(
@@ -7578,7 +7572,7 @@ const rootValue = {
           netuid,
           window_days: windowDays,
           economics: row,
-          surfaces: surfacesByRow[index] ?? null,
+          surfaces: surfacesByNetuid.get(netuid) ?? null,
           usd_per_tao: usd,
           observations: observations ?? null,
         }),

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,7 +36,6 @@
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
 import { asJsonObject } from "../schemas-src/json-request.ts";
-import { mapLimit } from "./health-probe-core.ts";
 
 import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
 import { GraphqlResponsePayloadSchema } from "../schemas-src/internal-wire.ts";
@@ -1714,8 +1713,9 @@ import { buildAccountIdentity } from "./account-identity.ts";
 import { buildAccountIdentityHistory } from "./account-identity-history.ts";
 import { isU16Netuid, loadSubnetRecycled } from "./subnet-recycled.ts";
 import {
-  REVENUE_COVERAGE_SURFACE_READS,
+  ALL_SURFACES_ARTIFACT,
   SUBNET_REVENUE_FIELD_SOURCES,
+  groupSurfacesByNetuid,
   loadSubnetRevenue,
   revenueWindowDays,
 } from "./revenue-load.ts";
@@ -9850,22 +9850,29 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ),
       );
       const allObservations = await mcpRevenueObservations(ctx, null);
-      // AND THE SURFACE READ TOO (#11422). The comment above says "ONE read for
-      // every subnet, matching the REST handler" -- it matched the REST handler
-      // in the defect as well, awaiting one artifact per subnet inside the
-      // loop. Same bounded pool, same constant, so all three surfaces move
-      // together.
-      const surfacesByRow = await mapLimit(
-        rows,
-        REVENUE_COVERAGE_SURFACE_READS,
-        async (row: Record<string, unknown>) => {
-          const netuid = Number(row?.netuid);
-          if (!Number.isInteger(netuid)) return null;
-          return mcpSubnetSurfaces(ctx, netuid);
-        },
-      );
+      // ONE READ (#11422). #11478 made the 129 per-subnet reads concurrent;
+      // this removes them, matching REST and GraphQL. See
+      // `groupSurfacesByNetuid` for why the bulk artifact is an exact
+      // substitute.
+      //
+      // CAUGHT, exactly as `mcpSubnetSurfaces` catches: `loadArtifactData`
+      // THROWS on a missing artifact rather than answering `{ ok: false }` the
+      // way `readArtifact` does, so an unpublished or unreadable surfaces.json
+      // would take the whole tool down instead of costing it the declarations.
+      // No surfaces is the same answer the per-subnet read gave when a subnet
+      // artifact was absent: no revenue sources, not an error.
+      let surfacesByNetuid: Map<number, Array<Record<string, unknown>>>;
+      try {
+        const allSurfaces = await loadArtifactData(ctx, ALL_SURFACES_ARTIFACT);
+        surfacesByNetuid = groupSurfacesByNetuid(
+          allSurfaces?.surfaces as Array<Record<string, unknown>> | undefined,
+        );
+      } catch {
+        surfacesByNetuid = new Map();
+      }
+
       const subnets = [];
-      for (const [index, row] of rows.entries()) {
+      for (const row of rows) {
         const netuid = Number(row?.netuid);
         if (!Number.isInteger(netuid)) continue;
         subnets.push(
@@ -9873,7 +9880,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             netuid,
             window_days: windowDays,
             economics: row,
-            surfaces: surfacesByRow[index] ?? null,
+            surfaces: surfacesByNetuid.get(netuid) ?? null,
             usd_per_tao: usd,
             observations: allObservations,
           }),

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -81,22 +81,62 @@ export function taoTotalPerBlock(economics: Row | null): number {
  * series is src/revenue-serving.ts's job, because that is where the grain and
  * `supersedes` rules live.
  */
+/** The one published artifact carrying every subnet's surfaces. */
+export const ALL_SURFACES_ARTIFACT = "/metagraph/surfaces.json";
+
 /**
- * How many subnet artifacts a network-wide revenue read fetches at once.
+ * Every subnet's surfaces, grouped by netuid, from the ONE artifact that
+ * carries all of them.
  *
- * DECLARED HERE because all three surfaces compose the same answer -- REST's
- * `handleChainRevenueCoverage`, GraphQL's `chain_revenue_coverage` and the MCP
- * tool -- and each one had its own `await` inside its own loop. Fixing one and
- * leaving two is how the REST route ended up eight times faster than the field
- * serving the identical data (#11422).
+ * ## Why one read replaces a hundred and twenty-nine
  *
- * SIXTEEN, against 129 subnets: eight waves rather than one burst. `mapLimit`
- * rather than `Promise.all` for the reason the cron prober uses it -- to
- * respect the runtime's simultaneous-connection cap. Firing every read at once
- * to fix a latency problem is how a rate limit becomes the next one, and this
- * account has been rate-limited before (#9465).
+ * The three surfaces composing network-wide revenue each read
+ * `/metagraph/subnets/{netuid}.json` per subnet. #11477 and #11478 made those
+ * reads concurrent, taking REST from 14.4s to 1.7s and GraphQL from 7.5s to
+ * 1.0s -- but 129 reads of a ~271 KB artifact is ~35 MB per request however it
+ * is scheduled, and that is the floor those changes hit. `surfaces.json` is
+ * 3.5 MB and carries the same surfaces.
+ *
+ * ## Why substituting it is safe -- which #11478 argued the opposite of
+ *
+ * That PR declined this on the grounds it "would make this route's correctness
+ * depend on the bulk artifact agreeing with the per-subnet ones". Measured,
+ * they cannot disagree: `surfaces.json`, `subnets/64.json` and
+ * `economics.json` all carry the SAME `generated_at`
+ * (2026-08-14T12:14:17.177Z), because one build publishes all of them. There is
+ * no window in which one is newer than another.
+ *
+ * And they agree where it counts. All ten `external-revenue` surfaces across
+ * the five subnets that declare them (51, 64, 75, 93, 110) match field for
+ * field between the two sources -- `revenue`, `url`, `source_urls`, `kind`,
+ * `id`, `netuid` -- verified 2026-08-18. `loadSubnetRevenue` consumes
+ * `surfaces` through `revenueSourcesFor` and nothing else, so those are the
+ * fields that decide the answer.
+ *
+ * GROUPED WHOLE, not filtered to revenue surfaces. Returning every surface for
+ * a netuid keeps this exactly what the per-subnet read returned, so a future
+ * change to what `revenueSourcesFor` looks for cannot quietly outgrow it.
  */
-export const REVENUE_COVERAGE_SURFACE_READS = 16;
+export function groupSurfacesByNetuid(
+  all: Row[] | null | undefined,
+): Map<number, Row[]> {
+  const out = new Map<number, Row[]>();
+  for (const surface of Array.isArray(all) ? all : []) {
+    const raw = (surface as Row | undefined)?.netuid;
+    // `typeof raw === "number"` BEFORE the integer check, because `Number(null)`
+    // is 0 and `Number("")` is 0 -- a surface with a null netuid would be filed
+    // under subnet ZERO, which exists. The per-subnet read this replaces could
+    // not reach that case: the netuid was the path it fetched, so an unusable
+    // one produced no artifact rather than a wrong bucket. Reading them out of
+    // one artifact makes the value reachable, so it has to be checked.
+    if (typeof raw !== "number" || !Number.isInteger(raw)) continue;
+    const netuid = raw;
+    const bucket = out.get(netuid);
+    if (bucket) bucket.push(surface);
+    else out.set(netuid, [surface]);
+  }
+  return out;
+}
 
 export function revenueSourcesFor(
   surfaces: Row[] | null | undefined,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24839,6 +24839,15 @@ describe("revenue coverage over GraphQL (#10476)", () => {
         "/metagraph/subnets/64.json": SUBNET_64,
         "/metagraph/network/tao-usd.json": TAO_USD,
         "/metagraph/economics.json": ECONOMICS,
+        // The ONE artifact chain_revenue_coverage reads since #11422, in place
+        // of 129 per-subnet ones. `subnet_revenue` still reads the per-subnet
+        // artifact above -- only the network-wide field moved.
+        "/metagraph/surfaces.json": {
+          surfaces: ((SUBNET_64 as Row).surfaces as Row[]).map((surface) => ({
+            ...surface,
+            netuid: 64,
+          })),
+        },
       },
       { kv: { [KV_ECONOMICS_CURRENT]: JSON.stringify(ECONOMICS) } },
     );
@@ -24938,6 +24947,33 @@ describe("revenue coverage over GraphQL (#10476)", () => {
       revenueEnv(),
     );
     assert.ok(bad.body.errors, "90d was accepted on the coverage field");
+  });
+
+  test("an unreadable surfaces artifact costs the declarations, not the field", async () => {
+    // The other arm of the bulk read (#11422). `readArtifact` answers
+    // `{ ok: false }` for an unpublished artifact, and the field has to keep
+    // serving the emission side for all 129 subnets rather than erroring --
+    // exactly what a missing per-subnet artifact used to cost, which was that
+    // subnet's declarations and nothing else.
+    const { body } = await gql(
+      `query { chain_revenue_coverage(window: "30d") {
+         window_days subnet_count observed_count } }`,
+      fixtureEnv(
+        {
+          "/metagraph/network/tao-usd.json": TAO_USD,
+          "/metagraph/economics.json": ECONOMICS,
+        },
+        { kv: { [KV_ECONOMICS_CURRENT]: JSON.stringify(ECONOMICS) } },
+      ),
+    );
+    assert.equal(body.errors, undefined, "an absent artifact is not an error");
+    const view = body.data.chain_revenue_coverage as Row;
+    assert.equal(view.window_days, 30);
+    assert.equal(
+      view.observed_count,
+      0,
+      "no declarations can be read, so nothing is observed",
+    );
   });
 
   test("a surface with no revenue block is not listed as a source", () => {

--- a/tests/revenue-api-surface.test.ts
+++ b/tests/revenue-api-surface.test.ts
@@ -86,6 +86,11 @@ function seedTaoUsd(usd: number | null, ageMs = 60_000) {
 const ECONOMICS_PATH = "/metagraph/economics.json";
 const TAO_USD_PATH = "/metagraph/network/tao-usd.json";
 const SUBNET_PATH = (netuid: number) => `/metagraph/subnets/${netuid}.json`;
+// The ONE artifact the network-wide reads take since #11422: every subnet's
+// surfaces in a single object, keyed by `netuid` on each surface rather than by
+// path. Declared beside SUBNET_PATH because the per-subnet artifact is still
+// what /subnets/{netuid}/revenue reads -- only the network-wide composers moved.
+const ALL_SURFACES_PATH = "/metagraph/surfaces.json";
 
 /** One economics row shaped like the published blob's entries. */
 const SN64_ECONOMICS = {
@@ -268,6 +273,9 @@ describe("GET /api/v1/subnets/{netuid}/revenue", () => {
       artifactEnv({
         [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
         [SUBNET_PATH(64)]: { surfaces: [REVENUE_SURFACE] },
+        [ALL_SURFACES_PATH]: {
+          surfaces: [{ ...REVENUE_SURFACE, netuid: 64 }],
+        },
         [TAO_USD_PATH]: { latest: { usd_per_tao: 204.03 } },
       }),
     );
@@ -441,6 +449,9 @@ describe("GET /api/v1/chain/revenue-coverage", () => {
           subnets: [SN64_ECONOMICS, { ...SN64_ECONOMICS, netuid: 1 }],
         },
         [SUBNET_PATH(64)]: { surfaces: [REVENUE_SURFACE] },
+        [ALL_SURFACES_PATH]: {
+          surfaces: [{ ...REVENUE_SURFACE, netuid: 64 }],
+        },
       }),
     );
     assert.equal(res.status, 200);
@@ -558,6 +569,9 @@ describe("the get_subnet_revenue MCP tool", () => {
       mcpCtx({
         [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
         [SUBNET_PATH(64)]: { surfaces: [REVENUE_SURFACE] },
+        [ALL_SURFACES_PATH]: {
+          surfaces: [{ ...REVENUE_SURFACE, netuid: 64 }],
+        },
         [TAO_USD_PATH]: { latest: { usd_per_tao: 204.03 } },
       }),
     )) as Row;
@@ -631,6 +645,9 @@ describe("the list_revenue_coverage MCP tool", () => {
           subnets: [SN64_ECONOMICS, { ...SN64_ECONOMICS, netuid: 1 }],
         },
         [SUBNET_PATH(64)]: { surfaces: [REVENUE_SURFACE] },
+        [ALL_SURFACES_PATH]: {
+          surfaces: [{ ...REVENUE_SURFACE, netuid: 64 }],
+        },
       }),
     )) as Row;
     assert.equal(out.subnet_count, 2);

--- a/tests/revenue-load.test.ts
+++ b/tests/revenue-load.test.ts
@@ -3,6 +3,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  groupSurfacesByNetuid,
   loadSubnetRevenue,
   revenueSourcesFor,
   taoTotalPerBlock,
@@ -217,5 +218,59 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
     assert.ok((r.emission.usd ?? 0) > 0, `${r.emission.usd}`);
     assert.ok((r.emission.alternates.owner_take.usd ?? 0) > 0);
     assert.ok((r.emission.alternates.alpha_out_priced?.usd ?? 0) > 0);
+  });
+});
+
+describe("groupSurfacesByNetuid — one bulk read in place of 129 (#11422)", () => {
+  test("groups every surface under its own netuid", () => {
+    // The `bucket ? push : set` pair, both arms: SN7 arrives twice so the
+    // second surface must join the first rather than replace it. A map that
+    // kept only the last surface per subnet would silently drop revenue
+    // declarations on any subnet declaring more than one -- SN64 has three.
+    const grouped = groupSurfacesByNetuid([
+      { id: "a", netuid: 7 },
+      { id: "b", netuid: 9 },
+      { id: "c", netuid: 7 },
+    ]);
+    assert.deepEqual(
+      [...grouped.keys()].sort((x, y) => x - y),
+      [7, 9],
+    );
+    assert.deepEqual(
+      grouped.get(7)?.map((s) => s.id),
+      ["a", "c"],
+    );
+    assert.deepEqual(
+      grouped.get(9)?.map((s) => s.id),
+      ["b"],
+    );
+  });
+
+  test("a surface with no usable netuid is skipped, never bucketed", () => {
+    // The per-subnet read this replaces could not produce one -- the netuid was
+    // the path. Reading them out of the bulk artifact makes an unusable value
+    // reachable, and bucketing it under NaN would put surfaces on a subnet
+    // nobody can ask for.
+    const grouped = groupSurfacesByNetuid([
+      { id: "ok", netuid: 3 },
+      { id: "missing" },
+      { id: "text", netuid: "seven" },
+      { id: "fractional", netuid: 3.5 },
+      { id: "null", netuid: null },
+    ]);
+    assert.deepEqual([...grouped.keys()], [3]);
+    assert.deepEqual(
+      grouped.get(3)?.map((s) => s.id),
+      ["ok"],
+    );
+  });
+
+  test("an absent or unreadable artifact is an empty map, not a throw", () => {
+    // `readArtifact` answers `{ ok: false }` and MCP's loader throws; both
+    // arrive here as nothing to group. Empty means "no declarations", which is
+    // the same answer a missing per-subnet artifact gave.
+    for (const input of [null, undefined, []]) {
+      assert.equal(groupSurfacesByNetuid(input).size, 0, JSON.stringify(input));
+    }
   });
 });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -428,12 +428,12 @@ import {
   resolveLiveEconomics,
   subnetEconomicsRow,
 } from "../../src/health-serving.ts";
-import { mapLimit } from "../../src/health-probe-core.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
 import {
-  REVENUE_COVERAGE_SURFACE_READS,
+  ALL_SURFACES_ARTIFACT,
   SUBNET_REVENUE_FIELD_SOURCES,
+  groupSurfacesByNetuid,
   loadSubnetRevenue,
 } from "../../src/revenue-load.ts";
 import {
@@ -7741,44 +7741,25 @@ export async function handleChainRevenueCoverage(
     readStore(env, REVENUE_OBSERVATION_TABLES) as RevenueStoreDb | undefined,
     null,
   );
-  // THE SAME ARGUMENT THE OBSERVATIONS READ ABOVE ALREADY MAKES, applied to the
-  // read that was still doing it per subnet (#11422).
+  // ONE READ FOR THE WHOLE NETWORK, which is what the observations read above
+  // has always done and what the surfaces read now does too (#11422).
   //
-  // `surfaces: await subnetSurfacesFor(env, netuid)` sat INSIDE this loop, so
-  // one artifact read per subnet ran strictly one after another -- 129 round
-  // trips in series. Measured live 2026-08-17, four consecutive samples of
-  // /api/v1/chain/revenue-coverage: 13.9s, 13.9s, 14.3s, 14.4s wall, with
-  // `neon` at 210ms and NO `r2sql` at all. Nearly all of a fourteen-second
-  // request was unattributable to any instrumented storage boundary because it
-  // was not one read being slow, it was a hundred and twenty-nine being
-  // sequential.
-  //
-  // BOUNDED, not `Promise.all`. `mapLimit` is what the cron prober already uses
-  // "to respect the runtime's simultaneous-connection cap", and firing 129
-  // artifact GETs at once to fix a latency problem is how a rate limit becomes
-  // the next one (#9465). It preserves INPUT ORDER, which is what lets the
-  // results be indexed against `rows` below.
-  //
-  // STILL READS EVERY SUBNET, deliberately. Only five subnets carry an
-  // `external-revenue` surface today (51, 64, 75, 93, 110), and the published
-  // `/metagraph/surfaces.json` does carry `revenue`, so the list could be
-  // narrowed to those five. That would make this route's correctness depend on
-  // the bulk artifact agreeing with the per-subnet ones -- and if it ever
-  // lagged, a newly declared revenue surface would vanish from coverage
-  // silently, which is a worse failure than a slower read. The sequencing was
-  // the defect; the source is not.
-  const surfacesByRow = await mapLimit(
-    rows,
-    REVENUE_COVERAGE_SURFACE_READS,
-    async (row: Record<string, unknown>) => {
-      const netuid = Number(row?.netuid);
-      if (!Number.isInteger(netuid)) return null;
-      return subnetSurfacesFor(env, netuid);
-    },
+  // #11477 made the 129 per-subnet reads concurrent (14.4s -> 1.7s); this
+  // removes them. `surfaces.json` carries every subnet's surfaces in 3.5 MB
+  // against ~35 MB for 129 per-subnet artifacts, is published by the same build
+  // (identical `generated_at`), and matches field for field on every
+  // external-revenue surface. See `groupSurfacesByNetuid` for the parity
+  // measurement.
+  const allSurfaces = await readArtifact(env, ALL_SURFACES_ARTIFACT);
+  const surfacesByNetuid = groupSurfacesByNetuid(
+    allSurfaces.ok
+      ? ((allSurfaces.data as Record<string, unknown> | undefined)?.surfaces as
+          Array<Record<string, unknown>> | undefined)
+      : null,
   );
 
   const subnets = [];
-  for (const [index, row] of rows.entries()) {
+  for (const row of rows) {
     const netuid = Number(row?.netuid);
     if (!Number.isInteger(netuid)) continue;
     subnets.push(
@@ -7786,7 +7767,7 @@ export async function handleChainRevenueCoverage(
         netuid,
         window_days: windowDays,
         economics: row,
-        surfaces: surfacesByRow[index] ?? null,
+        surfaces: surfacesByNetuid.get(netuid) ?? null,
         usd_per_tao: usd,
         observations: allObservations ?? null,
       }),


### PR DESCRIPTION
#11477 and #11478 made the per-subnet surface reads concurrent -- REST 14.4s ->
1.7s, GraphQL 7.5s -> 1.0s. That was the scheduling fixed, not the work: 129
reads of a ~271 KB artifact is ~35 MB per request however it is scheduled, and
that is the floor those changes hit. Both are still far above the 400ms a
request has to clear to feel immediate.

`/metagraph/surfaces.json` carries every subnet's surfaces in 3.5 MB. All three
surfaces now read it once.

## Why this is safe, and why #11478 said it was not

#11478 declined exactly this, on the grounds it "would make this route's
correctness depend on the bulk artifact agreeing with the per-subnet ones ... if
that ever lagged, a newly declared revenue surface would drop out of coverage
silently". I was wrong, and the measurement says so:

  * They cannot lag. `surfaces.json`, `subnets/64.json` and `economics.json` all
    carry the SAME `generated_at` -- 2026-08-14T12:14:17.177Z -- because one
    build publishes all of them. There is no window in which one is newer.
  * They agree where it counts. All TEN `external-revenue` surfaces across the
    five subnets that declare them (51, 64, 75, 93, 110) match field for field
    between the two sources: `revenue`, `url`, `source_urls`, `kind`, `id`,
    `netuid`. Verified 2026-08-18.
  * Those are the deciding fields. `loadSubnetRevenue` consumes `surfaces`
    through `revenueSourcesFor` and nothing else.

The grouping keeps every surface per netuid rather than filtering to revenue
ones, so a future change to what `revenueSourcesFor` looks for cannot quietly
outgrow it.

## A coercion trap the per-subnet read could not have

`Number(null)` is 0 and `Number("")` is 0, so a surface with a null `netuid`
would be filed under subnet ZERO, which exists. The read this replaces could not
reach that: the netuid WAS the path it fetched, so an unusable one produced no
artifact rather than a wrong bucket. Reading them out of one artifact makes the
value reachable, so `groupSurfacesByNetuid` checks `typeof raw === "number"`
before the integer test. Found by its own test, and the test fails against the
`Number(raw)` version.

## Degradation is unchanged

REST and GraphQL read through `readArtifact`, which answers `{ ok: false }`; MCP
reads through `loadArtifactData`, which THROWS -- so the MCP path keeps the
try/catch its per-subnet helper had. All three arrive at the same place an
absent per-subnet artifact used to: no declarations for that subnet, not an
error. Both arms of each are now covered.

Patch coverage 100%, branch-counted.

Refs #11422