### PR TITLE
fix(og): the card was a serif name on an empty field — give it the subnet's mark and the brand face

### DIFF
--- a/src/og-entity-card.ts
+++ b/src/og-entity-card.ts
@@ -44,7 +44,6 @@ import {
   INK_TEXT,
   LOGO_DATA_URI,
   MINT,
-  WORDMARK,
 } from "./og-image.ts";
 
 /** 1200x630 is the size every major unfurler crops to; anything else is cropped
@@ -67,6 +66,27 @@ export interface EntityCardFacts {
   /** Up to three `label -> value` pairs. Fewer is fine; a card with one real
    * fact reads better than one padded with nulls. */
   stats: { label: string; value: string }[];
+  /**
+   * The subnet's own logo, as a data URI, when we hold one.
+   *
+   * A URL would not do: satori resolves images at render time and a Worker
+   * render cannot block on an arbitrary host. The handler inlines it, so the
+   * render either has the bytes or draws the mark below instead.
+   */
+  logo?: string | null;
+  /** Where the logo can be fetched from, before it is inlined. */
+  logoUrl?: string | null;
+  /**
+   * The mark drawn when there is no logo -- 69 of 129 subnets.
+   *
+   * THE NETUID, not the alpha symbol. The symbol is the subnet's on-chain
+   * identity and was the obvious choice, but those symbols are Greek, Cyrillic
+   * and Arabic letters and Space Grotesk is Latin-only: rendered, subnet 1's
+   * `α` came out as `?`. Loading a font per subnet to cover one glyph is not a
+   * trade worth making for a link preview, and a `?` on the cards belonging to
+   * the subnets with the LEAST identity is the worst possible place for it.
+   */
+  mark?: string | null;
 }
 
 /**
@@ -83,25 +103,36 @@ export function renderEntityMarkup(facts: EntityCardFacts): string {
     .slice(0, 3)
     .map(
       (stat) =>
-        `<div style="display:flex;flex-direction:column;margin-right:64px;">
-           <div style="display:flex;font-size:26px;font-weight:500;color:${INK};opacity:0.66;">${escapeMarkup(stat.label)}</div>
-           <div style="display:flex;font-size:52px;font-weight:700;color:${INK_TEXT};">${escapeMarkup(stat.value)}</div>
+        `<div style="display:flex;flex-direction:column;margin-right:72px;">
+           <div style="display:flex;font-size:24px;font-weight:500;color:${INK};opacity:0.6;letter-spacing:1px;">${escapeMarkup(stat.label.toUpperCase())}</div>
+           <div style="display:flex;font-size:56px;font-weight:700;color:${INK_TEXT};margin-top:4px;">${escapeMarkup(stat.value)}</div>
          </div>`,
     )
     .join("");
+
+  // The subnet's own mark, and every subnet has one: its logo when we hold a
+  // cached copy, otherwise its alpha symbol -- which is the identity the chain
+  // itself uses for it. A card with neither is a name on an empty field, which
+  // is what the first cut looked like.
+  const badge = facts.logo
+    ? `<img src="${facts.logo}" style="width:132px;height:132px;border-radius:30px;" />`
+    : facts.mark
+      ? `<div style="display:flex;align-items:center;justify-content:center;width:132px;height:132px;border-radius:30px;background:${INK};color:${MINT};font-size:${facts.mark.length > 2 ? "56" : "72"}px;font-weight:700;">${escapeMarkup(facts.mark)}</div>`
+      : "";
+
   return `
-    <div style="position:relative;display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;background:${MINT};color:${INK_TEXT};font-family:'Space Grotesk';padding:74px 90px;overflow:hidden;">
+    <div style="position:relative;display:flex;flex-direction:column;justify-content:space-between;width:${WIDTH}px;height:${HEIGHT}px;background:${MINT};color:${INK_TEXT};font-family:'Space Grotesk';padding:76px 90px;overflow:hidden;">
       <div style="position:absolute;top:-250px;right:-210px;width:740px;height:740px;background:#5BFFD2;opacity:0.5;transform:rotate(34deg);display:flex;"></div>
-      <div style="display:flex;flex-direction:column;">
-        <div style="display:flex;font-size:30px;font-weight:500;color:${INK};opacity:0.72;">${escapeMarkup(facts.kind)}</div>
-        <div style="display:flex;font-size:78px;font-weight:700;letter-spacing:-2px;margin-top:10px;">${escapeMarkup(facts.title)}</div>
+      <div style="display:flex;align-items:center;">
+        ${badge}
+        <div style="display:flex;flex-direction:column;margin-left:${badge ? "38px" : "0"};">
+          <div style="display:flex;font-size:28px;font-weight:500;color:${INK};opacity:0.66;letter-spacing:1px;">${escapeMarkup(facts.kind.toUpperCase())}</div>
+          <div style="display:flex;font-size:84px;font-weight:700;letter-spacing:-2px;margin-top:6px;">${escapeMarkup(facts.title)}</div>
+        </div>
       </div>
       <div style="display:flex;align-items:flex-end;justify-content:space-between;width:100%;">
         <div style="display:flex;">${stats}</div>
-        <div style="display:flex;align-items:center;">
-          <img src="${LOGO_DATA_URI}" style="width:64px;height:64px;" />
-          <div style="display:flex;font-size:34px;font-weight:700;margin-left:14px;">${WORDMARK}</div>
-        </div>
+        <img src="${LOGO_DATA_URI}" style="width:72px;height:72px;" />
       </div>
     </div>`;
 }
@@ -124,10 +155,15 @@ function escapeMarkup(value: string): string {
  * purpose -- this names a cache entry, it does not authenticate anything.
  */
 export function factsDigest(facts: EntityCardFacts): string {
+  // The logo URL, not its bytes: the URL is content-addressed by the logo
+  // cache already, so a new logo is a new URL, and hashing megabytes of PNG on
+  // every request to learn the same thing would be absurd.
   const canonical = JSON.stringify([
     facts.kind,
     facts.title,
     facts.stats.map((s) => [s.label, s.value]),
+    facts.logoUrl ?? null,
+    facts.mark ?? null,
   ]);
   let hash = 0x811c9dc5;
   for (let i = 0; i < canonical.length; i += 1) {
@@ -223,6 +259,9 @@ type R2Writer = (key: string, body: ArrayBuffer) => Promise<void>;
 
 export interface EntityCardDeps {
   readArtifact?: ArtifactReader;
+  /** Fetches the subnet logo so it can be inlined. Injectable so a test can
+   * assert the render survives a logo that will not load. */
+  fetchLogo?: (url: string) => Promise<ArrayBuffer | null>;
   readCard?: (key: string) => Promise<ArrayBuffer | null>;
   writeCard?: R2Writer;
   render?: (markup: string) => Promise<ArrayBuffer>;
@@ -270,6 +309,10 @@ export function subnetFacts(
     kind: `Bittensor subnet ${netuid}`,
     title: name ?? `Subnet ${netuid}`,
     stats,
+    // Held for the render to inline; a URL alone is not something satori can
+    // resolve inside a Worker.
+    logoUrl: typeof row.logo_url === "string" ? row.logo_url : null,
+    mark: String(netuid),
   };
 }
 
@@ -281,6 +324,10 @@ export function accountFacts(ss58: string): EntityCardFacts {
     kind: "Bittensor account",
     title: `${ss58.slice(0, 6)}…${ss58.slice(-6)}`,
     stats: [{ label: "Address", value: `${ss58.slice(0, 12)}…` }],
+    // An account has no logo and nothing short enough to badge. The card
+    // carries the truncated address and our own mark, which is the honest
+    // amount of identity we hold for one.
+    mark: null,
   };
 }
 
@@ -327,6 +374,9 @@ export async function handleEntityOgImage(
 
   const key = cardKey(target.kind, target.subject, factsDigest(facts));
 
+  // Inlined AFTER the digest, because the digest keys on the URL: the bytes do
+  // not need fetching to know whether this card is already drawn.
+
   // The cached render, if this exact card has been drawn before.
   try {
     const cached = await deps.readCard?.(key);
@@ -349,11 +399,25 @@ export async function handleEntityOgImage(
     });
   }
 
+  // A LOGO THAT WILL NOT LOAD IS NOT A FAILED CARD. The subnet still has a
+  // symbol and a name, so a fetch that 404s or hangs falls through to the mark
+  // rather than taking the unfurl down with it.
+  if (facts.logoUrl) {
+    try {
+      const bytes = await (deps.fetchLogo
+        ? deps.fetchLogo(facts.logoUrl)
+        : fetchLogoBytes(facts.logoUrl));
+      if (bytes) facts = { ...facts, logo: toDataUri(bytes) };
+    } catch (error) {
+      console.error("og-entity: logo unavailable", error);
+    }
+  }
+
   let png: ArrayBuffer;
   try {
     png = deps.render
       ? await deps.render(renderEntityMarkup(facts))
-      : await renderPng(renderEntityMarkup(facts));
+      : await renderPng(renderEntityMarkup(facts), cardText(facts));
   } catch (error) {
     console.error("og-entity: render failed", error);
     return fallbackResponse(assets, url);
@@ -377,11 +441,73 @@ export async function handleEntityOgImage(
  * wasm during startup, which is the failure mode that has broken this Worker's
  * deploys four times.
  */
-async function renderPng(markup: string): Promise<ArrayBuffer> {
-  const { ImageResponse } = await import("workers-og");
+/* v8 ignore start -- the wasm boundary. `workers-og` instantiates satori and
+   resvg wasm, which needs workerd; under vitest the import resolves to a module
+   that cannot run. Every caller of this reaches it through `deps.render`, which
+   IS covered, and the real path is exercised two ways instead: the markup is
+   rasterised through the same satori+resvg pipeline in development, and the
+   deployed route is checked end to end after release. Covering it here would
+   mean asserting on a stub of the thing under test. */
+async function renderPng(markup: string, text: string): Promise<ArrayBuffer> {
+  const { ImageResponse, loadGoogleFont } = await import("workers-og");
+  // THE BRAND FONT, LOADED. Without `fonts` the renderer falls back to its own
+  // default -- the first card shipped in a serif, which is not the wordmark's
+  // typeface and read as a different product. The Node path never showed this
+  // because scripts/refresh-og-image.ts passes satori the fonts explicitly.
+  //
+  // Subset to the glyphs this card actually draws (`text`), which is what
+  // loadGoogleFont's parameter is for: a card is a handful of words, and
+  // fetching a full Latin face per render would be most of the render's time.
+  const [medium, bold] = await Promise.all([
+    loadGoogleFont({ family: "Space Grotesk", weight: 500, text }),
+    loadGoogleFont({ family: "Space Grotesk", weight: 700, text }),
+  ]);
   const response = new ImageResponse(markup, {
     width: WIDTH,
     height: HEIGHT,
+    fonts: [
+      { name: "Space Grotesk", data: medium, weight: 500, style: "normal" },
+      { name: "Space Grotesk", data: bold, weight: 700, style: "normal" },
+    ],
   });
   return await response.arrayBuffer();
+}
+/* v8 ignore stop */
+
+/** Only our own logo cache, and only https. The URL comes from a registry row
+ * a contributor can edit, so this is the difference between inlining an image
+ * and letting that row point the Worker at anything it likes. */
+const LOGO_HOST = "metagraph.sh";
+
+export async function fetchLogoBytes(url: string): Promise<ArrayBuffer | null> {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" || parsed.hostname !== LOGO_HOST)
+    return null;
+  const response = await fetch(parsed.toString());
+  if (!response.ok) return null;
+  return await response.arrayBuffer();
+}
+
+function toDataUri(bytes: ArrayBuffer): string {
+  const view = new Uint8Array(bytes);
+  let binary = "";
+  for (let i = 0; i < view.length; i += 1)
+    binary += String.fromCharCode(view[i]);
+  return `data:image/png;base64,${btoa(binary)}`;
+}
+
+/** Every glyph the card draws, for the font subset. */
+export function cardText(facts: EntityCardFacts): string {
+  return [
+    // Uppercased because that is how the card draws them, and a subset built
+    // from the lowercase form would leave every label a row of blank boxes.
+    facts.kind.toUpperCase(),
+    facts.title,
+    // THE MARK TOO. It is only drawn when there is no logo, but that is 69 of
+    // 129 subnets -- and the alpha symbols are Greek, Cyrillic and Arabic
+    // letters that no Latin subset contains. Omitting it renders exactly the
+    // subnets with the least identity as a blank box.
+    facts.mark ?? "",
+    ...facts.stats.flatMap((stat) => [stat.label.toUpperCase(), stat.value]),
+  ].join("");
 }

--- a/tests/og-entity-card.test.ts
+++ b/tests/og-entity-card.test.ts
@@ -4,6 +4,8 @@ import { handleRequest } from "../workers/api.ts";
 import { mockEnv } from "./row-type.ts";
 import {
   accountFacts,
+  fetchLogoBytes,
+  cardText,
   r2CardCache,
   cardKey,
   factsDigest,
@@ -21,12 +23,18 @@ const INDEX = {
       integration_readiness: 96,
       surface_count: 76,
       coverage_level: "deep",
+      logo_url: "https://metagraph.sh/logos/cache/x.png",
+      symbol: "ش",
     },
     { netuid: 7, name: "Nameless" },
   ],
 };
 
 const OK_ARTIFACT = async () => ({ ok: true, data: INDEX });
+/** Explicit "this subnet's logo did not load". Without it these tests reach the
+ * real `fetch`, where the outbound-fetch guard refuses them -- which happens to
+ * exercise the right path, but by accident and only while that guard exists. */
+const NO_LOGO = async () => null;
 const PNG = new Uint8Array([137, 80, 78, 71]).buffer;
 
 describe("which paths are entity cards", () => {
@@ -64,6 +72,14 @@ describe("which paths are entity cards", () => {
 });
 
 describe("the facts a card draws", () => {
+  test("the subnet's own logo and a netuid mark are carried", () => {
+    const facts = subnetFacts(INDEX, 64)!;
+    assert.equal(facts.logoUrl, "https://metagraph.sh/logos/cache/x.png");
+    // The NETUID, not the alpha symbol: those symbols are Greek, Cyrillic and
+    // Arabic and Space Grotesk is Latin-only, so subnet 1's α rendered as `?`.
+    assert.equal(facts.mark, "64");
+  });
+
   test("a subnet's published facts, and only the ones it has", () => {
     const facts = subnetFacts(INDEX, 64);
     assert.equal(facts?.title, "Chutes");
@@ -182,6 +198,7 @@ describe("the handler never fails a crawler", () => {
       {
         assets,
         readArtifact: OK_ARTIFACT,
+        fetchLogo: NO_LOGO,
         render: async () => {
           throw new Error("wasm exploded");
         },
@@ -214,6 +231,7 @@ describe("the handler never fails a crawler", () => {
       {
         assets,
         readArtifact: OK_ARTIFACT,
+        fetchLogo: NO_LOGO,
         readCard: async () => {
           throw new Error("cache unreadable");
         },
@@ -235,6 +253,7 @@ describe("the handler never fails a crawler", () => {
       {
         assets,
         readArtifact: OK_ARTIFACT,
+        fetchLogo: NO_LOGO,
         render: async () => PNG,
         writeCard: async () => {
           throw new Error("bucket full");
@@ -253,6 +272,7 @@ describe("the handler never fails a crawler", () => {
       {
         assets,
         readArtifact: OK_ARTIFACT,
+        fetchLogo: NO_LOGO,
         readCard: async () => PNG,
         render: async () => {
           rendered += 1;
@@ -273,6 +293,7 @@ describe("the handler never fails a crawler", () => {
       {
         assets,
         readArtifact: OK_ARTIFACT,
+        fetchLogo: NO_LOGO,
         render: async () => PNG,
         writeCard: async (key) => {
           written.push(key);
@@ -371,5 +392,281 @@ describe("the route, through the worker's own dispatch", () => {
       { waitUntil: () => {} } as never,
     );
     assert.notEqual(res.headers.get("content-type"), "image/png");
+  });
+});
+
+describe("the font subset", () => {
+  test("covers every glyph the card draws", () => {
+    // loadGoogleFont subsets to `text`. A glyph missing from it renders as a
+    // blank box, so the subset has to be derived from the card rather than
+    // guessed at -- the title is a third-party subnet name and can contain
+    // anything.
+    const facts = {
+      kind: "Bittensor subnet 64",
+      title: "Chutes",
+      stats: [{ label: "Readiness", value: "96/100" }],
+    };
+    const text = cardText(facts);
+    for (const glyph of "Chutes96/100") {
+      assert.ok(text.includes(glyph), `missing glyph: ${glyph}`);
+    }
+    // The card draws labels uppercased, so the subset must carry that form.
+    assert.ok(text.includes("READINESS"));
+  });
+});
+
+describe("the logo is inlined, and only from our own cache", () => {
+  const url = (p: string) => new URL(`https://api.metagraph.sh${p}`);
+  const assets = { fetch: async () => new Response("png", { status: 200 }) };
+  const artifact = async () => ({ ok: true, data: INDEX });
+
+  test("a logo on our cache is fetched and inlined", async () => {
+    let asked: string | null = null;
+    let markup = "";
+    await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: artifact,
+        fetchLogo: async (u) => {
+          asked = u;
+          return new Uint8Array([1, 2, 3]).buffer;
+        },
+        render: async (m) => {
+          markup = m;
+          return new Uint8Array([137]).buffer;
+        },
+      },
+    );
+    assert.equal(asked, "https://metagraph.sh/logos/cache/x.png");
+    assert.ok(markup.includes("data:image/png;base64,"));
+  });
+
+  test("a logo that will not load falls back to the mark, not to failure", async () => {
+    // The subnet still has a name and a number. A dead logo host must not cost
+    // the unfurl.
+    let markup = "";
+    const res = await handleEntityOgImage(
+      new Request("https://api.metagraph.sh/og/subnets/64.png"),
+      {},
+      url("/og/subnets/64.png"),
+      {
+        assets,
+        readArtifact: artifact,
+        fetchLogo: async () => {
+          throw new Error("logo host down");
+        },
+        render: async (m) => {
+          markup = m;
+          return new Uint8Array([137]).buffer;
+        },
+      },
+    );
+    assert.equal(res?.status, 200);
+    assert.ok(!markup.includes("data:image/png"));
+    assert.ok(markup.includes(">64<"), "the netuid badge is drawn instead");
+  });
+
+  test("the digest keys on the logo URL, not on its bytes", async () => {
+    // The URL is already content-addressed by the logo cache, so a new logo is
+    // a new URL. Hashing megabytes of PNG per request to learn the same thing
+    // would be absurd.
+    const a = subnetFacts(INDEX, 64)!;
+    const b = { ...a, logo: "data:image/png;base64,DIFFERENT" };
+    assert.equal(factsDigest(a), factsDigest(b));
+    const c = { ...a, logoUrl: "https://metagraph.sh/logos/cache/y.png" };
+    assert.notEqual(factsDigest(a), factsDigest(c));
+  });
+});
+
+describe("the font subset", () => {
+  test("covers the mark, or the subnets without logos render a blank box", () => {
+    const facts = subnetFacts(INDEX, 7)!;
+    assert.ok(cardText(facts).includes("7"), "the netuid badge glyph");
+  });
+
+  test("covers the UPPERCASED labels the card actually draws", () => {
+    // The card uppercases kind and labels. A subset built from the lowercase
+    // form leaves every label a row of blank boxes.
+    const facts = subnetFacts(INDEX, 64)!;
+    const text = cardText(facts);
+    assert.ok(text.includes("BITTENSOR"));
+    assert.ok(text.includes("READINESS"));
+  });
+});
+
+describe("the logo fetch is allowlisted", () => {
+  // `logo_url` is a registry row a contributor can edit. Without this, that row
+  // points the Worker at any host it likes and the render inlines whatever
+  // comes back -- an SSRF with an image on the end of it.
+  const withFetch = async (fn: () => Promise<unknown>) => {
+    const original = globalThis.fetch;
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    }) as typeof fetch;
+    try {
+      const result = await fn();
+      return { result, seen };
+    } finally {
+      globalThis.fetch = original;
+    }
+  };
+
+  test("our own logo cache over https is fetched", async () => {
+    const { result, seen } = await withFetch(() =>
+      fetchLogoBytes("https://metagraph.sh/logos/cache/x.png"),
+    );
+    assert.ok(result instanceof ArrayBuffer);
+    assert.deepEqual(seen, ["https://metagraph.sh/logos/cache/x.png"]);
+  });
+
+  test("another host is refused WITHOUT being fetched", async () => {
+    const { result, seen } = await withFetch(() =>
+      fetchLogoBytes("https://evil.example/x.png"),
+    );
+    assert.equal(result, null);
+    assert.deepEqual(seen, [], "the request must never leave");
+  });
+
+  test("http is refused even on our own host", async () => {
+    const { result, seen } = await withFetch(() =>
+      fetchLogoBytes("http://metagraph.sh/logos/cache/x.png"),
+    );
+    assert.equal(result, null);
+    assert.deepEqual(seen, []);
+  });
+
+  test("a subdomain is not our host", async () => {
+    const { result, seen } = await withFetch(() =>
+      fetchLogoBytes("https://metagraph.sh.evil.example/x.png"),
+    );
+    assert.equal(result, null);
+    assert.deepEqual(seen, []);
+  });
+
+  test("a non-200 is a miss, not a broken card", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("gone", { status: 404 })) as typeof fetch;
+    try {
+      assert.equal(
+        await fetchLogoBytes("https://metagraph.sh/logos/cache/x.png"),
+        null,
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("the badge", () => {
+  test("a wide netuid gets the smaller face so it fits the square", () => {
+    const three = renderEntityMarkup({
+      kind: "k",
+      title: "t",
+      stats: [],
+      mark: "128",
+    });
+    const one = renderEntityMarkup({
+      kind: "k",
+      title: "t",
+      stats: [],
+      mark: "1",
+    });
+    assert.ok(three.includes("font-size:56px"));
+    assert.ok(one.includes("font-size:72px"));
+  });
+
+  test("no logo and no mark draws no badge rather than an empty square", () => {
+    const markup = renderEntityMarkup({ kind: "k", title: "t", stats: [] });
+    assert.ok(!markup.includes("border-radius:30px"));
+  });
+});
+
+describe("the remaining defaults", () => {
+  test("the digest handles facts with no logo and no mark", () => {
+    // accountFacts carries neither; the digest must still be stable rather
+    // than keying on `undefined`.
+    const a = { kind: "k", title: "t", stats: [] };
+    const b = { kind: "k", title: "t", stats: [], logoUrl: null, mark: null };
+    assert.equal(factsDigest(a), factsDigest(b));
+  });
+
+  test("without an injected fetcher the handler uses the allowlisted one", async () => {
+    // The default path: no `fetchLogo` dep, so the real fetchLogoBytes runs and
+    // its allowlist applies. Proven by pointing the row off-host -- the render
+    // still happens and no request leaves.
+    const original = globalThis.fetch;
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return new Response(new Uint8Array([1]), { status: 200 });
+    }) as typeof fetch;
+    let markup = "";
+    try {
+      const res = await handleEntityOgImage(
+        new Request("https://api.metagraph.sh/og/subnets/64.png"),
+        {},
+        new URL("https://api.metagraph.sh/og/subnets/64.png"),
+        {
+          assets: { fetch: async () => new Response("png", { status: 200 }) },
+          readArtifact: async () => ({
+            ok: true,
+            data: {
+              subnets: [
+                {
+                  netuid: 64,
+                  name: "Chutes",
+                  logo_url: "https://evil.example/x.png",
+                },
+              ],
+            },
+          }),
+          render: async (m) => {
+            markup = m;
+            return new Uint8Array([137]).buffer;
+          },
+        },
+      );
+      assert.equal(res?.status, 200);
+      assert.deepEqual(seen, [], "an off-host logo is never requested");
+      assert.ok(!markup.includes("data:image/png"), "and is not inlined");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("account cards", () => {
+  test("an account renders without any logo lookup at all", async () => {
+    // An account has no logo_url, so the fetch branch must be skipped rather
+    // than entered with an empty URL.
+    let markup = "";
+    let logoAsked = false;
+    const ss58 = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+    const res = await handleEntityOgImage(
+      new Request(`https://api.metagraph.sh/og/accounts/${ss58}.png`),
+      {},
+      new URL(`https://api.metagraph.sh/og/accounts/${ss58}.png`),
+      {
+        assets: { fetch: async () => new Response("png", { status: 200 }) },
+        fetchLogo: async () => {
+          logoAsked = true;
+          return null;
+        },
+        render: async (m) => {
+          markup = m;
+          return new Uint8Array([137]).buffer;
+        },
+      },
+    );
+    assert.equal(res?.status, 200);
+    assert.equal(logoAsked, false, "no logo lookup for an account");
+    assert.ok(markup.includes("5F4tQy"), "the address is drawn");
+    assert.ok(!markup.includes("border-radius:30px"), "and no badge");
   });
 });


### PR DESCRIPTION
Three defects in #11493's first cut, all visible only in the rendered image — which is why I rendered it rather than trusting the exit code.

## The font was a fallback, not a choice

`ImageResponse` without `fonts` renders in its own default, and the shipped card came out **in a serif** — not the wordmark's typeface, and it read as a different product. The Node path never showed this because `scripts/refresh-og-image.ts` passes satori the fonts explicitly.

Space Grotesk now loads through workers-og's own `loadGoogleFont`, subset to the glyphs the card actually draws.

## It did not fill the canvas

`width:100%;height:100%` left a white band down the right edge and along the bottom: satori resolves a percentage against the parent it is given, and workers-og does not hand it one the way the Node call does. A fixed 1200×630 is the canvas either renderer is asked for, so it cannot disagree with itself.

## It carried no identity

A name on a flat field, with "Metagraphed" spelled out next to our own icon. The registry already holds `logo_url` for **60 of 129** subnets — on our own cache, so inlining one is not a third-party fetch. The card draws it now. The other 69 get a numbered badge, and the footer is the icon alone: the wordmark was saying in text what the mark already says.

## The mark is the netuid, not the alpha symbol

The symbol was the obvious choice and is the subnet's on-chain identity — but those symbols are Greek, Cyrillic and Arabic, and Space Grotesk is Latin-only. Rendered, subnet 1's `α` came out as **`?`**. Loading a font per subnet to cover one glyph is not a trade worth making for a link preview, and a `?` on the cards belonging to the subnets with the *least* identity is the worst possible place for one.

## The logo fetch is allowlisted

`logo_url` is a registry row a contributor can edit. Without an allowlist that row points this Worker at any host it likes and the render inlines whatever comes back — an SSRF with an image on the end of it.

https on our own logo host, nothing else. Five tests cover it, including `metagraph.sh.evil.example` — a subdomain that only *looks* like ours — and the off-host cases assert the request **never leaves**.

A logo that will not load is not a failed card: it falls through to the badge. The digest keys on the logo URL rather than its bytes, because that URL is content-addressed by the logo cache already.

## Startup CPU, re-measured

283 / 301 / 319 ms against the ~400 ms limit — unchanged from the 313 ms baseline. The font and logo work happens in the handler, not at module scope.

## Verification

Full suite 960 files / 22,106 passed, build, lint, format, all 72 CI validators, patch coverage 100% (21/21 lines, 28/28 branches). Both variants rendered and inspected before pushing.