### PR TITLE
feat(lane-alarm): a lane that breaks a third of the time is broken, however short each break is

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -84,6 +84,7 @@ type LaneAlarmEnv = StoreEnv &
     GITHUB_TOKEN?: unknown;
     LANE_ALARM_GITHUB_TOKEN?: unknown;
     LANE_ALARM_MIN_STALE_MS?: unknown;
+    LANE_ALARM_RATE_WINDOW_MS?: unknown;
     LANE_ALARM_REPO?: unknown;
   };
 
@@ -113,6 +114,47 @@ export const LANE_ALARM_MIN_STALE_MS = 60 * 60 * 1000;
  * something whose whole job is to act on its own without supervision.
  */
 export const LANE_ALARM_MAX_OPENS_PER_TICK = 4;
+
+/**
+ * How far back the FLAPPING rule looks (#11488).
+ *
+ * A run is the unbroken tail of one verdict, so a lane that goes stale,
+ * recovers, and goes stale again never accumulates one -- and this file's
+ * one-hour minimum is measured on that run. Measured 2026-08-19,
+ * `chain-detail-staleness` spent 12.5 minutes at 851s behind against a 300s
+ * threshold, recorded `stale` in lane_health, and opened nothing, because no
+ * single episode lasted the 45 minutes three consecutive quarter-hourly ticks
+ * would need. `chain_detail`'s own write-latency tail says that is not rare:
+ * p95 718s, p99 969s.
+ *
+ * A lane that is broken a third of the time is broken. Twenty-four hours is
+ * long enough that a deploy's one-tick blip cannot dominate the ratio, and
+ * short enough that a lane which recovered yesterday stops alarming today.
+ */
+export const LANE_ALARM_RATE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The share of ticks in that window that must be faulty.
+ *
+ * A THIRD. Deliberately well above the noise floor this file already
+ * documents -- `chain-detail` flicked stale 64 times in one day while being
+ * fundamentally healthy, which on a quarter-hourly cadence is 96 ticks and
+ * about 67%... and that lane WAS the one with the real fault. The number has
+ * to sit below the case it was written for and above a deploy, and a third is
+ * the widest gap between those two.
+ */
+export const LANE_ALARM_RATE_THRESHOLD = 1 / 3;
+
+/**
+ * The fewest ticks a lane must have written in the window to be rated at all.
+ *
+ * TWELVE. A ratio over three samples is not a rate, it is an anecdote: a daily
+ * lane that happens to have logged twice, once badly, would read as 50%
+ * faulty. Twelve is half a day of quarter-hourly ticks, so a lane too slow to
+ * reach it is left to the run rule, which is the right rule for a lane whose
+ * episodes are longer than its cadence anyway.
+ */
+export const LANE_ALARM_RATE_MIN_SAMPLES = 12;
 
 /**
  * How much history the cadence estimate reads.
@@ -237,7 +279,7 @@ export function laneAlarmTitle(lane: string): string {
 /** `stale` and `unknown` are VERDICTS the watchdog wrote; `silent` is this
  * module's own finding -- the absence of any verdict at all -- so it is the one
  * member not derived from the schema. */
-export type LaneAlarmKind = LaneFindingVerdict | "silent";
+export type LaneAlarmKind = LaneFindingVerdict | "silent" | "flapping";
 
 export interface LaneAlarm {
   lane: string;
@@ -245,8 +287,12 @@ export interface LaneAlarm {
   /** When the fault started: the first tick of the stale run, or the last
    * verdict written before the lane went quiet. */
   since: number;
-  /** Consecutive stale ticks. Always 0 for `silent` -- there were none. */
+  /** Consecutive stale ticks. Always 0 for `silent` -- there were none. For
+   * `flapping` this is the FAULTY tick count in the window, not a run. */
   ticks: number;
+  /** `flapping` only: how many ticks the lane wrote in the window, so the
+   * share is reported rather than asserted. */
+  sampled?: number;
   /** The watchdog's own reason string, verbatim. Null when it wrote none. */
   detail: string | null;
   /** How far behind the lane itself was, as the watchdog measured it. */
@@ -322,6 +368,78 @@ export const LANE_STALE_RUN_SQL = VERDICT_RUN_SQL.stale;
  * verdict means.
  */
 export const LANE_UNKNOWN_RUN_SQL = VERDICT_RUN_SQL.unknown;
+
+/**
+ * Faulty-tick RATE per lane over the rate window (#11488).
+ *
+ * COUNTS BOTH FAULT VERDICTS, because the question this answers is "is this
+ * lane reliable", and a lane alternating `stale` and `unknown` is no more
+ * trustworthy than one doing either consistently -- while the run rule, which
+ * keys on a single verdict, would see two short runs and alarm on neither.
+ *
+ * The window bound is a parameter rather than interpolated: it is a timestamp
+ * computed at call time, which is exactly what placeholders are for. The
+ * verdict list is not -- it is the same closed, schema-derived union
+ * `laneRunSql` interpolates, for the same reason.
+ */
+export const LANE_FAULT_RATE_SQL =
+  "SELECT lane, COUNT(*) AS sampled, " +
+  "SUM(CASE WHEN verdict IN ('stale','unknown') THEN 1 ELSE 0 END) AS faulty, " +
+  "MIN(checked_at) AS since " +
+  "FROM lane_health WHERE checked_at >= ? GROUP BY lane";
+
+export interface LaneFaultRate {
+  sampled: number;
+  faulty: number;
+  since: number;
+}
+
+/** Faulty-tick rates keyed by lane. `{}` on any failure -- a reader that
+ * throws is a reader that stops reading. */
+export async function loadLaneFaultRates(
+  db: LaneHealthDb | null | undefined,
+  windowStartMs: number,
+): Promise<Record<string, LaneFaultRate>> {
+  if (!db?.query) return {};
+  try {
+    const rows = (await db.query(LANE_FAULT_RATE_SQL, [
+      windowStartMs,
+    ])) as Record<string, unknown>[];
+    const out: Record<string, LaneFaultRate> = {};
+    for (const row of rows) {
+      const lane = row.lane == null ? "" : String(row.lane);
+      if (!lane) continue;
+      out[lane] = {
+        sampled: countOrZero(row.sampled),
+        faulty: countOrZero(row.faulty),
+        since: countOrZero(row.since),
+      };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Is this lane flapping badly enough to open on?
+ *
+ * Three gates, and all of them exist to keep this from becoming noise: enough
+ * samples to be a rate at all, a share above the threshold, and -- the one
+ * that matters most -- NOT already covered by the run rule. A lane in a long
+ * unbroken stale run is also 100% faulty by this measure, and opening a second
+ * issue about it would be the same fault twice.
+ */
+export function isFlapping(
+  rate: LaneFaultRate | undefined,
+  hasOpenRun: boolean,
+  threshold: number = LANE_ALARM_RATE_THRESHOLD,
+  minSamples: number = LANE_ALARM_RATE_MIN_SAMPLES,
+): boolean {
+  if (!rate || hasOpenRun) return false;
+  if (rate.sampled < minSamples) return false;
+  return rate.faulty / rate.sampled >= threshold;
+}
 
 /* LANE_CADENCE_SQL / laneCadenceMs / loadLaneCadence were REMOVED here (#10723).
  *
@@ -479,6 +597,12 @@ export interface LaneAlarmPlanInput {
   /** Current unbroken `unknown` runs, keyed by lane (#10695). */
   unknownRuns: LaneVerdictRuns;
   /**
+   * Faulty-tick rate per lane over the rate window (#11488). Optional so every
+   * existing caller and fixture keeps compiling: absent means the flapping rule
+   * simply does not fire, which is the same behaviour as before it existed.
+   */
+  faultRates?: Record<string, LaneFaultRate>;
+  /**
    * Observed MAXIMUM gap per lane, keyed by lane. Null where uncalibrated.
    *
    * The max, not the mean (#10232, and this file's own LANE_MAX_GAP_SQL comment
@@ -595,6 +719,7 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     latest,
     runs,
     unknownRuns,
+    faultRates = {},
     observedMaxGap,
     openAlarms,
     // Defaulted, and the default suppresses NOTHING. A caller that cannot read
@@ -668,6 +793,37 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
       age_ms: record.age_ms,
       cadence_ms: cadenceFor(record.lane),
     });
+  }
+
+  // FLAPPING (#11488). A lane that recovers between episodes never builds a run
+  // the minimum can reach, however often it breaks: `chain-detail-staleness`
+  // sat 851s behind a 300s threshold for 12.5 minutes, recorded `stale`, and
+  // opened nothing, because no single episode lasted the 45 minutes three
+  // consecutive quarter-hourly ticks would need.
+  //
+  // AFTER the run loops and gated on their output, so a lane in a long unbroken
+  // run -- which is also 100% faulty by this measure -- reports once as `stale`
+  // rather than twice. The run rule is the better description when it applies;
+  // this only speaks where it cannot.
+  const alreadyQualified = new Set(qualified.map((alarm) => alarm.lane));
+  for (const [lane, rate] of Object.entries(faultRates)) {
+    if (!isFlapping(rate, alreadyQualified.has(lane))) continue;
+    const record = latest[lane];
+    // No latest verdict for a lane with rows in the window means the two reads
+    // disagree; the silence loop below is the right reporter for that.
+    if (!record) continue;
+    if (nowMs - record.checked_at > LANE_ALARM_MAX_VERDICT_AGE_MS) continue;
+    qualified.push({
+      lane,
+      kind: "flapping",
+      since: rate.since,
+      ticks: rate.faulty,
+      sampled: rate.sampled,
+      detail: record.detail,
+      age_ms: record.age_ms,
+      cadence_ms: cadenceFor(lane),
+    });
+    alreadyQualified.add(lane);
   }
 
   for (const record of Object.values(latest)) {
@@ -835,6 +991,15 @@ function issueOpening(alarm: LaneAlarm, forHow: string): string {
       );
     case "silent":
       return `\`${alarm.lane}\` has written **no verdict at all** for **${forHow}**. Its watchdog appears to have stopped running -- the last verdict it did write said \`${alarm.detail ?? "ok"}\`, so nothing else will report this.`;
+    case "flapping": {
+      const sampled = alarm.sampled ?? 0;
+      const share = sampled ? Math.round((alarm.ticks / sampled) * 100) : 0;
+      return (
+        `\`${alarm.lane}\` has been **faulty on ${alarm.ticks} of its last ${sampled} ticks (${share}%)** over **${forHow}**, ` +
+        "recovering between each one. No single episode lasted long enough for the run rule to reach it, which is why nothing opened until now -- " +
+        "a lane that is broken a third of the time is broken, however short each individual break is."
+      );
+    }
   }
 }
 
@@ -1204,18 +1369,25 @@ export async function runLaneAlarm(
   const minStaleMs =
     Number(env?.LANE_ALARM_MIN_STALE_MS) || LANE_ALARM_MIN_STALE_MS;
 
-  const [latest, runs, unknownRuns, observedMaxGap] = await Promise.all([
-    loadLatestLaneHealth(db),
-    loadLaneStaleRuns(db),
-    loadLaneUnknownRuns(db),
-    // THE MAX GAP, not the mean (#10723). This file already owned both queries
-    // and already documented why the max is the only column that survives a
-    // container reboot and a many-rows-per-pass mirror lane -- but the alarm path
-    // kept reading the mean, so `neon:account-balances` was judged against a
-    // ONE-MINUTE cadence and alarmed on every gap between its six-hourly passes.
-    // src/self-health.ts and src/self-health-mcp.ts already read it this way.
-    loadLaneMaxGap(db, nowMs - LANE_ALARM_CADENCE_WINDOW_MS),
-  ]);
+  const rateWindowMs =
+    Number(env?.LANE_ALARM_RATE_WINDOW_MS) || LANE_ALARM_RATE_WINDOW_MS;
+
+  const [latest, runs, unknownRuns, faultRates, observedMaxGap] =
+    await Promise.all([
+      loadLatestLaneHealth(db),
+      loadLaneStaleRuns(db),
+      loadLaneUnknownRuns(db),
+      // #11488: the rate, for lanes that recover between episodes and so never
+      // build a run the minimum can reach.
+      loadLaneFaultRates(db, nowMs - rateWindowMs),
+      // THE MAX GAP, not the mean (#10723). This file already owned both queries
+      // and already documented why the max is the only column that survives a
+      // container reboot and a many-rows-per-pass mirror lane -- but the alarm path
+      // kept reading the mean, so `neon:account-balances` was judged against a
+      // ONE-MINUTE cadence and alarmed on every gap between its six-hourly passes.
+      // src/self-health.ts and src/self-health-mcp.ts already read it this way.
+      loadLaneMaxGap(db, nowMs - LANE_ALARM_CADENCE_WINDOW_MS),
+    ]);
 
   // Read the open alarms BEFORE planning: without them every tick would open a
   // duplicate of every alarm still outstanding, which is the failure that makes
@@ -1243,6 +1415,7 @@ export async function runLaneAlarm(
     latest,
     runs,
     unknownRuns,
+    faultRates,
     observedMaxGap,
     openAlarms: openAlarms ?? {},
     acknowledged,
@@ -1270,7 +1443,12 @@ export async function runLaneAlarm(
       error: new Error(laneAlarmSummary(alarm, nowMs)),
       route: "watchdog:lane-alarm",
       fingerprintDetail: alarm.lane,
-      errorCode: alarm.kind === "stale" ? "lane_stale" : "lane_silent",
+      errorCode:
+        alarm.kind === "stale"
+          ? "lane_stale"
+          : alarm.kind === "flapping"
+            ? "lane_flapping"
+            : "lane_silent",
     }).catch(() => false);
     if (!github || listUnavailable) continue;
     const number = await github

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -38,6 +38,11 @@ import {
   LANE_ALARM_TITLE_PREFIX,
   LANE_MAX_GAP_SQL,
   LANE_STALE_RUN_SQL,
+  LANE_ALARM_RATE_MIN_SAMPLES,
+  LANE_ALARM_RATE_THRESHOLD,
+  LANE_FAULT_RATE_SQL,
+  isFlapping,
+  loadLaneFaultRates,
   laneAlarmGitHub,
   laneAlarmIssueBody,
   laneAlarmLossComment,
@@ -1267,12 +1272,19 @@ describe("runLaneAlarm", () => {
     /** LANE_MAX_GAP_SQL rows: `{ lane, n, max_gap }` (#10723). The alarm reads the
      * MAX gap now, not the mean, so this bucket answers that query's shape. */
     maxGap?: Record<string, unknown>[];
+    /** LANE_FAULT_RATE_SQL rows: `{ lane, sampled, faulty, since }` (#11488). */
+    rates?: Record<string, unknown>[];
   }) {
     const written: Record<string, unknown>[] = [];
     pg.control.queries.length = 0;
     pg.control.rows = null;
     pg.control.failNext = null;
     pg.control.answers = [
+      // BEFORE the runs match, which is a substring of this query too: the rate
+      // SQL also selects `MIN(checked_at) AS since`, so a fixture that matched
+      // on that alone would hand run rows to the rate reader and quietly make
+      // every flapping test a no-op.
+      { match: "AS sampled", rows: rows.rates ?? [] },
       { match: "MIN(checked_at) AS since", rows: rows.runs ?? [] },
       { match: "COUNT(*) AS n", rows: rows.maxGap ?? [] },
       {
@@ -1998,6 +2010,54 @@ describe("runLaneAlarm", () => {
     assert.equal(out.ok, true);
     assert.equal(out.alarming, 1);
   });
+
+  test("a flapping lane opens with its own error code, not lane_stale", async () => {
+    // `lane_flapping` is its own code because it is a different finding: the
+    // lane is not down, it is unreliable, and a dashboard that folds the two
+    // together cannot tell a broken producer from a flaky one.
+    const db = healthDb({
+      latest: [
+        {
+          lane: "chain-detail-staleness",
+          verdict: "ok",
+          age_ms: 30_000,
+          detail: null,
+          checked_at: NOW - 60_000,
+        },
+      ],
+      runs: [],
+      maxGap: [{ lane: "chain-detail-staleness", n: 96, max_gap: 15 * 60_000 }],
+      rates: [
+        {
+          lane: "chain-detail-staleness",
+          sampled: 96,
+          faulty: 32,
+          since: NOW - 24 * HOUR,
+        },
+      ],
+    });
+    const github = fakeGitHub({});
+    const seen: Array<{ errorCode?: string }> = [];
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      {
+        github,
+        now: () => NOW,
+        recordException: async (_env, payload) => {
+          seen.push(payload as { errorCode?: string });
+          return true;
+        },
+      },
+    );
+    assert.equal(out.opened, 1);
+    assert.deepEqual(
+      seen.map((p) => p.errorCode),
+      ["lane_flapping"],
+    );
+    // The double records the lane it was asked to open; the body itself is
+    // asserted directly against laneAlarmIssueBody in the plan tests above.
+    assert.deepEqual(github.opened, ["chain-detail-staleness"]);
+  });
 });
 
 describe("laneAlarmTitle", () => {
@@ -2181,5 +2241,257 @@ describe("a closed dead-letter alarm is an acknowledgement", () => {
       plan.open.map((a) => a.lane),
       ["chain-detail"],
     );
+  });
+});
+
+describe("flapping: a lane that recovers between episodes (#11488)", () => {
+  const base = {
+    latest: {},
+    runs: {},
+    unknownRuns: {},
+    observedMaxGap: {},
+    openAlarms: {},
+    nowMs: NOW,
+    minStaleMs: LANE_ALARM_MIN_STALE_MS,
+  };
+
+  test("the case this exists for: broken a third of the time, never for an hour", () => {
+    // chain-detail-staleness, measured 2026-08-19: 851s behind a 300s threshold
+    // for 12.5 minutes, recorded `stale`, opened nothing -- no episode lasted
+    // the 45 minutes three consecutive quarter-hourly ticks would need.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        "chain-detail-staleness": record({ lane: "chain-detail-staleness" }),
+      },
+      runs: {},
+      faultRates: {
+        "chain-detail-staleness": {
+          sampled: 96,
+          faulty: 32,
+          since: NOW - 24 * HOUR,
+        },
+      },
+      observedMaxGap: { "chain-detail-staleness": 15 * 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "flapping");
+    assert.equal(plan.open[0].ticks, 32);
+    assert.equal(plan.open[0].sampled, 96);
+  });
+
+  test("a lane already alarming as STALE is not ALSO reported as flapping", () => {
+    // A long unbroken run is 100% faulty by this measure too. The run rule is
+    // the better description when it applies; two issues for one fault is the
+    // noise this whole file exists to end.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a" }) },
+      runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
+      faultRates: { a: { sampled: 96, faulty: 96, since: NOW - 24 * HOUR } },
+      observedMaxGap: { a: 15 * 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "stale");
+  });
+
+  test("below the threshold does not alarm", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "ok" }) },
+      faultRates: { a: { sampled: 96, faulty: 8, since: NOW - 24 * HOUR } },
+      observedMaxGap: { a: 15 * 60_000 },
+    });
+    assert.equal(plan.open.length, 0);
+  });
+
+  test("too few samples is an anecdote, not a rate", () => {
+    // A daily lane that logged twice, once badly, reads as 50% faulty. That is
+    // not a rate and must not open an issue.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "ok" }) },
+      faultRates: { a: { sampled: 2, faulty: 1, since: NOW - 24 * HOUR } },
+      observedMaxGap: { a: 24 * HOUR },
+    });
+    assert.equal(plan.open.length, 0);
+  });
+
+  test("absent rates behave exactly as before this rule existed", () => {
+    // Every existing caller omits `faultRates`. That must be a no-op, not a
+    // silent change of behaviour for lanes this rule was never asked about.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "ok" }) },
+      observedMaxGap: { a: 15 * 60_000 },
+    });
+    assert.equal(plan.open.length, 0);
+  });
+
+  test("the issue body reports the share rather than asserting it", () => {
+    const body = laneAlarmIssueBody(
+      {
+        lane: "chain-detail-staleness",
+        kind: "flapping",
+        since: NOW - 24 * HOUR,
+        ticks: 32,
+        sampled: 96,
+        detail: "stale (head_block=8877513)",
+        age_ms: 762178,
+        cadence_ms: 15 * 60_000,
+      },
+      NOW,
+    );
+    assert.ok(body.includes("32 of its last 96 ticks (33%)"));
+    assert.ok(body.includes("recovering between each one"));
+  });
+});
+
+describe("the flapping predicate", () => {
+  const rate = (faulty: number, sampled: number) => ({
+    faulty,
+    sampled,
+    since: NOW - 24 * HOUR,
+  });
+
+  test("an open run suppresses it", () => {
+    assert.equal(isFlapping(rate(96, 96), true), false);
+    assert.equal(isFlapping(rate(96, 96), false), true);
+  });
+
+  test("exactly at the threshold alarms", () => {
+    const sampled = 96;
+    const faulty = Math.ceil(sampled * LANE_ALARM_RATE_THRESHOLD);
+    assert.equal(isFlapping(rate(faulty, sampled), false), true);
+  });
+
+  test("exactly at the minimum sample count is enough", () => {
+    const n = LANE_ALARM_RATE_MIN_SAMPLES;
+    assert.equal(isFlapping(rate(n, n), false), true);
+    assert.equal(isFlapping(rate(n - 1, n - 1), false), false);
+  });
+
+  test("an absent rate is not a fault", () => {
+    assert.equal(isFlapping(undefined, false), false);
+  });
+});
+
+describe("the fault-rate reader", () => {
+  test("counts BOTH fault verdicts, and bounds the window with a parameter", async () => {
+    // A lane alternating stale and unknown is no more trustworthy than one
+    // doing either consistently -- and the run rule, keyed on a single verdict,
+    // sees two short runs and alarms on neither.
+    assert.ok(LANE_FAULT_RATE_SQL.includes("'stale'"));
+    assert.ok(LANE_FAULT_RATE_SQL.includes("'unknown'"));
+    assert.ok(LANE_FAULT_RATE_SQL.includes("checked_at >= ?"));
+
+    const seen: { sql?: string; values?: unknown[] } = {};
+    const rates = await loadLaneFaultRates(
+      {
+        query: async (sql: string, values?: unknown[]) => {
+          seen.sql = sql;
+          seen.values = values;
+          return [{ lane: "a", sampled: 96, faulty: 32, since: NOW - HOUR }];
+        },
+        run: async () => ({ changes: 0 }),
+      },
+      NOW - 24 * HOUR,
+    );
+    assert.deepEqual(seen.values, [NOW - 24 * HOUR]);
+    assert.deepEqual(rates.a, { sampled: 96, faulty: 32, since: NOW - HOUR });
+  });
+
+  test("a reader that throws returns {} rather than stopping the tick", async () => {
+    const rates = await loadLaneFaultRates(
+      {
+        query: async () => {
+          throw new Error("db down");
+        },
+        run: async () => ({ changes: 0 }),
+      },
+      NOW - 24 * HOUR,
+    );
+    assert.deepEqual(rates, {});
+  });
+
+  test("no db is {}", async () => {
+    assert.deepEqual(await loadLaneFaultRates(null, NOW), {});
+  });
+});
+
+describe("flapping edge cases", () => {
+  const base = {
+    latest: {},
+    runs: {},
+    unknownRuns: {},
+    observedMaxGap: {},
+    openAlarms: {},
+    nowMs: NOW,
+    minStaleMs: LANE_ALARM_MIN_STALE_MS,
+  };
+
+  test('a rate row with no lane name is skipped, not stored under ""', async () => {
+    const rates = await loadLaneFaultRates(
+      {
+        query: async () => [
+          { lane: null, sampled: 96, faulty: 96, since: NOW },
+          { lane: "a", sampled: 96, faulty: 32, since: NOW },
+        ],
+        run: async () => ({ changes: 0 }),
+      },
+      NOW - 24 * HOUR,
+    );
+    assert.deepEqual(Object.keys(rates), ["a"]);
+  });
+
+  test("a rate with no matching latest verdict is left to the silence loop", () => {
+    // The two reads disagree -- rows in the window but no newest verdict. This
+    // loop must not invent one; a lane that stopped reporting is the silence
+    // loop's finding.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {},
+      faultRates: {
+        ghost: { sampled: 96, faulty: 96, since: NOW - 24 * HOUR },
+      },
+    });
+    assert.equal(plan.open.filter((a) => a.kind === "flapping").length, 0);
+  });
+
+  test("a stale-dated verdict is residue, not a flap", () => {
+    // Same bound the stale loop applies: a verdict older than the max age is
+    // left over from a lane nobody reads any more.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({
+          lane: "a",
+          verdict: "ok",
+          checked_at: NOW - 30 * 24 * HOUR,
+        }),
+      },
+      faultRates: { a: { sampled: 96, faulty: 96, since: NOW - 24 * HOUR } },
+      observedMaxGap: { a: 15 * 60_000 },
+    });
+    assert.equal(plan.open.filter((a) => a.kind === "flapping").length, 0);
+  });
+
+  test("a flapping alarm with no sample count reports 0%, never NaN", () => {
+    // `sampled` is optional on the shape, so the body must not divide by
+    // undefined and publish `NaN%` into an issue title someone reads at 3am.
+    const body = laneAlarmIssueBody(
+      {
+        lane: "a",
+        kind: "flapping",
+        since: NOW - 24 * HOUR,
+        ticks: 3,
+        detail: null,
+        age_ms: null,
+        cadence_ms: null,
+      },
+      NOW,
+    );
+    assert.ok(body.includes("(0%)"));
+    assert.ok(!body.includes("NaN"));
   });
 });


### PR DESCRIPTION
The escalation rule is a **run** — the unbroken tail of one verdict, measured against a one-hour minimum. A lane that recovers between episodes never builds one, however often it breaks.

## The case

Measured 2026-08-19, `chain-detail-staleness`:

```
head_age  338 → 383 → 429 → 512 → 572 → 633 → 693 → 776 → 851s
lane_health: verdict=stale, age_ms=762178, checked_at=08:21:18
issues opened: none
```

851s against a **300s threshold** — 2.8x over — recorded faithfully, escalated nowhere, because no single episode lasted the 45 minutes three consecutive quarter-hourly ticks would need.

That is not a rare shape. `chain_detail`'s own write-latency tail is p95 718s / p99 969s, and metagraphed-infra#492 measured p99 1244s a week earlier. So a lane can sit past its threshold for minutes, several times a day, forever, and the tracker stays empty.

## The second rule

Faulty on at least **a third of a lane's ticks over 24 hours**. Its own kind, not folded into `stale`, because it is a different finding — the lane is not down, it is *unreliable*, and an issue saying "stale on every tick" about a lane that is fine most of the time would be false.

```
`chain-detail-staleness` has been faulty on 32 of its last 96 ticks (33%) over 24h,
recovering between each one. No single episode lasted long enough for the run rule
to reach it, which is why nothing opened until now — a lane that is broken a third
of the time is broken, however short each individual break is.
```

## Three gates against noise

- **Twelve samples minimum.** A ratio over three ticks is an anecdote: a daily lane that logged twice, once badly, reads as 50% faulty.
- **A third.** This file already documents the noise floor — `chain-detail` flicked stale 64 times in a day while healthy — so the threshold has to sit above a deploy blip and below the case this was written for.
- **Not already in a run.** A lane in a long unbroken stale run is *also* 100% faulty by this measure. The run rule describes it better, and two issues for one fault is exactly what this file's own comments call the failure that gets an alerting system muted.

It counts **both** fault verdicts: a lane alternating `stale` and `unknown` is no more trustworthy than one doing either consistently, and the run rule — keyed on a single verdict — sees two short runs and alarms on neither.

## Compatibility

`faultRates` is optional on the plan input, so every existing caller keeps exactly its previous behaviour; a test pins that. The exhaustive `LaneAlarmKind` switch made the compiler *demand* the new message rather than letting it fall through — which is the property its comment already claimed and now has been exercised.

## A fixture bug this surfaced

The rate SQL also selects `MIN(checked_at) AS since`, which the test fixture matched on to serve run rows. Left alone it would have handed run rows to the rate reader and made every flapping test a silent no-op. The fixture now matches the rate query first, on a substring unique to it.

## Verification

Full suite 960 files / 22,124 passed, build, lint, format, all 72 CI validators, patch coverage 100% (30/30 lines, 31/31 branches). 18 new tests.

Closes #11488