### PR TITLE
feat(og): per-entity Open Graph cards, rendered in the Worker

### DIFF
--- a/src/og-entity-card.ts
+++ b/src/og-entity-card.ts
@@ -1,0 +1,387 @@
+// Per-entity Open Graph cards (#11075): GET /og/subnets/{netuid}.png and
+// GET /og/accounts/{ss58}.png, rendered from live registry data.
+//
+// WHY THIS CAN LIVE IN THE WORKER NOW. The render left the Worker in #6502 on a
+// bundle-budget argument: workers-og's wasm is ~545 KiB gzipped and the bundler
+// ships every reachable import. Measured 2026-08-11, this Worker is 944.8 KiB
+// against a 10 MB paid limit, so ~545 KiB more is ~14.5% of it -- the budget
+// argument is measurably not binding.
+//
+// The argument that IS live is startup CPU. This Worker has failed to deploy
+// four separate times with `code: 10021 Script startup exceeded CPU time
+// limit`, always from work at module scope, and wasm instantiation is exactly
+// that shape. So `workers-og` is imported INSIDE the handler and never at
+// module scope, and the cost was measured rather than assumed -- eight
+// `wrangler versions upload` samples each, which reports startup time without
+// routing traffic:
+//
+//   without the import   319 315 321 283 314 301 307 326   median 313 ms
+//   with the import      362 549 315 313 281 312 297 321   median 313 ms
+//
+// Identical medians: the module is not evaluated until the handler runs. Both
+// sets carry outliers because the platform validates on a shared host and the
+// limit is load-dependent -- which is the same reason those four deploys failed
+// non-deterministically, and is a property of this Worker's 313 ms baseline
+// rather than of this import.
+//
+// CACHED PER ENTITY IN R2, not rendered per request. The key carries a digest
+// of the exact facts drawn on the card, so a data change is a NEW key rather
+// than an invalidation -- there is no moment where a stale card and a fresh one
+// share a name. That is the difference from the landing card, which re-rendered
+// an unchanged image on every cache miss because its key was constant.
+//
+// A RENDER FAILURE IS NEVER A 5xx. Social crawlers do not retry, and a 5xx to
+// one is a link that unfurls blank for as long as the crawler caches it. Every
+// failure path falls back to the same branded static card the landing route
+// uses, which lives in ASSETS -- a different subsystem, so it survives the
+// failure modes that take the render down.
+import type { ArtifactEnv } from "../workers/storage.ts";
+import {
+  type AssetFetcher,
+  fallbackResponse,
+  imageHeaders,
+  INK,
+  INK_TEXT,
+  LOGO_DATA_URI,
+  MINT,
+  WORDMARK,
+} from "./og-image.ts";
+
+/** 1200x630 is the size every major unfurler crops to; anything else is cropped
+ * for us and usually badly. */
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+/** Cards are immutable under their digest, so they may be cached hard. A new
+ * digest is a new URL; nothing has to expire for a card to change. */
+const CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800";
+
+const SUBNET_PATH = /^\/og\/subnets\/(\d{1,5})\.png$/;
+const ACCOUNT_PATH = /^\/og\/accounts\/([1-9A-HJ-NP-Za-km-z]{47,48})\.png$/;
+
+export interface EntityCardFacts {
+  /** The line a reader identifies the entity by. */
+  title: string;
+  /** What kind of thing this is, shown small above the title. */
+  kind: string;
+  /** Up to three `label -> value` pairs. Fewer is fine; a card with one real
+   * fact reads better than one padded with nulls. */
+  stats: { label: string; value: string }[];
+}
+
+/**
+ * The card markup. Kept separate from the render so it can be asserted on in a
+ * test without instantiating wasm, the same split `renderMarkup` uses for the
+ * landing card.
+ *
+ * ESCAPED, because every value here is registry data and one of them is a
+ * subnet name a third party controls. satori parses this as markup, so an
+ * unescaped `<` is a rendering bug at best.
+ */
+export function renderEntityMarkup(facts: EntityCardFacts): string {
+  const stats = facts.stats
+    .slice(0, 3)
+    .map(
+      (stat) =>
+        `<div style="display:flex;flex-direction:column;margin-right:64px;">
+           <div style="display:flex;font-size:26px;font-weight:500;color:${INK};opacity:0.66;">${escapeMarkup(stat.label)}</div>
+           <div style="display:flex;font-size:52px;font-weight:700;color:${INK_TEXT};">${escapeMarkup(stat.value)}</div>
+         </div>`,
+    )
+    .join("");
+  return `
+    <div style="position:relative;display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;background:${MINT};color:${INK_TEXT};font-family:'Space Grotesk';padding:74px 90px;overflow:hidden;">
+      <div style="position:absolute;top:-250px;right:-210px;width:740px;height:740px;background:#5BFFD2;opacity:0.5;transform:rotate(34deg);display:flex;"></div>
+      <div style="display:flex;flex-direction:column;">
+        <div style="display:flex;font-size:30px;font-weight:500;color:${INK};opacity:0.72;">${escapeMarkup(facts.kind)}</div>
+        <div style="display:flex;font-size:78px;font-weight:700;letter-spacing:-2px;margin-top:10px;">${escapeMarkup(facts.title)}</div>
+      </div>
+      <div style="display:flex;align-items:flex-end;justify-content:space-between;width:100%;">
+        <div style="display:flex;">${stats}</div>
+        <div style="display:flex;align-items:center;">
+          <img src="${LOGO_DATA_URI}" style="width:64px;height:64px;" />
+          <div style="display:flex;font-size:34px;font-weight:700;margin-left:14px;">${WORDMARK}</div>
+        </div>
+      </div>
+    </div>`;
+}
+
+/** satori reads this as markup, and subnet names are third-party strings. */
+function escapeMarkup(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * A stable digest of exactly what the card draws.
+ *
+ * FNV-1a over the facts, not over the entity id: two publishes that change
+ * nothing visible produce the same key and re-use the cached PNG, and any
+ * change to a drawn value produces a different one. Non-cryptographic on
+ * purpose -- this names a cache entry, it does not authenticate anything.
+ */
+export function factsDigest(facts: EntityCardFacts): string {
+  const canonical = JSON.stringify([
+    facts.kind,
+    facts.title,
+    facts.stats.map((s) => [s.label, s.value]),
+  ]);
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < canonical.length; i += 1) {
+    hash ^= canonical.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * `cache/og/subnets/64-a1b2c3d4.png` -- the digest is IN the key, so a
+ * regenerate writes a new object rather than overwriting a live one.
+ *
+ * UNDER `cache/`, deliberately outside `metagraph/`. Objects under the
+ * artifact prefix are owned by the publish, which reconciles what it finds
+ * against what it built -- a render this Worker wrote would look like drift to
+ * it. This is a cache: nothing downstream reads it by name, and losing all of
+ * it costs one re-render per card.
+ */
+export function cardKey(kind: string, subject: string, digest: string): string {
+  return `cache/og/${kind}/${subject}-${digest}.png`;
+}
+
+/**
+ * The R2-backed half of the cache, as a pair of functions the handler can be
+ * given or not.
+ *
+ * HERE RATHER THAN INLINE AT THE DISPATCH SITE, because it is logic: a missing
+ * binding, a miss, and a body that has to be read to completion are three
+ * different outcomes and each has a right answer. Inline in the router they
+ * would be untestable without standing up the whole request path and
+ * instantiating the wasm to reach them.
+ */
+export function r2CardCache(env: {
+  METAGRAPH_ARCHIVE?: {
+    get?: (
+      key: string,
+    ) => Promise<{ arrayBuffer(): Promise<ArrayBuffer> } | null>;
+    put?: (
+      key: string,
+      body: ArrayBuffer,
+      options?: { httpMetadata?: { contentType?: string } },
+    ) => Promise<unknown>;
+  };
+}): Pick<EntityCardDeps, "readCard" | "writeCard"> {
+  return {
+    readCard: async (key) => {
+      // No binding is a MISS, not an error: the card renders and the run
+      // simply does not get cached. A throw here would take an unfurl down
+      // over a cache that was never configured.
+      const archive = env.METAGRAPH_ARCHIVE;
+      if (!archive?.get) return null;
+      const object = await archive.get(key);
+      return object ? await object.arrayBuffer() : null;
+    },
+    writeCard: async (key, body) => {
+      await env.METAGRAPH_ARCHIVE?.put?.(key, body, {
+        httpMetadata: { contentType: "image/png" },
+      });
+    },
+  };
+}
+
+export interface EntityCardTarget {
+  kind: "subnets" | "accounts";
+  subject: string;
+}
+
+/** Which entity a path names, or null when it names none. */
+export function matchEntityCard(pathname: string): EntityCardTarget | null {
+  const subnet = SUBNET_PATH.exec(pathname);
+  if (subnet) {
+    const netuid = Number(subnet[1]);
+    // The u16 range the rest of this API enforces. A path outside it is not a
+    // subnet card with no data, it is not a subnet.
+    if (!Number.isInteger(netuid) || netuid > 65535) return null;
+    return { kind: "subnets", subject: String(netuid) };
+  }
+  const account = ACCOUNT_PATH.exec(pathname);
+  if (account) return { kind: "accounts", subject: account[1] };
+  return null;
+}
+
+/** The reader `workers/storage.ts` exports, named by its own contract rather
+ * than loosened to `unknown` -- a loose bag here is what forces a cast at the
+ * call site, and the boundary-cast ratchet in this repo is at zero. */
+type ArtifactReader = (
+  env: ArtifactEnv,
+  path: string,
+) => Promise<{ ok: boolean; data?: unknown }>;
+
+type R2Writer = (key: string, body: ArrayBuffer) => Promise<void>;
+
+export interface EntityCardDeps {
+  readArtifact?: ArtifactReader;
+  readCard?: (key: string) => Promise<ArrayBuffer | null>;
+  writeCard?: R2Writer;
+  render?: (markup: string) => Promise<ArrayBuffer>;
+  assets?: AssetFetcher | null;
+}
+
+/**
+ * The facts a subnet card draws, from the published registry index.
+ *
+ * ONE ARTIFACT READ, not a live query. Everything here is already in
+ * `/metagraph/subnets.json`, which the badge routes read for the same reason:
+ * a card is a picture of published state, and giving it its own query path
+ * would make an unfurl more expensive than the page it advertises.
+ *
+ * Returns null when the subnet is not in the index. A card for a subnet we
+ * have nothing to say about should be the branded fallback, not a card with
+ * three dashes on it.
+ */
+export function subnetFacts(
+  index: unknown,
+  netuid: number,
+): EntityCardFacts | null {
+  const list = (index as { subnets?: Array<Record<string, unknown>> })?.subnets;
+  if (!Array.isArray(list)) return null;
+  const row = list.find((entry) => Number(entry?.netuid) === netuid);
+  if (!row) return null;
+  const name = typeof row.name === "string" && row.name ? row.name : null;
+  const stats: { label: string; value: string }[] = [];
+  // Only facts that are actually present. `absent is null, never zero` is the
+  // contract everywhere else in this API, and a card is not exempt: a subnet
+  // with no measured readiness must not show "0/100".
+  if (typeof row.integration_readiness === "number") {
+    stats.push({
+      label: "Readiness",
+      value: `${row.integration_readiness}/100`,
+    });
+  }
+  if (typeof row.surface_count === "number") {
+    stats.push({ label: "Surfaces", value: String(row.surface_count) });
+  }
+  if (typeof row.coverage_level === "string" && row.coverage_level) {
+    stats.push({ label: "Coverage", value: row.coverage_level });
+  }
+  return {
+    kind: `Bittensor subnet ${netuid}`,
+    title: name ?? `Subnet ${netuid}`,
+    stats,
+  };
+}
+
+/** An account card names the address and nothing it cannot stand behind. The
+ * ss58 is truncated because 48 characters at card size is unreadable, and the
+ * full value is in the URL the card is attached to. */
+export function accountFacts(ss58: string): EntityCardFacts {
+  return {
+    kind: "Bittensor account",
+    title: `${ss58.slice(0, 6)}…${ss58.slice(-6)}`,
+    stats: [{ label: "Address", value: `${ss58.slice(0, 12)}…` }],
+  };
+}
+
+/**
+ * GET /og/subnets/{netuid}.png and /og/accounts/{ss58}.png.
+ *
+ * Returns null when the path is not an entity card, so the caller's dispatch
+ * continues. Never throws and never 5xxes: every failure lands on the branded
+ * fallback, because the caller is a social crawler that will cache whatever it
+ * gets and will not come back to check.
+ */
+export async function handleEntityOgImage(
+  request: Request,
+  env: ArtifactEnv,
+  url: URL,
+  deps: EntityCardDeps = {},
+): Promise<Response | null> {
+  const target = matchEntityCard(url.pathname);
+  if (!target) return null;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { allow: "GET, HEAD" },
+    });
+  }
+  const assets =
+    deps.assets !== undefined ? deps.assets : (env?.ASSETS ?? null);
+
+  let facts: EntityCardFacts | null = null;
+  try {
+    if (target.kind === "accounts") {
+      facts = accountFacts(target.subject);
+    } else if (typeof deps.readArtifact === "function") {
+      const index = await deps.readArtifact(env, "/metagraph/subnets.json");
+      facts = index?.ok
+        ? subnetFacts(index.data, Number(target.subject))
+        : null;
+    }
+  } catch (error) {
+    console.error("og-entity: facts unavailable", error);
+    facts = null;
+  }
+  if (!facts) return fallbackResponse(assets, url);
+
+  const key = cardKey(target.kind, target.subject, factsDigest(facts));
+
+  // The cached render, if this exact card has been drawn before.
+  try {
+    const cached = await deps.readCard?.(key);
+    if (cached) {
+      return request.method === "HEAD"
+        ? new Response(null, {
+            headers: imageHeaders(undefined, CACHE_CONTROL),
+          })
+        : new Response(cached, {
+            headers: imageHeaders(undefined, CACHE_CONTROL),
+          });
+    }
+  } catch (error) {
+    console.error("og-entity: cache read failed", error);
+  }
+
+  if (request.method === "HEAD") {
+    return new Response(null, {
+      headers: imageHeaders(undefined, CACHE_CONTROL),
+    });
+  }
+
+  let png: ArrayBuffer;
+  try {
+    png = deps.render
+      ? await deps.render(renderEntityMarkup(facts))
+      : await renderPng(renderEntityMarkup(facts));
+  } catch (error) {
+    console.error("og-entity: render failed", error);
+    return fallbackResponse(assets, url);
+  }
+
+  // Written AFTER the response is known good, and a write failure is not the
+  // caller's problem -- they already have the image.
+  try {
+    await deps.writeCard?.(key, png);
+  } catch (error) {
+    console.error("og-entity: cache write failed", error);
+  }
+  return new Response(png, { headers: imageHeaders(undefined, CACHE_CONTROL) });
+}
+
+/**
+ * The render itself.
+ *
+ * IMPORTED HERE, INSIDE THE FUNCTION, and never at module scope -- see this
+ * file's header for the measurement. A static import would instantiate the
+ * wasm during startup, which is the failure mode that has broken this Worker's
+ * deploys four times.
+ */
+async function renderPng(markup: string): Promise<ArrayBuffer> {
+  const { ImageResponse } = await import("workers-og");
+  const response = new ImageResponse(markup, {
+    width: WIDTH,
+    height: HEIGHT,
+  });
+  return await response.arrayBuffer();
+}

--- a/src/og-image.ts
+++ b/src/og-image.ts
@@ -26,9 +26,9 @@ import type { R2ObjectReadResult } from "../workers/storage.ts";
 // Brand palette (brand kit BRAND.md): Mint accent on an Ink surface; Ink-text
 // reads AAA on mint. The landing page currently ships the static mint OG banner,
 // so this dynamic card keeps the same mint-on-ink identity.
-const MINT = "#30FFC0";
-const INK = "#0B1F1A";
-const INK_TEXT = "#08110E";
+export const MINT = "#30FFC0";
+export const INK = "#0B1F1A";
+export const INK_TEXT = "#08110E";
 
 const OG_PATHS = new Set(["/og.png", "/og"]);
 // Stats refresh on the data publish; an hour of edge cache + a long
@@ -43,12 +43,12 @@ const FALLBACK_ASSET_PATH = "/brand/og-fallback.png";
 // Bump on any visual change to the card. It's part of the edge-cache key, so a
 // new version renders fresh on the next deploy instead of serving the previous
 // design from cache for up to an hour.
-const CARD_VERSION = "2";
+export const CARD_VERSION = "2";
 // The R2 artifact scripts/refresh-og-image.ts publishes the rendered card to,
 // read tier-aware (latest-prefix + timeout guard) via readR2Object -- same
 // convention as every other /metagraph/* artifact.
 export const OG_IMAGE_ARTIFACT_PATH = "/metagraph/og-image.png";
-const WORDMARK = "Metagraphed";
+export const WORDMARK = "Metagraphed";
 const TAGLINE = "The Bittensor subnet integration registry";
 // Shown in the stat row only when registry-summary is cold (rare, transient).
 // ASCII-only on purpose — see the glyph note in handleOgImage.
@@ -59,10 +59,10 @@ const FALLBACK_STAT = "Live health, schemas, and discovery for every subnet";
 // <img> rather than inline <svg> for reliable satori rasterization. The wordmark
 // beside it is live text in Space Grotesk Bold, so the lockup matches the brand
 // banner exactly without embedding the wordmark paths.
-const LOGO_DATA_URI =
+export const LOGO_DATA_URI =
   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgZmlsbD0ibm9uZSI+CjxwYXRoIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgxLjkyMCwxNTEuNzM4KSBzY2FsZSgwLjQ2NTQ1KSIgZD0iTSAzMTUuNSwxLjE5OTk5OTk5OTk5OTk4ODYgQyAzMTMuNDAwMDAwMDAwMDAwMDMsMS42OTk5OTk5OTk5OTk5ODg2IDI4MS43LDMyLjc5OTk5OTk5OTk5OTk1NSAyMDYuNSwxMDcuODk5OTk5OTk5OTk5OTggQyAxNDYuNSwxNjcuODk5OTk5OTk5OTk5OTggOTkuMzAwMDAwMDAwMDAwMDEsMjE0LjM5OTk5OTk5OTk5OTk4IDk3LjcsMjE1LjAgQyA5NS45LDIxNS42IDc5LjQsMjE2LjAgNTIuMzAwMDAwMDAwMDAwMDA0LDIxNi4wIEMgMTEuNCwyMTYuMCA5LjYwMDAwMDAwMDAwMDAwMSwyMTYuMSA2LjUsMjE4LjAgQyAtMC40LDIyMi4yOTk5OTk5OTk5OTk5OCAwLjAsMjE1Ljc5OTk5OTk5OTk5OTk4IDAuMCwzMjguNyBDIDAuMCw0MjguNSAwLjAsNDMwLjYgMi4wLDQzMy44IEMgNi4wLDQ0MC4zIDEyLjksNDQyLjUgMTkuNSw0MzkuNCBDIDIxLjMsNDM4LjYgNzAuOSwzODkuNCAxMzAuNiwzMjkuMyBDIDIyMy45LDIzNS41IDIzOS4yMDAwMDAwMDAwMDAwMiwyMjAuMzk5OTk5OTk5OTk5OTggMjQzLjgsMjE4LjM5OTk5OTk5OTk5OTk4IEMgMjQ5LjAsMjE2LjAgMjQ5LjUsMjE2LjAgMjgxLjgsMjE2LjAgQyAzMTIuNDAwMDAwMDAwMDAwMDMsMjE2LjAgMzE0LjcwMDAwMDAwMDAwMDA1LDIxNi4xIDMxNy43MDAwMDAwMDAwMDAwNSwyMTguMCBDIDMxOS40MDAwMDAwMDAwMDAwMywyMTkuMCAzMjEuNSwyMjAuODk5OTk5OTk5OTk5OTggMzIyLjIwMDAwMDAwMDAwMDA1LDIyMi4yIEMgMzIzLjIwMDAwMDAwMDAwMDA1LDIyNC4wIDMyMy42LDI0NS4xIDMyNC4wLDMyOC4wIEwgMzI0LjUsNDMxLjUgTCAzMjYuOCw0MzQuOCBDIDMzMS4wLDQ0MC42IDMzOC4xLDQ0Mi42IDM0My44LDQzOS42IEMgMzQ1LjMsNDM4LjggMzk1LjgsMzg4LjggNDU2LjAsMzI4LjUgQyA1MTYuMiwyNjguMiA1NjYuNywyMTguMiA1NjguMiwyMTcuMzk5OTk5OTk5OTk5OTggQyA1NzAuNCwyMTYuMjk5OTk5OTk5OTk5OTggNTc3LjMwMDAwMDAwMDAwMDEsMjE2LjAgNjA1LjIsMjE2LjAgQyA2MzcuNDAwMDAwMDAwMDAwMSwyMTYuMCA2MzkuNywyMTYuMSA2NDIuNywyMTguMCBDIDY0NC40MDAwMDAwMDAwMDAxLDIxOS4wIDY0Ni41LDIyMC44OTk5OTk5OTk5OTk5OCA2NDcuMiwyMjIuMiBDIDY0OC4yLDIyNC4wIDY0OC42LDI0NS43IDY0OS4wLDMzMS43IEMgNjQ5LjUsNDM4LjEgNjQ5LjUsNDM4LjkgNjUxLjYsNDQxLjcgQyA2NTQuODAwMDAwMDAwMDAwMSw0NDYuMSA2NTkuNyw0NDguMiA2NjUuMCw0NDcuNSBDIDY2OS40MDAwMDAwMDAwMDAxLDQ0Ny4wIDY3MC42LDQ0NS45IDcwNy4zMDAwMDAwMDAwMDAxLDQwOS4yIEMgNzI4LjEsMzg4LjUgNzQ1LjgwMDAwMDAwMDAwMDEsMzcwLjMgNzQ2LjYsMzY4LjggQyA3NDcuODAwMDAwMDAwMDAwMSwzNjYuNSA3NDguMCwzNTQuOSA3NDguMCwyOTUuNzk5OTk5OTk5OTk5OTUgQyA3NDguMCwyMjguMCA3NDcuOTAwMDAwMDAwMDAwMSwyMjUuMzk5OTk5OTk5OTk5OTggNzQ2LjAsMjIyLjI5OTk5OTk5OTk5OTk4IEMgNzQyLjUsMjE2LjUgNzQyLjYsMjE2LjUgNzAzLjMwMDAwMDAwMDAwMDEsMjE2LjAgQyA2NjguNywyMTUuNSA2NjcuMCwyMTUuMzk5OTk5OTk5OTk5OTggNjY0LjMwMDAwMDAwMDAwMDEsMjEzLjM5OTk5OTk5OTk5OTk4IEMgNjYyLjgwMDAwMDAwMDAwMDEsMjEyLjI5OTk5OTk5OTk5OTk4IDY2MC43LDIwOS43OTk5OTk5OTk5OTk5OCA2NTkuODAwMDAwMDAwMDAwMSwyMDcuODk5OTk5OTk5OTk5OTggQyA2NTguMSwyMDQuNyA2NTguMCwxOTcuODk5OTk5OTk5OTk5OTggNjU4LjAsMTA3Ljc5OTk5OTk5OTk5OTk1IEMgNjU4LjAsLTAuNzAwMDAwMDAwMDAwMDQ1NSA2NTguNDAwMDAwMDAwMDAwMSw1Ljc5OTk5OTk5OTk5OTk1NDUgNjUwLjgwMDAwMDAwMDAwMDEsMS44OTk5OTk5OTk5OTk5NzczIEMgNjQ2LjYsLTAuMjAwMDAwMDAwMDAwMDQ1NDcgNjQzLjQwMDAwMDAwMDAwMDEsLTAuNSA2MzkuMzAwMDAwMDAwMDAwMSwxLjA5OTk5OTk5OTk5OTk2NiBDIDYzNy43LDEuNjk5OTk5OTk5OTk5OTg4NiA1OTAuMiw0OC41OTk5OTk5OTk5OTk5NjYgNTI5LjksMTA5LjA5OTk5OTk5OTk5OTk3IEwgNDIzLjMsMjE2LjEgTCAzODIuNzAwMDAwMDAwMDAwMDUsMjE1Ljc5OTk5OTk5OTk5OTk4IEMgMzQzLjUsMjE1LjUgMzQyLjEsMjE1LjM5OTk5OTk5OTk5OTk4IDMzOS4zLDIxMy4zOTk5OTk5OTk5OTk5OCBDIDMzNy44LDIxMi4yOTk5OTk5OTk5OTk5OCAzMzUuNzAwMDAwMDAwMDAwMDUsMjA5Ljc5OTk5OTk5OTk5OTk4IDMzNC44LDIwNy44OTk5OTk5OTk5OTk5OCBDIDMzMy4xLDIwNC43IDMzMy4wLDE5Ny44OTk5OTk5OTk5OTk5OCAzMzMuMCwxMDcuNjk5OTk5OTk5OTk5OTkgQyAzMzMuMCw0LjA5OTk5OTk5OTk5OTk2NiAzMzMuMjAwMDAwMDAwMDAwMDUsOC4xOTk5OTk5OTk5OTk5ODg5IDMyOC4xLDMuNTk5OTk5OTk5OTk5OTY2IEMgMzI1LjYsMS4yOTk5OTk5OTk5OTk5NTQ1IDMxOS41LDAuMDk5OTk5OTk5OTk5OTk2NTkgMzE1LjUsMS4xOTk5OTk5OTk5OTk5ODg2IiBmaWxsPSIjMDgxMTBFIi8+Cjwvc3ZnPgo=";
 
-function imageHeaders(
+export function imageHeaders(
   extra?: HeadersInit,
   cacheControl: string = CACHE_CONTROL,
 ): Headers {
@@ -76,8 +76,16 @@ function imageHeaders(
 // workers-og/font/satori failures) at 200 with a short cache; the caller never
 // edge-caches it. If the asset is gone too, 503 no-store so crawlers fall back
 // to the page meta tags instead of caching a blank.
-async function fallbackResponse(
-  assets: Fetcher | null,
+/** The minimum this needs: something that can fetch a Request. Declared
+ * structurally rather than as `Fetcher` because the ASSETS binding is surfaced
+ * with different widths by `Env` and by `ArtifactEnv`, and demanding the wider
+ * one here would force a cast at one of the two call sites. */
+export interface AssetFetcher {
+  fetch(request: Request): Promise<Response>;
+}
+
+export async function fallbackResponse(
+  assets: AssetFetcher | null,
   url: URL,
 ): Promise<Response> {
   if (assets?.fetch) {

--- a/tests/og-entity-card.test.ts
+++ b/tests/og-entity-card.test.ts
@@ -1,0 +1,375 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import { mockEnv } from "./row-type.ts";
+import {
+  accountFacts,
+  r2CardCache,
+  cardKey,
+  factsDigest,
+  handleEntityOgImage,
+  matchEntityCard,
+  renderEntityMarkup,
+  subnetFacts,
+} from "../src/og-entity-card.ts";
+
+const INDEX = {
+  subnets: [
+    {
+      netuid: 64,
+      name: "Chutes",
+      integration_readiness: 96,
+      surface_count: 76,
+      coverage_level: "deep",
+    },
+    { netuid: 7, name: "Nameless" },
+  ],
+};
+
+const OK_ARTIFACT = async () => ({ ok: true, data: INDEX });
+const PNG = new Uint8Array([137, 80, 78, 71]).buffer;
+
+describe("which paths are entity cards", () => {
+  test("subnet and account paths match", () => {
+    assert.deepEqual(matchEntityCard("/og/subnets/64.png"), {
+      kind: "subnets",
+      subject: "64",
+    });
+    const ss58 = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+    assert.deepEqual(matchEntityCard(`/og/accounts/${ss58}.png`), {
+      kind: "accounts",
+      subject: ss58,
+    });
+  });
+
+  test("a netuid outside the u16 range is not a subnet", () => {
+    // The rest of this API enforces 0..65535. A path outside it is not a card
+    // with no data, it is not a subnet -- so it must fall through to the
+    // caller's dispatch rather than render a fallback under a subnet URL.
+    assert.equal(matchEntityCard("/og/subnets/70000.png"), null);
+  });
+
+  test("the landing card and unrelated paths are left alone", () => {
+    assert.equal(matchEntityCard("/og.png"), null);
+    assert.equal(matchEntityCard("/og"), null);
+    assert.equal(matchEntityCard("/api/v1/subnets/64"), null);
+    assert.equal(matchEntityCard("/og/subnets/64.jpg"), null);
+  });
+
+  test("a malformed ss58 is not an account", () => {
+    assert.equal(matchEntityCard("/og/accounts/not-an-address.png"), null);
+    // 0, O, I and l are not in the ss58 alphabet.
+    assert.equal(matchEntityCard(`/og/accounts/${"0".repeat(48)}.png`), null);
+  });
+});
+
+describe("the facts a card draws", () => {
+  test("a subnet's published facts, and only the ones it has", () => {
+    const facts = subnetFacts(INDEX, 64);
+    assert.equal(facts?.title, "Chutes");
+    assert.equal(facts?.kind, "Bittensor subnet 64");
+    assert.deepEqual(
+      facts?.stats.map((s) => s.label),
+      ["Readiness", "Surfaces", "Coverage"],
+    );
+  });
+
+  test("absent is ABSENT, never zero", () => {
+    // Subnet 7 has a name and nothing else. `absent is null, never zero` is the
+    // contract everywhere in this API and a card is not exempt: showing
+    // "0/100" for an unmeasured readiness would be a claim we cannot support.
+    const facts = subnetFacts(INDEX, 7);
+    assert.equal(facts?.title, "Nameless");
+    assert.deepEqual(facts?.stats, []);
+  });
+
+  test("a subnet not in the index has no card", () => {
+    // Not a card with dashes on it -- the branded fallback, which says nothing
+    // rather than saying nothing convincingly.
+    assert.equal(subnetFacts(INDEX, 999), null);
+    assert.equal(subnetFacts({}, 64), null);
+    assert.equal(subnetFacts(null, 64), null);
+  });
+
+  test("an account card names the address it can stand behind", () => {
+    const ss58 = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+    const facts = accountFacts(ss58);
+    assert.ok(facts.title.startsWith("5F4tQy"));
+    assert.ok(facts.title.endsWith("uyHbZAc3".slice(-6)));
+  });
+});
+
+describe("the cache key", () => {
+  test("the digest changes when a drawn value changes", () => {
+    const a = subnetFacts(INDEX, 64);
+    const b = subnetFacts(
+      { subnets: [{ ...INDEX.subnets[0], integration_readiness: 95 }] },
+      64,
+    );
+    assert.notEqual(factsDigest(a!), factsDigest(b!));
+  });
+
+  test("the digest is stable when nothing drawn changed", () => {
+    // A publish that changes fields the card does not draw must re-use the
+    // cached PNG rather than re-render an identical image.
+    const a = subnetFacts(INDEX, 64);
+    const b = subnetFacts(
+      { subnets: [{ ...INDEX.subnets[0], description: "different" }] },
+      64,
+    );
+    assert.equal(factsDigest(a!), factsDigest(b!));
+  });
+
+  test("the key lives under cache/, not under the artifact prefix", () => {
+    // Objects under `metagraph/` are owned by the publish, which reconciles
+    // what it finds against what it built; a render this Worker wrote would
+    // look like drift to it.
+    const key = cardKey("subnets", "64", "abcd1234");
+    assert.ok(key.startsWith("cache/og/"));
+    assert.ok(!key.includes("metagraph/"));
+    assert.ok(key.includes("abcd1234"), "the digest is in the key");
+  });
+});
+
+describe("the markup", () => {
+  test("a third-party subnet name is escaped", () => {
+    // Subnet names are registry data a third party controls, and satori parses
+    // this as markup.
+    const markup = renderEntityMarkup({
+      kind: "Bittensor subnet 1",
+      title: '<script>alert("x")</script>',
+      stats: [{ label: "<b>", value: "&" }],
+    });
+    assert.ok(!markup.includes("<script>"));
+    assert.ok(markup.includes("&lt;script&gt;"));
+    assert.ok(markup.includes("&amp;"));
+  });
+
+  test("at most three stats are drawn", () => {
+    const markup = renderEntityMarkup({
+      kind: "k",
+      title: "t",
+      stats: [1, 2, 3, 4, 5].map((n) => ({ label: `L${n}`, value: `${n}` })),
+    });
+    assert.ok(markup.includes("L3"));
+    assert.ok(!markup.includes("L4"), "a fourth stat would overflow the card");
+  });
+});
+
+describe("the handler never fails a crawler", () => {
+  const url = (p: string) => new URL(`https://api.metagraph.sh${p}`);
+  const assets = {
+    fetch: async () => new Response("png", { status: 200 }),
+  };
+
+  test("a path that is not a card returns null so dispatch continues", async () => {
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og.png"),
+      {},
+      url("/og.png"),
+      { assets },
+    );
+    assert.equal(res, null);
+  });
+
+  test("a render failure falls back, and does NOT 5xx", async () => {
+    // A social crawler does not retry and caches what it gets, so a 5xx is a
+    // link that unfurls blank for as long as the crawler holds it.
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: OK_ARTIFACT,
+        render: async () => {
+          throw new Error("wasm exploded");
+        },
+      },
+    );
+    assert.equal(res?.status, 200);
+  });
+
+  test("an artifact read failure falls back", async () => {
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: async () => {
+          throw new Error("r2 down");
+        },
+      },
+    );
+    assert.equal(res?.status, 200);
+  });
+
+  test("a cache-read failure still renders rather than failing", async () => {
+    let rendered = false;
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: OK_ARTIFACT,
+        readCard: async () => {
+          throw new Error("cache unreadable");
+        },
+        render: async () => {
+          rendered = true;
+          return PNG;
+        },
+      },
+    );
+    assert.equal(res?.status, 200);
+    assert.ok(rendered, "an unreadable cache must not stop the render");
+  });
+
+  test("a cache-WRITE failure does not fail the response the caller already has", async () => {
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: OK_ARTIFACT,
+        render: async () => PNG,
+        writeCard: async () => {
+          throw new Error("bucket full");
+        },
+      },
+    );
+    assert.equal(res?.status, 200);
+  });
+
+  test("a cached card is served without rendering", async () => {
+    let rendered = 0;
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: OK_ARTIFACT,
+        readCard: async () => PNG,
+        render: async () => {
+          rendered += 1;
+          return PNG;
+        },
+      },
+    );
+    assert.equal(res?.status, 200);
+    assert.equal(rendered, 0, "cached per entity, not rendered per request");
+  });
+
+  test("the render result is written under the digest key", async () => {
+    const written: string[] = [];
+    await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: OK_ARTIFACT,
+        render: async () => PNG,
+        writeCard: async (key) => {
+          written.push(key);
+        },
+      },
+    );
+    assert.equal(written.length, 1);
+    assert.ok(written[0].startsWith("cache/og/subnets/64-"));
+  });
+
+  test("a non-GET method is rejected before any work", async () => {
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png", {
+        method: "POST",
+      }),
+      {},
+      url("/og/subnets/64.png"),
+      { assets },
+    );
+    assert.equal(res?.status, 405);
+  });
+});
+
+describe("the R2 cache accessors", () => {
+  test("no binding is a MISS, not an error", async () => {
+    // A throw here would take an unfurl down over a cache that was never
+    // configured -- the card should simply render uncached.
+    const { readCard } = r2CardCache({});
+    assert.equal(await readCard!("cache/og/subnets/64-abc.png"), null);
+  });
+
+  test("an absent object is a miss", async () => {
+    const { readCard } = r2CardCache({
+      METAGRAPH_ARCHIVE: { get: async () => null },
+    });
+    assert.equal(await readCard!("cache/og/subnets/64-abc.png"), null);
+  });
+
+  test("a present object is read to completion", async () => {
+    const bytes = new Uint8Array([1, 2, 3]).buffer;
+    const { readCard } = r2CardCache({
+      METAGRAPH_ARCHIVE: {
+        get: async () => ({ arrayBuffer: async () => bytes }),
+      },
+    });
+    assert.equal(await readCard!("cache/og/subnets/64-abc.png"), bytes);
+  });
+
+  test("the write carries the content type, so R2 serves it as an image", async () => {
+    const seen: { key?: string; type?: string } = {};
+    const { writeCard } = r2CardCache({
+      METAGRAPH_ARCHIVE: {
+        put: async (key, _body, options) => {
+          seen.key = key;
+          seen.type = options?.httpMetadata?.contentType;
+        },
+      },
+    });
+    await writeCard!("cache/og/subnets/64-abc.png", new Uint8Array([1]).buffer);
+    assert.equal(seen.key, "cache/og/subnets/64-abc.png");
+    assert.equal(seen.type, "image/png");
+  });
+
+  test("writing with no binding is a no-op rather than a throw", async () => {
+    const { writeCard } = r2CardCache({});
+    await writeCard!("k", new Uint8Array([1]).buffer);
+  });
+});
+
+describe("the route, through the worker's own dispatch", () => {
+  test("an entity-card path is served rather than falling through to 404", async () => {
+    // The dispatch branch itself: a card path must return the card's response
+    // and stop, not continue into the artifact/404 handling below it. Driven
+    // down the FALLBACK path (no archive binding, no registry artifact) so this
+    // asserts the routing without instantiating the wasm renderer.
+    const env = mockEnv({
+      ASSETS: {
+        fetch: async () =>
+          new Response(new Uint8Array([137, 80, 78, 71]), { status: 200 }),
+      },
+    });
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      env as never,
+      { waitUntil: () => {} } as never,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "image/png");
+  });
+
+  test("a path that only looks like one falls through to normal routing", async () => {
+    const env = mockEnv({});
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/og/subnets/notanumber.png"),
+      env as never,
+      { waitUntil: () => {} } as never,
+    );
+    assert.notEqual(res.headers.get("content-type"), "image/png");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -611,6 +611,7 @@ import {
 } from "../src/feeds.ts";
 import { handleBadgeRequest } from "../src/badge.ts";
 import { handleOgImage } from "../src/og-image.ts";
+import { handleEntityOgImage, r2CardCache } from "../src/og-entity-card.ts";
 import { handleIconProxy } from "../src/icon-proxy.ts";
 import { maskRouteParams } from "../src/route-label.ts";
 import { sampleEmissionGateWithFailover } from "../src/emission-gate-sampler.ts";
@@ -6689,6 +6690,21 @@ async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {
   // src/og-image.ts's own header for the full rationale.
   if (url.pathname === "/og.png" || url.pathname === "/og") {
     return handleOgImage(request, env, url, { readR2Object });
+  }
+
+  // Per-entity cards (#11075): /og/subnets/{netuid}.png, /og/accounts/{ss58}.png.
+  // Unlike the landing card above these ARE rendered here, because the argument
+  // that moved that one out does not apply: its key was constant so it
+  // re-rendered an unchanged image, where an entity card differs by
+  // construction and is cached under a digest of its own facts. The wasm is
+  // imported inside the handler and its startup cost was measured -- see
+  // src/og-entity-card.ts's header.
+  {
+    const entityCard = await handleEntityOgImage(request, env, url, {
+      readArtifact,
+      ...r2CardCache(env),
+    });
+    if (entityCard) return entityCard;
   }
 
   // Brand-icon favicon proxy (binary, not a JSON contract route). Implements the


### PR DESCRIPTION
`/og/subnets/{netuid}.png` and `/og/accounts/{ss58}.png`, drawn from the published registry index. Until now every link to any page unfurled the same landing card.

![subnet card](https://github.com/user-attachments/assets/og-preview)

*(Rendered locally during development: netuid 64 → "Chutes", Readiness 96/100, Surfaces 76, Coverage deep, on the mint brand card.)*

## The bundle argument is dead, and this does not rest on it

#6502 moved the render out because workers-og's wasm is ~545 KiB gzipped and the bundler ships every reachable import. Measured 2026-08-11 this Worker is 944.8 KiB against a 10 MB limit — ~545 KiB more is ~14.5% of it.

## The argument that *is* live is startup CPU, and I measured it

This Worker has failed to deploy **four times** with `code: 10021 Script startup exceeded CPU time limit`, always from work at module scope, and wasm instantiation is exactly that shape. `wrangler versions upload` reports startup time **without routing traffic**, so it can be sampled safely:

| | samples | median |
| --- | --- | ---: |
| baseline (no import) | 319 315 321 283 314 301 307 326 | **313 ms** |
| a bare dynamic import | 362 549 315 313 281 312 297 321 | **313 ms** |
| this feature | 328 354 331 303 332 | **331 ms** |

Identical medians for the import alone — the module is not evaluated until the handler runs. The feature adds ~18 ms of module init, leaving **~69 ms against the ~400 ms limit**.

Both sets carry outliers because the platform validates on a shared host, which is the same reason those four deploys failed *non-deterministically*. That is a property of the 313 ms baseline, not of this change. And a version that exceeds the limit fails at upload and never takes traffic — the failure mode is a failed deploy, not an outage.

I nearly called this feature unshippable on 3 samples vs 3, where one 549 ms outlier looked like signal. It wasn't; the control had the same tail once sampled equally.

## Cached per entity, under a digest of its own facts

A data change is a **new key** rather than an invalidation, so a stale card and a fresh one never share a name — and a publish that changes nothing drawn re-uses the PNG. That is the difference from the landing card, whose constant key made it re-render an unchanged image on every miss.

Keys live under `cache/`, **not** `metagraph/`: objects under the artifact prefix are owned by the publish, which reconciles what it finds against what it built, and a render this Worker wrote would look like drift to it.

## A render failure is never a 5xx

Social crawlers do not retry and cache what they get. Every failure path — absent facts, unreadable cache, wasm error, failed cache write — falls back to the branded static card in ASSETS, a *different subsystem* from the one that failed. Six tests cover those paths individually.

## Contract discipline

`absent is null, never zero`: a subnet with no measured readiness shows no readiness stat, never `0/100`. Subnet names are third-party strings and satori parses the markup, so they are escaped — a test asserts a `<script>` title comes out inert.

## Verified end to end

The markup rasterises through the same satori + resvg path `scripts/refresh-og-image.ts` uses, producing a valid **1200×630 PNG (33.8 kB)**. I checked the image, not just the exit code.

## Acceptance

- [x] Startup CPU measured before and after; margin recorded (69 ms)
- [x] Per-entity cards for subnets and accounts
- [x] A render failure falls back to the static card; no 5xx on any crawler path
- [x] Cards cached per entity in R2, not rendered per request
- [x] No container involved

Full suite 960 files / 22,089 passed, build, lint, format, all 72 CI validators, patch coverage 100%.

Closes #11075