### PR TITLE
fix(watchdog): chain-prometheus is permanently empty by declaration, so stop alarming on it

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -169,6 +169,23 @@ export interface ProjectionLane {
    * PROJECTION_LANES_CRON tick, so none sets this yet. */
   intervalCron?: string;
   /**
+   * A lane whose EMPTY answer is correct and permanent, so zero rows is not a
+   * fault for it.
+   *
+   * `projection-staleness` treats zero rows as broken because on mainnet a
+   * block every 12s means an empty window cannot be real. That claim is right
+   * for every lane but this kind: `chain-prometheus` reads `PrometheusServed`
+   * from `account_events`, and our curation drops that variant, so the card is
+   * empty whatever tier answers -- which the route already states permanently
+   * via PROMETHEUS_DEGRADED_NOT_CURATED.
+   *
+   * Set only with the reason written down. The watchdog's own comment asks for
+   * exactly this -- exemption by NAME rather than weakening the rule into one
+   * that cannot fire -- and every OTHER rule still applies: absent, unreadable
+   * and stale-by-age all still fault for an exempted lane.
+   */
+  emptyIsExpected?: boolean;
+  /**
    * Names the reader that serves this artifact, for a lane that backs NO
    * chain-scope projection route.
    *
@@ -1570,6 +1587,12 @@ export const PROJECTION_LANES: ProjectionLane[] = [
     name: "chain-prometheus",
     artifactKey: CHAIN_PROMETHEUS_PROJECTION_KEY,
     compute: computeChainPrometheus,
+    // The chain emits PrometheusServed and `account_events` curation drops it,
+    // so this card is empty whatever tier answers -- stated permanently on the
+    // route as PROMETHEUS_DEGRADED_NOT_CURATED. Alarming on it every tick made
+    // the projection-staleness lane permanent noise (#11484) without ever
+    // describing a condition anyone could act on.
+    emptyIsExpected: true,
   },
   {
     name: "chain-weights",

--- a/src/projection-staleness-watchdog.ts
+++ b/src/projection-staleness-watchdog.ts
@@ -305,7 +305,11 @@ function watchedLanes(): {
       // Testnet keeps every OTHER rule: absent, unreadable and stale-by-age all
       // still fire, and `chain-stake-moves:testnet` was correctly flagged for
       // age in that same tick.
-      emptyIsFault: network === DEFAULT_CHAIN_NETWORK,
+      // ...unless the LANE says its empty is correct and permanent. That is a
+      // narrower claim than the network rule and is made per lane, with the
+      // reason at the declaration -- see ProjectionLane.emptyIsExpected.
+      emptyIsFault:
+        network === DEFAULT_CHAIN_NETWORK && lane.emptyIsExpected !== true,
     })),
   );
 }

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -749,3 +749,57 @@ describe("the watchdog lane, as the heartbeat runs it", () => {
     assert.equal(result.checked, reads.length);
   });
 });
+
+describe("a lane whose empty is DECLARED (#11484)", () => {
+  test("chain-prometheus is exempt from the zero-rows rule, and says why", () => {
+    const lane = PROJECTION_LANES.find((l) => l.name === "chain-prometheus");
+    assert.ok(lane, "chain-prometheus must still be a watched lane");
+    assert.equal(
+      lane?.emptyIsExpected,
+      true,
+      "the chain emits PrometheusServed and account_events curation drops it, " +
+        "so zero rows is the correct answer and not a stall",
+    );
+  });
+
+  test("no OTHER lane is exempt — this is a named exception, not a loosened rule", () => {
+    // The watchdog's own comment asks for exemption by name rather than a rule
+    // that cannot fire. If this list grows, each entry needs its own reason.
+    const exempt = PROJECTION_LANES.filter(
+      (l) => l.emptyIsExpected === true,
+    ).map((l) => l.name);
+    assert.deepEqual(exempt, ["chain-prometheus"]);
+  });
+
+  test("an exempt lane still faults on absent, unreadable and stale", () => {
+    // The exemption is scoped to ONE reason. A lane that stops being written
+    // at all, or whose artifact goes stale, must still alarm -- otherwise this
+    // trades noise for blindness, which is the worse trade.
+    const nowMs = Date.UTC(2026, 7, 19, 12, 0, 0);
+    const one = (generatedAt: string | null, rowCount: number | null) =>
+      evaluateProjectionStaleness({
+        artifacts: [
+          {
+            lane: "chain-prometheus",
+            generatedAt,
+            rowCount,
+            emptyIsFault: false,
+          },
+        ],
+        nowMs,
+        thresholdMs: HOUR,
+      }).entries[0];
+
+    const absent = one(null, null);
+    assert.equal(absent.stale, true);
+    assert.equal(absent.reason, "absent");
+
+    const stale = one(new Date(nowMs - 5 * HOUR).toISOString(), 12);
+    assert.equal(stale.stale, true);
+    assert.equal(stale.reason, "stale");
+
+    // ...and the one reason it IS exempt from.
+    const empty = one(new Date(nowMs - 60_000).toISOString(), 0);
+    assert.equal(empty.stale, false);
+  });
+});


### PR DESCRIPTION
`projection-staleness` has reported stale continuously since 2026-08-18, naming `chain-prometheus` (#11484).

**The lane is not broken.** The chain emits `PrometheusServed`, our `account_events` curation drops that variant, and the route already states this permanently as `PROMETHEUS_DEGRADED_NOT_CURATED`. Measured just now:

```
GET /api/v1/chain/prometheus  ->  200, rows: 0, published_at 2026-08-14
```

`chain-prometheus-artifact.ts` says it in as many words: *"the card is empty whatever tier answers … serving an empty from a cron instead of from a 15-second timeout does not make it less empty."*

So the alarm describes a condition nobody can act on, on every tick, forever. That is how a watchdog becomes wallpaper — the same argument the existing `emptyIsFault` comment already makes for testnet, where it notes *"a rule that stands permanently on testnet is how the whole lane becomes wallpaper, which costs more than the coverage it buys."*

## Exempted by name, which is what the code asked for

The watchdog's own comment prescribes the fix:

> a lane that can legitimately be empty should be exempted by name, with the reason written down, rather than by weakening this into a rule that cannot fire

There was no per-lane mechanism — only the network split — so this adds one. The reason lives at the declaration, not in a list somewhere else.

**No rule is weakened.** The exemption is scoped to zero-rows *and* to this lane. A test asserts an exempt lane still faults on `absent` and on `stale`, so a lane that genuinely stops being written still alarms — otherwise this would trade noise for blindness, which is the worse trade.

A second test pins that `chain-prometheus` is the **only** exemption, so the list cannot grow quietly: each future entry has to arrive with its own reason.

## Verification

Full suite 959 files / 22,059 passed, build, lint, format, all 72 CI validators, patch coverage 100% (2/2 branches).

Closes #11484