### PR TITLE
perf(revenue-coverage): the whole-network fold ran on every request

### DIFF
--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -30,6 +30,7 @@ import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
 import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
 import { resetObservedThroughCache } from "../src/lakehouse-observed-through.ts";
+import { resetSurfacesMemo } from "../src/revenue-load.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
 // Edge-cache coverage for the store-backed analytics routes (audit #6). These four
@@ -269,6 +270,9 @@ afterEach(() => {
 beforeEach(() => {
   resetDecodeWatermarkCache();
   resetObservedThroughCache();
+  // The revenue-coverage fold memoizes the surfaces artifact for five minutes,
+  // and registerModuleStateReset fires between test FILES, not between tests.
+  resetSurfacesMemo();
 });
 
 describe("analytics edge cache", () => {
@@ -715,6 +719,44 @@ describe("analytics edge cache", () => {
     assert.deepEqual(cache.putKeys, [
       expectedKey("subnet-owner-cut", "/api/v1/subnets/7/owner-cut"),
     ]);
+  });
+
+  test("chain revenue-coverage caches under the canonical window", async () => {
+    // A whole-network fold -- 129 subnets joined from the economics blob, the
+    // observation table and the surfaces artifact -- that ran on every request.
+    // Measured against production 2026-08-18 it answered in 0.69s and 1.10s on
+    // two consecutive requests, i.e. it was not caching at all.
+    originalCaches = globalWithCaches.caches;
+    const cache = mockCaches();
+    cache.install();
+    const env = analyticsEnv([]);
+
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/chain/revenue-coverage"),
+      mockEnv(env) as unknown as Env,
+      ctx,
+    );
+    await Promise.resolve();
+    assert.equal(res.status, 200);
+    assert.deepEqual(cache.putKeys, [
+      expectedKey(
+        "chain-revenue-coverage",
+        "/api/v1/chain/revenue-coverage",
+        "?window=1d",
+      ),
+    ]);
+
+    // The omitted window and its explicit default are the SAME answer, so they
+    // must share the slot rather than folding 129 subnets a second time.
+    const hit = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/chain/revenue-coverage?window=1d",
+      ),
+      mockEnv(env) as unknown as Env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(cache.store.size, 1);
   });
 
   test("subnet weights routes through the worker and caches at the default window", async () => {

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -114,6 +114,7 @@ import {
   handleExtrinsics,
   handleExtrinsic,
   canonicalSubnetHistoryCachePath,
+  canonicalChainRevenueCoverageCachePath,
   canonicalSubnetTurnoverCachePath,
   canonicalSubnetStakeFlowCachePath,
   canonicalSubnetWeightsCachePath,
@@ -1641,6 +1642,29 @@ describe("handleSubnetTurnover", () => {
       body.meta.artifact_path,
       `/metagraph/subnets/${NETUID}/turnover.json`,
     );
+  });
+
+  describe("canonicalChainRevenueCoverageCachePath", () => {
+    const PATH = "/api/v1/chain/revenue-coverage";
+    const at = (search = "") =>
+      canonicalChainRevenueCoverageCachePath(
+        new URL(`https://api.metagraph.sh${PATH}${search}`),
+      );
+
+    test("omitted window canonicalises to the default, so both share one entry", () => {
+      // This route folds all 129 subnets together. Two keys for one answer
+      // means folding them twice.
+      assert.equal(at(), `${PATH}?window=1d`);
+      assert.equal(at("?window=1d"), `${PATH}?window=1d`);
+      assert.equal(at("?window=30d"), `${PATH}?window=30d`);
+    });
+
+    test("a REJECTED query passes through verbatim, never onto a valid key", () => {
+      // Canonicalising an invalid query onto the default key would file the
+      // 400 under the slot the good answer lives in -- and, worse, let the
+      // rejected request be answered from a warm entry.
+      assert.equal(at("?window=nonsense"), `${PATH}?window=nonsense`);
+    });
   });
 
   describe("canonicalSubnetTurnoverCachePath", () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -345,6 +345,7 @@ import {
   handleSubnetTurnover,
   canonicalSubnetTurnoverCachePath,
   handleSubnetStakeFlow,
+  canonicalChainRevenueCoverageCachePath,
   canonicalSubnetStakeFlowCachePath,
   handleSubnetAlphaVolume,
   handleSubnetOhlc,
@@ -8606,7 +8607,19 @@ async function dispatchLiveChainRoute(
     return handleSubnetRevenue(request, env, Number(revenueMatch[1]), url);
   }
   if (pathname === CHAIN_REVENUE_COVERAGE_PATH) {
-    return handleChainRevenueCoverage(request, env, url);
+    // 129 subnets folded together from the economics blob, the observation
+    // table and the surfaces artifact -- a whole-network recomputation that
+    // was running on EVERY request. #11480 removed the per-request artifact
+    // read (1.72s -> 0.69s); the rest is the fold itself, and the fold is the
+    // same answer for every caller until the health cron stamps a new one.
+    return withEdgeCache(
+      request,
+      ctx,
+      env,
+      edgeCacheScope("chain-revenue-coverage", chain),
+      () => handleChainRevenueCoverage(request, env, url),
+      canonicalChainRevenueCoverageCachePath(url),
+    );
   }
   const recycledMatch = SUBNET_RECYCLED_PATH_PATTERN.exec(pathname);
   if (recycledMatch) {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -2344,6 +2344,23 @@ export function canonicalSubnetOwnerCaptureCachePath(url: URL) {
   return `${url.pathname}?window=${encodeURIComponent(label)}`;
 }
 
+/**
+ * Canonical edge-cache key for the chain-wide revenue-coverage route.
+ *
+ * `?window=` (one of SUBNET_REVENUE_WINDOWS) is the only parameter the handler
+ * reads, so an omitted window and an explicit `?window=1d` must share one slot
+ * rather than recomputing all 129 subnets twice.
+ */
+export function canonicalChainRevenueCoverageCachePath(url: URL) {
+  if ("error" in parseRouteQuery(url)) return `${url.pathname}${url.search}`;
+  const { label } = resolveWindow(
+    url,
+    SUBNET_REVENUE_WINDOW_DAYS,
+    DEFAULT_SUBNET_REVENUE_WINDOW,
+  );
+  return `${url.pathname}?window=${encodeURIComponent(label)}`;
+}
+
 // Canonical edge-cache key for the subnet-turnover route (?window= via
 // parseHistoryWindow). Distinct from canonicalSubnetConcentrationHistoryCachePath
 // which uses a different parse function (parseConcentrationHistoryWindow).


### PR DESCRIPTION
#11480 removed the per-request artifact read from `/api/v1/chain/revenue-coverage` (1.72s → 0.69s). What remained is the fold itself — 129 subnets joined from the economics blob, the revenue-observation table and the surfaces artifact — recomputed for every caller.

Measured against production 2026-08-18, two consecutive requests:

```
/api/v1/chain/revenue-coverage   0.69s   1.10s    neon;dur=55;desc="2 calls"
```

It was not caching at all, while its analytics siblings serve 0.25s from `withEdgeCache`. Confirmed with spaced samples afterwards — this one reproduces.

## Why this is safe

The fold is the same answer for every caller until the health cron stamps a new one — the freshness contract every wrapped sibling already has. The stamp rotates on the `*/15` cron, the payload carries its own `generated_at`, and the response keeps `max-age=60`.

`?window=` is the only parameter the handler reads, so the canonical key resolves it to its default: otherwise the bare path and an explicit `?window=1d` are two entries for one answer and the fold runs twice. A rejected query passes through verbatim rather than being canonicalised onto the valid key — filing a 400 under the slot the good answer lives in is the one way this collapse could serve a wrong response, so the test asserts that specifically.

## Two routes I checked and deliberately did not change

`/validators/{hotkey}/nominators` and `/subnets/{netuid}/events` stay expensive on a repeat, but both carry explicit comments saying they are uncached on purpose — "no edge cache — live/paginated" and "Live + continuously appended, so served direct". Caching a continuously-appended feed for up to 15 minutes changes its contract; overriding a stated decision needs its own argument, not a drive-by.

## A sweep finding I retracted

While looking for more of this defect I ran a two-hit probe over every resolvable GET route and concluded 42 registry routes were failing to cache. **That was wrong** — the probe fired ~0.2s apart across 146 routes and was measuring its own load. Re-measured with three spaced samples, only 4 of the 42 exceed 500ms, and all four are simply large bodies that come in at 0.24–0.53s once compressed. `/api/v1/providers`, which I had quoted at 2.04s, is 0.16s. I filed that as #11482 and have closed it with the corrected numbers. Nothing in this PR rests on it.

## Verification

Full suite 959 files / 22,054 passed, build, lint, format, all 72 CI validators, patch coverage 100% (5/5 lines, 2/2 branches) by diff intersection against `origin/main`.