### PR TITLE
feat(rpc): serve latency percentiles again — R2 SQL accepts PERCENTILE_CONT now

### DIFF
--- a/src/rpc-usage-answer.ts
+++ b/src/rpc-usage-answer.ts
@@ -30,11 +30,18 @@
 // with them -- and `coverage` publishes the span each store actually
 // contributed, including the hole between them that no store covers.
 //
-// PERCENTILES ARE NOT SUMMED, because they are not additive.
-// `quantileExactWeighted` cannot be merged with a store that has no percentile
-// function at all, and reporting AE's p50 as the whole window's p50 would be a
-// claim about a sub-range. They stay AE-only and `coverage.latency_percentiles`
-// says which sub-range they describe. Null still means "not measured".
+// PERCENTILES ARE NOT SUMMED, because they are not additive. Reporting AE's
+// p50 as the whole window's p50 would be a claim about a sub-range, so the
+// merged answer keeps the hot tier's and `coverage.latency_percentiles` says
+// which sub-range it describes. Null still means "not measured".
+//
+// The ORIGINAL reason given here -- that the lakehouse "has no percentile
+// function at all" -- stopped being true: `PERCENTILE_CONT(x) WITHIN GROUP`
+// is accepted now and the cold tier measures p50/p95 on its own span. That
+// changes nothing about this merge, because two exact percentiles over two
+// disjoint ranges still cannot be combined into one. It does mean a COLD-ONLY
+// answer now carries percentiles where it used to report null, which is the
+// case this route lost when Postgres went away.
 //
 // WHEN THE LAKEHOUSE IS READ AT ALL. Only when the hot tier does not already
 // cover the requested window back to its cutoff. That is what keeps this from

--- a/src/rpc-usage-cold-tier.ts
+++ b/src/rpc-usage-cold-tier.ts
@@ -13,15 +13,25 @@
 // projection it needs per query, and a JS re-aggregation of 578k rows would
 // not fit a request either way.
 //
-// PERCENTILES ARE DECLINED, NOT SYNTHESIZED. The Postgres route reported
-// latency p50/p95. R2 SQL has no percentile function -- `approx_percentile`
-// is rejected outright (measured 2026-08-03) -- and computing them in JS
-// needs every latency in the window, 578,507 rows for 7d, which is not a
-// request-time read. So `latency` is left undefined and the formatter
-// reports p50/p95 as null: "we did not measure this", which is true.
-// Deriving them from the average would put a number there that no percentile
-// of the data supports, and a caller cannot tell a made-up p95 from a real
-// one.
+// PERCENTILES ARE MEASURED AGAIN. They were declined here from 2026-08-03,
+// when `approx_percentile` was rejected outright and computing them in JS
+// meant pulling every latency in the window -- 578,507 rows for 7d, not a
+// request-time read. So the route reported p50/p95 as null, honestly.
+//
+// `PERCENTILE_CONT(x) WITHIN GROUP (ORDER BY ...)` is accepted now. Verified
+// against a positive control before it was trusted: p50 over a contiguous
+// 8000000..8000100 block range returns exactly 8000050, so the engine is
+// computing the percentile rather than approximating something near it.
+//
+// They ride on the totals query rather than adding a fifth: measured on the
+// live table, adding both percentiles left the scan at 2.46 MB across 15
+// files -- byte for byte what the same query cost without them, because the
+// column is already being read for `avg(latency_ms)`. At the widest window
+// the route offers (90d, 1,467,264 rows) the whole statement is 7.21 MB.
+//
+// EXACT, not approximate, for the reason `distinct_registrants` is exact
+// elsewhere in this codebase: a published percentile that is quietly an
+// estimate is a data defect wearing a performance argument.
 //
 // THE TABLE IS FROZEN, and the window is still honest about it. The proxy
 // that wrote these rows died with the box, so the newest row is fixed at the
@@ -131,6 +141,10 @@ export async function loadRpcUsageColdTier(
           ` sum(CASE WHEN attempts > 1 THEN 1 ELSE 0 END) AS failover_count,` +
           ` sum(CASE WHEN cache = 'hit' THEN 1 ELSE 0 END) AS cache_hits,` +
           ` avg(latency_ms) AS avg_latency_ms,` +
+          // Free: `latency_ms` is already projected for the average above, so
+          // the engine reads no extra column and the scan is unchanged.
+          ` PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY latency_ms) AS p50,` +
+          ` PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms) AS p95,` +
           // Both ends of the measured span. The newest reading has always been
           // published as `observed_at`; the oldest is what `coverage` needs so
           // a merged answer can say where the lakehouse's half of it stops and
@@ -176,10 +190,8 @@ export async function loadRpcUsageColdTier(
     window: windowLabel,
     observedAt: totals.observed_at ?? null,
     totals,
-    // Deliberately absent -- see the header. Not a TODO.
-    latency: undefined,
-    // What this tier measured. `latency` is omitted for the same reason
-    // p50/p95 are: there is no percentile here to scope.
+    // From the totals row, which now carries them.
+    latency: totals,
     coverage: {
       segments: [
         {
@@ -188,6 +200,14 @@ export async function loadRpcUsageColdTier(
           end: totals.observed_at ?? null,
         },
       ],
+      // The percentiles describe THIS store's span and no other. Scoped
+      // explicitly so a cold-only answer says which sub-range its p50/p95
+      // covers, rather than letting a reader assume it covers the window they
+      // asked for -- the same discipline the hot tier's own scope carries.
+      latency: {
+        start: totals.observed_from ?? null,
+        end: totals.observed_at ?? null,
+      },
     },
     // endpoints/networks derive their own error_rate from requests - ok
     // inside the formatter; only the bucket mapping reads a literal `errors`,

--- a/tests/rpc-usage-cold-tier.test.ts
+++ b/tests/rpc-usage-cold-tier.test.ts
@@ -149,8 +149,16 @@ describe("what the tier refuses to publish", () => {
 describe("the SQL it emits", () => {
   test("no rollup uses a function the engine rejects", async () => {
     // Measured against the live engine 2026-08-03: count_if and
-    // approx_percentile are both rejected outright. A refactor reaching for
-    // either would fail every query at runtime, not at build.
+    // approx_percentile are both rejected outright, and re-verified
+    // 2026-08-19 -- count_if still returns `40004: Invalid function`. A
+    // refactor reaching for either would fail every query at runtime, not at
+    // build.
+    //
+    // PERCENTILE_CONT is a different function and IS accepted (verified
+    // against a positive control: p50 over a contiguous 8000000..8000100
+    // range returns exactly 8000050), so it is allowed here by name while
+    // `approx_percentile` stays banned -- an approximate percentile on a
+    // published figure would be a data defect wearing a performance argument.
     const engine = fakeEngine({
       totals: [{ total: 1, ok_count: 1 }],
       endpoints: [],
@@ -168,7 +176,11 @@ describe("the SQL it emits", () => {
     assert.ok(engine.seen.length >= 4, "expected all four rollups");
     for (const sql of engine.seen) {
       assert.doesNotMatch(sql, /count_if/i, "count_if is rejected by R2 SQL");
-      assert.doesNotMatch(sql, /percentile/i, "no percentile function exists");
+      assert.doesNotMatch(
+        sql,
+        /approx_percentile/i,
+        "approx_percentile is rejected by R2 SQL, and would be approximate anyway",
+      );
     }
   });
 
@@ -385,7 +397,7 @@ describe("the rows it hands the shared formatter", () => {
     }
   });
 
-  test("publishes the span it measured, with no percentile range to scope", async () => {
+  test("publishes the span it measured, and scopes its percentiles to it", async () => {
     const oldest = 1_784_000_000_000;
     const newest = 1_784_900_000_000;
     const engine = fakeEngine({
@@ -406,9 +418,81 @@ describe("the rows it hands the shared formatter", () => {
     assert.deepEqual(coverage.segments, [
       { source: "lakehouse", start: oldest, end: newest },
     ]);
-    // Nothing measured a percentile here, and the payload says exactly that.
-    assert.equal(coverage.latency_percentiles, null);
+    // The percentiles this tier measures describe THIS span and no other, so
+    // the payload scopes them rather than letting a reader assume they cover
+    // the window they asked for.
+    assert.deepEqual(coverage.latency_percentiles, {
+      start: oldest,
+      end: newest,
+    });
     assert.ok(engine.seen[0].includes("min(observed_at) AS observed_from"));
+  });
+
+  test("measures p50/p95 and serves them, which this route lost with Postgres", async () => {
+    // The route reported percentiles on Postgres and went null when that box
+    // went away, because R2 SQL rejected approx_percentile and a JS
+    // computation needs every latency in the window (578,507 rows for 7d).
+    // PERCENTILE_CONT is accepted now, so the answer is measured again.
+    const engine = fakeEngine({
+      totals: [
+        {
+          total: 415494,
+          ok_count: 415493,
+          avg_latency_ms: 156.18,
+          p50: 141,
+          p95: 435,
+          observed_from: 1_786_525_607_000,
+          observed_at: 1_787_097_599_000,
+        },
+      ],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    const result = (await loadRpcUsageColdTier(
+      {} as never,
+      { window: "7d", now: NOW, query: engine.query } as never,
+    )) as Record<string, unknown>;
+    const latency = (result.summary as Record<string, unknown>)
+      .latency_ms as Record<string, unknown>;
+    assert.equal(latency.p50, 141);
+    assert.equal(latency.p95, 435);
+    assert.equal(
+      latency.avg,
+      156,
+      "the average is unchanged and still rounded",
+    );
+  });
+
+  test("percentiles ride the totals query rather than adding a fifth scan", async () => {
+    // The whole reason this is affordable: `latency_ms` is already projected
+    // for avg(), so the engine reads no extra column. Measured on the live
+    // table, adding both percentiles left the scan at 2.46 MB across 15 files
+    // -- byte for byte what the same query cost without them. A refactor that
+    // split them into their own statement would double the scan for nothing.
+    const engine = fakeEngine({
+      totals: [{ total: 1, ok_count: 1 }],
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+    await loadRpcUsageColdTier(
+      {} as never,
+      { window: "7d", now: NOW, query: engine.query } as never,
+    );
+    const withPercentiles = engine.seen.filter((sql) =>
+      /percentile_cont/i.test(sql),
+    );
+    assert.equal(
+      withPercentiles.length,
+      1,
+      "exactly one statement computes percentiles",
+    );
+    assert.ok(
+      withPercentiles[0].includes("count(*) AS total"),
+      "and it is the totals statement, not a new one",
+    );
+    assert.equal(engine.seen.length, 4, "still four rollups, not five");
   });
 
   test("a bucket row missing its counts reads as zero, not NaN", async () => {


### PR DESCRIPTION
`/api/v1/rpc/usage` reported p50/p95 on Postgres and has reported `null` since that box went away. The reason was recorded and correct at the time:

> PERCENTILES ARE DECLINED, NOT SYNTHESIZED … `approx_percentile` is rejected outright (measured 2026-08-03) — and computing them in JS needs every latency in the window, 578,507 rows for 7d, which is not a request-time read.

#11068 lists this as one of three answers that **"cannot be served at all"**.

## It can now

`PERCENTILE_CONT(x) WITHIN GROUP (ORDER BY ...)` is accepted. I verified it against a positive control before trusting it — p50 over a contiguous `8000000..8000100` block range returns exactly **8000050**, so the engine is computing the percentile rather than approximating something near it.

On the live table, 7d: **p50 141ms, p95 435ms over 415,494 rows.**

## Free, not merely affordable

They ride on the existing totals statement rather than adding a fifth. `latency_ms` is already projected there for `avg()`, so the engine reads no extra column:

| | scan |
| --- | --- |
| totals query as it is today | 2.46 MB / 15 files |
| **same query with p50 + p95** | **2.46 MB / 15 files** |
| widest window the route offers (90d, 1,467,264 rows) | 7.21 MB |

Byte for byte identical. A test pins that exactly one statement carries a percentile and that there are still four rollups, so a refactor cannot quietly split them out and double the scan.

## What stays banned, and why

`approx_percentile` is still rejected by the same test that has always rejected it — and would stay banned even if it worked. An approximate percentile on a published figure is a data defect wearing a performance argument, which is the reasoning `distinct_registrants` already follows elsewhere in this codebase.

## Scoped, not merged

`coverage.latency_percentiles` now says which sub-range these describe, because they describe *this* store's span and no other.

The merged answer still takes the **hot tier's** percentiles — two exact percentiles over two disjoint ranges cannot be combined into one. But the composer's stated reason ("cannot be merged with a store that has no percentile function at all") stopped being true, so it now gives the reason that is: percentiles are not additive. Same behaviour, honest comment.

## Two tests changed rather than added

Both pinned the old constraint and had to move:

- the engine-rejects test now bans `approx_percentile` by name instead of `/percentile/i`, and says why `PERCENTILE_CONT` is allowed
- "publishes the span it measured, **with no percentile range to scope**" became "…**and scopes its percentiles to it**"

## Verification

Full suite 959 files / 22,061 passed, build, lint, format, all 72 CI validators, patch coverage 100% (4/4 branches).

Part of #11068 — this is one of its three "impossible" answers. I have not closed it; the other two (JSON extraction on event args, deep pagination) are still genuinely rejected, which I re-verified: `json_extract` returns `40004: Invalid function` and `OFFSET` returns `40003: unsupported feature`.