### PR TITLE
fix(latency-gate): the sweep scored its own cache and never asked a third of the API

### DIFF
--- a/scripts/check-operation-latency.ts
+++ b/scripts/check-operation-latency.ts
@@ -119,11 +119,30 @@ const STALE_MARGIN = 0.5;
  * spread is the evidence that one sample per surface is noise around one
  * underlying cost, not three independent measurements.
  *
- * All 20 belong to #10312, and they are not 20 independent problems: the
+ * All 22 belong to #10312, and they are not 22 independent problems: the
  * account family and the extrinsics/chain-event reads are the lakehouse
  * access path (#9789), one root cause wearing most of these hats.
+ *
+ * NOTHING HAS BEEN RETIRED FROM THIS LIST YET, and the 2026-08-19 run is why.
+ * It reported five entries as stale -- `/api/v1/accounts/{ss58}`,
+ * `.../weight-setters`, `/api/v1/blocks/{ref}/extrinsics`, `/api/v1/extrinsics`
+ * and `/api/v1/subnets/{netuid}/ownership-history` -- on numbers its own
+ * confirmation pass had read out of the edge cache (see `Served`). Those five
+ * may well be genuinely fixed; the point is that THAT run could not tell, and
+ * retiring an exemption is the one move this gate cannot take back. The
+ * re-measurement happens once `x-metagraph-cache` is live, which is what makes
+ * the next run able to say.
  */
 const DECLARED: Record<string, string> = {
+  // Added 2026-08-19. Both are GRAPHQL medians, so both are uncontaminated by
+  // the cache correction that landed with them: the POST surfaces never reach
+  // `withEdgeCache`, which consults the cache for GET only (see `Served`).
+  "/api/v1/accounts/{ss58}/subnets/{netuid}/history":
+    "#10312 -- 7687ms worst of 3 surface(s) on 2026-08-19 (rest 7687ms, graphql 6060ms, mcp 1673ms); " +
+    "over budget on BOTH heavy surfaces -- graphql drew [6060, 975, 15124], rest [7687, cache, cache]",
+  "/api/v1/chain-events/stats":
+    "#10312 -- 5952ms worst of 3 surface(s) on 2026-08-19 (graphql 5952ms, rest 2121ms, mcp 1509ms); " +
+    "graphql drew [5952, 1313, 15046] -- an 11.4x spread around the 15s ceiling",
   "/api/v1/accounts/{ss58}":
     "#10312 -- 8832ms worst of 3 surface(s) on 2026-08-10 (graphql 8832ms, mcp 5717ms, rest 5205ms)",
   "/api/v1/accounts/{ss58}/counterparties":
@@ -182,8 +201,63 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  */
 type Answer = "ok" | "unaskable" | "failed";
 
+/**
+ * Whether a draw measured the READ, or a cache sitting in front of it.
+ *
+ * The distinction is the difference between this gate working and this gate
+ * lying. `confirmOverBudget` re-times an over-budget call to reject a one-off
+ * outlier -- but its own first draw FILLS the edge cache that the retries then
+ * read, so the retries are not redraws of the same distribution at all.
+ *
+ * Measured against production 2026-08-19, the same run, split by method:
+ *
+ *   GET   /api/v1/blocks/{ref}/extrinsics  [7290, 63, 43] -> median 63ms
+ *   GET   /api/v1/extrinsics/{hash}        [8703, 78, 66] -> median 78ms
+ *   GET   /api/v1/accounts/{ss58}/history  [17714, 10341, 51] -> median 10341ms
+ *   POST  graphql account_transfers        [17386, 14281, 11017]
+ *   POST  graphql subnet_ohlc              [9554, 5893, 5104]
+ *
+ * Every GET collapses to double digits; no POST does. That is not two
+ * populations of route, it is `withEdgeCache` consulting the cache only for
+ * GET -- so the POST surfaces are structurally uncacheable here and the REST
+ * surface is where a draw can measure the CDN instead of the warehouse.
+ *
+ * Scored the naive way this cost real exemptions: the 2026-08-19 run reported
+ * five DECLARED entries as "now comfortably under budget, delete them", among
+ * them `/api/v1/blocks/{ref}/extrinsics`, whose read still takes 7.3s cold.
+ * Deleting an exemption on the strength of the sweep's own cache is how a live
+ * regression gets retired by the gate that exists to catch it.
+ */
+export type Served = "origin" | "cache";
+
+/** One draw: how long it took, what came back, and whether it counted. */
+export type Draw = [ms: number, answer: Answer, served: Served];
+
+/**
+ * A cache hit is only sometimes visible, which is why the header exists.
+ *
+ * Cloudflare stamps `cf-cache-status` on its own zone cache, but a
+ * `caches.default` hit inside the Worker returns the stored response verbatim:
+ * `/api/v1/blocks/{ref}` measured 15,222ms then 2,216ms with NO cache header of
+ * any kind. `x-metagraph-cache` (#10312) is our own answer to that, set by
+ * `withEdgeCache` and `withChainDetailEdgeCache`; `cf-cache-status` stays as the
+ * fallback so this still detects the zone cache on any route that never reaches
+ * those wrappers.
+ */
+export function servedFrom(res: Response): Served {
+  const own = (res.headers.get("x-metagraph-cache") ?? "").toLowerCase();
+  if (own) return own === "hit" ? "cache" : "origin";
+  return (res.headers.get("cf-cache-status") ?? "").toUpperCase() === "HIT"
+    ? "cache"
+    : "origin";
+}
+
+/** Every surface this sweep is responsible for covering. */
+export const SURFACES = ["rest", "mcp", "graphql"] as const;
+export type SurfaceName = (typeof SURFACES)[number];
+
 export interface Timing {
-  surface: "rest" | "mcp" | "graphql";
+  surface: SurfaceName;
   operation: string;
   /**
    * The operation's SCORED time -- the median of `samples`, not one draw.
@@ -209,6 +283,16 @@ export interface Timing {
    * against a warehouse this account has been rate-limited on (#9465).
    */
   samples?: number[];
+  /**
+   * Whether the FIRST draw measured the read or the cache.
+   *
+   * Kept because a cache-served draw is not evidence of anything about the
+   * read, in either direction -- see `Served`. A first pass can land on a warm
+   * entry (an earlier sweep, or any caller, inside the same 15-minute health
+   * stamp), come in at 60ms, never qualify for the confirmation pass, and be
+   * scored as a fixed operation on one number that never touched the store.
+   */
+  served: Served;
 }
 
 export interface LatencyReport {
@@ -218,6 +302,15 @@ export interface LatencyReport {
   /** Calls the sweep could not pose properly -- its problem, not the API's. */
   unaskable: Timing[];
   stale: string[];
+  /**
+   * Surfaces that produced NO timing at all.
+   *
+   * A sweep that quietly measures two of three surfaces is worse than one that
+   * fails: the staleness rule retires an exemption when its read is under
+   * budget on EVERY surface, so a surface nobody asked is a surface that can
+   * never object. That is not hypothetical either -- see `SWEEP_CONTEXT`.
+   */
+  missingSurfaces: SurfaceName[];
 }
 
 export const key = (timing: Pick<Timing, "surface" | "operation">): string =>
@@ -290,17 +383,25 @@ async function timed(run: () => Promise<Answer>): Promise<[number, Answer]> {
   return [Date.now() - started, answer];
 }
 
+/** `timed` for a surface the edge cache structurally cannot answer. */
+async function originDraw(run: () => Promise<Answer>): Promise<Draw> {
+  const [ms, answer] = await timed(run);
+  return [ms, answer, "origin"];
+}
+
 function withTimeout(): [AbortSignal, () => void] {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   return [controller.signal, () => clearTimeout(timer)];
 }
 
-async function timeRest(path: string): Promise<[number, Answer]> {
-  return timed(async () => {
+async function timeRest(path: string): Promise<Draw> {
+  let served: Served = "origin";
+  const [ms, answer] = await timed(async () => {
     const [signal, done] = withTimeout();
     try {
       const res = await fetch(`${REST_ORIGIN}${path}`, { signal });
+      served = servedFrom(res);
       // Drain the body: a route is not "done" until its bytes are, and the
       // biggest answers here are the whole point (#10318 was 486 KB).
       await res.arrayBuffer();
@@ -309,6 +410,7 @@ async function timeRest(path: string): Promise<[number, Answer]> {
       done();
     }
   });
+  return [ms, answer, served];
 }
 
 /**
@@ -323,8 +425,10 @@ async function timeRest(path: string): Promise<[number, Answer]> {
 const UNASKABLE_MCP_CODES = new Set(["invalid_params", "not_found"]);
 
 let rpcId = 0;
-async function timeMcp(name: string, args: Row): Promise<[number, Answer]> {
-  return timed(async () => {
+// POST, so `withEdgeCache` never consults the cache for it -- see `Served` for
+// the measurement that pinned GET/POST as the line the cache falls on.
+async function timeMcp(name: string, args: Row): Promise<Draw> {
+  return originDraw(async () => {
     const [signal, done] = withTimeout();
     try {
       const res = await fetch(MCP_ENDPOINT, {
@@ -355,8 +459,9 @@ async function timeMcp(name: string, args: Row): Promise<[number, Answer]> {
   });
 }
 
-async function timeGraphql(plan: FieldPlan): Promise<[number, Answer]> {
-  return timed(async () => {
+// POST likewise -- see `timeMcp`.
+async function timeGraphql(plan: FieldPlan): Promise<Draw> {
+  return originDraw(async () => {
     const [signal, done] = withTimeout();
     try {
       const res = await fetch(GRAPHQL_ENDPOINT, {
@@ -425,7 +530,7 @@ async function listLiveTools(): Promise<{ name: string; args: Row }[]> {
 export async function run(): Promise<LatencyReport> {
   const timings: Timing[] = [];
   /** How to draw the same operation again, for the confirmation pass below. */
-  const retime = new Map<string, () => Promise<[number, Answer]>>();
+  const retime = new Map<string, () => Promise<Draw>>();
 
   for (const route of [...API_ROUTES, ...FEED_ROUTES]) {
     // GET only. `/api/v1/ask` is the one POST route in the table, and asking it
@@ -433,12 +538,13 @@ export async function run(): Promise<LatencyReport> {
     if (route.method !== "GET") continue;
     const path = concreteRoute(route.path);
     if (path === null) continue;
-    const [ms, answer] = await timeRest(path);
+    const [ms, answer, served] = await timeRest(path);
     const timing: Timing = {
       surface: "rest",
       operation: route.path,
       ms,
       answer,
+      served,
       samples: [ms],
     };
     timings.push(timing);
@@ -448,12 +554,13 @@ export async function run(): Promise<LatencyReport> {
   }
 
   for (const tool of await listLiveTools()) {
-    const [ms, answer] = await timeMcp(tool.name, tool.args);
+    const [ms, answer, served] = await timeMcp(tool.name, tool.args);
     const timing: Timing = {
       surface: "mcp",
       operation: tool.name,
       ms,
       answer,
+      served,
       samples: [ms],
     };
     timings.push(timing);
@@ -464,12 +571,13 @@ export async function run(): Promise<LatencyReport> {
 
   const { plans } = planAll(buildSchema(SDL));
   for (const plan of plans) {
-    const [ms, answer] = await timeGraphql(plan);
+    const [ms, answer, served] = await timeGraphql(plan);
     const timing: Timing = {
       surface: "graphql",
       operation: plan.field,
       ms,
       answer,
+      served,
       samples: [ms],
     };
     timings.push(timing);
@@ -504,7 +612,7 @@ export async function run(): Promise<LatencyReport> {
  */
 export async function confirmOverBudget(
   timings: Timing[],
-  retime: Map<string, () => Promise<[number, Answer]>>,
+  retime: Map<string, () => Promise<Draw>>,
   /** Overridable so the unit test does not sit through the real pacing. */
   spacingMs: number = CALL_SPACING_MS,
 ): Promise<void> {
@@ -516,6 +624,7 @@ export async function confirmOverBudget(
     `\nconfirming ${suspects.length} over-budget call(s) with ` +
       `${CONFIRM_SAMPLES - 1} more sample(s) each\n`,
   );
+  let cached = 0;
   for (const timing of suspects) {
     const draw = retime.get(key(timing));
     if (!draw) continue;
@@ -528,8 +637,19 @@ export async function confirmOverBudget(
       // fires. The first version of these tests passed alone and timed out at
       // 30s in CI for exactly that reason.
       if (spacingMs > 0) await sleep(spacingMs);
-      const [ms, answer] = await draw();
+      const [ms, answer, served] = await draw();
       if (answer !== "ok") continue;
+      // A CACHE HIT IS NOT A REDRAW. The draw above filled the edge cache, so
+      // this one can be answered without the read ever running -- 63ms against
+      // the 7290ms that seeded it. Folding that into the samples does not
+      // reduce noise, it replaces the measurement: the median of
+      // [cold, warm, warm] IS a warm number, and the operation gets scored as
+      // fixed. Discarded exactly like a non-`ok` answer, and for the same
+      // reason -- neither one is a draw of the thing being measured.
+      if (served === "cache") {
+        cached += 1;
+        continue;
+      }
       timing.samples = [...(timing.samples ?? [timing.ms]), ms];
     }
     // The upper median, which matters only when a draw was DISCARDED above and
@@ -543,6 +663,12 @@ export async function confirmOverBudget(
     process.stderr.write(
       `confirm ${timing.surface} ${timing.operation}` +
         ` [${timing.samples?.join(", ")}] -> median ${timing.ms}ms\n`,
+    );
+  }
+  if (cached > 0) {
+    process.stderr.write(
+      `\n${cached} confirmation draw(s) came from the edge cache and were ` +
+        `discarded -- those operations keep their uncached sample(s)\n`,
     );
   }
 }
@@ -566,7 +692,16 @@ export function summarise(timings: Timing[]): LatencyReport {
     timings
       .filter(
         (timing) =>
-          timing.answer !== "ok" || timing.ms > BUDGET_MS * STALE_MARGIN,
+          timing.answer !== "ok" ||
+          // A cache-served draw is not evidence the read got faster -- it is
+          // not evidence about the read at all. Same standing as the 4xx
+          // above: the sweep did not measure the operation, so it has nothing
+          // to say about whether the exemption is still warranted, and the
+          // exemption stays. Deleting one on this evidence is strictly worse
+          // than keeping a stale one, because the deletion is what lets the
+          // next real regression through unreported.
+          timing.served === "cache" ||
+          timing.ms > BUDGET_MS * STALE_MARGIN,
       )
       .map(family)
       .filter((name) => DECLARED[name]),
@@ -579,6 +714,9 @@ export function summarise(timings: Timing[]): LatencyReport {
     failed: timings.filter((timing) => timing.answer === "failed"),
     unaskable: timings.filter((timing) => timing.answer === "unaskable"),
     stale: Object.keys(DECLARED).filter((name) => !stillSlow.has(name)),
+    missingSurfaces: SURFACES.filter(
+      (surface) => !timings.some((timing) => timing.surface === surface),
+    ),
   };
 }
 
@@ -593,7 +731,7 @@ function percentile(sorted: number[], p: number): number {
 
 export function formatReport(report: LatencyReport): string {
   const lines: string[] = [];
-  for (const surface of ["rest", "mcp", "graphql"] as const) {
+  for (const surface of SURFACES) {
     const ms = report.timings
       .filter((timing) => timing.surface === surface && timing.answer === "ok")
       .map((timing) => timing.ms)
@@ -660,11 +798,27 @@ export function formatReport(report: LatencyReport): string {
     );
     for (const name of report.stale) lines.push(`  ${name}`);
   }
+  if (report.missingSurfaces.length > 0) {
+    lines.push(
+      "",
+      `${report.missingSurfaces.join(", ")} produced NO timings -- this run ` +
+        `covered ${SURFACES.length - report.missingSurfaces.length} of ` +
+        `${SURFACES.length} surfaces and its verdicts are not trustworthy. ` +
+        `A surface that was never asked cannot be over budget, so every ` +
+        `ruling above was decided without it.`,
+    );
+  }
   return lines.join("\n");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const report = await run();
   console.log(formatReport(report));
-  if (report.overBudget.length > 0 || report.stale.length > 0) process.exit(1);
+  if (
+    report.overBudget.length > 0 ||
+    report.stale.length > 0 ||
+    report.missingSurfaces.length > 0
+  ) {
+    process.exit(1);
+  }
 }

--- a/scripts/conformance-subjects.ts
+++ b/scripts/conformance-subjects.ts
@@ -43,9 +43,31 @@ const ACCOUNT_FIXTURE = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
  * with a made-up subject and then reported as slow or divergent when the only
  * thing wrong was the question.
  */
+/**
+ * Why a sweep is calling, for the `context` argument every MCP tool requires.
+ *
+ * #9644 made `context` required on ALL 242 tools to capture agent intent. Both
+ * sweeps read a tool's own `required` list and skip any tool naming an argument
+ * they have no subject for -- which, from that commit on, was every tool. The
+ * failure was silent in both: `check-operation-latency` reported `rest: 217
+ * timed` and `graphql: 200 timed` and simply printed no mcp line at all, and a
+ * surface that is absent cannot be over budget, so the sweep's own staleness
+ * rule ("comfortably under budget on EVERY surface") was being decided on two
+ * thirds of the evidence.
+ *
+ * The value is what this genuinely is. The argument is "analytics only; does
+ * not affect the result", so nothing depends on it being convincing -- and a
+ * fabricated user goal would put ~440 calls a run of fake intent into the
+ * telemetry the argument exists to collect.
+ */
+export const SWEEP_CONTEXT =
+  "Automated API conformance and latency sweep (metagraphed CI), not a user request";
+
 export const SUBJECTS: Readonly<
   Record<string, string | number | readonly number[]>
 > = {
+  // Required by every MCP tool since #9644 -- see SWEEP_CONTEXT.
+  context: SWEEP_CONTEXT,
   netuid: 64,
   uid: 0,
   ref: "4200000",
@@ -112,7 +134,10 @@ export function concreteRoute(template: string): string | null {
 
 /** Arguments for the MCP tool that mirrors this route template. */
 export function toolArguments(template: string): Row {
-  const args: Row = {};
+  // `context` is required by every tool but is not a path placeholder, so it
+  // can never come from the template -- see SWEEP_CONTEXT for what its absence
+  // cost the cross-surface sweep.
+  const args: Row = { context: SWEEP_CONTEXT };
   for (const name of placeholders(template)) {
     if (SUBJECTS[name] !== undefined) args[name] = SUBJECTS[name];
   }

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -398,6 +398,56 @@ describe("analytics edge cache", () => {
     assert.equal(mismatch.status, 200);
   });
 
+  test("every answer says which side of the cache produced it", async () => {
+    // #10312: a `caches.default` hit returns the STORED response verbatim, so
+    // before this a caller could not tell a 120ms cache hit from a 15s
+    // lakehouse read -- they differ only in a duration nobody records.
+    // `scripts/check-operation-latency.ts` was scoring the difference as the
+    // operation getting faster: measured 2026-08-19, /api/v1/blocks/{ref}
+    // drew [6034, 93, 91] and was reported as a fixed read.
+    originalCaches = globalWithCaches.caches;
+    const cache = mockCaches();
+    cache.install();
+    const env = storeUpstreamEnv([]);
+    const target =
+      "https://api.metagraph.sh/api/v1/subnets/9/health/percentiles?window=30d";
+
+    const miss = await handleRequest(
+      new Request(target),
+      env as unknown as Env,
+      ctx,
+    );
+    assert.equal(miss.status, 200);
+    assert.equal(miss.headers.get("x-metagraph-cache"), "miss");
+    assert.ok(await miss.text(), "a miss still carries its body");
+
+    const hit = await handleRequest(
+      new Request(target),
+      mockEnv(env) as unknown as Env,
+      ctx,
+    );
+    assert.equal(hit.status, 200);
+    assert.equal(hit.headers.get("x-metagraph-cache"), "hit");
+
+    // The 304 path is stamped too: it is served off the cached entry, and a
+    // polling agent that only ever gets 304s would otherwise never see one.
+    const conditional = await handleRequest(
+      new Request(target, {
+        headers: { "if-none-match": hit.headers.get("etag")! },
+      }),
+      mockEnv(env) as unknown as Env,
+      ctx,
+    );
+    assert.equal(conditional.status, 304);
+    assert.equal(conditional.headers.get("x-metagraph-cache"), "hit");
+
+    // And the label reaches a browser, or it is a header nobody can read.
+    assert.ok(
+      EXPOSED_RESPONSE_HEADERS_VALUE.includes("x-metagraph-cache"),
+      "the cache label is exposed cross-origin",
+    );
+  });
+
   test("INVARIANT: a different window and a different netuid key separately", async () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();

--- a/tests/chain-detail-edge-cache.test.ts
+++ b/tests/chain-detail-edge-cache.test.ts
@@ -52,7 +52,8 @@ function mockCaches() {
 
 const env = {} as unknown as Parameters<typeof chainDetailCacheKey>[0];
 const url = new URL("https://api.metagraph.sh/api/v1/blocks/8803541");
-const get = () => new Request(url.toString());
+const get = (headers: Record<string, string> = {}) =>
+  new Request(url.toString(), { headers });
 
 /** A handler response carrying `profile`, shaped like envelopeResponse's. */
 function answer(profile: "static" | "short", body = '{"ok":true}') {
@@ -131,6 +132,61 @@ describe("chain-detail edge cache (#11001)", () => {
     await Promise.all(waits);
     const stored = [...cache.store.values()][0];
     assert.equal(stored.headers.get("cache-control"), "public, s-maxage=3600");
+  });
+
+  test("labels which side of the cache answered, and never labels the stored copy", async () => {
+    // #10312: this cache is invisible from outside -- Cloudflare stamps
+    // `cf-cache-status` on its own zone cache, but a `caches.default` hit here
+    // returns the stored response verbatim. Measured against production
+    // 2026-08-19, /api/v1/blocks/6100011 went 15,222ms then 2,216ms with no
+    // cache header of any kind, and the latency gate scored the second number
+    // as the read getting faster.
+    const cache = mockCaches();
+    cache.install();
+    const waits: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+    const handler = producer(() => answer("static"));
+
+    const miss = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      ctx,
+      handler.produce,
+    );
+    assert.equal(miss.headers.get("x-metagraph-cache"), "miss");
+    assert.equal(await miss.text(), '{"ok":true}', "still readable");
+    await Promise.all(waits);
+
+    // The label describes a delivery, not a payload, so the stored copy is
+    // taken before the stamp. The hit path re-stamps, so a stored label would
+    // be overwritten rather than served -- this pins the intent, not a live
+    // failure.
+    const stored = [...cache.store.values()][0];
+    assert.equal(stored.headers.get("x-metagraph-cache"), null);
+
+    const hit = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      ctx,
+      handler.produce,
+    );
+    assert.equal(hit.headers.get("x-metagraph-cache"), "hit");
+    assert.equal(handler.calls, 1, "served without re-running the scan");
+
+    const conditional = await withChainDetailEdgeCache(
+      get({ "if-none-match": hit.headers.get("etag") ?? "" }),
+      env,
+      url,
+      "mainnet",
+      ctx,
+      handler.produce,
+    );
+    assert.equal(conditional.status, 304);
+    assert.equal(conditional.headers.get("x-metagraph-cache"), "hit");
   });
 
   test("does NOT store an unsettled (short) answer", async () => {

--- a/tests/conformance-subjects.test.ts
+++ b/tests/conformance-subjects.test.ts
@@ -1,0 +1,62 @@
+// The subjects both API sweeps call with (#10312).
+//
+// This file exists because a REQUIRED ARGUMENT SILENTLY DELETED A WHOLE
+// SURFACE. #9644 made `context` required on all 242 MCP tools to capture agent
+// intent; both sweeps skip any tool naming a required argument they have no
+// subject for, so from that commit on they skipped every tool. Neither said so
+// -- `check-operation-latency` printed `rest: 217 timed` and `graphql: 200
+// timed`, no mcp line, and a clean report.
+//
+// The damage was not just missing coverage. That sweep retires an exemption
+// when its read comes in "comfortably under budget on EVERY surface", and a
+// surface nobody asked cannot be over budget -- so it began recommending the
+// deletion of exemptions on two thirds of the evidence.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  SUBJECTS,
+  SWEEP_CONTEXT,
+  argumentsForRequired,
+  toolArguments,
+} from "../scripts/conformance-subjects.ts";
+
+describe("the argument every MCP tool requires", () => {
+  test("a tool requiring only `context` is askable", () => {
+    // 107 of the 242 live tools have exactly this required list. Before the
+    // fix this returned null, and those 107 were never called.
+    const args = argumentsForRequired(["context"]);
+    assert.notEqual(args, null, "a tool requiring only context must be asked");
+    assert.equal(args?.context, SWEEP_CONTEXT);
+  });
+
+  test("a tool requiring `context` alongside a subject is askable", () => {
+    // The next 74: required = ["context", "netuid"].
+    const args = argumentsForRequired(["context", "netuid"]);
+    assert.deepEqual(args, { context: SWEEP_CONTEXT, netuid: SUBJECTS.netuid });
+  });
+
+  test("the route-template entry point supplies it too", () => {
+    // `context` is not a path placeholder, so it can never come from the
+    // template -- which is how the cross-surface sweep lost its MCP half
+    // while still looking like it was calling the tools.
+    const args = toolArguments("/api/v1/subnets/{netuid}");
+    assert.equal(args.context, SWEEP_CONTEXT);
+    assert.equal(args.netuid, SUBJECTS.netuid);
+  });
+
+  test("an argument with no subject is still refused", () => {
+    // The control. The skip is CORRECT behaviour -- calling a tool with a
+    // made-up subject and reporting the decline as slowness is the failure it
+    // prevents. The bug was never the skip, it was having no subject for an
+    // argument every tool had started requiring.
+    assert.equal(argumentsForRequired(["context", "no_such_subject"]), null);
+  });
+
+  test("the context we send says what it actually is", () => {
+    // It is "analytics only; does not affect the result", so nothing depends
+    // on it being convincing -- and ~440 calls a run of a fabricated user goal
+    // would poison the telemetry the argument was added to collect.
+    assert.match(SWEEP_CONTEXT, /sweep/i);
+    assert.match(SWEEP_CONTEXT, /not a user request/i);
+  });
+});

--- a/tests/operation-latency-verdict.test.ts
+++ b/tests/operation-latency-verdict.test.ts
@@ -15,7 +15,11 @@ import { describe, test } from "vitest";
 import {
   confirmOverBudget,
   family,
+  formatReport,
+  servedFrom,
   summarise,
+  type Draw,
+  type Served,
   type Timing,
 } from "../scripts/check-operation-latency.ts";
 
@@ -32,8 +36,26 @@ const timing = (over: Partial<Timing> = {}): Timing => ({
   operation: "/api/v1/subnets",
   ms: 100,
   answer: "ok",
+  served: "origin",
   ...over,
 });
+
+/** A retime map whose draws are scripted, and which counts what it served. */
+function draws(script: Record<string, (number | [number, Served])[]>) {
+  const calls: string[] = [];
+  const map = new Map<string, () => Promise<Draw>>();
+  for (const [key, values] of Object.entries(script)) {
+    let i = 0;
+    map.set(key, async () => {
+      calls.push(key);
+      const value = values[Math.min(i++, values.length - 1)]!;
+      const [ms, served] =
+        typeof value === "number" ? ([value, "origin"] as const) : value;
+      return [ms, "ok", served];
+    });
+  }
+  return { map, calls };
+}
 
 describe("what the latency sweep rules on", () => {
   test("an undeclared operation over budget is reported", () => {
@@ -180,26 +202,13 @@ describe("a read is one entry, not three", () => {
 // and "at the 15s ceiling" are ordinary draws from that, so a single sample
 // decided the verdict by when the sweep happened to call.
 describe("confirming an over-budget draw before believing it", () => {
-  /** A retime map whose draws are scripted, and which counts what it served. */
-  function draws(script: Record<string, number[]>) {
-    const calls: string[] = [];
-    const map = new Map<string, () => Promise<[number, "ok"]>>();
-    for (const [key, values] of Object.entries(script)) {
-      let i = 0;
-      map.set(key, async () => {
-        calls.push(key);
-        return [values[Math.min(i++, values.length - 1)]!, "ok"];
-      });
-    }
-    return { map, calls };
-  }
-
   test("an operation that was slow ONCE is scored on its median, not that draw", async () => {
     const timing: Timing = {
       surface: "rest",
       operation: "/api/v1/blocks/{ref}",
       ms: 15032,
       answer: "ok",
+      served: "origin",
       samples: [15032],
     };
     const { map, calls } = draws({ "rest:/api/v1/blocks/{ref}": [898, 3647] });
@@ -223,6 +232,7 @@ describe("confirming an over-budget draw before believing it", () => {
       operation: "/api/v1/blocks/{ref}",
       ms: 12000,
       answer: "ok",
+      served: "origin",
       samples: [12000],
     };
     const { map } = draws({ "rest:/api/v1/blocks/{ref}": [11500, 13000] });
@@ -240,6 +250,7 @@ describe("confirming an over-budget draw before believing it", () => {
       operation: "/api/v1/subnets",
       ms: 300,
       answer: "ok",
+      served: "origin",
       samples: [300],
     };
     const { map, calls } = draws({ "rest:/api/v1/subnets": [9000, 9000] });
@@ -257,15 +268,18 @@ describe("confirming an over-budget draw before believing it", () => {
       operation: "/api/v1/blocks/{ref}",
       ms: 9000,
       answer: "ok",
+      served: "origin",
       samples: [9000],
     };
     const calls: string[] = [];
-    const map = new Map<string, () => Promise<[number, "ok" | "unaskable"]>>([
+    const map = new Map<string, () => Promise<Draw>>([
       [
         "rest:/api/v1/blocks/{ref}",
         async () => {
           calls.push("x");
-          return calls.length === 1 ? [12, "unaskable"] : [8000, "ok"];
+          return calls.length === 1
+            ? [12, "unaskable", "origin"]
+            : [8000, "ok", "origin"];
         },
       ],
     ]);
@@ -280,5 +294,144 @@ describe("confirming an over-budget draw before believing it", () => {
     // fixed on the other half is how a regression hides behind one lucky call.
     assert.equal(timing.ms, 9000, "the upper median, conservatively");
     assert.equal(summarise([timing]).overBudget.length, 1);
+  });
+});
+
+// The edge cache (#10312). `confirmOverBudget`'s first draw FILLS the cache its
+// retries then read, so before this the retries were not redraws of the same
+// distribution -- they were reads of the answer the first draw had just stored.
+describe("a draw that measured the cache instead of the read", () => {
+  const BLOCK_EXTRINSICS = "/api/v1/blocks/{ref}/extrinsics";
+
+  test("a confirmation draw served from cache is not a sample", async () => {
+    // The exact production draw, 2026-08-19: [7290, 63, 43] scored a median of
+    // 63ms -- the CDN. The read still takes 7.3s cold, and five distinct block
+    // refs (five cold keys) measured 1.3-5.6s while a repeat of one returned in
+    // 0.12s with `cf-cache-status: HIT`.
+    const timing: Timing = {
+      surface: "rest",
+      operation: BLOCK_EXTRINSICS,
+      ms: 7290,
+      answer: "ok",
+      served: "origin",
+      samples: [7290],
+    };
+    const { map } = draws({
+      [`rest:${BLOCK_EXTRINSICS}`]: [
+        [63, "cache"],
+        [43, "cache"],
+      ],
+    });
+    await confirmOverBudget([timing], map, 0);
+    assert.deepEqual(timing.samples, [7290], "neither cache hit became a time");
+    assert.equal(timing.ms, 7290, "it keeps the one draw that measured it");
+  });
+
+  test("a genuinely faster redraw still counts", async () => {
+    // The control. Without it, "discard cache draws" could be satisfied by
+    // discarding everything, and the confirmation pass would stop working.
+    const timing: Timing = {
+      surface: "rest",
+      operation: BLOCK_EXTRINSICS,
+      ms: 7290,
+      answer: "ok",
+      served: "origin",
+      samples: [7290],
+    };
+    const { map } = draws({ [`rest:${BLOCK_EXTRINSICS}`]: [900, 1100] });
+    await confirmOverBudget([timing], map, 0);
+    assert.deepEqual(timing.samples, [7290, 900, 1100]);
+    assert.equal(timing.ms, 1100, "the median of three real draws");
+  });
+
+  test("a cache-served draw cannot retire a declared exemption", () => {
+    // The failure this whole change exists to stop: the 2026-08-19 run reported
+    // five exemptions as "now comfortably under budget, delete them", and this
+    // was one of them -- on 63ms that never reached the warehouse.
+    const report = summarise([
+      timing({ operation: BLOCK_EXTRINSICS, ms: 63, served: "cache" }),
+    ]);
+    assert.ok(
+      !report.stale.includes(BLOCK_EXTRINSICS),
+      "a cache hit is not evidence the read got faster",
+    );
+  });
+
+  test("an ORIGIN draw that fast still retires it", () => {
+    // The positive control for the rule above: the exemption list must still be
+    // able to shrink, or it stops being a list that can ever empty.
+    const report = summarise([
+      timing({ operation: BLOCK_EXTRINSICS, ms: 63, served: "origin" }),
+    ]);
+    assert.ok(
+      report.stale.includes(BLOCK_EXTRINSICS),
+      "a measured 63ms read IS a fixed read",
+    );
+  });
+
+  test("which header says a cache answered", () => {
+    const served = (headers: Record<string, string>) =>
+      servedFrom(new Response(null, { headers }));
+    // Our own header is authoritative: it is the only one that sees a
+    // `caches.default` hit inside the Worker.
+    assert.equal(served({ "x-metagraph-cache": "hit" }), "cache");
+    assert.equal(served({ "x-metagraph-cache": "miss" }), "origin");
+    // ...and it OVERRIDES the zone's, which reports its own layer only.
+    assert.equal(
+      served({ "x-metagraph-cache": "miss", "cf-cache-status": "HIT" }),
+      "origin",
+      "our miss beats the zone's hit -- the zone cached a response we built",
+    );
+    // The fallback, for any route that never reaches those wrappers.
+    assert.equal(served({ "cf-cache-status": "HIT" }), "cache");
+    assert.equal(served({ "cf-cache-status": "MISS" }), "origin");
+    // A miss stamps no header at all, as measured against production.
+    assert.equal(served({}), "origin");
+  });
+});
+
+// A surface that vanishes from the sweep (#10312). Measured 2026-08-19: the run
+// timed `rest: 217` and `graphql: 200` and printed no mcp line whatsoever,
+// because #9644 had made an argument required that no subject satisfied. The
+// report looked clean.
+describe("a surface the sweep never asked", () => {
+  test("is reported, and fails the run", () => {
+    const report = summarise([
+      timing({ surface: "rest" }),
+      timing({ surface: "graphql" }),
+    ]);
+    assert.deepEqual(report.missingSurfaces, ["mcp"]);
+    assert.match(formatReport(report), /produced NO timings/);
+  });
+
+  test("a complete run reports none", () => {
+    // The positive control: this must not fire on every ordinary sweep.
+    const report = summarise([
+      timing({ surface: "rest" }),
+      timing({ surface: "mcp" }),
+      timing({ surface: "graphql" }),
+    ]);
+    assert.deepEqual(report.missingSurfaces, []);
+    assert.doesNotMatch(formatReport(report), /produced NO timings/);
+  });
+
+  test("a missing surface cannot be the reason an exemption looks fixed", () => {
+    // The consequence that makes this worth failing over rather than warning:
+    // the read below is comfortably under budget on the two surfaces that ran,
+    // and its exemption still must not be retired on a two-thirds sweep.
+    const report = summarise([
+      timing({ operation: "/api/v1/extrinsics", surface: "rest", ms: 260 }),
+      timing({ operation: "extrinsics", surface: "graphql", ms: 230 }),
+    ]);
+    assert.ok(report.missingSurfaces.includes("mcp"));
+    assert.ok(
+      report.stale.includes("/api/v1/extrinsics"),
+      "the staleness rule itself is unchanged...",
+    );
+    assert.match(
+      formatReport(report),
+      /every ruling above was decided without it/,
+      "...but the report says out loud that it was decided on a partial sweep",
+    );
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -233,6 +233,7 @@ import {
   ifNoneMatchSatisfied,
   isPathUnder,
   weakEtag,
+  withCacheStatus,
   X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER,
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   type CacheProfile,
@@ -4435,9 +4436,12 @@ export async function withChainDetailEdgeCache(
     // polling agent gets a 304 off a warm edge rather than the whole payload
     // (mirrors envelopeResponse and the artifact cache's own hit path).
     if (ifNoneMatchSatisfied(request, hit.headers.get("etag"))) {
-      return new Response(null, { status: 304, headers: hit.headers });
+      return withCacheStatus(
+        new Response(null, { status: 304, headers: hit.headers }),
+        "hit",
+      );
     }
-    return hit;
+    return withCacheStatus(hit, "hit");
   }
 
   const response = await produce();
@@ -4459,7 +4463,9 @@ export async function withChainDetailEdgeCache(
     );
     cacheWrite(ctx, () => cacheable.store.put(cacheable.key, stored));
   }
-  return response;
+  // Stamped on the returned response only -- `stored` above is the cache's own
+  // copy and must not carry this request's verdict. See `withCacheStatus`.
+  return withCacheStatus(response, "miss");
 }
 
 /**

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -21,6 +21,56 @@ export const X_METAGRAPH_ARTIFACT_SOURCE_HEADER = "x-metagraph-artifact-source";
 export const X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER =
   "x-metagraph-artifact-resolution";
 
+/**
+ * Which side of an edge cache produced this response: `hit` | `miss`.
+ *
+ * The Worker's Cache API is INVISIBLE from outside. Cloudflare stamps
+ * `cf-cache-status` on its own zone cache, but a `caches.default` hit served by
+ * `withEdgeCache` / `withChainDetailEdgeCache` returns the stored response
+ * verbatim, so a caller cannot tell a 120 ms cache hit from a 15 s lakehouse
+ * read -- they differ only in a duration nobody records.
+ *
+ * That blindness is not hypothetical. `scripts/check-operation-latency.ts`
+ * re-times an over-budget call to reject a one-off outlier, and its own first
+ * draw fills the cache the retries then read: measured 2026-08-19,
+ * `/api/v1/blocks/{ref}/extrinsics` drew [7290, 63, 43] ms and scored the
+ * MEDIAN, 63 ms -- the CDN, not the read. Scored that way the gate reported
+ * five exemptions as "now comfortably under budget, delete them", which would
+ * have retired live 7-second reads on the evidence of its own cache.
+ *
+ * Named `hit`/`miss` after `x-metagraph-rpc-cache`, which answers exactly this
+ * question for the RPC proxy and is the reason that one is not guessing.
+ */
+export const X_METAGRAPH_CACHE_HEADER = "x-metagraph-cache";
+
+/** Statuses the Response constructor forbids a body on (null body only). */
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+/**
+ * Copy `response`, labelled with which side of the cache produced it.
+ *
+ * A COPY, because `Response.headers` from `cache.match()` is immutable and
+ * `set` on it throws.
+ *
+ * Stamped on the way OUT, after the caller has stored its `response.clone()`,
+ * because the label describes ONE DELIVERY and a cache entry outlives the
+ * request that produced it. Every return path re-stamps today, so a label
+ * baked into the stored copy would be overwritten rather than served -- this
+ * is not load-bearing, it is keeping a header that means "how you got this"
+ * out of a body that will be handed to someone who got it another way.
+ */
+export function withCacheStatus(
+  response: Response,
+  status: "hit" | "miss",
+): Response {
+  const headers = new Headers(response.headers);
+  headers.set(X_METAGRAPH_CACHE_HEADER, status);
+  return new Response(
+    NULL_BODY_STATUSES.has(response.status) ? null : response.body,
+    { status: response.status, statusText: response.statusText, headers },
+  );
+}
+
 const EXPOSED_RESPONSE_HEADERS = [
   "etag", // conditional-request validator (If-None-Match → 304)
   "link", // RFC 8288 pagination links (next/prev/first/last) on list routes
@@ -49,6 +99,7 @@ const EXPOSED_RESPONSE_HEADERS = [
   // measured one -- the whole point of the header is that it reaches the
   // consumer, and an unexposed header does not.
   "x-metagraph-degraded",
+  X_METAGRAPH_CACHE_HEADER,
   "x-metagraph-rpc-cache",
   "x-metagraph-rpc-endpoint-id",
   "x-metagraph-rpc-provider",

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -52,7 +52,11 @@ import { loadChainWeightsFromArtifact } from "../../src/chain-weights-artifact.t
 import { loadChainWeightSettersColdTier } from "../../src/chain-weight-setters-loader.ts";
 import { loadChainWeightSettersFromArtifact } from "../../src/chain-weight-setters-artifact.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
-import { errorResponse, ifNoneMatchSatisfied } from "../http.ts";
+import {
+  errorResponse,
+  ifNoneMatchSatisfied,
+  withCacheStatus,
+} from "../http.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
 import {
   contractVersion,
@@ -596,11 +600,17 @@ export async function withEdgeCache(
       // Honour conditional requests against the cached body's weak ETag so
       // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
       if (ifNoneMatchSatisfied(request, hit.headers.get("etag") || "")) {
-        return new Response(null, { status: 304, headers: hit.headers });
+        return withCacheStatus(
+          new Response(null, { status: 304, headers: hit.headers }),
+          "hit",
+        );
       }
-      return normalizesHead
-        ? new Response(null, { status: hit.status, headers: hit.headers })
-        : hit;
+      return withCacheStatus(
+        normalizesHead
+          ? new Response(null, { status: hit.status, headers: hit.headers })
+          : hit,
+        "hit",
+      );
     }
   }
   const before = degradedSnapshot();
@@ -651,9 +661,17 @@ export async function withEdgeCache(
   ) {
     ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
   }
-  return normalizesHead
-    ? new Response(null, { status: response.status, headers: response.headers })
-    : response;
+  // Stamped AFTER the `cache.put` above, which stores `response.clone()`, so
+  // the stored copy stays unlabelled. See `withCacheStatus`.
+  return withCacheStatus(
+    normalizesHead
+      ? new Response(null, {
+          status: response.status,
+          headers: response.headers,
+        })
+      : response,
+    "miss",
+  );
 }
 
 // Postgres-backed 7d/30d daily uptime + latency trends across all subnets


### PR DESCRIPTION
## What was wrong

The operation-latency sweep re-draws an over-budget call to reject a one-off outlier. **Its own first draw fills the edge cache the retries then read**, so the retries were not redraws of the same distribution — they were reads of the answer the first draw had just stored.

Measured 2026-08-19, the same run, split by method:

| method | operation | draws | scored |
|---|---|---|---|
| GET | `/api/v1/blocks/{ref}/extrinsics` | `[7290, 63, 43]` | **63ms** |
| GET | `/api/v1/extrinsics/{hash}` | `[8703, 78, 66]` | **78ms** |
| GET | `/api/v1/accounts/{ss58}/history` | `[17714, 10341, 51]` | 10341ms |
| POST | `graphql account_transfers` | `[17386, 14281, 11017]` | 14281ms |
| POST | `graphql subnet_ohlc` | `[9554, 5893, 5104]` | 5893ms |

Every GET collapses to double digits; no POST does. That is not two populations of route — `withEdgeCache` consults the cache for GET only.

Scored that way, the run reported **five exemptions as "now comfortably under budget, delete them"**, among them a read that still takes 7.3s cold. Confirmed directly against production: five *distinct* block refs (five cold cache keys) took 3.72 / 3.13 / 2.85 / 5.57 / 1.32s, while repeating one returned in 0.12s with `cf-cache-status: HIT`. Retiring an exemption is the one move this gate cannot take back.

## Why not just bypass the cache

Tested, all three fail:

| attempt | result |
|---|---|
| `?_cb=<nonce>` | **400** — routes reject unknown query params |
| `Cache-Control: no-cache` | ignored, still `HIT` |
| `Pragma: no-cache` | ignored, still `HIT` |

So the cache is made **observable** instead. `withEdgeCache` and `withChainDetailEdgeCache` now stamp `x-metagraph-cache: hit|miss`, named after the existing `x-metagraph-rpc-cache` that answers exactly this question for the RPC proxy. Cloudflare's own `cf-cache-status` is not enough: it covers the zone cache only, and a `caches.default` hit inside the Worker returns the stored response verbatim — `/api/v1/blocks/6100011` went 15,222ms then 2,216ms with **no cache header of any kind**. That is a real observability gap independent of this gate: nobody, including us, could tell a 120ms cache hit from a 15s lakehouse read.

The gate then refuses to score a cache-served draw in both halves — a cached retry is discarded like a non-`ok` answer, and a cache-served draw can no longer be the evidence that retires an exemption.

## The second defect: a third of the API was never asked

The same run timed `rest: 217` and `graphql: 200` and printed **no mcp line at all**. #9644 made `context` required on all 242 MCP tools; both sweeps skip a tool whose required argument they have no subject for, so from that commit on they skipped every tool — silently, in `check-operation-latency` and `check-cross-surface-values` alike.

That is not only lost coverage. An exemption is retired when its read is under budget on **every** surface, and a surface nobody asked can never object — so the staleness rule was being decided on two thirds of the evidence, which is an independent reason those five verdicts were untrustworthy. Both entry points now supply it (216/242 tools go from unaskable to asked, verified against production), and a surface producing no timings now **fails** the run instead of being skipped in the report.

## What is deliberately not done here

**No exemption is retired.** Every stale verdict in that run was produced by the two defects above, so the list is re-measured once the header is live rather than pruned on evidence this PR is in the middle of proving wrong.

Two reads that *are* genuinely over budget on honest (POST, uncached) evidence are declared: `/api/v1/accounts/{ss58}/subnets/{netuid}/history` (graphql 6060ms, and rest 7687ms once its cache-served draws stop counting) and `/api/v1/chain-events/stats` (graphql 5952ms).

## Verification

- 961 test files / 22,139 tests pass; 73/74 CI validators pass locally (the 74th is `build`, run separately — clean, no artifact drift)
- **Patch coverage 100%** on both lines (12/12) and branches (6/6) for `src/**`/`workers/**`, measured by diff intersection against `origin/main`
- Every new rule has a positive control: an origin-served 63ms draw still retires an exemption, a genuinely faster redraw still counts, and a complete run reports no missing surface

Closes #10312