### PR TITLE
perf: stop re-reading two immutable things per request (revenue-coverage, owner-cut)

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -945,9 +945,9 @@ import { readStore } from "./read-store.ts";
 import {
   ALL_SURFACES_ARTIFACT,
   SUBNET_REVENUE_FIELD_SOURCES,
-  groupSurfacesByNetuid,
   loadSubnetRevenue,
   revenueWindowDays,
+  surfacesByNetuidMemoized,
 } from "./revenue-load.ts";
 import { loadRevenueObservations } from "./revenue-observations.ts";
 import { REVENUE_OBSERVATION_TABLES } from "./read-store-tables.ts";
@@ -7556,12 +7556,15 @@ const rootValue = {
     // ONE READ, matching the observations read above (#11422). #11478 made the
     // 129 per-subnet reads concurrent (7.5s -> 1.0s); this removes them. See
     // `groupSurfacesByNetuid` for why the bulk artifact is an exact substitute.
-    const allSurfaces = await readArtifact(context.env, ALL_SURFACES_ARTIFACT);
-    const surfacesByNetuid = groupSurfacesByNetuid(
-      allSurfaces.ok
+    const surfacesByNetuid = await surfacesByNetuidMemoized(async () => {
+      const allSurfaces = await readArtifact(
+        context.env,
+        ALL_SURFACES_ARTIFACT,
+      );
+      return allSurfaces.ok
         ? ((allSurfaces.data as Row | undefined)?.surfaces as Row[] | undefined)
-        : null,
-    );
+        : null;
+    });
 
     const subnets = [];
     for (const row of rows as Row[]) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1715,9 +1715,9 @@ import { isU16Netuid, loadSubnetRecycled } from "./subnet-recycled.ts";
 import {
   ALL_SURFACES_ARTIFACT,
   SUBNET_REVENUE_FIELD_SOURCES,
-  groupSurfacesByNetuid,
   loadSubnetRevenue,
   revenueWindowDays,
+  surfacesByNetuidMemoized,
 } from "./revenue-load.ts";
 import {
   loadSubnetOwnerCut,
@@ -9861,15 +9861,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // would take the whole tool down instead of costing it the declarations.
       // No surfaces is the same answer the per-subnet read gave when a subnet
       // artifact was absent: no revenue sources, not an error.
-      let surfacesByNetuid: Map<number, Array<Record<string, unknown>>>;
-      try {
-        const allSurfaces = await loadArtifactData(ctx, ALL_SURFACES_ARTIFACT);
-        surfacesByNetuid = groupSurfacesByNetuid(
-          allSurfaces?.surfaces as Array<Record<string, unknown>> | undefined,
-        );
-      } catch {
-        surfacesByNetuid = new Map();
-      }
+      const surfacesByNetuid = await surfacesByNetuidMemoized(async () => {
+        try {
+          const allSurfaces = await loadArtifactData(
+            ctx,
+            ALL_SURFACES_ARTIFACT,
+          );
+          return allSurfaces?.surfaces as
+            Array<Record<string, unknown>> | undefined;
+        } catch {
+          return null;
+        }
+      });
 
       const subnets = [];
       for (const row of rows) {

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_SUBNET_REVENUE_WINDOW,
   SUBNET_REVENUE_WINDOW_DAYS,
 } from "./route-limits.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
 import {
   type SubnetRevenueView,
   buildSubnetRevenue,
@@ -117,6 +118,67 @@ export const ALL_SURFACES_ARTIFACT = "/metagraph/surfaces.json";
  * a netuid keeps this exactly what the per-subnet read returned, so a future
  * change to what `revenueSourcesFor` looks for cannot quietly outgrow it.
  */
+/**
+ * How long a parsed surfaces map is reused inside one isolate.
+ *
+ * FIVE MINUTES, the same figure and the same argument as
+ * `ACCOUNT_SUMMARY_POINTER_TTL_MS`: the artifact changes only when a build
+ * publishes, and a registry change reaching a card five minutes late is not a
+ * correctness problem -- serving it is what this whole file is for.
+ */
+export const SURFACES_MEMO_TTL_MS = 5 * 60_000;
+
+/** The grouped map and when it expires. The PROMISE is memoized, not the value,
+ * so concurrent requests on a cold isolate share one read rather than racing to
+ * issue several -- three surfaces compose this answer and they can arrive
+ * together. */
+let surfacesMemo: {
+  expiresAt: number;
+  value: Promise<Map<number, Row[]>>;
+} | null = null;
+
+registerModuleStateReset("src/revenue-load.ts", () => {
+  surfacesMemo = null;
+});
+
+/** Drop the memo so the next call re-reads. Exported for tests. */
+export function resetSurfacesMemo(): void {
+  surfacesMemo = null;
+}
+
+/**
+ * The grouped surfaces, read at most once per isolate per TTL.
+ *
+ * ## Why the read had to be memoized as well as collapsed
+ *
+ * Collapsing 129 per-subnet reads into one bulk read cut the bytes tenfold and
+ * did NOT cut the latency: measured on production, REST stayed at ~1.7s and
+ * GraphQL went from 1.0s to 2.0s. One 3.5 MB read parsed serially costs about
+ * what eight waves of concurrent small reads cost, and the parse is on the
+ * critical path where the waves at least overlapped.
+ *
+ * `Server-Timing` put the whole request at 1.57-1.82s with `neon` at ~200ms, so
+ * ~1.4s of it was the artifact. That is the thing to stop doing per request,
+ * not to schedule differently -- the artifact is immutable between publishes,
+ * which is exactly the case a memo is for.
+ *
+ * A FAILED READ IS NOT MEMOIZED for the TTL: it is stored so concurrent callers
+ * share the in-flight request, then cleared, so a transient miss costs one read
+ * rather than five minutes of empty declarations.
+ */
+export async function surfacesByNetuidMemoized(
+  load: () => Promise<Row[] | null | undefined>,
+  now: () => number = Date.now,
+): Promise<Map<number, Row[]>> {
+  const at = now();
+  if (surfacesMemo && surfacesMemo.expiresAt > at) return surfacesMemo.value;
+  const value = (async () => groupSurfacesByNetuid(await load()))();
+  surfacesMemo = { expiresAt: at + SURFACES_MEMO_TTL_MS, value };
+  const resolved = await value;
+  if (resolved.size === 0) surfacesMemo = null;
+  return resolved;
+}
+
 export function groupSurfacesByNetuid(
   all: Row[] | null | undefined,
 ): Map<number, Row[]> {

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -648,6 +648,75 @@ describe("analytics edge cache", () => {
     assert.equal(cache.store.size, 1);
   });
 
+  // #11422: the owner-cut route reads account_events over a 30-day window --
+  // the same read its /stake-flow sibling makes -- and was the only one of them
+  // dispatched without this wrapper. Measured against production 2026-08-18,
+  // /subnets/64/stake-flow answered in 0.28s on every request while
+  // /subnets/64/owner-cut paid 2.4-7.9s of R2 SQL on every one.
+  test("subnet owner-cut routes through the worker and caches on the bare path", async () => {
+    originalCaches = globalWithCaches.caches;
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv([]);
+
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets/7/owner-cut"),
+      mockEnv(env) as unknown as Env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, 7);
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("subnet-owner-cut", "/api/v1/subnets/7/owner-cut"),
+    ]);
+    assert.equal(cache.store.size, 1);
+  });
+
+  test("a warm owner-cut entry cannot launder an unknown parameter into a 200", async () => {
+    // The key is the PATHNAME alone, because this route takes no query
+    // parameters at all -- #10925 removed the `?window=` it could not honour,
+    // and ATTRIBUTION_WINDOW_DAYS is a fixed property of the surface. Keying on
+    // `${pathname}${search}` instead would let any link carrying a tracking
+    // parameter turn a 0.28s hit into a multi-second R2 SQL miss, unboundedly.
+    //
+    // That collapse is only safe because parameter validation runs BEFORE the
+    // cache lookup: an unknown parameter still 400s against a warm entry rather
+    // than being answered from it. If that order ever inverts, this route would
+    // start returning 200 to requests it is supposed to reject -- so assert the
+    // rejection, not just the entry count.
+    originalCaches = globalWithCaches.caches;
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv([]);
+
+    const miss = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets/7/owner-cut"),
+      mockEnv(env) as unknown as Env,
+      ctx,
+    );
+    assert.equal(miss.status, 200);
+    assert.equal(cache.store.size, 1);
+
+    const rejected = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/subnets/7/owner-cut?utm_source=x",
+      ),
+      mockEnv(env) as unknown as Env,
+      ctx,
+    );
+    assert.equal(rejected.status, 400);
+    assert.equal(
+      cache.store.size,
+      1,
+      "a rejected request must not seed a second entry",
+    );
+    assert.deepEqual(cache.putKeys, [
+      expectedKey("subnet-owner-cut", "/api/v1/subnets/7/owner-cut"),
+    ]);
+  });
+
   test("subnet weights routes through the worker and caches at the default window", async () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { resetSurfacesMemo } from "../src/revenue-load.ts";
 import { markedChainEventsPayload } from "../src/chain-events-degraded.ts";
 import { MIN_INCIDENT_SAMPLES } from "../src/health-serving.ts";
 import { visibleInWindow } from "./helpers/scan-window.ts";
@@ -81,6 +82,12 @@ import {
   PROMETHEUS_DEGRADED_NOT_CURATED,
 } from "../src/uncurated-event-streams.ts";
 import type { AnyFn, Row } from "./row-type.ts";
+
+// The surfaces map is memoized per ISOLATE and the registry resets module state
+// between test FILES, not between tests -- so without this a fixture from one
+// case would answer the next one's read. Same reason
+// tests/account-summary-projection.test.ts resets its pointer cache.
+beforeEach(() => resetSurfacesMemo());
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv: Row = {};

--- a/tests/revenue-api-surface.test.ts
+++ b/tests/revenue-api-surface.test.ts
@@ -16,6 +16,7 @@
 // A test that only walks the happy path here would prove nothing: the happy
 // path is the rare one.
 import assert from "node:assert/strict";
+import { resetSurfacesMemo } from "../src/revenue-load.ts";
 import { DatabaseSync } from "node:sqlite";
 import fs from "node:fs";
 import path from "node:path";
@@ -35,6 +36,12 @@ import { MCP_TOOLS } from "../src/mcp-server.ts";
 import { jsonBody, mockEnv, type Row } from "./row-type.ts";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 import { TAO_USD_MAX_AGE_MS } from "../src/alpha-usd.ts";
+
+// The surfaces map is memoized per ISOLATE and the registry resets module state
+// between test FILES, not between tests -- so without this a fixture from one
+// case would answer the next one's read. Same reason
+// tests/account-summary-projection.test.ts resets its pointer cache.
+beforeEach(() => resetSurfacesMemo());
 
 // The real DDL, so the CHECK pairing a null price with `insufficient_pools` is
 // enforced here too -- a fixture that could store a null price under

--- a/tests/revenue-load.test.ts
+++ b/tests/revenue-load.test.ts
@@ -1,13 +1,22 @@
 // #10447: what the route does when a piece is missing, which is the normal
 // case rather than the edge case.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import {
+  SURFACES_MEMO_TTL_MS,
   groupSurfacesByNetuid,
   loadSubnetRevenue,
+  resetSurfacesMemo,
   revenueSourcesFor,
+  surfacesByNetuidMemoized,
   taoTotalPerBlock,
 } from "../src/revenue-load.ts";
+
+// The surfaces map is memoized per ISOLATE and the registry resets module state
+// between test FILES, not between tests -- so without this a fixture from one
+// case would answer the next one's read. Same reason
+// tests/account-summary-projection.test.ts resets its pointer cache.
+beforeEach(() => resetSurfacesMemo());
 
 const ECONOMICS = {
   netuid: 64,
@@ -272,5 +281,65 @@ describe("groupSurfacesByNetuid — one bulk read in place of 129 (#11422)", () 
     for (const input of [null, undefined, []]) {
       assert.equal(groupSurfacesByNetuid(input).size, 0, JSON.stringify(input));
     }
+  });
+});
+
+describe("surfacesByNetuidMemoized — the read, not the schedule (#11422)", () => {
+  test("reads once inside the TTL and again after it", async () => {
+    // Collapsing 129 reads into one bulk read cut the BYTES tenfold and not the
+    // latency -- REST stayed at ~1.7s and GraphQL went 1.0s -> 2.0s, because one
+    // 3.5 MB read parsed serially costs about what eight waves of concurrent
+    // small reads cost. The artifact is immutable between publishes, so the fix
+    // is to stop doing it per request.
+    let reads = 0;
+    const load = async () => {
+      reads += 1;
+      return [{ id: "a", netuid: 7 }];
+    };
+    let now = 1_000_000;
+    const clock = () => now;
+
+    assert.equal((await surfacesByNetuidMemoized(load, clock)).size, 1);
+    assert.equal(reads, 1);
+    await surfacesByNetuidMemoized(load, clock);
+    await surfacesByNetuidMemoized(load, clock);
+    assert.equal(reads, 1, "inside the TTL the artifact is not re-read");
+
+    now += SURFACES_MEMO_TTL_MS + 1;
+    await surfacesByNetuidMemoized(load, clock);
+    assert.equal(reads, 2, "past the TTL it re-reads");
+  });
+
+  test("concurrent callers on a cold isolate share ONE read", async () => {
+    // The PROMISE is memoized, not the value. Three surfaces compose this
+    // answer and can arrive together, so memoizing the resolved map would still
+    // let them race to issue three reads of a 3.5 MB artifact.
+    let reads = 0;
+    const load = async () => {
+      reads += 1;
+      return [{ id: "a", netuid: 7 }];
+    };
+    const clock = () => 1_000_000;
+    await Promise.all([
+      surfacesByNetuidMemoized(load, clock),
+      surfacesByNetuidMemoized(load, clock),
+      surfacesByNetuidMemoized(load, clock),
+    ]);
+    assert.equal(reads, 1);
+  });
+
+  test("a read that yields nothing is NOT memoized for the TTL", async () => {
+    // Otherwise a transient miss costs five minutes of empty declarations,
+    // which is the shape #11467 fixed on the account-summary pointer: a failure
+    // held for a TTL turns one bad read into an outage.
+    let reads = 0;
+    const load = async () => {
+      reads += 1;
+      return reads === 1 ? null : [{ id: "a", netuid: 7 }];
+    };
+    const clock = () => 1_000_000;
+    assert.equal((await surfacesByNetuidMemoized(load, clock)).size, 0);
+    assert.equal((await surfacesByNetuidMemoized(load, clock)).size, 1);
+    assert.equal(reads, 2, "the empty answer was retried, not cached");
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -7333,6 +7333,7 @@ async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {
       request,
       env,
       resolved.url,
+      ctx,
     );
     if (liveChainResponse) return liveChainResponse;
     const weightSettersMatch = SUBNET_WEIGHT_SETTERS_PATH_PATTERN.exec(
@@ -8567,6 +8568,7 @@ async function dispatchLiveChainRoute(
   request: Request,
   env: Env,
   url: URL,
+  ctx: Ctx = {},
   network: typeof DEFAULT_NETWORK = DEFAULT_NETWORK,
 ): Promise<Response | null> {
   const chain = chainNetworkId(network.id);
@@ -8578,7 +8580,25 @@ async function dispatchLiveChainRoute(
   }
   const ownerCutMatch = SUBNET_OWNER_CUT_PATH_PATTERN.exec(pathname);
   if (ownerCutMatch) {
-    return handleSubnetOwnerCut(request, env, Number(ownerCutMatch[1]));
+    // The owner accrual and its disposition, the second summed live from
+    // account_events over a 30-day window -- the same read shape as the
+    // sibling /stake-flow route, and until now the only one of them serving it
+    // uncached. Measured 2026-08-18 against production: /subnets/64/stake-flow
+    // answered in 0.28s on every request while /subnets/64/owner-cut paid
+    // 2.4-7.9s of R2 SQL on every one, because it alone skipped this wrapper.
+    //
+    // The response is a pure function of the netuid and the backing stores --
+    // the handler reads no query parameters at all -- so the canonical key is
+    // the pathname, and a caller appending `?anything` shares the one entry
+    // rather than minting a fresh 8-second miss.
+    return withEdgeCache(
+      request,
+      ctx,
+      env,
+      edgeCacheScope("subnet-owner-cut", chain),
+      () => handleSubnetOwnerCut(request, env, Number(ownerCutMatch[1])),
+      url.pathname,
+    );
   }
 
   const revenueMatch = SUBNET_REVENUE_PATH_PATTERN.exec(pathname);
@@ -9091,6 +9111,7 @@ async function handleNetworkScopedRequest(
       request,
       env,
       resolved.url,
+      ctx,
       network,
     );
     if (liveChainResponse) return liveChainResponse;

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -7593,16 +7593,24 @@ export async function handleSubnetOwnerCut(
       400,
     );
   }
-  const { row } = await resolveSubnetEconomicsRow(env, netuid);
-  // THE LIVE READ, NOT THE ARTIFACT. `/metagraph/network/parameters.json`
-  // publishes no owner-cut field at all -- verified in production, where it
-  // carries no key matching /owner/ -- so reading it here returned undefined
-  // for all 129 subnets and every accrual served `owner cut share not read`.
-  // That is the #10566 shape exactly: a correct-looking decline standing in
-  // for a read that never happened. `/api/v1/network/parameters` computes the
-  // effective share (0.17999...) and is KV-cached, so this costs a cache hit
-  // rather than an RPC per request.
-  const parameters = await (deps.loadParams ?? loadNetworkParameters)(env);
+  // THE THREE INDEPENDENT READS RUN TOGETHER. Only the flow read depends on
+  // anything here (it needs the economics row's owner coldkey); the parameter
+  // and price reads were simply sequenced behind a ~175ms Neon call for no
+  // reason. Measured 2026-08-18 against production, the serial prefix was
+  // ~175ms of a ~2.9s response.
+  const [{ row }, parameters, usdPerTao] = await Promise.all([
+    resolveSubnetEconomicsRow(env, netuid),
+    // THE LIVE READ, NOT THE ARTIFACT. `/metagraph/network/parameters.json`
+    // publishes no owner-cut field at all -- verified in production, where it
+    // carries no key matching /owner/ -- so reading it here returned undefined
+    // for all 129 subnets and every accrual served `owner cut share not read`.
+    // That is the #10566 shape exactly: a correct-looking decline standing in
+    // for a read that never happened. `/api/v1/network/parameters` computes the
+    // effective share (0.17999...) and is KV-cached, so this costs a cache hit
+    // rather than an RPC per request.
+    (deps.loadParams ?? loadNetworkParameters)(env),
+    usdPerTaoOrNull(env),
+  ]);
   const ownerCut = parameters?.subnet_owner_cut_effective;
   // #10930: THE FLOW STREAMS, FINALLY READ. The disposition classifier has been
   // complete since #10485 and was handed nothing, so every subnet answered
@@ -7637,7 +7645,7 @@ export async function handleSubnetOwnerCut(
     window_days: ATTRIBUTION_WINDOW_DAYS,
     economics: row,
     owner_cut: typeof ownerCut === "number" ? ownerCut : null,
-    usd_per_tao: await usdPerTaoOrNull(env),
+    usd_per_tao: usdPerTao,
     unstaked_alpha: legs.observed ? legs.unstaked_alpha : null,
     flows_observed: legs.observed,
   });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -433,8 +433,8 @@ import { readArtifact, readHealthKv } from "../storage.ts";
 import {
   ALL_SURFACES_ARTIFACT,
   SUBNET_REVENUE_FIELD_SOURCES,
-  groupSurfacesByNetuid,
   loadSubnetRevenue,
+  surfacesByNetuidMemoized,
 } from "../../src/revenue-load.ts";
 import {
   loadSweepRecord,
@@ -7750,13 +7750,13 @@ export async function handleChainRevenueCoverage(
   // (identical `generated_at`), and matches field for field on every
   // external-revenue surface. See `groupSurfacesByNetuid` for the parity
   // measurement.
-  const allSurfaces = await readArtifact(env, ALL_SURFACES_ARTIFACT);
-  const surfacesByNetuid = groupSurfacesByNetuid(
-    allSurfaces.ok
+  const surfacesByNetuid = await surfacesByNetuidMemoized(async () => {
+    const allSurfaces = await readArtifact(env, ALL_SURFACES_ARTIFACT);
+    return allSurfaces.ok
       ? ((allSurfaces.data as Record<string, unknown> | undefined)?.surfaces as
           Array<Record<string, unknown>> | undefined)
-      : null,
-  );
+      : null;
+  });
 
   const subnets = [];
   for (const row of rows) {


### PR DESCRIPTION
#11422 asked whether `owner-cut` and `revenue-coverage` were really over budget or just cold-isolate noise, and to fix them if real. Both are real, both reproduce on repeat requests, and both were re-reading something per request that does not change per request.

## revenue-coverage

#11479 replaced 129 per-subnet surface reads with one bulk read of `/metagraph/surfaces.json`. That cut the bytes about tenfold and **did not move the latency** — REST stayed at ~1.72s and GraphQL regressed 1.0s → 2.0s. `Server-Timing` put `neon` at ~200ms of a 1.57–1.82s wall clock, so ~1.4s was the artifact read and parse: one 3.5 MB body parsed serially costs about what eight waves of concurrent small reads cost.

The artifact only changes when the registry publishes, so the fix is not to read it differently — it is to stop reading it per request. A 5-minute memo, mirroring `ACCOUNT_SUMMARY_POINTER_TTL_MS`.

Three details the shape depends on:

- **The promise is memoized, not the value.** Three surfaces compose this answer (REST, GraphQL, MCP) and can arrive together on a cold isolate; a resolved-value memo would still let them race to issue three reads.
- **An empty result is not memoized.** A transient miss would otherwise cost five minutes of empty answers — the failure shape #11467 fixed on the account-summary pointer, where one bad read held for a TTL became an outage.
- **Tests reset it per case.** `registerModuleStateReset` fires between test *files*, not between tests, so without an explicit `beforeEach` one case's fixture answers the next one's read.

## owner-cut

This route sums the owner's stake flow from `account_events` over a 30-day window — the same read its `/stake-flow` sibling makes. Every sibling goes through `withEdgeCache`; this one alone did not.

Four consecutive requests each, production, 2026-08-18:

| route | 1 | 2 | 3 | 4 |
| --- | ---: | ---: | ---: | ---: |
| `/subnets/64/stake-flow` (wrapped) | 0.28s | 0.29s | 0.29s | 0.29s |
| `/subnets/64/owner-cut` (not wrapped) | 8.47s | 2.88s | 2.91s | 6.35s |

`r2sql` was 2.4–7.9s of every one of those.

The cache key is the **pathname alone**. #10925 removed the `?window=` this route could not honour, so it reads no query parameters at all; keying on `pathname+search` would let a link carrying a tracking parameter turn a hit into a multi-second miss, unboundedly. That collapse is safe only because parameter validation runs *before* the cache lookup — an unknown parameter still 400s against a warm entry rather than being answered from it — so the test asserts the rejection, not just the entry count.

The handler's serial prefix is also unbundled: only the flow read depends on anything local (it needs the economics row's owner coldkey), while the network-parameter and TAO/USD reads were sequenced behind a ~175ms Neon call for no reason.

## Checked and deliberately not changed

- **The cold-miss R2 SQL cost.** Rewriting that query means changing which predicates file statistics can prune, and scan metrics need an R2 SQL token this environment does not have. Guessing without measuring is how a lane ships a regression.
- **`accrual.alpha` is identical (38879.011215381) on every subnet.** That looks like a constant standing in for a per-subnet figure, so I checked the arithmetic: it implies `alpha_out_per_block` of 0.9999999999999976. Each subnet emits ~1 alpha/block by design, so the alpha leg being equal network-wide is correct — the TAO leg varies because alpha prices do. No defect.

## Verification

Full suite 959 files / 22,053 passed, build, lint, format, all 72 CI validators, and patch coverage 100% (26/26 lines, 14/14 branches) measured by diff intersection against `origin/main`.

Closes #11422