### PR TITLE
feat(ui): establish metagraph terminal design system

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -113,7 +113,7 @@ export default defineConfig({
       // peak.
       name: "interaction",
       testMatch:
-        /(crawlable-subnet-index|evidence-deep-link|indexable-routes|multisig-related-error|offline|sticky-table-header)\.spec\.ts$/,
+        /(crawlable-subnet-index|evidence-deep-link|indexable-routes|multisig-related-error|offline|sticky-table-header|subnets-directory-controls)\.spec\.ts$/,
       dependencies: ["overflow"],
       // Serial within the phase costs a few seconds and removes the last
       // source of self-contention for exactly the tests that proved sensitive

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -71,8 +71,8 @@ function Brand({ onNavigate }: { onNavigate?: () => void }) {
       aria-label="Metagraphed — home"
       className="flex items-center shrink-0 group text-ink-strong"
     >
-      {/* Adaptive wordmark: mint M + currentColor text → follows text-ink-strong
-          across light/dark. h-6 ≈ the prior 24px logo footprint. */}
+      {/* Adaptive wordmark: the existing mark remains Metagraphed's own while
+          the surrounding terminal system follows the active theme. */}
       <Wordmark className="h-6 w-auto" />
     </Link>
   );
@@ -237,12 +237,12 @@ export function AppShell({
           {/* Top bar */}
           <header
             data-scrolled={scrolled ? "true" : "false"}
-            className="mg-header sticky top-0 z-[var(--mg-z-nav)] border-b border-border bg-paper/90 backdrop-blur supports-[backdrop-filter]:bg-paper/75"
+            className="mg-header sticky top-0 z-[var(--mg-z-nav)] border-b border-border bg-paper"
           >
             <div className="max-w-shell-max mx-auto px-4 md:px-8 flex h-nav items-center gap-3">
               <button
                 ref={hamburgerRef}
-                className="lg:hidden rounded-md p-2 text-ink hover:bg-surface min-h-11 min-w-11 inline-flex items-center justify-center"
+                className="lg:hidden rounded p-2 text-ink hover:bg-surface-2 min-h-11 min-w-11 inline-flex items-center justify-center"
                 onClick={() => setMobileOpen(true)}
                 aria-label="Open menu"
               >
@@ -270,7 +270,7 @@ export function AppShell({
                   onClick={(e) => openPaletteFrom(e.currentTarget)}
                   aria-label="Open search"
                   title="Search"
-                  className="md:hidden inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                  className="md:hidden inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-accent/60 transition-colors"
                 >
                   <Search className="size-4" aria-hidden="true" />
                 </button>
@@ -288,7 +288,7 @@ export function AppShell({
                     <Link
                       to="/settings"
                       aria-label="Developer settings"
-                      className="hidden md:inline-flex lg:hidden xl:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                      className="hidden md:inline-flex lg:hidden xl:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-accent/60 transition-colors"
                     >
                       <Webhook className="size-3.5" aria-hidden="true" />
                     </Link>
@@ -453,11 +453,7 @@ function ApiBaseRow() {
 
 function SiteFooter() {
   return (
-    <footer className="mt-24 border-t border-border bg-surface/30 relative overflow-hidden">
-      <div
-        aria-hidden
-        className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent"
-      />
+    <footer className="mt-20 border-t border-border bg-surface/30 relative overflow-hidden">
       <div className="max-w-shell-max mx-auto px-4 md:px-10 py-12 grid gap-10 md:grid-cols-5 mg-type-caption text-ink-muted">
         <div className="md:col-span-2">
           <div className="font-display text-base font-semibold text-ink-strong inline-flex items-baseline gap-1">
@@ -477,7 +473,7 @@ function SiteFooter() {
               href={GITHUB_HREF}
               ariaLabel="GitHub repository"
               title="Open source on GitHub"
-              className="inline-flex items-center justify-center rounded-md size-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+              className="inline-flex items-center justify-center rounded size-8 text-ink-muted hover:text-ink-strong hover:bg-surface-2 transition-colors"
             >
               <Github className="size-4" />
             </ExternalLink>
@@ -486,7 +482,7 @@ function SiteFooter() {
               href={DISCORD_HREF}
               ariaLabel="Discord community"
               title="Join us on Discord"
-              className="inline-flex items-center justify-center rounded-md size-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+              className="inline-flex items-center justify-center rounded size-8 text-ink-muted hover:text-ink-strong hover:bg-surface-2 transition-colors"
             >
               <DiscordIcon className="size-4" />
             </ExternalLink>
@@ -499,7 +495,7 @@ function SiteFooter() {
               href={`${API_BASE}/api/v1/feeds/registry.rss`}
               ariaLabel="Registry changes RSS feed"
               title="Subscribe to the registry-changes feed (RSS)"
-              className="inline-flex items-center justify-center rounded-md size-8 text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+              className="inline-flex items-center justify-center rounded size-8 text-ink-muted hover:text-ink-strong hover:bg-surface-2 transition-colors"
             >
               <Rss className="size-4" />
             </ExternalLink>

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -219,13 +219,9 @@ export function AppShell({
   return (
     <TooltipProvider delayDuration={150}>
       <ApiSourceProvider>
-        {/* Deliberately NO background here. `body` already paints --color-paper
-            AND the brand background pattern on top of it (ui-kit's base layer:
-            hairline grid + dot field + soft accent vignette). An opaque
-            `bg-paper` on this full-height wrapper covered that pattern
-            completely — the app rendered as a flat fill on every route, which
-            is not what the design system draws. The colour is unchanged; only
-            the occlusion is removed. */}
+        {/* Deliberately no background here. The page plane is intentionally
+            quiet; routes add the one structural cue they need instead of a
+            decorative texture being forced behind every explorer table. */}
         <div className="min-h-dvh text-ink flex flex-col">
           {/* Skip link: first focusable element, visible only on keyboard focus. */}
           <a
@@ -242,7 +238,7 @@ export function AppShell({
             <div className="max-w-shell-max mx-auto px-4 md:px-8 flex h-nav items-center gap-3">
               <button
                 ref={hamburgerRef}
-                className="lg:hidden rounded p-2 text-ink hover:bg-surface-2 min-h-11 min-w-11 inline-flex items-center justify-center"
+                className="lg:hidden p-2 text-ink hover:bg-surface-2 min-h-11 min-w-11 inline-flex items-center justify-center transition-colors"
                 onClick={() => setMobileOpen(true)}
                 aria-label="Open menu"
               >
@@ -270,7 +266,7 @@ export function AppShell({
                   onClick={(e) => openPaletteFrom(e.currentTarget)}
                   aria-label="Open search"
                   title="Search"
-                  className="md:hidden inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-accent/60 transition-colors"
+                  className="md:hidden inline-flex items-center justify-center p-1.5 min-h-11 min-w-11 text-ink-muted hover:bg-surface hover:text-ink-strong transition-colors"
                 >
                   <Search className="size-4" aria-hidden="true" />
                 </button>
@@ -288,7 +284,7 @@ export function AppShell({
                     <Link
                       to="/settings"
                       aria-label="Developer settings"
-                      className="hidden md:inline-flex lg:hidden xl:inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-accent/60 transition-colors"
+                      className="hidden md:inline-flex lg:hidden xl:inline-flex items-center justify-center p-1.5 min-h-11 min-w-11 text-ink-muted hover:bg-surface hover:text-ink-strong transition-colors"
                     >
                       <Webhook className="size-3.5" aria-hidden="true" />
                     </Link>

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -422,7 +422,7 @@ export function AppShell({
                   ),
             )}
           >
-            {children}
+            {fullBleedMain ? children : <div className="mg-route-frame">{children}</div>}
           </main>
 
           <SiteFooter />

--- a/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/author-share-panel.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { Panel } from "@/components/metagraphed/primitives";
+import { DataPageModule } from "@/components/metagraphed/primitives";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { InfoTooltip } from "@jsonbored/ui-kit";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
@@ -32,15 +32,15 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
   const max = top[0]?.count ?? 1;
 
   return (
-    <Panel
-      className="mb-6"
+    <DataPageModule
+      kind="question"
       title={
         <span className="inline-flex items-center gap-1.5">
-          Top authors this page
+          Authors
           <InfoTooltip label="Validators that produced the most blocks in this page window. Click a row to filter the feed to only their blocks." />
         </span>
       }
-      caption={`${distinct} distinct authors across ${formatNumber(total)} blocks`}
+      caption={`${distinct} distinct authors across ${formatNumber(total)} blocks.`}
     >
       <ol className="divide-y divide-border/60">
         {top.map(({ author, count }) => {
@@ -107,6 +107,6 @@ export function AuthorSharePanel({ rows }: { rows: Block[] }) {
           );
         })}
       </ol>
-    </Panel>
+    </DataPageModule>
   );
 }

--- a/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/cadence-heatmap.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Link } from "@tanstack/react-router";
-import { Panel } from "@/components/metagraphed/primitives";
+import { DataPageModule } from "@/components/metagraphed/primitives";
 import { InfoTooltip } from "@jsonbored/ui-kit";
 import { classNames, formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import type { Block } from "@/lib/metagraphed/types";
@@ -39,15 +39,16 @@ export function CadenceHeatmap({ rows }: { rows: Block[] }) {
   const stalled = measured.filter((c) => (c.gapSec ?? 0) > 48).length;
 
   return (
-    <Panel
-      className="mb-8"
+    <DataPageModule
+      kind="question"
       title={
         <span className="inline-flex items-center gap-1.5">
-          Cadence heatmap
+          Cadence
           <InfoTooltip label="Seconds between consecutive blocks on this page. Subtensor targets ~12s; deeper mint = faster, amber = slow, red = stalled slot." />
         </span>
       }
-      action={
+      caption="Inter-block intervals in this page window."
+      actions={
         <div className="flex items-center gap-3 mg-type-caption text-ink-muted">
           {mean != null ? <span>mean {humaniseSeconds(mean)}</span> : null}
           <span className={slow ? "text-health-warn-text" : ""}>slow {slow}</span>
@@ -84,7 +85,7 @@ export function CadenceHeatmap({ rows }: { rows: Block[] }) {
         })}
       </ol>
       <Legend />
-    </Panel>
+    </DataPageModule>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/blocks/live-block-rail.tsx
@@ -1,7 +1,6 @@
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
-import { Panel } from "@/components/metagraphed/primitives";
 import { Sparkline, TimeAgo } from "@jsonbored/ui-kit";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { useChainStream } from "@/hooks/use-chain-stream";
@@ -68,14 +67,18 @@ export function LiveBlockRail() {
   const dailyPts = chrono.map((d) => ({ t: d.day, v: d.block_count }));
 
   return (
-    <Panel
-      as="div"
-      dense
-      className="mb-3"
-      bodyClassName="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,0.9fr)]"
-      role="status"
-      aria-live="polite"
+    <section
+      className="mg-live-block-rail mb-3 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,0.9fr)]"
+      aria-labelledby="live-block-rail-title"
     >
+      {/* The feed refreshes every block. Announce the one fact that changed,
+          rather than re-reading the whole visual rail to screen readers. */}
+      <span id="live-block-rail-title" className="sr-only">
+        Live block activity
+      </span>
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        Latest indexed block {formatNumber(latest.block_number)}
+      </span>
       {/* LATEST BLOCK. Not a single wrapping <Link>: AddressDisplay below
           renders its own <a>/<button> (account link + copy button), and an
           anchor/button can't contain another without invalid HTML nesting
@@ -198,6 +201,6 @@ export function LiveBlockRail() {
           />
         ) : null}
       </div>
-    </Panel>
+    </section>
   );
 }

--- a/apps/ui/src/components/metagraphed/chain-concentration-snapshot.tsx
+++ b/apps/ui/src/components/metagraphed/chain-concentration-snapshot.tsx
@@ -21,16 +21,17 @@ export function ChainConcentrationSnapshot({
 
   return (
     <ChartCard
-      title="Stake & emission concentration"
-      caption="Current snapshot, not a trend — the network-wide concentration endpoint has no historical window."
+      variant="data"
+      title="Stake and emission concentration"
+      caption="How much of each sits with the top 10% of holders. This is a current network snapshot, not a trend."
       updatedAt={concentration.captured_at}
-      height={120}
+      height={156}
       empty={!hasData}
     >
       <BarMini
         data={[
-          { label: "Stake", value: stakeShare ?? 0 },
-          { label: "Emission", value: emissionShare ?? 0 },
+          { label: "Stake", value: stakeShare ?? 0, color: "var(--chart-1)" },
+          { label: "Emission", value: emissionShare ?? 0, color: "var(--chart-4)" },
         ]}
         max={1}
         formatValue={formatShare}

--- a/apps/ui/src/components/metagraphed/chain-emission-trend.tsx
+++ b/apps/ui/src/components/metagraphed/chain-emission-trend.tsx
@@ -23,9 +23,10 @@ export function ChainEmissionTrend({
 
   return (
     <ChartCard
-      title="Mean emission share"
-      caption={`Average per-subnet emission share, ${window} — a widening spread means emission is concentrating into fewer subnets.`}
-      height={120}
+      variant="data"
+      title="Emission share"
+      caption={`Average per-subnet share over ${window}. A widening spread means emission is concentrating into fewer subnets.`}
+      height={192}
       empty={points.length === 0}
     >
       <Sparkline
@@ -33,8 +34,9 @@ export function ChainEmissionTrend({
         points={points}
         formatValue={formatShare}
         ariaLabel="Mean emission share over time"
-        width={480}
-        height={100}
+        width={920}
+        height={168}
+        color="var(--chart-2)"
       />
     </ChartCard>
   );

--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -343,6 +343,8 @@ export function ChainEventsFeed({ pallet, method, cursor, showNoise = false, onF
     // exactly the case a per-row timer adds up for.
     <LiveTickerProvider>
       <ListShell
+        presentation="canvas"
+        responsiveAt="lg"
         filters={filters}
         table={table}
         cards={cards}

--- a/apps/ui/src/components/metagraphed/chain-idle-stake-snapshot.tsx
+++ b/apps/ui/src/components/metagraphed/chain-idle-stake-snapshot.tsx
@@ -4,6 +4,14 @@ import { formatTao } from "@/lib/metagraphed/format";
 import type { ChainIdleStake } from "@/lib/metagraphed/types";
 
 const MAX_SHOWN = 8;
+const RANK_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+];
 
 /** Also a current snapshot — /api/v1/chain/idle-stake has no `window` param. */
 export function ChainIdleStakeSnapshot({ idleStake }: { idleStake: ChainIdleStake }) {
@@ -14,19 +22,24 @@ export function ChainIdleStakeSnapshot({ idleStake }: { idleStake: ChainIdleStak
 
   return (
     <ChartCard
-      title="Idle stake by subnet"
+      variant="data"
+      title="Idle stake"
       caption={
         idleStake.total_idle_stake_alpha != null
-          ? `${formatTao(idleStake.total_idle_stake_alpha)} idle network-wide — current snapshot, top ${top.length} subnets shown.`
-          : "Current snapshot — stake registered to a subnet with no corresponding active neuron."
+          ? `${formatTao(idleStake.total_idle_stake_alpha)} across the network. Top ${top.length} subnets are shown in this current snapshot.`
+          : "Stake registered to a subnet without a corresponding active neuron. Current snapshot."
       }
       updatedAt={idleStake.captured_at}
-      height={140}
+      height={236}
       empty={top.length === 0}
       emptyLabel="No idle stake"
     >
       <BarMini
-        data={top.map((s) => ({ label: `SN${s.netuid}`, value: s.idle_stake_alpha ?? 0 }))}
+        data={top.map((s, index) => ({
+          label: `SN${s.netuid}`,
+          value: s.idle_stake_alpha ?? 0,
+          color: RANK_COLORS[index % RANK_COLORS.length],
+        }))}
         formatValue={formatTao}
         ariaLabel="Idle stake by subnet"
       />

--- a/apps/ui/src/components/metagraphed/chain-idle-stake-snapshot.tsx
+++ b/apps/ui/src/components/metagraphed/chain-idle-stake-snapshot.tsx
@@ -11,6 +11,8 @@ const RANK_COLORS = [
   "var(--chart-4)",
   "var(--chart-5)",
   "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
 ];
 
 /** Also a current snapshot — /api/v1/chain/idle-stake has no `window` param. */

--- a/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
+++ b/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
@@ -1,11 +1,13 @@
+import { Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { Sparkline } from "@jsonbored/ui-kit";
 import {
   chainBurnQuery,
   chainHoldersQuery,
   chainConcentrationSubnetsQuery,
   chainConcentrationHistoryQuery,
 } from "@/lib/metagraphed/queries";
-import { Panel } from "@/components/metagraphed/primitives";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { formatNumber, formatTao, formatRelative } from "@/lib/metagraphed/format";
 import {
@@ -13,24 +15,31 @@ import {
   spansBuilderVersions,
   capturesDiverge,
 } from "@/lib/metagraphed/network-coverage.functions";
+import type {
+  ChainBurn,
+  ChainHolders,
+  NetworkConcentrationHistory,
+  NetworkConcentrationSubnets,
+} from "@/lib/metagraphed/types";
 
 const TOP_SHOWN = 8;
+const RANK_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+];
 
 /**
- * The four network-wide surfaces #10300 found rendered nowhere:
- * `/chain/burn`, `/chain/holders`, `/chain/concentration/subnets` and
- * `/chain/concentration/history`.
- *
- * Grouped rather than scattered because they answer one question between them
- * -- how evenly is the network held, and what does it cost to join -- and
- * because they share a caveat that only makes sense stated once per aggregate:
- * EVERY ONE OF THEM PUBLISHES A READ COUNT BESIDE A TOTAL. An aggregate over a
- * partial read describes the subset that was read. The panels say which, rather
- * than presenting a spread over 120 subnets as a fact about 129.
+ * Network-wide concentration is a continuous part of the analytics document,
+ * not a grid of secondary cards. Each module answers a single question and
+ * keeps its coverage caveat beside the measurement it qualifies.
  */
 export function ChainNetworkConcentration() {
   return (
-    <div className="space-y-6">
+    <div className="contents">
       <BurnSpread />
       <HolderConcentration />
       <ConcentrationRanking />
@@ -42,11 +51,24 @@ export function ChainNetworkConcentration() {
 /** What it costs to register, cheapest to dearest. */
 function BurnSpread() {
   const { data, isLoading, isError, error, refetch } = useQuery(chainBurnQuery());
-  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
-  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
   const b = data?.data;
-  if (!b) return <EmptyState title="No registration costs" description="Nothing read yet." />;
 
+  return (
+    <DataModule
+      title="Registration cost"
+      caption="The current price of entry across the subnets that were read. The rank rail makes the expensive end easy to compare."
+    >
+      {isLoading ? <Skeleton className="h-[15rem] w-full" /> : null}
+      {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
+      {!isLoading && !isError && !b ? (
+        <EmptyState title="No registration costs" description="Nothing has been read yet." />
+      ) : null}
+      {b ? <BurnSpreadData data={b} /> : null}
+    </DataModule>
+  );
+}
+
+function BurnSpreadData({ data: b }: { data: ChainBurn }) {
   const note = coverageNote(b.subnet_count, b.read_count);
   const dearest = [...b.subnets]
     .filter((s) => s.burn_tao != null)
@@ -54,9 +76,8 @@ function BurnSpread() {
     .slice(0, TOP_SHOWN);
 
   return (
-    <Panel as="section" dense>
-      <h3 className="mb-3 mg-type-label text-ink-muted">Registration cost across subnets</h3>
-      <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+    <>
+      <div className="mg-data-measure-grid mg-data-measure-grid--3">
         <Figure
           label="cheapest"
           value={formatTao(b.cheapest_burn_tao)}
@@ -65,94 +86,116 @@ function BurnSpread() {
         <Figure
           label="median"
           value={formatTao(b.median_burn_tao)}
-          hint="Median registration cost — the typical price of entry."
+          hint="The typical current price of entry."
         />
         <Figure
           label="dearest"
           value={formatTao(b.dearest_burn_tao)}
-          hint="Highest current registration cost."
+          hint="Highest current registration cost across the subnets read."
         />
       </div>
       {dearest.length > 0 ? (
-        <ul className="mt-4 space-y-1">
-          {dearest.map((s) => (
-            <li key={s.netuid} className="flex justify-between mg-type-data-sm">
-              <span className="text-ink-muted">SN{s.netuid}</span>
-              <span className="tabular-nums text-ink">{formatTao(s.burn_tao)}</span>
-            </li>
-          ))}
-        </ul>
+        <RankedRows
+          label="Subnets with the highest registration costs"
+          entries={dearest.map((s) => ({
+            id: String(s.netuid),
+            label: `SN${s.netuid}`,
+            netuid: s.netuid,
+            value: s.burn_tao ?? 0,
+            valueLabel: formatTao(s.burn_tao),
+          }))}
+        />
       ) : null}
-      {note ? <p className="mt-3 mg-type-label text-ink-muted">{note}</p> : null}
-    </Panel>
+      {note ? <p className="mg-data-module-note">{note}</p> : null}
+    </>
   );
 }
 
 /** Who holds the alpha, and where one account holds all of it. */
 function HolderConcentration() {
   const { data, isLoading, isError, error, refetch } = useQuery(chainHoldersQuery());
-  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
-  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
   const h = data?.data;
-  if (!h) return <EmptyState title="No holder data" description="Nothing read yet." />;
 
+  return (
+    <DataModule
+      title="Alpha holders"
+      caption="How concentrated alpha ownership is across measured subnets — including the cases where a single account holds it all."
+    >
+      {isLoading ? <Skeleton className="h-[13rem] w-full" /> : null}
+      {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
+      {!isLoading && !isError && !h ? (
+        <EmptyState title="No holder data" description="Nothing has been read yet." />
+      ) : null}
+      {h ? <HolderConcentrationData data={h} /> : null}
+    </DataModule>
+  );
+}
+
+function HolderConcentrationData({ data: h }: { data: ChainHolders }) {
   const note = coverageNote(h.subnet_count, h.subnets_measured);
-  // Two stamps, stated separately only when they actually disagree.
   const split = capturesDiverge(h.captured_at, h.positions_captured_at);
 
   return (
-    <Panel as="section" dense>
-      <h3 className="mb-3 mg-type-label text-ink-muted">Alpha holders across subnets</h3>
-      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+    <>
+      <div className="mg-data-measure-grid mg-data-measure-grid--3">
         <Figure
           label="median top-1 share"
           value={h.median_top1_share == null ? "—" : `${formatNumber(h.median_top1_share * 100)}%`}
-          hint="In the typical subnet, this is the share held by its largest holder."
+          hint="In the typical subnet, the share held by its largest holder."
         />
         <Figure
           label="majority-held"
           value={formatNumber(h.subnets_with_majority_holder)}
-          hint="Subnets where one account holds over half the alpha."
+          hint="Subnets where one account holds over half of the alpha."
         />
         <Figure
           label="single-holder"
           value={formatNumber(h.subnets_with_single_holder)}
-          hint="Subnets where ONE account holds all of it — a stronger claim than a majority, so it is counted separately."
+          hint="Subnets where one account holds all alpha."
         />
       </div>
       {split ? (
-        <p className="mt-3 mg-type-label text-ink-muted">
+        <p className="mg-data-module-note">
           Subnet set read {formatRelative(h.captured_at)}; holder positions{" "}
           {formatRelative(h.positions_captured_at)}. The two halves describe different moments.
         </p>
       ) : null}
-      {note ? <p className="mt-2 mg-type-label text-ink-muted">{note}</p> : null}
-    </Panel>
+      {note ? <p className="mg-data-module-note">{note}</p> : null}
+    </>
   );
 }
 
 /** Concentration ranked per subnet, with the unmeasured ones named as such. */
 function ConcentrationRanking() {
   const { data, isLoading, isError, error, refetch } = useQuery(chainConcentrationSubnetsQuery());
-  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
-  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
   const c = data?.data;
-  if (!c) return <EmptyState title="No concentration data" description="Nothing read yet." />;
 
+  return (
+    <DataModule
+      title="Most concentrated subnets"
+      caption="A ranked view of stake inequality. Unmeasured subnets are excluded rather than presented as perfectly even."
+    >
+      {isLoading ? <Skeleton className="h-[18rem] w-full" /> : null}
+      {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
+      {!isLoading && !isError && !c ? (
+        <EmptyState title="No concentration data" description="Nothing has been read yet." />
+      ) : null}
+      {c ? <ConcentrationRankingData data={c} /> : null}
+    </DataModule>
+  );
+}
+
+function ConcentrationRankingData({ data: c }: { data: NetworkConcentrationSubnets }) {
   const note = coverageNote(c.subnet_count, c.measured_subnet_count);
-  // An unmeasured subnet is DROPPED from the ranking rather than ranked at
-  // zero: no reading is not perfect equality, and sorting it to one end of the
-  // list would put it at an extreme it was never measured to occupy.
   const ranked = c.subnets.filter((s) => !s.unmeasured).slice(0, TOP_SHOWN);
 
   return (
-    <Panel as="section" dense>
-      <h3 className="mb-3 mg-type-label text-ink-muted">Most concentrated subnets</h3>
-      <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+    <>
+      <div className="mg-data-measure-grid mg-data-measure-grid--3">
         <Figure
           label="median gini"
           value={formatNumber(c.median_gini)}
-          hint="Median inequality of stake across subnets. 0 is even, 1 is one holder."
+          hint="Median inequality of stake across measured subnets. Zero is even; one is one holder."
         />
         <Figure
           label="median nakamoto"
@@ -162,23 +205,24 @@ function ConcentrationRanking() {
         <Figure
           label="single-holder"
           value={formatNumber(c.single_holder_subnet_count)}
-          hint="Subnets whose stake sits with one account."
+          hint="Measured subnets whose stake sits with one account."
         />
       </div>
       {ranked.length > 0 ? (
-        <ul className="mt-4 space-y-1">
-          {ranked.map((s) => (
-            <li key={s.netuid} className="flex justify-between mg-type-data-sm">
-              <span className="text-ink-muted">SN{s.netuid}</span>
-              <span className="tabular-nums text-ink">
-                gini {formatNumber(s.gini)} · nakamoto {formatNumber(s.nakamoto_coefficient)}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <RankedRows
+          label="Subnet concentration ranking"
+          entries={ranked.map((s) => ({
+            id: String(s.netuid),
+            label: `SN${s.netuid}`,
+            netuid: s.netuid,
+            value: s.gini ?? 0,
+            valueLabel: `gini ${formatNumber(s.gini)}`,
+            detail: `nakamoto ${formatNumber(s.nakamoto_coefficient)}`,
+          }))}
+        />
       ) : null}
-      {note ? <p className="mt-3 mg-type-label text-ink-muted">{note}</p> : null}
-    </Panel>
+      {note ? <p className="mg-data-module-note">{note}</p> : null}
+    </>
   );
 }
 
@@ -187,62 +231,150 @@ function ConcentrationDrift() {
   const { data, isLoading, isError, error, refetch } = useQuery(
     chainConcentrationHistoryQuery("30d"),
   );
-  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
-  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
   const hist = data?.data;
-  if (!hist || hist.points.length === 0) {
-    return (
-      <EmptyState
-        title="No concentration history"
-        description="The daily concentration series has no points in this window."
-      />
-    );
-  }
 
+  return (
+    <DataModule
+      title="Concentration drift"
+      caption="The network-wide stake Gini over time. The definition seam is surfaced rather than smoothed into a false trend."
+    >
+      {isLoading ? <Skeleton className="h-[20rem] w-full" /> : null}
+      {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
+      {!isLoading && !isError && (!hist || hist.points.length === 0) ? (
+        <EmptyState
+          title="No concentration history"
+          description="The daily concentration series has no points in this window."
+        />
+      ) : null}
+      {hist && hist.points.length > 0 ? <ConcentrationDriftData data={hist} /> : null}
+    </DataModule>
+  );
+}
+
+function ConcentrationDriftData({ data: hist }: { data: NetworkConcentrationHistory }) {
   const first = hist.points[0];
   const last = hist.points[hist.points.length - 1];
   const mixed = spansBuilderVersions(hist.builder_versions);
+  const giniPoints = hist.points
+    .filter((point): point is typeof point & { gini: number } => point.gini != null)
+    .map((point) => ({ t: point.day, v: point.gini }));
 
   return (
-    <Panel as="section" dense>
-      <h3 className="mb-3 mg-type-label text-ink-muted">Concentration drift · {hist.window}</h3>
-      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
-        <Figure label="days" value={formatNumber(hist.point_count)} hint="Days in the series." />
+    <>
+      <div className="mg-data-wide-chart">
+        <Sparkline
+          values={giniPoints.map((point) => point.v)}
+          points={giniPoints}
+          width={1100}
+          height={168}
+          color="var(--chart-3)"
+          ariaLabel="Network stake Gini over time"
+          formatValue={formatNumber}
+        />
+      </div>
+      <div className="mg-data-measure-grid mg-data-measure-grid--4">
+        <Figure label="days" value={formatNumber(hist.point_count)} hint="Days in this series." />
         <Figure
           label="gini then"
           value={formatNumber(first?.gini)}
-          hint={`Stake gini on ${hist.oldest_day ?? "the oldest day"}.`}
+          hint={`Stake Gini on ${hist.oldest_day ?? "the oldest day"}.`}
         />
         <Figure
           label="gini now"
           value={formatNumber(last?.gini)}
-          hint={`Stake gini on ${hist.newest_day ?? "the newest day"}.`}
+          hint={`Stake Gini on ${hist.newest_day ?? "the newest day"}.`}
         />
         <Figure
           label="nakamoto now"
           value={formatNumber(last?.nakamoto_coefficient)}
-          hint="Accounts needed to reach a controlling share of stake, on the newest day."
+          hint="Accounts needed to reach a controlling share on the newest day."
         />
       </div>
-      {/* THE SEAM. A trend drawn across a builder-version change compares two
-          definitions rather than measuring a movement, so it is named rather
-          than smoothed over. */}
       {mixed ? (
-        <p className="mt-3 mg-type-label text-ink-muted">
+        <p className="mg-data-module-note">
           This window spans builder versions {hist.builder_versions.join(", ")} — points either side
-          were computed differently, so a change across the seam is a change of definition, not of
-          the network.
+          were computed differently, so movement across the seam is a definition change, not a
+          network change.
         </p>
       ) : null}
-    </Panel>
+    </>
+  );
+}
+
+function DataModule({
+  title,
+  caption,
+  children,
+}: {
+  title: string;
+  caption: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="mg-data-module">
+      <header className="mg-data-module-heading">
+        <h2 className="mg-data-module-title">
+          <strong>{title}.</strong>
+          <span>{caption}</span>
+        </h2>
+      </header>
+      <div className="mg-data-module-body">{children}</div>
+    </section>
   );
 }
 
 function Figure({ label, value, hint }: { label: string; value: string; hint: string }) {
   return (
-    <div title={hint}>
-      <div className="mg-type-label text-ink-muted">{label}</div>
-      <div className="mg-type-data tabular-nums text-ink">{value}</div>
+    <div className="mg-data-measure" title={hint}>
+      <div>{label}</div>
+      <div>{value}</div>
     </div>
+  );
+}
+
+interface RankedEntry {
+  id: string;
+  label: string;
+  netuid: number;
+  value: number;
+  valueLabel: string;
+  detail?: string;
+}
+
+function RankedRows({ label, entries }: { label: string; entries: RankedEntry[] }) {
+  const cap = Math.max(1, ...entries.map((entry) => entry.value));
+
+  return (
+    <ol className="mg-data-rank-list" aria-label={label}>
+      {entries.map((entry, index) => {
+        const width = Math.max(2, Math.round((entry.value / cap) * 100));
+        return (
+          <li key={entry.id}>
+            <Link
+              to="/subnets/$netuid"
+              params={{ netuid: entry.netuid }}
+              className="mg-data-rank-row mg-focus-ring"
+              aria-label={`${entry.label}: ${entry.valueLabel}${entry.detail ? `, ${entry.detail}` : ""}`}
+            >
+              <span className="mg-data-rank-index">{String(index + 1).padStart(2, "0")}</span>
+              <span className="mg-data-rank-label">{entry.label}</span>
+              <span className="mg-data-rank-track" aria-hidden="true">
+                <span
+                  className="mg-data-rank-fill"
+                  style={{
+                    width: `${width}%`,
+                    background: RANK_COLORS[index % RANK_COLORS.length],
+                  }}
+                />
+              </span>
+              <span className="mg-data-rank-value">
+                {entry.valueLabel}
+                {entry.detail ? <small>{entry.detail}</small> : null}
+              </span>
+            </Link>
+          </li>
+        );
+      })}
+    </ol>
   );
 }

--- a/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
+++ b/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import type { ReactNode } from "react";
 import { Sparkline } from "@jsonbored/ui-kit";
 import {
   chainBurnQuery,
@@ -9,6 +8,7 @@ import {
   chainConcentrationHistoryQuery,
 } from "@/lib/metagraphed/queries";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { DataPageModule } from "@/components/metagraphed/primitives";
 import { formatNumber, formatTao, formatRelative } from "@/lib/metagraphed/format";
 import {
   coverageNote,
@@ -30,6 +30,8 @@ const RANK_COLORS = [
   "var(--chart-4)",
   "var(--chart-5)",
   "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
 ];
 
 /**
@@ -54,9 +56,10 @@ function BurnSpread() {
   const b = data?.data;
 
   return (
-    <DataModule
+    <DataPageModule
       title="Registration cost"
       caption="The current price of entry across the subnets that were read. The rank rail makes the expensive end easy to compare."
+      kind="question"
     >
       {isLoading ? <Skeleton className="h-[15rem] w-full" /> : null}
       {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
@@ -64,7 +67,7 @@ function BurnSpread() {
         <EmptyState title="No registration costs" description="Nothing has been read yet." />
       ) : null}
       {b ? <BurnSpreadData data={b} /> : null}
-    </DataModule>
+    </DataPageModule>
   );
 }
 
@@ -117,9 +120,10 @@ function HolderConcentration() {
   const h = data?.data;
 
   return (
-    <DataModule
+    <DataPageModule
       title="Alpha holders"
       caption="How concentrated alpha ownership is across measured subnets — including the cases where a single account holds it all."
+      kind="question"
     >
       {isLoading ? <Skeleton className="h-[13rem] w-full" /> : null}
       {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
@@ -127,7 +131,7 @@ function HolderConcentration() {
         <EmptyState title="No holder data" description="Nothing has been read yet." />
       ) : null}
       {h ? <HolderConcentrationData data={h} /> : null}
-    </DataModule>
+    </DataPageModule>
   );
 }
 
@@ -171,9 +175,10 @@ function ConcentrationRanking() {
   const c = data?.data;
 
   return (
-    <DataModule
+    <DataPageModule
       title="Most concentrated subnets"
       caption="A ranked view of stake inequality. Unmeasured subnets are excluded rather than presented as perfectly even."
+      kind="question"
     >
       {isLoading ? <Skeleton className="h-[18rem] w-full" /> : null}
       {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
@@ -181,7 +186,7 @@ function ConcentrationRanking() {
         <EmptyState title="No concentration data" description="Nothing has been read yet." />
       ) : null}
       {c ? <ConcentrationRankingData data={c} /> : null}
-    </DataModule>
+    </DataPageModule>
   );
 }
 
@@ -234,9 +239,10 @@ function ConcentrationDrift() {
   const hist = data?.data;
 
   return (
-    <DataModule
+    <DataPageModule
       title="Concentration drift"
       caption="The network-wide stake Gini over time. The definition seam is surfaced rather than smoothed into a false trend."
+      kind="question"
     >
       {isLoading ? <Skeleton className="h-[20rem] w-full" /> : null}
       {isError ? <ErrorState error={error} onRetry={() => void refetch()} /> : null}
@@ -247,7 +253,7 @@ function ConcentrationDrift() {
         />
       ) : null}
       {hist && hist.points.length > 0 ? <ConcentrationDriftData data={hist} /> : null}
-    </DataModule>
+    </DataPageModule>
   );
 }
 
@@ -298,28 +304,6 @@ function ConcentrationDriftData({ data: hist }: { data: NetworkConcentrationHist
         </p>
       ) : null}
     </>
-  );
-}
-
-function DataModule({
-  title,
-  caption,
-  children,
-}: {
-  title: string;
-  caption: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="mg-data-module">
-      <header className="mg-data-module-heading">
-        <h2 className="mg-data-module-title">
-          <strong>{title}.</strong>
-          <span>{caption}</span>
-        </h2>
-      </header>
-      <div className="mg-data-module-body">{children}</div>
-    </section>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/chain-registration-economics.tsx
+++ b/apps/ui/src/components/metagraphed/chain-registration-economics.tsx
@@ -1,4 +1,3 @@
-import { StatTile } from "@jsonbored/ui-kit";
 import { computeRegistrationCostStats } from "@/lib/metagraphed/chain-analytics";
 import { formatTao } from "@/lib/metagraphed/format";
 import type { SubnetEconomics } from "@/lib/metagraphed/types";
@@ -16,10 +15,19 @@ export function ChainRegistrationEconomics({ subnets }: { subnets: SubnetEconomi
   if (stats.count === 0) return null;
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-      <StatTile eyebrow="Lowest registration cost" value={formatTao(stats.minTao)} />
-      <StatTile eyebrow="Median registration cost" value={formatTao(stats.medianTao)} />
-      <StatTile eyebrow="Highest registration cost" value={formatTao(stats.maxTao)} />
+    <dl className="mg-data-measure-grid mg-data-measure-grid--3">
+      <Metric label="lowest entry cost" value={formatTao(stats.minTao)} />
+      <Metric label="median entry cost" value={formatTao(stats.medianTao)} />
+      <Metric label="highest entry cost" value={formatTao(stats.maxTao)} />
+    </dl>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="mg-data-measure">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/chain-stake-flow-sankey.tsx
+++ b/apps/ui/src/components/metagraphed/chain-stake-flow-sankey.tsx
@@ -7,6 +7,8 @@ import { formatTao } from "@/lib/metagraphed/format";
 import type { ChainStakeFlow, GlobalValidators } from "@/lib/metagraphed/types";
 
 const MOBILE_QUERY = "(max-width: 640px)";
+const DESKTOP_SANKEY_LIMIT = 7;
+const MOBILE_SANKEY_LIMIT = 5;
 
 // SSR-safe viewport check, same shape as use-coarse-pointer.ts: default false
 // on the server, corrected on the client after mount. A narrow-viewport
@@ -54,38 +56,49 @@ export function ChainStakeFlowSankey({
 }) {
   const navigate = useNavigate();
   const isMobile = useNarrowViewport();
-  // Fewer nodes on mobile: the vertical layout stacks nodes side by side
-  // along a ~375px width, so 10 subnets read as illegible slivers even with
-  // the primitive's own label-hiding threshold — 5 keeps every shown node
-  // wide enough to label.
+  // A sankey can be technically complete and still fail as a reading surface.
+  // Seven desktop paths preserve comparison without a tangle of labels; the
+  // vertical mobile layout narrows that to five so each path stays tappable.
   const { nodes, links, shownNetuids } = buildStakeFlowSankeyData(
     stakeFlow,
     validators,
-    isMobile ? 5 : undefined,
-    isMobile ? 5 : undefined,
+    isMobile ? MOBILE_SANKEY_LIMIT : DESKTOP_SANKEY_LIMIT,
+    isMobile ? MOBILE_SANKEY_LIMIT : DESKTOP_SANKEY_LIMIT,
   );
   const empty = shownNetuids.length === 0;
 
   return (
     <ChartCard
-      title="Stake flow"
-      caption={`Root → top ${shownNetuids.length || 0} subnets by ${window} stake movement → top validators' current stake in those subnets. The two hops are different kinds of number — flow on the left, current holdings on the right.`}
-      height={isMobile ? 420 : 320}
+      variant="data"
+      className="mg-data-module--stake-flow"
+      title="Stake movement"
+      caption={`Flow over ${window}, then current validator stake in the ${shownNetuids.length || 0} most active subnets. Select a node to inspect it.`}
+      footer={
+        <span>
+          Mint and red links show movement direction; prism links keep each subnet traceable into
+          its validator holdings.
+        </span>
+      }
+      height={isMobile ? 420 : 404}
       empty={empty}
       emptyLabel="No stake movement in this window"
     >
-      <SankeyMini
-        nodes={nodes}
-        links={links}
-        orientation={isMobile ? "vertical" : "horizontal"}
-        columnExtent={isMobile ? 380 : 720}
-        stackExtent={isMobile ? 340 : 300}
-        formatValue={(v) => formatTao(v)}
-        onNodeSelect={(nodeId) => {
-          const target = resolveSankeyNode(nodeId);
-          if (target) navigate({ to: target.to, params: target.params });
-        }}
-      />
+      <div className="mg-data-plot-grid h-full">
+        <SankeyMini
+          nodes={nodes}
+          links={links}
+          className="h-full"
+          orientation={isMobile ? "vertical" : "horizontal"}
+          columnExtent={isMobile ? 380 : 920}
+          stackExtent={isMobile ? 340 : 384}
+          formatValue={(v) => formatTao(v)}
+          ariaLabel="Stake movement from root through active subnets into validator holdings"
+          onNodeSelect={(nodeId) => {
+            const target = resolveSankeyNode(nodeId);
+            if (target) navigate({ to: target.to, params: target.params });
+          }}
+        />
+      </div>
     </ChartCard>
   );
 }

--- a/apps/ui/src/components/metagraphed/hub-prose.tsx
+++ b/apps/ui/src/components/metagraphed/hub-prose.tsx
@@ -1,4 +1,5 @@
 import { SectionHeading } from "@jsonbored/ui-kit";
+import { DataPageDisclosure } from "@/components/metagraphed/primitives";
 import { HUB_COPY, type HubPath } from "@/lib/metagraphed/hub-copy";
 
 /**
@@ -26,7 +27,7 @@ import { HUB_COPY, type HubPath } from "@/lib/metagraphed/hub-copy";
  */
 
 /**
- * The one-or-two-sentence answer, for the masthead's `description`.
+ * The single-sentence answer, for the masthead's `description`.
  *
  * Every hub had a hand-written masthead description AND a separately written
  * `<meta name="description">` saying nearly the same thing in different words —
@@ -34,7 +35,7 @@ import { HUB_COPY, type HubPath } from "@/lib/metagraphed/hub-copy";
  * `og:title` naming the page differently. One source now.
  */
 export function hubLede(path: HubPath): string {
-  return HUB_COPY[path].intro.lede.body;
+  return HUB_COPY[path].description;
 }
 
 /**
@@ -46,12 +47,16 @@ export function hubLede(path: HubPath): string {
 export function HubSections({ path }: { path: HubPath }) {
   const { sections } = HUB_COPY[path].intro;
   return (
-    <div className="mt-10 space-y-section">
-      {sections.map((section) => (
-        <section key={section.heading}>
-          <SectionHeading title={section.heading} intro={section.body} />
-        </section>
-      ))}
+    <div className="mt-10">
+      <DataPageDisclosure label="How this data is measured">
+        <div className="space-y-section">
+          {sections.map((section) => (
+            <section key={section.heading}>
+              <SectionHeading title={section.heading} intro={section.body} />
+            </section>
+          ))}
+        </div>
+      </DataPageDisclosure>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/hub-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/hub-tabs.tsx
@@ -39,7 +39,15 @@ export function activeHubTab<T extends HubTab>(tabs: readonly T[], pathname: str
  * beside it (#8254/#8281) — per-tab actions render inside the tab content via
  * HubTabActions instead, so the tabs always own the full width.
  */
-export function HubTabs({ tabs, ariaLabel }: { tabs: readonly HubTab[]; ariaLabel: string }) {
+export function HubTabs({
+  tabs,
+  ariaLabel,
+  className,
+}: {
+  tabs: readonly HubTab[];
+  ariaLabel: string;
+  className?: string;
+}) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const active = activeHubTab(tabs, pathname);
   const ref = useRef<HTMLElement>(null);
@@ -50,7 +58,10 @@ export function HubTabs({ tabs, ariaLabel }: { tabs: readonly HubTab[]; ariaLabe
     <nav
       ref={ref}
       aria-label={ariaLabel}
-      className="sticky z-[var(--mg-z-sticky)] -mx-4 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 md:mx-0"
+      className={classNames(
+        "sticky z-[var(--mg-z-sticky)] -mx-4 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 md:mx-0",
+        className,
+      )}
       style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
     >
       <ScrollShadow className="min-w-0" innerClassName="scroll-smooth">

--- a/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
@@ -254,7 +254,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
               aria-haspopup="true"
               onKeyDown={(e) => onTriggerKeyDown(e, p.key)}
               className={classNames(
-                "relative inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 h-9 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                "relative inline-flex min-h-11 items-center px-2 py-1.5 mg-type-caption-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
                 active || isOpen
                   ? "text-ink-strong font-medium"
                   : "text-ink-muted hover:text-ink-strong",
@@ -265,7 +265,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
               }}
               preload="intent"
             >
-              <Icon className={classNames("size-3.5", active ? "text-accent" : "opacity-70")} />
+              <Icon className="hidden" aria-hidden="true" />
               <span>{p.label}</span>
               {active ? (
                 <span
@@ -286,7 +286,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
           params={{ _splat: "mcp" }}
           aria-current={pathname === "/docs/mcp" ? "page" : undefined}
           className={classNames(
-            "relative inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 h-9 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+            "relative inline-flex min-h-11 items-center px-2 py-1.5 mg-type-caption-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
             pathname === "/docs/mcp"
               ? "text-ink-strong font-medium"
               : "text-ink-muted hover:text-ink-strong",
@@ -297,12 +297,7 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
           }}
           preload="intent"
         >
-          <Plug
-            className={classNames(
-              "size-3.5",
-              pathname === "/docs/mcp" ? "text-accent" : "opacity-70",
-            )}
-          />
+          <Plug className="hidden" aria-hidden="true" />
           <span>MCP</span>
           {pathname === "/docs/mcp" ? (
             <span

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -411,7 +411,7 @@ export function NavOmnibox({ onOpenPalette }: Props) {
         as="div"
         flush
         className={classNames(
-          "w-full !rounded-full text-left text-sm transition-all",
+          "w-full !rounded-none text-left text-sm transition-all",
           open ? "!border-accent/60 ring-2 ring-accent/20" : "hover:border-accent/40",
         )}
         bodyClassName="inline-flex w-full items-center gap-2 !pl-3 !pr-2 !py-2 min-h-10"

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -75,7 +75,7 @@ export function NetworkSwitcher() {
         <button
           type="button"
           aria-label={`Network: ${network.label}`}
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 mg-type-caption text-ink hover:border-ink/30 transition-colors min-h-11"
+          className="inline-flex min-h-11 items-center gap-1.5 border border-transparent bg-transparent px-2 py-1 mg-type-caption text-ink transition-colors hover:border-border hover:bg-surface"
           title={`Network: ${network.label} · ${base}`}
         >
           <Globe2 className="size-3 text-ink-muted" />

--- a/apps/ui/src/components/metagraphed/primitives/chart-card.tsx
+++ b/apps/ui/src/components/metagraphed/primitives/chart-card.tsx
@@ -19,6 +19,12 @@ export interface ChartCardProps {
   emptyLabel?: ReactNode;
   children?: ReactNode;
   className?: string;
+  /**
+   * `data` turns the card into one continuous section of the analytics canvas
+   * instead of another floating dashboard panel. `panel` remains the default
+   * for the operational routes that still use the compact card treatment.
+   */
+  variant?: "panel" | "data";
 }
 
 /**
@@ -39,6 +45,7 @@ export function ChartCard({
   emptyLabel = "Not enough data yet",
   children,
   className,
+  variant = "panel",
 }: ChartCardProps) {
   const headerAction = (
     <>
@@ -46,6 +53,39 @@ export function ChartCard({
       {action}
     </>
   );
+  const hasHeaderAction = Boolean(updatedAt || action);
+  if (variant === "data") {
+    return (
+      <section className={classNames("mg-data-module", className)}>
+        <header className="mg-data-module-heading">
+          <div className="min-w-0">
+            <h2 className="mg-data-module-title">
+              <strong>{typeof title === "string" ? `${title}.` : title}</strong>
+              {caption ? <span>{caption}</span> : null}
+            </h2>
+          </div>
+          {hasHeaderAction ? <div className="mg-data-module-action">{headerAction}</div> : null}
+        </header>
+        <div
+          className="mg-data-module-chart relative w-full"
+          style={{ height }}
+          aria-busy={loading || undefined}
+        >
+          {loading ? (
+            <div className="absolute inset-0 mg-skel animate-pulse" />
+          ) : empty ? (
+            <div className="absolute inset-0 flex items-center justify-center mg-type-caption-lg text-ink-muted">
+              {emptyLabel}
+            </div>
+          ) : (
+            children
+          )}
+        </div>
+        {footer != null ? <div className="mg-data-module-footer">{footer}</div> : null}
+      </section>
+    );
+  }
+
   return (
     <Panel title={title} caption={caption} action={headerAction} className={className}>
       <div className="relative w-full" style={{ height }} aria-busy={loading || undefined}>

--- a/apps/ui/src/components/metagraphed/primitives/index.ts
+++ b/apps/ui/src/components/metagraphed/primitives/index.ts
@@ -55,6 +55,7 @@ export {
   type GhostButtonProps,
   type GhostButtonSize,
   type GhostButtonTone,
+  type GhostButtonAppearance,
   PagerFooter,
   type PagerFooterProps,
   MetaStrip,
@@ -94,6 +95,17 @@ export {
   type FilterChipItem,
   RoutePending,
   type RoutePendingProps,
+  DataPageCanvas,
+  DataPageDisclosure,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  DataPageWindowTabs,
+  type DataPageCanvasVariant,
+  type DataPageHeroVariant,
+  type DataPageModuleKind,
+  type DataPageStageVariant,
+  type DataPageWindowOption,
 } from "@jsonbored/ui-kit";
 
 /* Still local: genuinely coupled to apps/ui's router, query, or hooks. */

--- a/apps/ui/src/components/metagraphed/profile-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/profile-tabs.tsx
@@ -71,7 +71,7 @@ export function ProfileTabs({
     <nav
       ref={navRef}
       aria-label="Profile sections"
-      className="sticky z-[var(--mg-z-sticky)] -mx-4 md:mx-0 mb-8 border-b border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
+      className="mg-profile-tabs sticky z-[var(--mg-z-sticky)] -mx-4 md:mx-0 mb-8 border-y border-border bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
       style={{ top: "var(--mg-sticky-offset, 3.5rem)" }}
     >
       {/*

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -449,7 +449,7 @@ export function PageHeading({
   right?: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between mb-6">
+    <div className="mg-page-heading flex flex-col gap-3 md:flex-row md:items-end md:justify-between mb-6">
       <div>
         {eyebrow ? <div className="mg-label mb-1">{eyebrow}</div> : null}
         <h1 className="font-display text-2xl font-semibold tracking-tight text-ink-strong">

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -478,7 +478,7 @@ export function SubnetMasthead({
     ) : null;
 
   return (
-    <header className="mb-6">
+    <header className="mg-subnet-masthead mb-6">
       {/* Top accent rail — color = current health state. Subtle but
           gives every subnet a recognizable identity colour. */}
       <div
@@ -654,7 +654,7 @@ export function SubnetMasthead({
       <Panel
         as="div"
         flush
-        className="mt-4"
+        className="mg-subnet-kpi-grid mt-4"
         bodyClassName="grid grid-cols-2 divide-x divide-y divide-border overflow-hidden sm:grid-cols-3 sm:divide-y-0 xl:grid-cols-6"
       >
         <StatWithSpark

--- a/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-saved-views.tsx
@@ -122,7 +122,7 @@ export function SubnetsSavedViews() {
                 aria-pressed={active}
                 onClick={() => apply(p.patch)}
                 className={classNames(
-                  "relative inline-flex shrink-0 items-center px-3 py-2 mg-type-caption-lg transition-colors",
+                  "relative inline-flex min-h-11 shrink-0 items-center px-3 py-2 mg-type-caption-lg transition-colors",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded",
                   active ? "text-ink-strong" : "text-ink-muted hover:text-ink-strong",
                 )}

--- a/apps/ui/src/hooks/use-mobile.tsx
+++ b/apps/ui/src/hooks/use-mobile.tsx
@@ -7,18 +7,18 @@ export function isMobileWidth(width: number, breakpoint: number = MOBILE_BREAKPO
   return width < breakpoint;
 }
 
-export function useIsMobile() {
+export function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
     const onChange = () => {
-      setIsMobile(isMobileWidth(window.innerWidth));
+      setIsMobile(isMobileWidth(window.innerWidth, breakpoint));
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(isMobileWidth(window.innerWidth));
+    setIsMobile(isMobileWidth(window.innerWidth, breakpoint));
     return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [breakpoint]);
 
   return !!isMobile;
 }

--- a/apps/ui/src/lib/metagraphed/chain-analytics.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-analytics.test.ts
@@ -4,6 +4,7 @@ import {
   computeRegistrationCostStats,
   MAX_SANKEY_SUBNETS,
   MAX_SANKEY_VALIDATORS,
+  STAKE_FLOW_SERIES_COLORS,
 } from "./chain-analytics";
 import type { ChainStakeFlow, GlobalValidators } from "./types";
 
@@ -114,6 +115,27 @@ describe("buildStakeFlowSankeyData", () => {
     const va = nodes.find((n) => n.id === "validator:5AAA");
     expect(va?.value).toBe(40);
     expect(links.some((l) => l.source === "subnet:1" && l.target === "validator:5AAA")).toBe(true);
+  });
+
+  it("uses direction only for the first hop and a stable chart series for the subnet trace", () => {
+    const flow = stakeFlow([subnetFlow(1, 100, "gaining"), subnetFlow(2, 50, "losing")]);
+    const vs = validators([
+      validator("5AAA", [{ netuid: 1, stake_tao: 40 }]),
+      validator("5BBB", [{ netuid: 2, stake_tao: 20 }]),
+    ]);
+    const { nodes, links } = buildStakeFlowSankeyData(flow, vs);
+
+    expect(nodes.find((node) => node.id === "subnet:1")?.color).toBe(STAKE_FLOW_SERIES_COLORS[0]);
+    expect(nodes.find((node) => node.id === "subnet:2")?.color).toBe(STAKE_FLOW_SERIES_COLORS[1]);
+    expect(links.find((link) => link.source === "root" && link.target === "subnet:1")?.color).toBe(
+      "var(--accent)",
+    );
+    expect(links.find((link) => link.source === "root" && link.target === "subnet:2")?.color).toBe(
+      "var(--health-down)",
+    );
+    expect(links.find((link) => link.source === "subnet:1")?.color).toBe(
+      STAKE_FLOW_SERIES_COLORS[0],
+    );
   });
 
   it("ignores a validator's stake in a subnet that wasn't shown", () => {

--- a/apps/ui/src/lib/metagraphed/chain-analytics.ts
+++ b/apps/ui/src/lib/metagraphed/chain-analytics.ts
@@ -11,8 +11,22 @@ export const MAX_SANKEY_VALIDATORS = 10;
 const OTHER_SUBNETS_ID = "subnet:other";
 const OTHER_VALIDATORS_ID = "validator:other";
 
+/**
+ * Ordered categorical colors for the second sankey hop. These are purposely
+ * not status colors: they let a reader follow one subnet into its validator
+ * holdings without mistaking a color for a health or direction signal.
+ */
+export const STAKE_FLOW_SERIES_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;
+
 function directionColor(direction: string): string {
-  if (direction === "gaining") return "var(--health-ok)";
+  if (direction === "gaining") return "var(--accent)";
   if (direction === "losing") return "var(--health-down)";
   return "var(--ink-muted)";
 }
@@ -44,6 +58,12 @@ export function buildStakeFlowSankeyData(
   const rest = bySize.slice(maxSubnets);
   const shownNetuids = shown.map((s) => s.netuid);
   const shownNetuidSet = new Set(shownNetuids);
+  const seriesColorByNetuid = new Map(
+    shown.map((s, index) => [
+      s.netuid,
+      STAKE_FLOW_SERIES_COLORS[index % STAKE_FLOW_SERIES_COLORS.length]!,
+    ]),
+  );
 
   const nodes: SankeyNode[] = [
     {
@@ -51,6 +71,7 @@ export function buildStakeFlowSankeyData(
       label: "Root",
       value: shown.reduce((sum, s) => sum + s.gross_flow_tao, 0),
       column: 0,
+      color: "var(--accent)",
     },
   ];
   const links: SankeyLink[] = [];
@@ -61,7 +82,7 @@ export function buildStakeFlowSankeyData(
       label: `SN${s.netuid}`,
       value: s.gross_flow_tao,
       column: 1,
-      color: directionColor(s.direction),
+      color: seriesColorByNetuid.get(s.netuid),
     });
     links.push({
       source: "root",
@@ -118,7 +139,12 @@ export function buildStakeFlowSankeyData(
       if (!membership || membership.stake_tao <= 0) continue;
       const target = topHotkeys.has(v.hotkey) ? `validator:${v.hotkey}` : null;
       if (target) {
-        links.push({ source: `subnet:${s.netuid}`, target, value: membership.stake_tao });
+        links.push({
+          source: `subnet:${s.netuid}`,
+          target,
+          value: membership.stake_tao,
+          color: seriesColorByNetuid.get(s.netuid),
+        });
       }
     }
     if (hasOtherValidators) {
@@ -131,6 +157,7 @@ export function buildStakeFlowSankeyData(
           source: `subnet:${s.netuid}`,
           target: OTHER_VALIDATORS_ID,
           value: otherStakeForSubnet,
+          color: seriesColorByNetuid.get(s.netuid),
         });
       }
     }

--- a/apps/ui/src/lib/metagraphed/chain-analytics.ts
+++ b/apps/ui/src/lib/metagraphed/chain-analytics.ts
@@ -23,6 +23,11 @@ export const STAKE_FLOW_SERIES_COLORS = [
   "var(--chart-4)",
   "var(--chart-5)",
   "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+  "var(--chart-9)",
+  "var(--chart-10)",
+  "var(--chart-11)",
 ] as const;
 
 function directionColor(direction: string): string {

--- a/apps/ui/src/lib/metagraphed/chart-palette.ts
+++ b/apps/ui/src/lib/metagraphed/chart-palette.ts
@@ -1,6 +1,8 @@
 // The categorical chart palette, declared once (#10987 follow-up): the
 // holdings history chart and the explorer's call-mix legend each carried the
-// six-swatch list privately, and a seventh chart would have made a third.
+// six-swatch list privately, and a seventh chart would have made a third. The
+// terminal prism now carries eleven ordered categorical series, so dense
+// analytics can preserve identity without reusing mint or status colors.
 export const CHART_PALETTE = [
   "var(--chart-1)",
   "var(--chart-2)",
@@ -8,4 +10,9 @@ export const CHART_PALETTE = [
   "var(--chart-4)",
   "var(--chart-5)",
   "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+  "var(--chart-9)",
+  "var(--chart-10)",
+  "var(--chart-11)",
 ] as const;

--- a/apps/ui/src/routes/-about-page.tsx
+++ b/apps/ui/src/routes/-about-page.tsx
@@ -11,7 +11,13 @@ import {
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { CopyableCode, ExternalLink } from "@jsonbored/ui-kit";
-import { PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import {
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+  Panel,
+} from "@/components/metagraphed/primitives";
 import { API_BASE, GITHUB_REPO } from "@/lib/metagraphed/config";
 import { coverageQuery, freshnessQuery, healthQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
@@ -21,139 +27,163 @@ import { statPhase, type StatPhase } from "@/lib/metagraphed/stat-phase";
 export function AboutPage() {
   return (
     <AppShell>
-      <PageMasthead
-        eyebrow="About"
-        title="Methodology & scope"
-        description="An unofficial, public explorer and integration registry for Bittensor — blocks, subnets, validators, and accounts alongside the public interfaces each subnet exposes, all machine-readable for developers and AI agents."
-        actions={
-          <ExternalLink
-            href={GITHUB_REPO}
-            bare
-            className="inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-4 py-2 text-sm font-medium text-paper hover:opacity-90 transition-opacity"
+      <DataPageStage>
+        <PageMasthead
+          eyebrow="About"
+          title="Methodology & scope"
+          description="An unofficial, public explorer and integration registry for Bittensor — blocks, subnets, validators, and accounts alongside the public interfaces each subnet exposes, all machine-readable for developers and AI agents."
+          actions={
+            <ExternalLink
+              href={GITHUB_REPO}
+              bare
+              className="inline-flex min-h-11 items-center gap-1.5 bg-ink-strong px-4 py-2 text-sm font-medium text-paper transition-opacity hover:opacity-90"
+            >
+              <Github className="size-3.5" /> View on GitHub
+              <ArrowUpRight className="size-3.5" />
+            </ExternalLink>
+          }
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title="How to read the registry."
+            caption="What we measure, how curation is labeled, and where the same public data can be read by people, scripts, and agents."
           >
-            <Github className="size-3.5" /> View on GitHub
-            <ArrowUpRight className="size-3.5" />
-          </ExternalLink>
-        }
-      />
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="space-y-8 min-w-0">
-          <Section title="What this is">
-            <p>
-              An unofficial, public explorer and integration registry for Bittensor. The explorer
-              reads chain-direct data — blocks, subnets, validators, and accounts — with endpoint
-              health, schema drift, and freshness. The registry maps every public interface a subnet
-              exposes — APIs, OpenAPI schemas, docs, repos, SSE streams, data artifacts, and
-              providers — with source evidence and the curation gaps still to fill. Everything is
-              machine-readable, served over REST, GraphQL, and MCP for developers and AI agents
-              alike.
-            </p>
-          </Section>
-          <Section title="What this is not">
-            <ul className="list-disc pl-6 space-y-1.5">
-              <li>
-                Not an OpenTensor or Bittensor Foundation product — an independent, unofficial
-                project.
-              </li>
-              <li>
-                Not a custodial wallet or exchange — non-custodial by design: your keys and funds
-                never leave your own wallet, and any signing stays local, never on our servers.
-              </li>
-              <li>No private keys, PATs, or token-gated data are ever requested or displayed.</li>
-              <li>Endpoint pool eligibility is metadata only — proxy routing is future-scoped.</li>
-            </ul>
-          </Section>
-          <Section title="Curation levels">
-            <dl className="grid gap-2.5">
-              <Term name="Native" desc="Sourced directly from the Bittensor chain." />
-              <Term
-                name="Candidate-discovered"
-                desc="Leads from public sources, not yet verified."
-              />
-              <Term
-                name="Machine-verified"
-                desc="Reachable and shape-checked by automated probes."
-              />
-              <Term name="Maintainer-reviewed" desc="A human reviewer accepted the overlay." />
-              <Term
-                name="Adapter-backed"
-                desc="A typed adapter publishes live metrics (e.g. SN7, SN74)."
-              />
-            </dl>
-          </Section>
-          <Section title="Coverage levels">
-            <dl className="grid gap-2.5">
-              <Term name="Native-only" desc="Chain identity present, no curated overlay yet." />
-              <Term name="Manifested" desc="Curated overlay with at least one public surface." />
-              <Term
-                name="Probed"
-                desc="Surfaces or endpoints actively probed for health and freshness."
-              />
-            </dl>
-          </Section>
-          <Section title="Contributing">
-            <p>
-              Corrections, new candidate leads, and maintainer review happen through the public
-              repository. There is no in-app submission flow — registry truth lives in version
-              control, reviewed in the open.
-            </p>
-            <div className="mt-3">
-              <ExternalLink href={GITHUB_REPO}>{GITHUB_REPO}</ExternalLink>
-            </div>
-          </Section>
-          <Section title="API & artifacts">
-            <p className="mb-3">
-              JSON Schema is canonical; OpenAPI and the typed clients are projections of it. Every
-              public list and detail view is reachable over REST, GraphQL, and MCP — or as a static
-              JSON artifact — so a human, a script, or an agent all read the same data.
-            </p>
-            <div className="space-y-2">
-              <CopyableCode
-                label="REST"
-                value={`${API_BASE}/api/v1`}
-                truncate={false}
-                className="w-full"
-              />
-              <CopyableCode
-                label="GraphQL"
-                value={`${API_BASE}/api/v1/graphql`}
-                truncate={false}
-                className="w-full"
-              />
-              <CopyableCode
-                label="MCP"
-                value={`${API_BASE}/mcp`}
-                truncate={false}
-                className="w-full"
-              />
-              <CopyableCode
-                label="OpenAPI"
-                value={`${API_BASE}/api/v1/openapi.json`}
-                truncate={false}
-                className="w-full"
-              />
-              <CopyableCode
-                label="Artifacts"
-                value={`${API_BASE}/metagraph/`}
-                truncate={false}
-                className="w-full"
-              />
-            </div>
-          </Section>
-        </div>
+            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_18rem]">
+              <div className="space-y-0 min-w-0">
+                <Section title="What this is">
+                  <p>
+                    An unofficial, public explorer and integration registry for Bittensor. The
+                    explorer reads chain-direct data — blocks, subnets, validators, and accounts —
+                    with endpoint health, schema drift, and freshness. The registry maps every
+                    public interface a subnet exposes — APIs, OpenAPI schemas, docs, repos, SSE
+                    streams, data artifacts, and providers — with source evidence and the curation
+                    gaps still to fill. Everything is machine-readable, served over REST, GraphQL,
+                    and MCP for developers and AI agents alike.
+                  </p>
+                </Section>
+                <Section title="What this is not">
+                  <ul className="list-disc pl-6 space-y-1.5">
+                    <li>
+                      Not an OpenTensor or Bittensor Foundation product — an independent, unofficial
+                      project.
+                    </li>
+                    <li>
+                      Not a custodial wallet or exchange — non-custodial by design: your keys and
+                      funds never leave your own wallet, and any signing stays local, never on our
+                      servers.
+                    </li>
+                    <li>
+                      No private keys, PATs, or token-gated data are ever requested or displayed.
+                    </li>
+                    <li>
+                      Endpoint pool eligibility is metadata only — proxy routing is future-scoped.
+                    </li>
+                  </ul>
+                </Section>
+                <Section title="Curation levels">
+                  <dl className="grid gap-2.5">
+                    <Term name="Native" desc="Sourced directly from the Bittensor chain." />
+                    <Term
+                      name="Candidate-discovered"
+                      desc="Leads from public sources, not yet verified."
+                    />
+                    <Term
+                      name="Machine-verified"
+                      desc="Reachable and shape-checked by automated probes."
+                    />
+                    <Term
+                      name="Maintainer-reviewed"
+                      desc="A human reviewer accepted the overlay."
+                    />
+                    <Term
+                      name="Adapter-backed"
+                      desc="A typed adapter publishes live metrics (e.g. SN7, SN74)."
+                    />
+                  </dl>
+                </Section>
+                <Section title="Coverage levels">
+                  <dl className="grid gap-2.5">
+                    <Term
+                      name="Native-only"
+                      desc="Chain identity present, no curated overlay yet."
+                    />
+                    <Term
+                      name="Manifested"
+                      desc="Curated overlay with at least one public surface."
+                    />
+                    <Term
+                      name="Probed"
+                      desc="Surfaces or endpoints actively probed for health and freshness."
+                    />
+                  </dl>
+                </Section>
+                <Section title="Contributing">
+                  <p>
+                    Corrections, new candidate leads, and maintainer review happen through the
+                    public repository. There is no in-app submission flow — registry truth lives in
+                    version control, reviewed in the open.
+                  </p>
+                  <div className="mt-3">
+                    <ExternalLink href={GITHUB_REPO}>{GITHUB_REPO}</ExternalLink>
+                  </div>
+                </Section>
+                <Section title="API & artifacts">
+                  <p className="mb-3">
+                    JSON Schema is canonical; OpenAPI and the typed clients are projections of it.
+                    Every public list and detail view is reachable over REST, GraphQL, and MCP — or
+                    as a static JSON artifact — so a human, a script, or an agent all read the same
+                    data.
+                  </p>
+                  <div className="space-y-2">
+                    <CopyableCode
+                      label="REST"
+                      value={`${API_BASE}/api/v1`}
+                      truncate={false}
+                      className="w-full"
+                    />
+                    <CopyableCode
+                      label="GraphQL"
+                      value={`${API_BASE}/api/v1/graphql`}
+                      truncate={false}
+                      className="w-full"
+                    />
+                    <CopyableCode
+                      label="MCP"
+                      value={`${API_BASE}/mcp`}
+                      truncate={false}
+                      className="w-full"
+                    />
+                    <CopyableCode
+                      label="OpenAPI"
+                      value={`${API_BASE}/api/v1/openapi.json`}
+                      truncate={false}
+                      className="w-full"
+                    />
+                    <CopyableCode
+                      label="Artifacts"
+                      value={`${API_BASE}/metagraph/`}
+                      truncate={false}
+                      className="w-full"
+                    />
+                  </div>
+                </Section>
+              </div>
 
-        <aside className="lg:sticky lg:top-24 h-fit">
-          <AtAGlance />
-        </aside>
-      </div>
-      <ApiSourceFooter paths={["/api/v1", "/api/v1/openapi.json", "/api/v1/build"]} />
+              <aside className="border-t border-border pt-4 lg:sticky lg:top-24 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0 h-fit">
+                <AtAGlance />
+              </aside>
+            </div>
+          </DataPageModule>
+        </DataPageCanvas>
+        <ApiSourceFooter paths={["/api/v1", "/api/v1/openapi.json", "/api/v1/build"]} />
+      </DataPageStage>
     </AppShell>
   );
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section>
+    <section className="mg-static-section">
       <h2 className="font-display text-sm font-semibold uppercase tracking-wider text-ink-strong mb-2">
         {title}
       </h2>

--- a/apps/ui/src/routes/-accounts-index-page.tsx
+++ b/apps/ui/src/routes/-accounts-index-page.tsx
@@ -8,7 +8,14 @@ import { Skeleton } from "@/components/metagraphed/states";
 import { TopActiveAccounts } from "@/components/metagraphed/top-active-accounts";
 import { TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS } from "@/components/metagraphed/top-active-accounts-ranking";
 import { ActionBar, ShareButton } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  Panel,
+} from "@/components/metagraphed/primitives";
 import { Ss58Inspector } from "@/components/metagraphed/ss58-inspector";
 import { TopHoldersPanel } from "@/components/metagraphed/top-holders-panel";
 import { YourPositionsPanel } from "@/components/metagraphed/your-positions-panel";
@@ -50,135 +57,133 @@ export function AccountsPage() {
 
   return (
     <AppShell>
-      <PageMasthead
-        eyebrow="Explorer"
-        live
-        title="Accounts"
-        description="Look up a Bittensor account by ss58 address (hotkey or coldkey) — its balance, staked positions, cross-subnet activity, and first-party chain-event history."
-        actions={
-          <ActionBar>
-            <ShareButton bare />
-          </ActionBar>
-        }
-      />
-      <EvmAddressRedirect />
-      <form onSubmit={submit} className="mx-auto w-full max-w-2xl">
-        <label htmlFor="ss58" className="mb-2 block mg-type-caption text-ink-muted">
-          Account address (ss58 or EVM)
-        </label>
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <div className="relative flex-1">
-            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-ink-muted" />
-            <input
-              id="ss58"
-              type="text"
-              inputMode="text"
-              autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck={false}
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              placeholder="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-              className="w-full rounded border border-border bg-card py-2.5 pl-10 pr-3 font-mono text-sm text-ink-strong placeholder:text-ink-muted/60 focus:border-ink/30 focus:outline-none min-h-11"
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={!valid}
-            className="inline-flex items-center justify-center gap-1.5 rounded border border-border bg-card px-4 py-2.5 text-sm font-medium hover:border-ink/30 disabled:cursor-not-allowed disabled:opacity-40 min-h-11"
+      <DataPageStage>
+        <DataPageHero
+          id="accounts-title"
+          eyebrow="Account explorer"
+          live
+          title="Accounts."
+          description="Look up a Bittensor account by ss58 address or EVM address — then inspect balances, stake, and first-party chain activity."
+          actions={
+            <ActionBar>
+              <ShareButton bare />
+            </ActionBar>
+          }
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title="Find an account."
+            caption="Paste a hotkey, coldkey, or EVM address to jump directly to the on-chain record."
           >
-            Look up
-          </button>
-        </div>
-        <p className="mt-2 mg-type-data text-ink-muted">
-          {touched && !valid
-            ? "That doesn't look like a valid ss58 or EVM address."
-            : "Paste a hotkey or coldkey ss58 address — or an EVM (0x) address — to view its activity."}
-        </p>
-      </form>
+            <EvmAddressRedirect />
+            <form onSubmit={submit} className="w-full max-w-2xl">
+              <label htmlFor="ss58" className="mb-2 block mg-type-caption text-ink-muted">
+                Account address (ss58 or EVM)
+              </label>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <div className="relative flex-1">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-ink-muted" />
+                  <input
+                    id="ss58"
+                    type="text"
+                    inputMode="text"
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                    placeholder="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+                    className="w-full border border-border bg-card py-2.5 pl-10 pr-3 font-mono text-sm text-ink-strong placeholder:text-ink-muted/60 focus:border-ink/30 focus:outline-none min-h-11"
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={!valid}
+                  className="inline-flex min-h-11 items-center justify-center gap-1.5 border border-border bg-card px-4 py-2.5 mg-type-caption font-medium hover:border-ink/30 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Look up
+                </button>
+              </div>
+              <p className="mt-2 mg-type-data text-ink-muted">
+                {touched && !valid
+                  ? "That doesn't look like a valid ss58 or EVM address."
+                  : "Paste a hotkey or coldkey ss58 address — or an EVM (0x) address — to view its activity."}
+              </p>
+            </form>
+          </DataPageModule>
 
-      {/* #8252: /portfolio folded in as "Your wallet" -- a whole route for a
-          connect prompt was the thing the redesign removed. Read-only
-          connect + flows unchanged. */}
-      <YourWalletPanel />
+          <DataPageModule
+            title="Your wallet."
+            caption="Read-only positions for a connected browser wallet; no transaction is constructed or signed here."
+          >
+            <YourWalletPanel />
+          </DataPageModule>
 
-      {/* #8252: the two new leaderboards the issue asks for, wired to the
-          already-shipped /api/v1/accounts sorts (which had no frontend
-          consumer until now). Stake and emission are the two aggregates that
-          endpoint actually ranks by -- there is no balance-ranked tier on it
-          (balance is a per-account live RPC call, not an indexed column), so
-          "Top by balance" would have to fabricate a ranking it can't compute.
-          Ranking by what the data really supports instead. */}
-      <div className="mx-auto mt-10 grid w-full max-w-4xl gap-4 md:grid-cols-2">
-        <AsyncPanel
-          context="top accounts by stake"
-          fallback={<Skeleton className="h-64 w-full" />}
-          retryQueryKeys={[accountsListQuery({ sort: "total_stake" }).queryKey]}
-        >
-          <AccountsLeaderboard
-            sort="total_stake"
-            title="Top by stake"
-            blurb="Accounts holding the most stake across every subnet."
-            metric={(a) => `${taoCompact(a.total_stake_tao)} τ`}
-          />
-        </AsyncPanel>
-        <AsyncPanel
-          context="top accounts by emission"
-          fallback={<Skeleton className="h-64 w-full" />}
-          retryQueryKeys={[accountsListQuery({ sort: "total_emission" }).queryKey]}
-        >
-          <AccountsLeaderboard
-            sort="total_emission"
-            title="Top by emission"
-            blurb="Accounts earning the most emission across every subnet."
-            metric={(a) => `${taoCompact(a.total_emission_tao)} τ`}
-          />
-        </AsyncPanel>
-      </div>
+          <DataPageModule
+            title="Account leaders."
+            caption="Compare the accounts holding the most stake or earning the most emission, then inspect current chain activity."
+          >
+            <div className="grid gap-6 md:grid-cols-2">
+              <AsyncPanel
+                context="top accounts by stake"
+                fallback={<Skeleton className="h-64 w-full" />}
+                retryQueryKeys={[accountsListQuery({ sort: "total_stake" }).queryKey]}
+              >
+                <AccountsLeaderboard
+                  sort="total_stake"
+                  title="Top by stake"
+                  blurb="Accounts holding the most stake across every subnet."
+                  metric={(a) => `${taoCompact(a.total_stake_tao)} τ`}
+                />
+              </AsyncPanel>
+              <AsyncPanel
+                context="top accounts by emission"
+                fallback={<Skeleton className="h-64 w-full" />}
+                retryQueryKeys={[accountsListQuery({ sort: "total_emission" }).queryKey]}
+              >
+                <AccountsLeaderboard
+                  sort="total_emission"
+                  title="Top by emission"
+                  blurb="Accounts earning the most emission across every subnet."
+                  metric={(a) => `${taoCompact(a.total_emission_tao)} τ`}
+                />
+              </AsyncPanel>
+            </div>
+            <section className="mt-8" data-testid="top-active-accounts-section">
+              <h3 className="mg-type-label text-ink-muted">Most active accounts</h3>
+              <p className="mt-1 mb-4 mg-type-data text-ink-muted">
+                Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS}{" "}
+                days — jump straight to an account below.
+              </p>
+              <AsyncPanel
+                context="active accounts"
+                fallback={<Skeleton className="h-40 w-full" />}
+                retryQueryKeys={[chainSignersQuery().queryKey]}
+              >
+                <TopActiveAccounts />
+              </AsyncPanel>
+            </section>
+          </DataPageModule>
 
-      <Panel
-        dense
-        className="mx-auto mt-10 w-full max-w-2xl"
-        data-testid="top-active-accounts-section"
-      >
-        <h2 className="mb-1 mg-type-label uppercase text-ink-muted">Most active accounts</h2>
-        <p className="mb-4 mg-type-data text-ink-muted">
-          Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS} days —
-          jump straight to an account below.
-        </p>
-        <AsyncPanel
-          context="active accounts"
-          fallback={<Skeleton className="h-40 w-full" />}
-          retryQueryKeys={[chainSignersQuery().queryKey]}
-        >
-          <TopActiveAccounts />
-        </AsyncPanel>
-      </Panel>
-
-      {/* #8252: /tools/ss58 folded in as an "Inspect address" utility. */}
-      <Panel dense className="mx-auto mt-10 w-full max-w-2xl">
-        <h2 className="mb-1 mg-type-label uppercase text-ink-muted">Inspect an address</h2>
-        <p className="mb-4 mg-type-data text-ink-muted">
-          Decode any SS58 address&apos;s network prefix and public key, and verify its checksum —
-          useful for catching a mistyped or wrong-network address before sending to it.
-        </p>
-        {/* #10300: the network-wide holder leaderboard was published and
-            rendered nowhere. */}
-        <section className="mt-8">
-          <TopHoldersPanel />
-        </section>
-
-        <Ss58Inspector />
-      </Panel>
-
-      <ApiSourceFooter
-        paths={[
-          "/api/v1/accounts/{ss58}",
-          "/api/v1/accounts",
-          "/api/v1/chain/signers",
-          "/api/v1/accounts/top-holders",
-        ]}
-      />
+          <DataPageModule
+            title="Inspect an address."
+            caption="Decode SS58 prefixes, verify checksums, and compare the current holder leaderboard before you act elsewhere."
+          >
+            <TopHoldersPanel />
+            <div className="mt-8">
+              <Ss58Inspector />
+            </div>
+          </DataPageModule>
+        </DataPageCanvas>
+        <ApiSourceFooter
+          paths={[
+            "/api/v1/accounts/{ss58}",
+            "/api/v1/accounts",
+            "/api/v1/chain/signers",
+            "/api/v1/accounts/top-holders",
+          ]}
+        />
+      </DataPageStage>
     </AppShell>
   );
 }
@@ -191,12 +196,7 @@ function YourWalletPanel() {
     // exactly that reason (see REPLAY_BLOCKED_ROUTES in lib/analytics.ts);
     // /accounts is a public any-address lookup page, so the protection moves
     // to this element rather than blocking the whole route.
-    <Panel dense className="ph-no-capture mx-auto mt-10 w-full max-w-4xl">
-      <h2 className="mb-1 mg-type-label uppercase text-ink-muted">Your wallet</h2>
-      <p className="mb-4 mg-type-data text-ink-muted">
-        Your staking positions across every subnet for the connected wallet — hotkey-owned and
-        delegated. Read-only: this app never constructs or signs a transaction.
-      </p>
+    <Panel dense className="ph-no-capture w-full max-w-4xl">
       {wallet ? (
         <AsyncPanel context="your positions" fallback={<Skeleton className="h-64 w-full" />}>
           <YourPositionsPanel address={wallet.address} />

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -51,12 +51,18 @@ import {
   SectionAnchor,
   StatTile,
   BarMini,
-  Chip,
   DownloadCsvButton,
   ExternalLink,
   BackToTop,
 } from "@jsonbored/ui-kit";
-import { PageMasthead, AsyncPanel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageDisclosure,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+} from "@/components/metagraphed/primitives";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
 import { AccountPositionHistoryChart } from "@/components/metagraphed/account-position-history-chart";
 import { AccountHoldingsHistory } from "@/components/metagraphed/account-holdings-history";
@@ -286,278 +292,290 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
     return { ...t };
   });
 
+  const accountDescription =
+    identity?.has_identity && identity.description
+      ? identity.description
+      : "Positions, transfers, and first-party chain activity for this Bittensor account.";
+
   return (
-    <>
-      <PageMasthead
-        eyebrow="Explorer · account"
-        live
-        title={resolvedTitle.display}
-        description={
-          <div className="space-y-4">
-            <p className="max-w-2xl">
-              {identity?.has_identity && identity.description
-                ? identity.description
-                : "Cross-subnet registrations, first-party chain events, and daily activity rollups for one Bittensor account."}
-            </p>
-            <div className="flex flex-wrap items-center gap-2">
-              {/* eslint-disable-next-line no-restricted-syntax -- genuinely 80% (#8554): this tier is 95%; .mg-glass would add blur(8px), a real visual change */}
-              <div className="max-w-full sm:max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 mg-card-glow">
-                <CopyableCode value={ss58} truncate={false} className="max-w-full" />
-              </div>
-              <RoleChip role={detectedRole} dual={dualRole} />
-              {resolvedTitle.source === "nametag" && resolvedTitle.category ? (
-                <Chip tone="muted" title={`Curated nametag · ${resolvedTitle.category}`}>
-                  {resolvedTitle.category}
-                </Chip>
+    <DataPageStage variant="profile">
+      <PageMasthead live title={resolvedTitle.display} description={accountDescription} />
+
+      <DataPageCanvas variant="profile">
+        <DataPageModule
+          kind="profile"
+          title="Account state"
+          caption="The current on-chain picture. Use the sections below for history, transfers, activity, and raw API access."
+          actions={
+            <div className="flex flex-wrap items-center gap-3">
+              {isStaleFreshness(generatedAt) ? (
+                <StaleBanner
+                  compact
+                  generatedAt={generatedAt}
+                  refreshQueryKeys={[accountQuery(ss58).queryKey]}
+                />
               ) : null}
+              <ActionBar>
+                <WatchStarButton kind="account" id={ss58} label="this account" iconOnly />
+                <ShareButton bare iconOnly />
+              </ActionBar>
             </div>
+          }
+        >
+          <div className="flex flex-col gap-4 border-b border-border pb-6 sm:flex-row sm:items-end sm:justify-between">
+            <div className="min-w-0 max-w-2xl">
+              <p className="mg-type-label uppercase text-ink-muted">On-chain address</p>
+              <CopyableCode value={ss58} truncate={false} className="mt-2 max-w-full" />
+            </div>
+            <dl className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:justify-end">
+              <div className="inline-flex items-center gap-2">
+                <dt className="mg-type-label uppercase text-ink-muted">Role</dt>
+                <dd>
+                  <RoleChip role={detectedRole} dual={dualRole} />
+                </dd>
+              </div>
+              {resolvedTitle.source === "nametag" && resolvedTitle.category ? (
+                <div className="inline-flex items-center gap-2">
+                  <dt className="mg-type-label uppercase text-ink-muted">Category</dt>
+                  <dd className="mg-type-caption text-ink-strong">{resolvedTitle.category}</dd>
+                </div>
+              ) : null}
+            </dl>
           </div>
-        }
-        actions={
-          <>
-            <ActionBar>
-              <WatchStarButton kind="account" id={ss58} label="this account" iconOnly />
-              <ShareButton bare iconOnly />
-            </ActionBar>
-            {/* #8484: outside the ActionBar (its children need their own
-                `bare` variant for the segmented look) but still in `actions`
-                -- unlike `description`, this row isn't `line-clamp`-collapsed,
-                so the entry point stays reachable regardless of how long the
-                description text runs. */}
-            <AddressLabelEditor ss58={ss58} />
-            {isStaleFreshness(generatedAt) ? (
-              <StaleBanner
-                compact
-                generatedAt={generatedAt}
-                refreshQueryKeys={[accountQuery(ss58).queryKey]}
-              />
-            ) : null}
-          </>
-        }
-        caption="explorer / v1"
-      />
 
-      <AccountKpiBand
-        role={dualRole ? roleView : detectedRole}
-        dual={dualRole}
-        onRoleChange={setRoleView}
-        account={account}
-        balance={balance}
-        balanceError={balanceResult.isError}
-        balanceImplausible={balanceImplausible}
-        onRetryBalance={() => void balanceResult.refetch()}
-        portfolio={portfolio}
-        portfolioPhase={statPhase(portfolioResult)}
-        stakeFlow={stakeFlow}
-        validator={validator}
-        estApyPct={estApyPct}
-        lastAnnouncedAt={lastAnnouncedAt}
-      />
+          <AccountKpiBand
+            role={dualRole ? roleView : detectedRole}
+            dual={dualRole}
+            onRoleChange={setRoleView}
+            account={account}
+            balance={balance}
+            balanceError={balanceResult.isError}
+            balanceImplausible={balanceImplausible}
+            onRetryBalance={() => void balanceResult.refetch()}
+            portfolio={portfolio}
+            portfolioPhase={statPhase(portfolioResult)}
+            stakeFlow={stakeFlow}
+            validator={validator}
+            estApyPct={estApyPct}
+            lastAnnouncedAt={lastAnnouncedAt}
+          />
 
-      <ProfileTabs tabs={tabsWithCounts} defaultTab="overview" />
+          <DataPageDisclosure label="Personal label">
+            <div className="max-w-xs">
+              <AddressLabelEditor ss58={ss58} trigger="button" />
+            </div>
+          </DataPageDisclosure>
+        </DataPageModule>
 
-      {!hasActivity ? (
-        <EmptyState
-          title="No activity indexed for this account"
-          description="The chain poller indexes first-party events for recent blocks. Cold accounts or those without recent on-chain activity won't appear yet."
-          action={{ label: "Back to accounts", href: "/accounts" }}
-        />
-      ) : null}
+        <DataPageModule kind="profile">
+          <ProfileTabs tabs={tabsWithCounts} defaultTab="overview" />
 
-      {tab === "overview" && (
-        <>
-          {identity?.has_identity ? <AccountIdentitySection ss58={ss58} /> : null}
-          <AccountRecentActivityPreview events={account.recent_events} />
-          <AccountEntitiesSection ss58={ss58} />
-        </>
-      )}
+          {!hasActivity ? (
+            <EmptyState
+              title="No activity indexed for this account"
+              description="The chain poller indexes first-party events for recent blocks. Cold accounts or those without recent on-chain activity won't appear yet."
+              action={{ label: "Back to accounts", href: "/accounts" }}
+            />
+          ) : null}
 
-      {tab === "positions" && (
-        <>
-          {/* #8252: coldkey leads with what it holds; hotkey leads with its
-              registrations. Both render the same section set within this tab. */}
-          {detectedRole === "coldkey" ? (
+          {tab === "overview" && (
             <>
-              <AccountPortfolioSection ss58={ss58} />
-              <AccountStakeFlowSection ss58={ss58} />
-              <AccountStakeMovesSection ss58={ss58} />
-              <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
-            </>
-          ) : (
-            <>
-              <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
-              <AccountStakeFlowSection ss58={ss58} />
-              <AccountPortfolioSection ss58={ss58} />
-              <AccountStakeMovesSection ss58={ss58} />
+              {identity?.has_identity ? <AccountIdentitySection ss58={ss58} /> : null}
+              <AccountRecentActivityPreview events={account.recent_events} />
+              <AccountEntitiesSection ss58={ss58} />
             </>
           )}
-          {/* #6723: live child/parent-hotkey stake-weight delegation graph. */}
-          <AccountDelegationSection ss58={ss58} />
-        </>
-      )}
 
-      {tab === "holdings" && (
-        <SectionAnchor
-          id="holdings-history"
-          title="Holdings over time"
-          subtitle="Staked τ by subnet from daily position snapshots — free balance stays a live read in the band above."
-          tone="accent"
-          info="Depth is limited by how far back daily snapshots reach; it grows as the genesis backfill (#8368) lands."
-        >
-          <AccountHoldingsHistory ss58={ss58} />
-        </SectionAnchor>
-      )}
+          {tab === "positions" && (
+            <>
+              {/* #8252: coldkey leads with what it holds; hotkey leads with its
+              registrations. Both render the same section set within this tab. */}
+              {detectedRole === "coldkey" ? (
+                <>
+                  <AccountPortfolioSection ss58={ss58} />
+                  <AccountStakeFlowSection ss58={ss58} />
+                  <AccountStakeMovesSection ss58={ss58} />
+                  <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
+                </>
+              ) : (
+                <>
+                  <AccountFootprintSection ss58={ss58} fallback={account.registrations} />
+                  <AccountStakeFlowSection ss58={ss58} />
+                  <AccountPortfolioSection ss58={ss58} />
+                  <AccountStakeMovesSection ss58={ss58} />
+                </>
+              )}
+              {/* #6723: live child/parent-hotkey stake-weight delegation graph. */}
+              <AccountDelegationSection ss58={ss58} />
+            </>
+          )}
 
-      {tab === "holdings" && (
-        <SectionAnchor
-          id="root-claim"
-          title="Root claim"
-          subtitle="What this account's root stake would do in a swap, and which hotkeys it reaches."
-          info="GET /api/v1/accounts/{ss58}/root-claim — the payload's own `field_sources` marks the claim type as MEASURED (read from SubtensorModule.RootClaimType) and the hotkey list as RECONSTRUCTED (inferred from other state). The panel shows that provenance beside the figure it qualifies rather than rendering an inference with the authority of a reading."
-        >
-          <AccountRootClaim ss58={ss58} />
-        </SectionAnchor>
-      )}
+          {tab === "holdings" && (
+            <SectionAnchor
+              id="holdings-history"
+              title="Holdings over time"
+              subtitle="Staked τ by subnet from daily position snapshots — free balance stays a live read in the band above."
+              tone="accent"
+              info="Depth is limited by how far back daily snapshots reach; it grows as the genesis backfill (#8368) lands."
+            >
+              <AccountHoldingsHistory ss58={ss58} />
+            </SectionAnchor>
+          )}
 
-      {tab === "transfers" && (
-        <>
-          <AccountTransfersSection
-            ss58={ss58}
-            rows={transfers}
-            isPending={transfersResult.isPending}
-            isError={transfersResult.isError}
-            error={transfersResult.error}
-            onRetry={() => void transfersResult.refetch()}
-          />
-          {/* #3340: the aggregated fund-flow view over the same transfer data. */}
-          <AccountCounterpartiesSection ss58={ss58} />
-        </>
-      )}
+          {tab === "holdings" && (
+            <SectionAnchor
+              id="root-claim"
+              title="Root claim"
+              subtitle="What this account's root stake would do in a swap, and which hotkeys it reaches."
+              info="GET /api/v1/accounts/{ss58}/root-claim — the payload's own `field_sources` marks the claim type as MEASURED (read from SubtensorModule.RootClaimType) and the hotkey list as RECONSTRUCTED (inferred from other state). The panel shows that provenance beside the figure it qualifies rather than rendering an inference with the authority of a reading."
+            >
+              <AccountRootClaim ss58={ss58} />
+            </SectionAnchor>
+          )}
 
-      {tab === "activity" && (
-        <>
-          {/* Daily activity is a hotkey-keyed rollup -- rendering it for a
+          {tab === "transfers" && (
+            <>
+              <AccountTransfersSection
+                ss58={ss58}
+                rows={transfers}
+                isPending={transfersResult.isPending}
+                isError={transfersResult.isError}
+                error={transfersResult.error}
+                onRetry={() => void transfersResult.refetch()}
+              />
+              {/* #3340: the aggregated fund-flow view over the same transfer data. */}
+              <AccountCounterpartiesSection ss58={ss58} />
+            </>
+          )}
+
+          {tab === "activity" && (
+            <>
+              {/* Daily activity is a hotkey-keyed rollup -- rendering it for a
               coldkey guarantees the framed "No daily hotkey activity yet"
               panel the redesign removes, so it's hotkey-only by construction
               rather than relying on an empty state to explain itself. */}
-          {detectedRole === "hotkey" ? (
-            <SectionAnchor
-              id="history"
-              title="Daily activity"
-              subtitle="Per-day first-party account events, newest rollups from the chain-direct explorer."
-              tone="accent"
-              info="History is keyed by hotkey activity only."
-              right={<SectionBadge tone="accent">hotkey rollup</SectionBadge>}
-            >
-              <AccountHistoryChart ss58={ss58} />
-            </SectionAnchor>
-          ) : null}
-          <AccountTeardownActivitySection ss58={ss58} />
-          <AccountRegistrationActivitySection ss58={ss58} />
-          <AccountDeregistrationActivitySection ss58={ss58} />
-          <AccountWeightSettingSection ss58={ss58} />
-          <AccountEndpointAnnouncementSection ss58={ss58} />
-          {account.event_kinds.length > 0 ? (
-            <SectionAnchor
-              id="kinds"
-              title="Activity by kind"
-              subtitle="Relative event mix across the indexed sample for this account."
-              tone="accent"
-              right={<SectionBadge>{formatNumber(account.event_kinds.length)} kinds</SectionBadge>}
-            >
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                {account.event_kinds.map((entry) => (
-                  <div
-                    key={entry.kind}
-                    className="rounded-2xl border border-border/80 mg-glass-opaque px-4 py-3 mg-card-glow"
-                  >
-                    <div className="mg-type-caption text-ink-muted">event kind</div>
-                    <div className="mt-2 flex items-end justify-between gap-3">
-                      <span className="min-w-0 truncate font-mono mg-type-caption text-ink-strong">
-                        {entry.kind}
-                      </span>
-                      <span className="font-display text-xl font-semibold tabular-nums text-ink-strong">
-                        {formatNumber(entry.count)}
-                      </span>
-                    </div>
+              {detectedRole === "hotkey" ? (
+                <SectionAnchor
+                  id="history"
+                  title="Daily activity"
+                  subtitle="Per-day first-party account events, newest rollups from the chain-direct explorer."
+                  tone="accent"
+                  info="History is keyed by hotkey activity only."
+                  right={<SectionBadge tone="accent">hotkey rollup</SectionBadge>}
+                >
+                  <AccountHistoryChart ss58={ss58} />
+                </SectionAnchor>
+              ) : null}
+              <AccountTeardownActivitySection ss58={ss58} />
+              <AccountRegistrationActivitySection ss58={ss58} />
+              <AccountDeregistrationActivitySection ss58={ss58} />
+              <AccountWeightSettingSection ss58={ss58} />
+              <AccountEndpointAnnouncementSection ss58={ss58} />
+              {account.event_kinds.length > 0 ? (
+                <SectionAnchor
+                  id="kinds"
+                  title="Activity by kind"
+                  subtitle="Relative event mix across the indexed sample for this account."
+                  tone="accent"
+                  right={
+                    <SectionBadge>{formatNumber(account.event_kinds.length)} kinds</SectionBadge>
+                  }
+                >
+                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                    {account.event_kinds.map((entry) => (
+                      <div
+                        key={entry.kind}
+                        className="rounded-2xl border border-border/80 mg-glass-opaque px-4 py-3 mg-card-glow"
+                      >
+                        <div className="mg-type-caption text-ink-muted">event kind</div>
+                        <div className="mt-2 flex items-end justify-between gap-3">
+                          <span className="min-w-0 truncate font-mono mg-type-caption text-ink-strong">
+                            {entry.kind}
+                          </span>
+                          <span className="font-display text-xl font-semibold tabular-nums text-ink-strong">
+                            {formatNumber(entry.count)}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
+                </SectionAnchor>
+              ) : null}
+              <AccountEventsSection ss58={ss58} kindOptions={account.event_kinds} />
+            </>
+          )}
+
+          {tab === "extrinsics" && (
+            <AccountExtrinsicsSection
+              ss58={ss58}
+              rows={signedExtrinsics}
+              isPending={extrinsicsResult.isPending}
+              isError={extrinsicsResult.isError}
+              error={extrinsicsResult.error}
+              onRetry={() => void extrinsicsResult.refetch()}
+            />
+          )}
+
+          {tab === "api" && (
+            <SectionAnchor
+              id="call"
+              title="Call this endpoint"
+              subtitle="Copy a ready-to-run request for this account."
+            >
+              <EndpointSnippet
+                rows={[
+                  { label: "summary", path: `/api/v1/accounts/${sourceRef}` },
+                  { label: "balance", path: `/api/v1/accounts/${sourceRef}/balance` },
+                  { label: "identity", path: `/api/v1/accounts/${sourceRef}/identity` },
+                  { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
+                  { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
+                  { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
+                  { label: "counterparties", path: `/api/v1/accounts/${sourceRef}/counterparties` },
+                  { label: "children", path: `/api/v1/accounts/${sourceRef}/children` },
+                  { label: "parents", path: `/api/v1/accounts/${sourceRef}/parents` },
+                  { label: "entities", path: `/api/v1/accounts/${sourceRef}/entities` },
+                  { label: "stake-flow", path: `/api/v1/accounts/${sourceRef}/stake-flow` },
+                  { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
+                  { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
+                ]}
+              />
             </SectionAnchor>
-          ) : null}
-          <AccountEventsSection ss58={ss58} kindOptions={account.event_kinds} />
-        </>
-      )}
+          )}
 
-      {tab === "extrinsics" && (
-        <AccountExtrinsicsSection
-          ss58={ss58}
-          rows={signedExtrinsics}
-          isPending={extrinsicsResult.isPending}
-          isError={extrinsicsResult.isError}
-          error={extrinsicsResult.error}
-          onRetry={() => void extrinsicsResult.refetch()}
-        />
-      )}
-
-      {tab === "api" && (
-        <SectionAnchor
-          id="call"
-          title="Call this endpoint"
-          subtitle="Copy a ready-to-run request for this account."
-        >
-          <EndpointSnippet
-            rows={[
-              { label: "summary", path: `/api/v1/accounts/${sourceRef}` },
-              { label: "balance", path: `/api/v1/accounts/${sourceRef}/balance` },
-              { label: "identity", path: `/api/v1/accounts/${sourceRef}/identity` },
-              { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
-              { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
-              { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
-              { label: "counterparties", path: `/api/v1/accounts/${sourceRef}/counterparties` },
-              { label: "children", path: `/api/v1/accounts/${sourceRef}/children` },
-              { label: "parents", path: `/api/v1/accounts/${sourceRef}/parents` },
-              { label: "entities", path: `/api/v1/accounts/${sourceRef}/entities` },
-              { label: "stake-flow", path: `/api/v1/accounts/${sourceRef}/stake-flow` },
-              { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
-              { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
-            ]}
-          />
-        </SectionAnchor>
-      )}
-
-      {/* #6432: deliberately NOT "← All accounts" like the other detail pages'
+          {/* #6432: deliberately NOT "← All accounts" like the other detail pages'
           back-links. /accounts is a lookup form, not an index -- there is no
           list of every chain account to go back to -- so the label names what
           the destination actually is. Sibling pages (blocks, extrinsics,
           validators, subnets) do point at real directories and use "← All X". */}
-      <div className="mt-6">
-        <Link
-          to="/accounts"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-data font-medium hover:border-ink/30"
-        >
-          ← Account lookup
-        </Link>
-      </div>
+          <div className="mt-6">
+            <Link
+              to="/accounts"
+              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-data font-medium hover:border-ink/30"
+            >
+              ← Account lookup
+            </Link>
+          </div>
 
-      <ApiSourceFooter
-        paths={[
-          `/api/v1/accounts/${sourceRef}`,
-          `/api/v1/accounts/${sourceRef}/identity`,
-          `/api/v1/accounts/${sourceRef}/history`,
-          `/api/v1/accounts/${sourceRef}/events`,
-          `/api/v1/accounts/${sourceRef}/subnets`,
-          `/api/v1/accounts/${sourceRef}/counterparties`,
-          `/api/v1/accounts/${sourceRef}/children`,
-          `/api/v1/accounts/${sourceRef}/parents`,
-          `/api/v1/accounts/${sourceRef}/entities`,
-          `/api/v1/accounts/${sourceRef}/stake-flow`,
-          `/api/v1/accounts/${sourceRef}/serving`,
-          `/api/v1/accounts/${sourceRef}/prometheus`,
-        ]}
-      />
-      <BackToTop />
-    </>
+          <ApiSourceFooter
+            paths={[
+              `/api/v1/accounts/${sourceRef}`,
+              `/api/v1/accounts/${sourceRef}/identity`,
+              `/api/v1/accounts/${sourceRef}/history`,
+              `/api/v1/accounts/${sourceRef}/events`,
+              `/api/v1/accounts/${sourceRef}/subnets`,
+              `/api/v1/accounts/${sourceRef}/counterparties`,
+              `/api/v1/accounts/${sourceRef}/children`,
+              `/api/v1/accounts/${sourceRef}/parents`,
+              `/api/v1/accounts/${sourceRef}/entities`,
+              `/api/v1/accounts/${sourceRef}/stake-flow`,
+              `/api/v1/accounts/${sourceRef}/serving`,
+              `/api/v1/accounts/${sourceRef}/prometheus`,
+            ]}
+          />
+          <BackToTop />
+        </DataPageModule>
+      </DataPageCanvas>
+    </DataPageStage>
   );
 }
 
@@ -566,7 +584,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
 function RoleChip({ role, dual }: { role: AccountRole; dual: boolean }) {
   const label = dual ? "coldkey + hotkey" : role;
   return (
-    <span className="inline-flex items-center rounded-full border border-border bg-card px-3 py-1.5 mg-type-caption text-ink-muted">
+    <span className="inline-flex items-center gap-1.5 mg-type-caption text-ink-muted">
+      <span aria-hidden className="size-1.5 rounded-full bg-accent" />
       {label}
     </span>
   );
@@ -657,7 +676,7 @@ function AccountKpiBand({
     netFlow == null ? "—" : `${netFlow >= 0 ? "+" : "−"}${fmtTaoCompact(Math.abs(netFlow))}`;
 
   return (
-    <div className="mb-8">
+    <div>
       {dual ? (
         <div className="mb-3 flex items-center gap-2">
           <span className="mg-type-caption text-ink-muted">Showing:</span>

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -2,7 +2,13 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { ActionBar, ShareButton, SectionHeading } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+} from "@/components/metagraphed/primitives";
 import { AgentContextCard } from "@/components/metagraphed/agent-context-card";
 import { AgentConnectCard } from "@/components/metagraphed/agent-connect-card";
 import { AgentLiveCard } from "@/components/metagraphed/agent-live-card";
@@ -16,24 +22,33 @@ import type { AgentResource, AgentResources } from "@/lib/metagraphed/types";
 export function AgentsPage() {
   return (
     <AppShell>
-      <PageMasthead
-        eyebrow="For AI agents"
-        title="Use AI to explore Bittensor"
-        description="Point any agent at metagraphed — over MCP, a typed SDK, or plain HTTP — and it can find, explain, and call the right Bittensor subnet for a task. No key, no account."
-        actions={
-          <ActionBar>
-            <ShareButton bare />
-          </ActionBar>
-        }
-      />
-      <AsyncPanel
-        context="agent resources"
-        fallback={<Skeleton className="h-[40rem] w-full" />}
-        retryQueryKeys={[agentResourcesQuery().queryKey]}
-      >
-        <AgentsBody />
-      </AsyncPanel>
-      <ApiSourceFooter paths={["/api/v1/agent-resources"]} />
+      <DataPageStage>
+        <PageMasthead
+          eyebrow="For AI agents"
+          title="Use AI to explore Bittensor"
+          description="Point any agent at metagraphed — over MCP, a typed SDK, or plain HTTP — and it can find, explain, and call the right Bittensor subnet for a task. No key, no account."
+          actions={
+            <ActionBar>
+              <ShareButton bare />
+            </ActionBar>
+          }
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title="Give an agent a working map."
+            caption="A short, sequential handoff: context first, connection second, then real tasks and deeper interfaces."
+          >
+            <AsyncPanel
+              context="agent resources"
+              fallback={<Skeleton className="h-[40rem] w-full" />}
+              retryQueryKeys={[agentResourcesQuery().queryKey]}
+            >
+              <AgentsBody />
+            </AsyncPanel>
+          </DataPageModule>
+        </DataPageCanvas>
+        <ApiSourceFooter paths={["/api/v1/agent-resources"]} />
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-apis-hub.tsx
+++ b/apps/ui/src/routes/-apis-hub.tsx
@@ -22,26 +22,22 @@ export const APIS_TABS: readonly ApisTab[] = [
   {
     to: "/apis",
     label: "Catalog",
-    blurb:
-      "Every verified public interface across subnets — APIs, schemas, docs, dashboards and SDKs, filterable by kind, provider and netuid.",
+    blurb: "Public APIs, schemas, docs, dashboards, and SDKs by subnet.",
   },
   {
     to: "/apis/endpoints",
     label: "Live endpoints",
-    blurb:
-      "Callable Subtensor and subnet endpoints — health, latency and pool eligibility, plus the managed RPC proxy.",
+    blurb: "Network and subnet endpoints with live health and latency.",
   },
   {
     to: "/apis/schemas",
     label: "Schemas",
-    blurb:
-      "JSON Schema is canonical truth. Drift compares the current snapshot against the previous published version.",
+    blurb: "Published JSON Schema snapshots and drift.",
   },
   {
     to: "/apis/providers",
     label: "Providers",
-    blurb:
-      "The teams, infra operators, docs registries and community sources behind these public interfaces.",
+    blurb: "Teams and operators behind public interfaces.",
   },
 ] as const;
 
@@ -49,8 +45,8 @@ export function activeApisTab(pathname: string): ApisTab {
   return activeHubTab(APIS_TABS, pathname);
 }
 
-export function ApisTabs() {
-  return <HubTabs tabs={APIS_TABS} ariaLabel="API sections" />;
+export function ApisTabs({ className }: { className?: string }) {
+  return <HubTabs tabs={APIS_TABS} ariaLabel="API sections" className={className} />;
 }
 
 export const ApisTabActions = HubTabActions;

--- a/apps/ui/src/routes/-blocks-index-page.tsx
+++ b/apps/ui/src/routes/-blocks-index-page.tsx
@@ -1,11 +1,11 @@
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Timer, Activity, Users } from "lucide-react";
 import {
   AsyncPanel,
+  DataPageDisclosure,
+  DataPageModule,
   TableSkeleton,
   PagerFooter,
-  MetricGrid,
   PanelSkeleton,
   QueryBar,
   FilterSheet,
@@ -22,7 +22,6 @@ import {
   ShareButton,
   DownloadCsvButton,
   ActionBar,
-  StatTile,
   CopyButton,
   CopyableCode,
   BackToTop,
@@ -34,10 +33,8 @@ import { AuthorSharePanel } from "@/components/metagraphed/blocks/author-share-p
 import { blocksQuery, blocksSummaryQuery, metagraphedQueryKey } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
-import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { ChainTabActions } from "./-chain-hub";
 import type { Block } from "@/lib/metagraphed/types";
 import type { BlocksSearch } from "./chain.blocks";
 
@@ -56,21 +53,10 @@ function blocksQueryParams(search: BlocksSearch): Record<string, string | number
 }
 
 export function BlocksPage() {
-  const search = useSearch({ from: "/chain/blocks" }) as BlocksSearch;
-  const blocksCsvUrl = buildUrl("/api/v1/blocks", blocksQueryParams(search));
-
   return (
     <>
-      {/* The hub owns the shell, title and description now (#8290). These
-          actions came off this page's own masthead and render above the tab
-          content rather than beside the tab strip — a shrink-0 sibling there is
-          exactly what starved the profile tabs to 196px on mobile (#8254). */}
-      <ChainTabActions>
-        <ActionBar>
-          <DownloadCsvButton url={blocksCsvUrl} bare />
-          <ShareButton bare />
-        </ActionBar>
-      </ChainTabActions>
+      {/* Exporting and sharing belong with the result controls in BlocksTable,
+          not in the hub chrome. The data task stays the first thing visible. */}
       <AsyncPanel
         context="Live block rail"
         retryQueryKeys={[metagraphedQueryKey("blocks"), metagraphedQueryKey("chain-activity")]}
@@ -79,25 +65,13 @@ export function BlocksPage() {
         <LiveBlockRail />
       </AsyncPanel>
       <AsyncPanel
-        context="Block production"
-        retryQueryKeys={[metagraphedQueryKey("blocks-summary")]}
-        fallback={
-          <div className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-3">
-            <PanelSkeleton height="sm" />
-            <PanelSkeleton height="sm" />
-            <PanelSkeleton height="sm" />
-          </div>
-        }
-      >
-        <BlockProductionHeader />
-      </AsyncPanel>
-      <AsyncPanel
         context="Blocks table"
         retryQueryKeys={[metagraphedQueryKey("blocks")]}
         fallback={<TableSkeleton rows={10} columns={6} />}
       >
         <BlocksTable />
       </AsyncPanel>
+      <BlockProductionContext />
       <ApiSourceFooter
         paths={["/api/v1/blocks", "/api/v1/blocks/summary", "/api/v1/chain/activity"]}
         artifacts={["/metagraph/blocks.json", "/metagraph/blocks/summary.json"]}
@@ -107,42 +81,73 @@ export function BlocksPage() {
   );
 }
 
-// #3488: point-in-time block-production health above the raw blocks feed —
-// inter-block cadence, per-block throughput, and block-author decentralization
-// from /api/v1/blocks/summary, in its own Suspense/error boundary so a slow or
-// failed summary never blocks the table below.
+/** Secondary context loads independently and stays behind a native disclosure.
+ * That lets the newest-block feed remain the page's primary task on every viewport. */
+function BlockProductionContext() {
+  return (
+    <DataPageDisclosure label="Block production" className="mt-6">
+      <AsyncPanel
+        context="Block production"
+        retryQueryKeys={[metagraphedQueryKey("blocks-summary")]}
+        fallback={
+          <DataPageModule
+            kind="question"
+            title="Production summary"
+            caption="Cadence, throughput, and block-author distribution."
+          >
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+              <PanelSkeleton height="sm" />
+              <PanelSkeleton height="sm" />
+              <PanelSkeleton height="sm" />
+            </div>
+          </DataPageModule>
+        }
+      >
+        <DataPageModule
+          kind="question"
+          title="Production summary"
+          caption="Cadence, throughput, and block-author distribution."
+        >
+          <BlockProductionHeader />
+        </DataPageModule>
+      </AsyncPanel>
+    </DataPageDisclosure>
+  );
+}
+
+// Point-in-time production health belongs in one lean measurement rail above
+// the feed — not another row of card-shaped KPIs competing with the data.
 function BlockProductionHeader() {
   const summary = useSuspenseQuery(blocksSummaryQuery()).data.data;
   const blockTime = summary.block_time;
   const throughput = summary.throughput;
   const nakamoto = summary.author_concentration?.nakamoto_coefficient;
-  const nakamotoStatTone = nakamotoTone(nakamoto);
   return (
-    <MetricGrid cols={{ base: 1, sm: 2, md: 3 }} gap="md" className="mb-8">
-      <StatTile
-        icon={Timer}
-        eyebrow="Inter-block time"
-        value={blockTime ? humaniseSeconds(blockTime.mean_ms / 1000) : "—"}
-        hint={blockTime ? `p90 ${humaniseSeconds(blockTime.p90_ms / 1000)}` : undefined}
-      />
-      <StatTile
-        icon={Activity}
-        eyebrow="Throughput"
-        value={throughput ? formatNumber(throughput.mean_extrinsics_per_block) : "—"}
-        hint={
-          throughput
-            ? `ext/block · ${formatNumber(throughput.mean_events_per_block)} events/block`
-            : undefined
-        }
-      />
-      <StatTile
-        icon={Users}
-        eyebrow="Author decentralization"
-        value={nakamoto != null ? formatNumber(nakamoto) : "—"}
-        hint="Nakamoto coefficient"
-        tone={nakamotoStatTone}
-      />
-    </MetricGrid>
+    <dl className="mg-data-measure-grid">
+      <div className="mg-data-measure">
+        <dt>Inter-block time</dt>
+        <dd>
+          {blockTime ? humaniseSeconds(blockTime.mean_ms / 1000) : "—"}
+          {blockTime ? <small>p90 {humaniseSeconds(blockTime.p90_ms / 1000)}</small> : null}
+        </dd>
+      </div>
+      <div className="mg-data-measure">
+        <dt>Throughput</dt>
+        <dd>
+          {throughput ? formatNumber(throughput.mean_extrinsics_per_block) : "—"}
+          {throughput ? (
+            <small>{formatNumber(throughput.mean_events_per_block)} events/block</small>
+          ) : null}
+        </dd>
+      </div>
+      <div className="mg-data-measure">
+        <dt>Author decentralization</dt>
+        <dd>
+          {nakamoto != null ? formatNumber(nakamoto) : "—"}
+          <small>Nakamoto coefficient</small>
+        </dd>
+      </div>
+    </dl>
   );
 }
 
@@ -182,6 +187,7 @@ function BlocksTable() {
 
   // Only send filters the user actually set, so an empty bar is the plain feed.
   const queryParams = blocksQueryParams(search);
+  const blocksCsvUrl = buildUrl("/api/v1/blocks", queryParams);
 
   // Blocks turn over fast (~12s/block) — poll the first page only, so paging
   // through older blocks (offset > 0) isn't yanked or reflowed mid-read.
@@ -306,7 +312,7 @@ function BlocksTable() {
             />
           </QueryBar.Utility>
         </QueryBar>
-        <FilterSheet label="Filters" activeCount={secondaryFilterCount}>
+        <FilterSheet label="Controls" activeCount={activeCount}>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <label className="flex flex-col gap-1.5">
               <span className="mg-type-caption text-ink-muted">Spec version</span>
@@ -395,6 +401,13 @@ function BlocksTable() {
               </button>
             </div>
           ) : null}
+          <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
+            <span className="mg-type-caption text-ink-muted">Current result</span>
+            <ActionBar>
+              <DownloadCsvButton url={blocksCsvUrl} bare />
+              <ShareButton bare />
+            </ActionBar>
+          </div>
         </FilterSheet>
       </div>
       <QueryBar.MetaRow
@@ -441,13 +454,9 @@ function BlocksTable() {
 
   return (
     <>
-      {rows.length > 0 ? (
-        <>
-          <CadenceHeatmap rows={rows} />
-          <AuthorSharePanel rows={rows} />
-        </>
-      ) : null}
       <ListShell
+        presentation="canvas"
+        responsiveAt="lg"
         filters={filters}
         isEmpty={rows.length === 0}
         empty={emptyNode}
@@ -484,11 +493,6 @@ function BlocksTable() {
                       : gapSec > 24
                         ? "text-health-warn-text"
                         : "text-ink-subtle";
-                // Free decentralization tell: count how often this author appears
-                // on the current page. A repeat on a short window is worth flagging.
-                const authorRepeat = b.author
-                  ? rows.reduce((n, r) => (r.author === b.author ? n + 1 : n), 0)
-                  : 0;
                 return (
                   <tr
                     key={b.block_hash || b.block_number}
@@ -544,22 +548,13 @@ function BlocksTable() {
                             )
                           }
                         />
-                        {authorRepeat > 1 ? (
-                          <span
-                            /* eslint-disable-next-line no-restricted-syntax -- micro-chip repeat badge (9px); the mg-type-* scale bottoms out at caption-lg (13px) with no nano tier, so there is no matching token (#9343 req 1 exception) */
-                            className="mg-chip h-4 px-1.5 text-[9px] text-accent-text border-accent/40"
-                            title={`Produced ${authorRepeat} blocks on this page`}
-                          >
-                            ×{authorRepeat}
-                          </span>
-                        ) : null}
                       </div>
                     </td>
                     <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink align-top">
-                      <ActivityCell value={b.extrinsic_count ?? 0} max={maxExt} tone="accent" />
+                      <ActivityCell value={b.extrinsic_count ?? 0} max={maxExt} tone="extrinsics" />
                     </td>
                     <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink align-top">
-                      <ActivityCell value={b.event_count ?? 0} max={maxEvt} tone="ink" />
+                      <ActivityCell value={b.event_count ?? 0} max={maxEvt} tone="events" />
                     </td>
                     <td
                       className="px-4 py-2.5 text-right mg-type-data text-ink-muted align-top"
@@ -575,6 +570,12 @@ function BlocksTable() {
         }
         footer={footerNode}
       />
+      {rows.length > 0 ? (
+        <DataPageDisclosure label="Page context" className="mt-6">
+          <CadenceHeatmap rows={rows} />
+          <AuthorSharePanel rows={rows} />
+        </DataPageDisclosure>
+      ) : null}
     </>
   );
 }
@@ -582,7 +583,8 @@ function BlocksTable() {
 /**
  * Right-aligned number with a thin horizontal bar underneath, normalized
  * against the page-max so busy blocks are visually obvious at a glance.
- * `tone="accent"` (extrinsics) uses mint; `tone="ink"` (events) uses ink.
+ * Extrinsics and events are two comparable, non-semantic series, so the
+ * chart prism distinguishes them. Mint stays reserved for interactive focus.
  */
 function ActivityCell({
   value,
@@ -591,10 +593,10 @@ function ActivityCell({
 }: {
   value: number;
   max: number;
-  tone: "accent" | "ink";
+  tone: "extrinsics" | "events";
 }) {
   const pct = max > 0 ? Math.max(2, Math.round((value / max) * 100)) : 0;
-  const barCls = tone === "accent" ? "bg-accent/70" : "bg-ink-strong/40";
+  const barCls = tone === "extrinsics" ? "bg-chart-4/80" : "bg-chart-6/80";
   return (
     <span className="inline-flex flex-col items-end gap-1 min-w-[3.5rem]">
       <span>{formatNumber(value)}</span>

--- a/apps/ui/src/routes/-blocks-ref-page.tsx
+++ b/apps/ui/src/routes/-blocks-ref-page.tsx
@@ -18,7 +18,14 @@ import { PalletMethodBreakdown } from "@/components/metagraphed/blocks/pallet-me
 import { ShortcutsDialog } from "@/components/metagraphed/blocks/shortcuts-dialog";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+  Panel,
+} from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
@@ -153,7 +160,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
 
   if (!block) {
     return (
-      <>
+      <DataPageStage>
         <PageHeading
           eyebrow="Explorer"
           title={`Block ${refValue}`}
@@ -168,12 +175,12 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           paths={[`/api/v1/blocks/${sourceRef}`]}
           artifacts={[`/metagraph/blocks/${sourceRef}.json`]}
         />
-      </>
+      </DataPageStage>
     );
   }
 
   return (
-    <>
+    <DataPageStage>
       <ShortcutsDialog blockRef={refValue} />
       <PageMasthead
         eyebrow="Explorer · block"
@@ -208,462 +215,484 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         caption="explorer / v1"
       />
 
-      <RelatedEntityChipRow>
-        {block.author ? (
-          <Link
-            to="/accounts/$ss58"
-            params={{ ss58: block.author }}
-            className={relatedEntityChipLinkClass}
-          >
-            <RelatedEntityChip label="author" title="Block author">
-              {shortSs58Chip(block.author)}
-            </RelatedEntityChip>
-          </Link>
-        ) : null}
-        {(block.extrinsic_count ?? 0) > 0 ? (
-          <RelatedEntityChipHash
-            label="extrinsics"
-            title="Jump to extrinsics in this block"
-            hash="extrinsics"
-          >
-            {formatNumber(block.extrinsic_count ?? 0)}
-          </RelatedEntityChipHash>
-        ) : null}
-      </RelatedEntityChipRow>
+      <DataPageCanvas>
+        <DataPageModule>
+          <RelatedEntityChipRow>
+            {block.author ? (
+              <Link
+                to="/accounts/$ss58"
+                params={{ ss58: block.author }}
+                className={relatedEntityChipLinkClass}
+              >
+                <RelatedEntityChip label="author" title="Block author">
+                  {shortSs58Chip(block.author)}
+                </RelatedEntityChip>
+              </Link>
+            ) : null}
+            {(block.extrinsic_count ?? 0) > 0 ? (
+              <RelatedEntityChipHash
+                label="extrinsics"
+                title="Jump to extrinsics in this block"
+                hash="extrinsics"
+              >
+                {formatNumber(block.extrinsic_count ?? 0)}
+              </RelatedEntityChipHash>
+            ) : null}
+          </RelatedEntityChipRow>
 
-      <div className="space-y-10">
-        {(() => {
-          const withResult = extrinsics.filter((e) => e.success != null);
-          const successful = withResult.filter((e) => e.success).length;
-          const successRate = withResult.length > 0 ? (successful / withResult.length) * 100 : null;
-          const rateTone: "accent" | "warn" | "down" | "default" =
-            successRate == null
-              ? "default"
-              : successRate >= 99
-                ? "accent"
-                : successRate >= 90
-                  ? "warn"
-                  : "down";
-          // Sum of τ moved by economically-relevant events in this block.
-          // Only events that expose an `amount_tao` contribute — this is a
-          // signal, not a settlement total.
-          const valueMoved = events.reduce(
-            (sum, ev) => sum + (typeof ev.amount_tao === "number" ? ev.amount_tao : 0),
-            0,
-          );
-          const valueMovedNode = eventsQuery.isPending ? (
-            <span className="text-ink-muted">…</span>
-          ) : valueMoved > 0 ? (
-            <TaoValue amount={valueMoved} layout="stacked" precision={2} align="left" size="md" />
-          ) : (
-            "—"
-          );
-          return (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              {/* `?? 0` here reported "0 events" for any block whose count is
+          <div className="space-y-10">
+            {(() => {
+              const withResult = extrinsics.filter((e) => e.success != null);
+              const successful = withResult.filter((e) => e.success).length;
+              const successRate =
+                withResult.length > 0 ? (successful / withResult.length) * 100 : null;
+              const rateTone: "accent" | "warn" | "down" | "default" =
+                successRate == null
+                  ? "default"
+                  : successRate >= 99
+                    ? "accent"
+                    : successRate >= 90
+                      ? "warn"
+                      : "down";
+              // Sum of τ moved by economically-relevant events in this block.
+              // Only events that expose an `amount_tao` contribute — this is a
+              // signal, not a settlement total.
+              const valueMoved = events.reduce(
+                (sum, ev) => sum + (typeof ev.amount_tao === "number" ? ev.amount_tao : 0),
+                0,
+              );
+              const valueMovedNode = eventsQuery.isPending ? (
+                <span className="text-ink-muted">…</span>
+              ) : valueMoved > 0 ? (
+                <TaoValue
+                  amount={valueMoved}
+                  layout="stacked"
+                  precision={2}
+                  align="left"
+                  size="md"
+                />
+              ) : (
+                "—"
+              );
+              return (
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                  {/* `?? 0` here reported "0 events" for any block whose count is
                   merely unknown -- true for every block newer than the decode
                   sync's head. A count we do not have is not a count of zero,
                   and the Success tile below already renders that distinction
                   correctly. */}
-              <StatTile
-                icon={FileText}
-                eyebrow="Extrinsics"
-                value={block.extrinsic_count == null ? "—" : formatNumber(block.extrinsic_count)}
-                tooltip={BLOCK_TERM_HINTS.extrinsic}
-              />
-              <StatTile
-                icon={Zap}
-                eyebrow="Events"
-                value={block.event_count == null ? "—" : formatNumber(block.event_count)}
-                tooltip={BLOCK_TERM_HINTS.event}
-              />
-              <StatTile
-                icon={CheckCircle2}
-                eyebrow="Success"
-                value={
-                  successRate == null ? "—" : `${successRate.toFixed(successRate === 100 ? 0 : 1)}%`
-                }
-                tone={rateTone}
-                tooltip={BLOCK_TERM_HINTS.successRate}
-              />
-              <StatTile
-                icon={DollarSign}
-                eyebrow="Value moved"
-                value={valueMovedNode}
-                tone={valueMoved > 0 ? "accent" : "default"}
-                tooltip={BLOCK_TERM_HINTS.valueMoved}
-              />
+                  <StatTile
+                    icon={FileText}
+                    eyebrow="Extrinsics"
+                    value={
+                      block.extrinsic_count == null ? "—" : formatNumber(block.extrinsic_count)
+                    }
+                    tooltip={BLOCK_TERM_HINTS.extrinsic}
+                  />
+                  <StatTile
+                    icon={Zap}
+                    eyebrow="Events"
+                    value={block.event_count == null ? "—" : formatNumber(block.event_count)}
+                    tooltip={BLOCK_TERM_HINTS.event}
+                  />
+                  <StatTile
+                    icon={CheckCircle2}
+                    eyebrow="Success"
+                    value={
+                      successRate == null
+                        ? "—"
+                        : `${successRate.toFixed(successRate === 100 ? 0 : 1)}%`
+                    }
+                    tone={rateTone}
+                    tooltip={BLOCK_TERM_HINTS.successRate}
+                  />
+                  <StatTile
+                    icon={DollarSign}
+                    eyebrow="Value moved"
+                    value={valueMovedNode}
+                    tone={valueMoved > 0 ? "accent" : "default"}
+                    tooltip={BLOCK_TERM_HINTS.valueMoved}
+                  />
+                </div>
+              );
+            })()}
+
+            <div className="flex items-center justify-end -mb-6">
+              <span className="mg-label inline-flex items-center gap-1.5">
+                Observed <TimeAgo at={block.observed_at} />
+              </span>
             </div>
-          );
-        })()}
 
-        <div className="flex items-center justify-end -mb-6">
-          <span className="mg-label inline-flex items-center gap-1.5">
-            Observed <TimeAgo at={block.observed_at} />
-          </span>
-        </div>
-
-        <SectionAnchor id="chain" title="Chain walk" info={BLOCK_SECTION_HINTS.chain}>
-          <div className="space-y-3">
-            <ChainWalkRibbon current={block} radius={3} />
-            <NeighborCompare current={block} />
-          </div>
-        </SectionAnchor>
-
-        <SectionAnchor id="details" title="Block details" info={BLOCK_SECTION_HINTS.details}>
-          <dl className="rounded border border-border bg-card divide-y divide-border">
-            <FieldRow label="Block number">
-              <span className="font-mono text-sm text-ink-strong tabular-nums">
-                {formatNumber(block.block_number)}
-              </span>
-            </FieldRow>
-            <FieldRow label="Block hash" hint={BLOCK_TERM_HINTS.blockHash}>
-              {block.block_hash ? (
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <span
-                    className="font-mono mg-type-caption text-ink-strong break-all md:hidden"
-                    title={block.block_hash}
-                  >
-                    {shortHash(block.block_hash, 10)}
-                  </span>
-                  <span className="hidden md:inline font-mono mg-type-caption text-ink-strong break-all">
-                    {block.block_hash}
-                  </span>
-                  <CopyButton value={block.block_hash} label="block hash" compact />
-                </div>
-              ) : (
-                <span className="text-ink-muted">—</span>
-              )}
-            </FieldRow>
-            <FieldRow label="Parent hash" hint={BLOCK_TERM_HINTS.parentHash}>
-              {block.parent_hash ? (
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <Link
-                    to="/blocks/$ref"
-                    params={{ ref: block.parent_hash }}
-                    className="font-mono mg-type-caption text-ink-strong hover:underline break-all md:hidden"
-                    title={block.parent_hash}
-                  >
-                    {shortHash(block.parent_hash, 10)}
-                  </Link>
-                  <Link
-                    to="/blocks/$ref"
-                    params={{ ref: block.parent_hash }}
-                    className="hidden md:inline font-mono mg-type-caption text-ink-strong hover:underline break-all"
-                  >
-                    {block.parent_hash}
-                  </Link>
-                  <CopyButton value={block.parent_hash} label="parent hash" compact />
-                </div>
-              ) : (
-                <span className="text-ink-muted">—</span>
-              )}
-            </FieldRow>
-            <FieldRow label="Author" hint={BLOCK_TERM_HINTS.author}>
-              {/* #6424: full ss58 on desktop for readability; on mobile use the
-                  shortened form so it fits without wrapping ugly on 393px. */}
-              <div className="min-w-0">
-                <div className="md:hidden">
-                  <AddressDisplay
-                    ss58={block.author}
-                    keep={8}
-                    compact
-                    fallback={<span className="text-ink-muted">—</span>}
-                  />
-                </div>
-                <div className="hidden md:block">
-                  <AddressDisplay
-                    ss58={block.author}
-                    truncate={false}
-                    fallback={<span className="text-ink-muted">—</span>}
-                  />
-                </div>
+            <SectionAnchor id="chain" title="Chain walk" info={BLOCK_SECTION_HINTS.chain}>
+              <div className="space-y-3">
+                <ChainWalkRibbon current={block} radius={3} />
+                <NeighborCompare current={block} />
               </div>
-            </FieldRow>
-            <FieldRow label="Extrinsics">
-              <span className="font-mono text-sm text-ink tabular-nums">
-                {block.extrinsic_count == null ? "—" : formatNumber(block.extrinsic_count)}
-              </span>
-            </FieldRow>
-            <FieldRow label="Events">
-              <span className="font-mono text-sm text-ink tabular-nums">
-                {block.event_count == null ? "—" : formatNumber(block.event_count)}
-              </span>
-            </FieldRow>
-            <FieldRow label="Observed at">
-              <span className="font-mono mg-type-caption text-ink-muted">
-                <TimeAgo at={block.observed_at} />
-              </span>
-            </FieldRow>
-          </dl>
-        </SectionAnchor>
+            </SectionAnchor>
 
-        <SectionAnchor
-          id="metadata"
-          title="Block metadata"
-          info="Extended header fields (runtime version, storage roots) returned by the block API."
-        >
-          <BlockMetadataPanel block={block} />
-        </SectionAnchor>
-
-        <SectionAnchor
-          id="extrinsics"
-          title="Extrinsics"
-          info={BLOCK_SECTION_HINTS.extrinsics}
-          right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)} />}
-        >
-          {extrinsicsQuery.isPending ? (
-            <Skeleton className="h-44" />
-          ) : extrinsicsQuery.error ? (
-            <TableState
-              variant="error"
-              title="Couldn't load block extrinsics"
-              description="This section is optional — the rest of the block detail is unaffected."
-              error={extrinsicsQuery.error}
-              onRetry={() => {
-                void extrinsicsQuery.refetch();
-              }}
-            />
-          ) : extrinsics.length === 0 ? (
-            <EmptyState
-              title="No block extrinsics"
-              description="This block has no indexed extrinsics (or the poller window for this shard is still catching up)."
-            />
-          ) : (
-            <Panel as="div" flush className="overflow-x-auto">
-              <table className="w-full text-left text-sm">
-                <thead className="bg-surface/40">
-                  <tr>
-                    <th className="px-4 py-2.5 text-right">Index</th>
-                    <th className="px-4 py-2.5">Extrinsic</th>
-                    <th className="px-4 py-2.5">Call</th>
-                    <th className="px-4 py-2.5">Result</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {extrinsics.map((extrinsic) => {
-                    const result =
-                      extrinsic.success == null ? "—" : extrinsic.success ? "Success" : "Failed";
-                    // This table spells the result out ("Success"/"Failed")
-                    // rather than the feeds' "ok"/"fail", so it keeps its own
-                    // rendering instead of the shared SuccessBadge -- swapping it
-                    // in would silently reword the page. What it borrows is the
-                    // token pair: the fail branch already used --health-down
-                    // while success stayed on raw emerald, so the two halves of
-                    // one ternary disagreed (#6403).
-                    const resultClass =
-                      extrinsic.success == null
-                        ? "text-ink-muted"
-                        : extrinsic.success
-                          ? "text-health-ok"
-                          : "text-health-down";
-
-                    return (
-                      <tr
-                        key={
-                          extrinsic.extrinsic_hash ||
-                          `${extrinsic.block_number}-${extrinsic.extrinsic_index}`
-                        }
-                        className="mg-row-accent hover:bg-surface/40"
+            <SectionAnchor id="details" title="Block details" info={BLOCK_SECTION_HINTS.details}>
+              <dl className="rounded border border-border bg-card divide-y divide-border">
+                <FieldRow label="Block number">
+                  <span className="font-mono text-sm text-ink-strong tabular-nums">
+                    {formatNumber(block.block_number)}
+                  </span>
+                </FieldRow>
+                <FieldRow label="Block hash" hint={BLOCK_TERM_HINTS.blockHash}>
+                  {block.block_hash ? (
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span
+                        className="font-mono mg-type-caption text-ink-strong break-all md:hidden"
+                        title={block.block_hash}
                       >
-                        <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
-                          {extrinsic.extrinsic_index != null
-                            ? formatNumber(extrinsic.extrinsic_index)
-                            : "—"}
-                        </td>
-                        <td className="px-4 py-2.5 mg-type-data text-ink-muted break-all">
-                          {extrinsic.extrinsic_hash ? (
-                            <Link
-                              to="/extrinsics/$hash"
-                              params={{ hash: extrinsic.extrinsic_hash }}
-                              className="font-medium text-ink-strong hover:underline"
-                            >
-                              {shortHash(extrinsic.extrinsic_hash, 10)}
-                            </Link>
-                          ) : (
-                            "—"
-                          )}
-                        </td>
-                        <td className="px-4 py-2.5 mg-type-data text-ink-strong">
-                          {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
-                        </td>
-                        <td className={`px-4 py-2.5 mg-type-data ${resultClass}`}>{result}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </Panel>
-          )}
-        </SectionAnchor>
+                        {shortHash(block.block_hash, 10)}
+                      </span>
+                      <span className="hidden md:inline font-mono mg-type-caption text-ink-strong break-all">
+                        {block.block_hash}
+                      </span>
+                      <CopyButton value={block.block_hash} label="block hash" compact />
+                    </div>
+                  ) : (
+                    <span className="text-ink-muted">—</span>
+                  )}
+                </FieldRow>
+                <FieldRow label="Parent hash" hint={BLOCK_TERM_HINTS.parentHash}>
+                  {block.parent_hash ? (
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <Link
+                        to="/blocks/$ref"
+                        params={{ ref: block.parent_hash }}
+                        className="font-mono mg-type-caption text-ink-strong hover:underline break-all md:hidden"
+                        title={block.parent_hash}
+                      >
+                        {shortHash(block.parent_hash, 10)}
+                      </Link>
+                      <Link
+                        to="/blocks/$ref"
+                        params={{ ref: block.parent_hash }}
+                        className="hidden md:inline font-mono mg-type-caption text-ink-strong hover:underline break-all"
+                      >
+                        {block.parent_hash}
+                      </Link>
+                      <CopyButton value={block.parent_hash} label="parent hash" compact />
+                    </div>
+                  ) : (
+                    <span className="text-ink-muted">—</span>
+                  )}
+                </FieldRow>
+                <FieldRow label="Author" hint={BLOCK_TERM_HINTS.author}>
+                  {/* #6424: full ss58 on desktop for readability; on mobile use the
+                  shortened form so it fits without wrapping ugly on 393px. */}
+                  <div className="min-w-0">
+                    <div className="md:hidden">
+                      <AddressDisplay
+                        ss58={block.author}
+                        keep={8}
+                        compact
+                        fallback={<span className="text-ink-muted">—</span>}
+                      />
+                    </div>
+                    <div className="hidden md:block">
+                      <AddressDisplay
+                        ss58={block.author}
+                        truncate={false}
+                        fallback={<span className="text-ink-muted">—</span>}
+                      />
+                    </div>
+                  </div>
+                </FieldRow>
+                <FieldRow label="Extrinsics">
+                  <span className="font-mono text-sm text-ink tabular-nums">
+                    {block.extrinsic_count == null ? "—" : formatNumber(block.extrinsic_count)}
+                  </span>
+                </FieldRow>
+                <FieldRow label="Events">
+                  <span className="font-mono text-sm text-ink tabular-nums">
+                    {block.event_count == null ? "—" : formatNumber(block.event_count)}
+                  </span>
+                </FieldRow>
+                <FieldRow label="Observed at">
+                  <span className="font-mono mg-type-caption text-ink-muted">
+                    <TimeAgo at={block.observed_at} />
+                  </span>
+                </FieldRow>
+              </dl>
+            </SectionAnchor>
 
-        <SectionAnchor
-          id="events"
-          title="Events"
-          info={BLOCK_SECTION_HINTS.events}
-          subtitle="Grouped by parent extrinsic. System events (fees, deposits, ExtrinsicSuccess) are collapsed by default."
-          right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)} />}
-        >
-          {eventsQuery.isPending ? (
-            <Skeleton className="h-44" />
-          ) : eventsQuery.error ? (
-            <TableState
-              variant="error"
-              title="Couldn't load block events"
-              description="This section is optional — the rest of the block detail is unaffected."
-              error={eventsQuery.error}
-              onRetry={() => {
-                void eventsQuery.refetch();
-              }}
-            />
-          ) : events.length === 0 ? (
-            <EmptyState
-              title="No block events"
-              description="This block has no decoded on-chain events indexed yet."
-            />
-          ) : (
-            <GroupedEvents events={events} extrinsics={extrinsics} />
-          )}
-        </SectionAnchor>
+            <SectionAnchor
+              id="metadata"
+              title="Block metadata"
+              info="Extended header fields (runtime version, storage roots) returned by the block API."
+            >
+              <BlockMetadataPanel block={block} />
+            </SectionAnchor>
 
-        {chainEvents.length > 0 ? (
-          <SectionAnchor
-            id="pallets"
-            title="Pallet · method breakdown"
-            info="Ranked runtime pallet.method calls emitted by this block."
-          >
-            <PalletMethodBreakdown events={chainEvents} />
-          </SectionAnchor>
-        ) : null}
-
-        <SectionAnchor
-          id="chain-events"
-          title="Chain events (raw)"
-          info={BLOCK_SECTION_HINTS.chainEventsRaw}
-          subtitle="Curated events above are grouped by extrinsic; this table is the raw per-event stream — every pallet-level event in the block, decoded from the chain."
-        >
-          <details className="group rounded border border-border bg-card">
-            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 mg-type-caption font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
-              <span>
-                {chainEventsQuery.isPending
-                  ? "Loading raw events…"
-                  : `${formatNumber(chainEvents.length)} raw pallet events`}
-              </span>
-              <span className="mg-type-caption">
-                <span className="group-open:hidden">Show</span>
-                <span className="hidden group-open:inline">Hide</span>
-              </span>
-            </summary>
-            <div className="border-t border-border p-2">
-              {chainEventsQuery.isPending ? (
+            <SectionAnchor
+              id="extrinsics"
+              title="Extrinsics"
+              info={BLOCK_SECTION_HINTS.extrinsics}
+              right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)} />}
+            >
+              {extrinsicsQuery.isPending ? (
                 <Skeleton className="h-44" />
-              ) : chainEventsQuery.error ? (
+              ) : extrinsicsQuery.error ? (
                 <TableState
                   variant="error"
-                  title="Couldn't load block chain events"
+                  title="Couldn't load block extrinsics"
                   description="This section is optional — the rest of the block detail is unaffected."
-                  error={chainEventsQuery.error}
+                  error={extrinsicsQuery.error}
                   onRetry={() => {
-                    void chainEventsQuery.refetch();
+                    void extrinsicsQuery.refetch();
                   }}
                 />
-              ) : chainEvents.length === 0 ? (
+              ) : extrinsics.length === 0 ? (
                 <EmptyState
-                  title="No chain events"
-                  description="This block has no decoded pallet events indexed yet, or the all-events backfill hasn't reached it."
+                  title="No block extrinsics"
+                  description="This block has no indexed extrinsics (or the poller window for this shard is still catching up)."
                 />
               ) : (
                 <Panel as="div" flush className="overflow-x-auto">
                   <table className="w-full text-left text-sm">
                     <thead className="bg-surface/40">
                       <tr>
-                        <th className="px-4 py-2.5">Pallet.method</th>
-                        <th className="px-4 py-2.5">Phase</th>
-                        <th className="px-4 py-2.5 text-right">Extrinsic</th>
-                        <th className="px-4 py-2.5">Args</th>
+                        <th className="px-4 py-2.5 text-right">Index</th>
+                        <th className="px-4 py-2.5">Extrinsic</th>
+                        <th className="px-4 py-2.5">Call</th>
+                        <th className="px-4 py-2.5">Result</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-border">
-                      {chainEvents.map((event) => (
-                        <tr
-                          key={`${event.block_number}-${event.event_index}`}
-                          className="mg-row-accent hover:bg-surface/40"
-                        >
-                          <td className="px-4 py-2.5 mg-type-data text-ink-strong">
-                            {extrinsicCall(event.pallet, event.method)}
-                          </td>
-                          <td className="px-4 py-2.5 mg-type-data text-ink-muted">
-                            {event.phase ?? "—"}
-                          </td>
-                          <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink">
-                            {event.extrinsic_index != null
-                              ? formatNumber(event.extrinsic_index)
-                              : "—"}
-                          </td>
-                          <td className="px-4 py-2.5 mg-type-data text-ink-muted">
-                            <div className="flex max-w-xs items-center gap-1.5">
-                              <span className="truncate" title={formatChainEventArgs(event.args)}>
-                                {formatChainEventArgs(event.args)}
-                              </span>
-                              <CopyButton
-                                value={formatChainEventArgs(event.args)}
-                                label="args"
-                                compact
-                              />
-                            </div>
-                          </td>
-                        </tr>
-                      ))}
+                      {extrinsics.map((extrinsic) => {
+                        const result =
+                          extrinsic.success == null
+                            ? "—"
+                            : extrinsic.success
+                              ? "Success"
+                              : "Failed";
+                        // This table spells the result out ("Success"/"Failed")
+                        // rather than the feeds' "ok"/"fail", so it keeps its own
+                        // rendering instead of the shared SuccessBadge -- swapping it
+                        // in would silently reword the page. What it borrows is the
+                        // token pair: the fail branch already used --health-down
+                        // while success stayed on raw emerald, so the two halves of
+                        // one ternary disagreed (#6403).
+                        const resultClass =
+                          extrinsic.success == null
+                            ? "text-ink-muted"
+                            : extrinsic.success
+                              ? "text-health-ok"
+                              : "text-health-down";
+
+                        return (
+                          <tr
+                            key={
+                              extrinsic.extrinsic_hash ||
+                              `${extrinsic.block_number}-${extrinsic.extrinsic_index}`
+                            }
+                            className="mg-row-accent hover:bg-surface/40"
+                          >
+                            <td className="px-4 py-2.5 text-right font-mono mg-type-caption tabular-nums text-ink">
+                              {extrinsic.extrinsic_index != null
+                                ? formatNumber(extrinsic.extrinsic_index)
+                                : "—"}
+                            </td>
+                            <td className="px-4 py-2.5 mg-type-data text-ink-muted break-all">
+                              {extrinsic.extrinsic_hash ? (
+                                <Link
+                                  to="/extrinsics/$hash"
+                                  params={{ hash: extrinsic.extrinsic_hash }}
+                                  className="font-medium text-ink-strong hover:underline"
+                                >
+                                  {shortHash(extrinsic.extrinsic_hash, 10)}
+                                </Link>
+                              ) : (
+                                "—"
+                              )}
+                            </td>
+                            <td className="px-4 py-2.5 mg-type-data text-ink-strong">
+                              {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
+                            </td>
+                            <td className={`px-4 py-2.5 mg-type-data ${resultClass}`}>{result}</td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </Panel>
               )}
-            </div>
-          </details>
-        </SectionAnchor>
+            </SectionAnchor>
 
-        <SectionAnchor
-          id="call"
-          title="Call this endpoint"
-          info={BLOCK_SECTION_HINTS.call}
-          subtitle="Copy a ready-to-run request for this block."
-        >
-          <details className="group rounded border border-border bg-card">
-            <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 mg-type-caption font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
-              <span>API &amp; artifact URLs</span>
-              <span className="mg-type-caption">
-                <span className="group-open:hidden">Show</span>
-                <span className="hidden group-open:inline">Hide</span>
-              </span>
-            </summary>
-            <div className="border-t border-border p-3">
-              <EndpointSnippet
-                rows={[
-                  { label: "block", path: `/api/v1/blocks/${sourceRef}` },
-                  { label: "extrinsics", path: `/api/v1/blocks/${sourceRef}/extrinsics` },
-                  { label: "events", path: `/api/v1/blocks/${sourceRef}/events` },
-                  {
-                    label: "chain events",
-                    path: `/api/v1/blocks/${sourceRef}/chain-events`,
-                  },
-                  { label: "artifact", path: `/metagraph/blocks/${sourceRef}.json` },
-                ]}
-              />
-            </div>
-          </details>
-        </SectionAnchor>
+            <SectionAnchor
+              id="events"
+              title="Events"
+              info={BLOCK_SECTION_HINTS.events}
+              subtitle="Grouped by parent extrinsic. System events (fees, deposits, ExtrinsicSuccess) are collapsed by default."
+              right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)} />}
+            >
+              {eventsQuery.isPending ? (
+                <Skeleton className="h-44" />
+              ) : eventsQuery.error ? (
+                <TableState
+                  variant="error"
+                  title="Couldn't load block events"
+                  description="This section is optional — the rest of the block detail is unaffected."
+                  error={eventsQuery.error}
+                  onRetry={() => {
+                    void eventsQuery.refetch();
+                  }}
+                />
+              ) : events.length === 0 ? (
+                <EmptyState
+                  title="No block events"
+                  description="This block has no decoded on-chain events indexed yet."
+                />
+              ) : (
+                <GroupedEvents events={events} extrinsics={extrinsics} />
+              )}
+            </SectionAnchor>
 
-        <ApiSourceFooter
-          paths={[
-            `/api/v1/blocks/${sourceRef}`,
-            `/api/v1/blocks/${sourceRef}/extrinsics`,
-            `/api/v1/blocks/${sourceRef}/events`,
-            `/api/v1/blocks/${sourceRef}/chain-events`,
-          ]}
-          artifacts={[`/metagraph/blocks/${sourceRef}.json`]}
-        />
-      </div>
-    </>
+            {chainEvents.length > 0 ? (
+              <SectionAnchor
+                id="pallets"
+                title="Pallet · method breakdown"
+                info="Ranked runtime pallet.method calls emitted by this block."
+              >
+                <PalletMethodBreakdown events={chainEvents} />
+              </SectionAnchor>
+            ) : null}
+
+            <SectionAnchor
+              id="chain-events"
+              title="Chain events (raw)"
+              info={BLOCK_SECTION_HINTS.chainEventsRaw}
+              subtitle="Curated events above are grouped by extrinsic; this table is the raw per-event stream — every pallet-level event in the block, decoded from the chain."
+            >
+              <details className="group rounded border border-border bg-card">
+                <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 mg-type-caption font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                  <span>
+                    {chainEventsQuery.isPending
+                      ? "Loading raw events…"
+                      : `${formatNumber(chainEvents.length)} raw pallet events`}
+                  </span>
+                  <span className="mg-type-caption">
+                    <span className="group-open:hidden">Show</span>
+                    <span className="hidden group-open:inline">Hide</span>
+                  </span>
+                </summary>
+                <div className="border-t border-border p-2">
+                  {chainEventsQuery.isPending ? (
+                    <Skeleton className="h-44" />
+                  ) : chainEventsQuery.error ? (
+                    <TableState
+                      variant="error"
+                      title="Couldn't load block chain events"
+                      description="This section is optional — the rest of the block detail is unaffected."
+                      error={chainEventsQuery.error}
+                      onRetry={() => {
+                        void chainEventsQuery.refetch();
+                      }}
+                    />
+                  ) : chainEvents.length === 0 ? (
+                    <EmptyState
+                      title="No chain events"
+                      description="This block has no decoded pallet events indexed yet, or the all-events backfill hasn't reached it."
+                    />
+                  ) : (
+                    <Panel as="div" flush className="overflow-x-auto">
+                      <table className="w-full text-left text-sm">
+                        <thead className="bg-surface/40">
+                          <tr>
+                            <th className="px-4 py-2.5">Pallet.method</th>
+                            <th className="px-4 py-2.5">Phase</th>
+                            <th className="px-4 py-2.5 text-right">Extrinsic</th>
+                            <th className="px-4 py-2.5">Args</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border">
+                          {chainEvents.map((event) => (
+                            <tr
+                              key={`${event.block_number}-${event.event_index}`}
+                              className="mg-row-accent hover:bg-surface/40"
+                            >
+                              <td className="px-4 py-2.5 mg-type-data text-ink-strong">
+                                {extrinsicCall(event.pallet, event.method)}
+                              </td>
+                              <td className="px-4 py-2.5 mg-type-data text-ink-muted">
+                                {event.phase ?? "—"}
+                              </td>
+                              <td className="px-4 py-2.5 text-right mg-type-data tabular-nums text-ink">
+                                {event.extrinsic_index != null
+                                  ? formatNumber(event.extrinsic_index)
+                                  : "—"}
+                              </td>
+                              <td className="px-4 py-2.5 mg-type-data text-ink-muted">
+                                <div className="flex max-w-xs items-center gap-1.5">
+                                  <span
+                                    className="truncate"
+                                    title={formatChainEventArgs(event.args)}
+                                  >
+                                    {formatChainEventArgs(event.args)}
+                                  </span>
+                                  <CopyButton
+                                    value={formatChainEventArgs(event.args)}
+                                    label="args"
+                                    compact
+                                  />
+                                </div>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </Panel>
+                  )}
+                </div>
+              </details>
+            </SectionAnchor>
+
+            <SectionAnchor
+              id="call"
+              title="Call this endpoint"
+              info={BLOCK_SECTION_HINTS.call}
+              subtitle="Copy a ready-to-run request for this block."
+            >
+              <details className="group rounded border border-border bg-card">
+                <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 mg-type-caption font-medium text-ink-muted hover:text-ink-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                  <span>API &amp; artifact URLs</span>
+                  <span className="mg-type-caption">
+                    <span className="group-open:hidden">Show</span>
+                    <span className="hidden group-open:inline">Hide</span>
+                  </span>
+                </summary>
+                <div className="border-t border-border p-3">
+                  <EndpointSnippet
+                    rows={[
+                      { label: "block", path: `/api/v1/blocks/${sourceRef}` },
+                      { label: "extrinsics", path: `/api/v1/blocks/${sourceRef}/extrinsics` },
+                      { label: "events", path: `/api/v1/blocks/${sourceRef}/events` },
+                      {
+                        label: "chain events",
+                        path: `/api/v1/blocks/${sourceRef}/chain-events`,
+                      },
+                      { label: "artifact", path: `/metagraph/blocks/${sourceRef}.json` },
+                    ]}
+                  />
+                </div>
+              </details>
+            </SectionAnchor>
+
+            <ApiSourceFooter
+              paths={[
+                `/api/v1/blocks/${sourceRef}`,
+                `/api/v1/blocks/${sourceRef}/extrinsics`,
+                `/api/v1/blocks/${sourceRef}/events`,
+                `/api/v1/blocks/${sourceRef}/chain-events`,
+              ]}
+              artifacts={[`/metagraph/blocks/${sourceRef}.json`]}
+            />
+          </div>
+        </DataPageModule>
+      </DataPageCanvas>
+    </DataPageStage>
   );
 }
 

--- a/apps/ui/src/routes/-chain-analytics-page.tsx
+++ b/apps/ui/src/routes/-chain-analytics-page.tsx
@@ -1,9 +1,15 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQueries } from "@tanstack/react-query";
-import type { ReactNode } from "react";
 import { Skeleton } from "@jsonbored/ui-kit";
 import type { AnalyticsSearch } from "./chain.analytics";
-import { AsyncPanel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  DataPageWindowTabs,
+} from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { ChainStakeFlowSankey } from "@/components/metagraphed/chain-stake-flow-sankey";
 import { ChainConcentrationSnapshot } from "@/components/metagraphed/chain-concentration-snapshot";
@@ -11,7 +17,6 @@ import { ChainIdleStakeSnapshot } from "@/components/metagraphed/chain-idle-stak
 import { ChainEmissionTrend } from "@/components/metagraphed/chain-emission-trend";
 import { ChainRegistrationEconomics } from "@/components/metagraphed/chain-registration-economics";
 import { ChainNetworkConcentration } from "@/components/metagraphed/chain-network-concentration";
-import { classNames } from "@/lib/metagraphed/format";
 import {
   chainStakeFlowQuery,
   validatorsQuery,
@@ -21,8 +26,10 @@ import {
   economicsQuery,
 } from "@/lib/metagraphed/queries";
 
-type Window = "7d" | "30d";
-const WINDOWS: Window[] = ["7d", "30d"];
+const WINDOW_OPTIONS = [
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+] as const;
 
 /**
  * This route intentionally holds the core view to six requests: root →
@@ -62,13 +69,14 @@ function AnalyticsBody() {
       <ChainIdleStakeSnapshot idleStake={idleStakeRes.data} />
       <ChainEmissionTrend days={trendsRes.data.days} window={win} />
       <ChainConcentrationSnapshot concentration={concentrationRes.data} />
-      <DataModule
+      <DataPageModule
         id="analytics-registration"
         title="Registration economics"
         caption="The spread of current cost to open a subnet, from the least to the most expensive."
+        kind="question"
       >
         <ChainRegistrationEconomics subnets={economicsRes.data} />
-      </DataModule>
+      </DataPageModule>
     </div>
   );
 }
@@ -78,49 +86,30 @@ export function ChainAnalyticsPage() {
   const navigate = useNavigate({ from: "/chain/analytics" });
 
   return (
-    <div className="mg-data-stage">
-      <section className="mg-data-hero" aria-labelledby="network-data-title">
-        <div className="mg-data-hero-field" aria-hidden="true" />
-        <div className="mg-data-hero-content">
-          <div>
-            <span className="mg-data-kicker">
-              <span className="mg-data-kicker-dot" aria-hidden="true" />
-              live chain data
-            </span>
-            <h1 id="network-data-title">Network Data.</h1>
-          </div>
-          <div className="mg-data-hero-detail">
-            <p>
-              Follow where stake moves, where alpha concentrates, and what it costs to enter — one
-              clean question at a time.
-            </p>
-            <div role="tablist" aria-label="Analytics time window" className="mg-data-window">
-              {WINDOWS.map((w) => (
-                <button
-                  key={w}
-                  type="button"
-                  role="tab"
-                  aria-selected={w === search.window}
-                  onClick={() =>
-                    navigate({
-                      search: (prev: Record<string, unknown>) => ({ ...prev, window: w }),
-                      resetScroll: false,
-                    })
-                  }
-                  className={classNames(
-                    "mg-data-window-button mg-focus-ring",
-                    w === search.window && "is-active",
-                  )}
-                >
-                  {w === "7d" ? "7 days" : "30 days"}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
+    <DataPageStage>
+      <DataPageHero
+        id="network-data-title"
+        variant="analytics"
+        eyebrow="live chain data"
+        live
+        title="Network Data."
+        description="Follow where stake moves, where alpha concentrates, and what it costs to enter — one clean question at a time."
+        actions={
+          <DataPageWindowTabs
+            label="Analytics time window"
+            options={WINDOW_OPTIONS}
+            value={search.window}
+            onValueChange={(window) =>
+              navigate({
+                search: (prev: Record<string, unknown>) => ({ ...prev, window }),
+                resetScroll: false,
+              })
+            }
+          />
+        }
+      />
 
-      <div className="mg-data-canvas">
+      <DataPageCanvas>
         <AsyncPanel context="chain analytics" fallback={<AnalyticsSkeleton />}>
           <AnalyticsBody />
         </AsyncPanel>
@@ -130,7 +119,7 @@ export function ChainAnalyticsPage() {
             back the movement view. They share the same data canvas rather than
             becoming a second wall of dashboard cards. */}
         <ChainNetworkConcentration />
-      </div>
+      </DataPageCanvas>
 
       <ApiSourceFooter
         paths={[
@@ -146,7 +135,7 @@ export function ChainAnalyticsPage() {
           "/api/v1/chain/concentration/history",
         ]}
       />
-    </div>
+    </DataPageStage>
   );
 }
 
@@ -157,29 +146,5 @@ function AnalyticsSkeleton() {
       <Skeleton className="mt-6 h-56 w-full" />
       <Skeleton className="mt-6 h-48 w-full" />
     </div>
-  );
-}
-
-function DataModule({
-  id,
-  title,
-  caption,
-  children,
-}: {
-  id?: string;
-  title: string;
-  caption: string;
-  children: ReactNode;
-}) {
-  return (
-    <section id={id} className="mg-data-module">
-      <header className="mg-data-module-heading">
-        <h2 className="mg-data-module-title">
-          <strong>{title}.</strong>
-          <span>{caption}</span>
-        </h2>
-      </header>
-      <div className="mg-data-module-body">{children}</div>
-    </section>
   );
 }

--- a/apps/ui/src/routes/-chain-analytics-page.tsx
+++ b/apps/ui/src/routes/-chain-analytics-page.tsx
@@ -1,10 +1,10 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import type { AnalyticsSearch } from "./chain.analytics";
 import { useSuspenseQueries } from "@tanstack/react-query";
-import { SectionLabel, Skeleton } from "@jsonbored/ui-kit";
+import type { ReactNode } from "react";
+import { Skeleton } from "@jsonbored/ui-kit";
+import type { AnalyticsSearch } from "./chain.analytics";
 import { AsyncPanel } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { ChainTabActions } from "./-chain-hub";
 import { ChainStakeFlowSankey } from "@/components/metagraphed/chain-stake-flow-sankey";
 import { ChainConcentrationSnapshot } from "@/components/metagraphed/chain-concentration-snapshot";
 import { ChainIdleStakeSnapshot } from "@/components/metagraphed/chain-idle-stake-snapshot";
@@ -25,20 +25,10 @@ type Window = "7d" | "30d";
 const WINDOWS: Window[] = ["7d", "30d"];
 
 /**
- * Chain hub Analytics tab (#8378). Own route (`/chain/analytics`), not a
- * client-side sub-tab — the hub's tabs are each a real router match, which
- * is what makes "only fetch when this tab is activated" free: the six
- * queries below only run once this route mounts.
- *
- * Deliberately six requests, not the sankey's full theoretical data need:
- * root->subnet uses windowed stake-flow (real flow); subnet->validator uses
- * the global validator leaderboard's CURRENT per-subnet stake (no endpoint
- * gives windowed flow at validator granularity — see chain-analytics.ts).
- * Two deliverables from the issue are scoped out rather than faked: bulk
- * "recycled totals" and a true registration-count trend have no bulk/
- * chain-level source in the current API without exceeding the 6-request
- * budget (either needs ~129 per-subnet calls). Posted as a scope note on
- * #8378 alongside the PR.
+ * This route intentionally holds the core view to six requests: root →
+ * subnet uses real windowed movement while subnet → validator uses current
+ * holdings from the global leaderboard. The visual hierarchy makes that
+ * distinction clear rather than pretending both hops are the same measure.
  */
 function AnalyticsBody() {
   const search = useSearch({ from: "/chain/analytics" }) as AnalyticsSearch;
@@ -63,29 +53,23 @@ function AnalyticsBody() {
   });
 
   return (
-    <>
+    <div className="contents">
       <ChainStakeFlowSankey
         stakeFlow={stakeFlowRes.data}
         validators={validatorsRes.data}
         window={win}
       />
-
-      <div id="analytics-trends" className="mt-6">
-        <SectionLabel as="h2">Trends</SectionLabel>
-        <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-3">
-          <ChainConcentrationSnapshot concentration={concentrationRes.data} />
-          <ChainIdleStakeSnapshot idleStake={idleStakeRes.data} />
-          <ChainEmissionTrend days={trendsRes.data.days} window={win} />
-        </div>
-      </div>
-
-      <div id="analytics-registration" className="mt-6">
-        <SectionLabel as="h2">Registration economics</SectionLabel>
-        <div className="mt-3">
-          <ChainRegistrationEconomics subnets={economicsRes.data} />
-        </div>
-      </div>
-    </>
+      <ChainIdleStakeSnapshot idleStake={idleStakeRes.data} />
+      <ChainEmissionTrend days={trendsRes.data.days} window={win} />
+      <ChainConcentrationSnapshot concentration={concentrationRes.data} />
+      <DataModule
+        id="analytics-registration"
+        title="Registration economics"
+        caption="The spread of current cost to open a subnet, from the least to the most expensive."
+      >
+        <ChainRegistrationEconomics subnets={economicsRes.data} />
+      </DataModule>
+    </div>
   );
 }
 
@@ -94,60 +78,59 @@ export function ChainAnalyticsPage() {
   const navigate = useNavigate({ from: "/chain/analytics" });
 
   return (
-    <>
-      <ChainTabActions>
-        <div
-          role="tablist"
-          aria-label="Window"
-          className="mr-auto inline-flex items-center gap-1 rounded-md border border-border bg-surface p-0.5"
-        >
-          {WINDOWS.map((w) => (
-            <button
-              key={w}
-              type="button"
-              role="tab"
-              aria-selected={w === search.window}
-              onClick={() =>
-                navigate({
-                  search: (prev: Record<string, unknown>) => ({ ...prev, window: w }),
-                  resetScroll: false,
-                })
-              }
-              className={classNames(
-                "rounded px-2.5 py-1 mg-type-caption font-medium transition-colors mg-focus-ring",
-                w === search.window
-                  ? "bg-card text-ink-strong"
-                  : "text-ink-muted hover:text-ink-strong",
-              )}
-            >
-              {w}
-            </button>
-          ))}
+    <div className="mg-data-stage">
+      <section className="mg-data-hero" aria-labelledby="network-data-title">
+        <div className="mg-data-hero-field" aria-hidden="true" />
+        <div className="mg-data-hero-content">
+          <div>
+            <span className="mg-data-kicker">
+              <span className="mg-data-kicker-dot" aria-hidden="true" />
+              live chain data
+            </span>
+            <h1 id="network-data-title">Network Data.</h1>
+          </div>
+          <div className="mg-data-hero-detail">
+            <p>
+              Follow where stake moves, where alpha concentrates, and what it costs to enter — one
+              clean question at a time.
+            </p>
+            <div role="tablist" aria-label="Analytics time window" className="mg-data-window">
+              {WINDOWS.map((w) => (
+                <button
+                  key={w}
+                  type="button"
+                  role="tab"
+                  aria-selected={w === search.window}
+                  onClick={() =>
+                    navigate({
+                      search: (prev: Record<string, unknown>) => ({ ...prev, window: w }),
+                      resetScroll: false,
+                    })
+                  }
+                  className={classNames(
+                    "mg-data-window-button mg-focus-ring",
+                    w === search.window && "is-active",
+                  )}
+                >
+                  {w === "7d" ? "7 days" : "30 days"}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
-      </ChainTabActions>
-
-      <p className="mb-6 max-w-3xl mg-type-caption-lg text-ink-muted">
-        Stake flow, concentration, idle stake, and registration economics — the questions analysts
-        currently script against the API, in one view.
-      </p>
-
-      <AsyncPanel context="chain analytics" fallback={<AnalyticsSkeleton />}>
-        <AnalyticsBody />
-      </AsyncPanel>
-
-      {/* #10300: four network-wide surfaces that were published and rendered
-          nowhere. Deliberately BELOW the suspense boundary above rather than
-          inside it — the body's six-request budget is a documented property of
-          that section, and these four fetch independently so a slow one cannot
-          hold the sankey back. */}
-      <section className="mt-8">
-        <SectionLabel>Network concentration & entry cost</SectionLabel>
-        <p className="mb-4 mt-1 max-w-3xl mg-type-caption-lg text-ink-muted">
-          What it costs to register, who holds the alpha, and how evenly — each computed over the
-          subnets that were actually read, which these panels state rather than assume.
-        </p>
-        <ChainNetworkConcentration />
       </section>
+
+      <div className="mg-data-canvas">
+        <AsyncPanel context="chain analytics" fallback={<AnalyticsSkeleton />}>
+          <AnalyticsBody />
+        </AsyncPanel>
+
+        {/* #10300: these network-wide surfaces fetch independently from the
+            six-request core above, so a slow concentration query never holds
+            back the movement view. They share the same data canvas rather than
+            becoming a second wall of dashboard cards. */}
+        <ChainNetworkConcentration />
+      </div>
 
       <ApiSourceFooter
         paths={[
@@ -163,24 +146,40 @@ export function ChainAnalyticsPage() {
           "/api/v1/chain/concentration/history",
         ]}
       />
-    </>
+    </div>
   );
 }
 
 function AnalyticsSkeleton() {
   return (
-    <div className="space-y-6">
-      <Skeleton className="h-80 w-full" />
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
-        <Skeleton className="h-32" />
-        <Skeleton className="h-32" />
-        <Skeleton className="h-32" />
-      </div>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <Skeleton className="h-20" />
-        <Skeleton className="h-20" />
-        <Skeleton className="h-20" />
-      </div>
+    <div className="mg-data-loading" aria-label="Loading chain analytics">
+      <Skeleton className="h-[30rem] w-full" />
+      <Skeleton className="mt-6 h-56 w-full" />
+      <Skeleton className="mt-6 h-48 w-full" />
     </div>
+  );
+}
+
+function DataModule({
+  id,
+  title,
+  caption,
+  children,
+}: {
+  id?: string;
+  title: string;
+  caption: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="mg-data-module">
+      <header className="mg-data-module-heading">
+        <h2 className="mg-data-module-title">
+          <strong>{title}.</strong>
+          <span>{caption}</span>
+        </h2>
+      </header>
+      <div className="mg-data-module-body">{children}</div>
+    </section>
   );
 }

--- a/apps/ui/src/routes/-chain-hub.tsx
+++ b/apps/ui/src/routes/-chain-hub.tsx
@@ -23,50 +23,42 @@ export const CHAIN_TABS: readonly ChainTab[] = [
   {
     to: "/chain",
     label: "Overview",
-    blurb:
-      "The network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers.",
+    blurb: "Live activity, fees, call mix, and active accounts.",
   },
   {
     to: "/chain/blocks",
     label: "Blocks",
-    blurb:
-      "Recent blocks indexed directly from the chain — newest first, with author, extrinsic and event counts.",
+    blurb: "Newest blocks with authors, extrinsics, and events.",
   },
   {
     to: "/chain/extrinsics",
     label: "Extrinsics",
-    blurb:
-      "Recent transactions indexed directly from the chain — newest first, with call, signer and result.",
+    blurb: "Newest transactions with calls, signers, and outcomes.",
   },
   {
     to: "/chain/events",
     label: "Events",
-    blurb:
-      "Individual pallet events indexed directly from the chain, distinct from the aggregate activity stats.",
+    blurb: "Runtime events, newest first.",
   },
   {
     to: "/chain/governance",
     label: "Governance",
-    blurb:
-      "Root-origin activity: Sudo calls and the AdminUtils config changes that tune subnet hyperparameters.",
+    blurb: "Root calls and parameter changes.",
   },
   {
     to: "/chain/emissions",
     label: "Emissions",
-    blurb:
-      "Where each block's TAO goes — every subnet's share decomposed from price share through the gate, and the split between pool liquidity and chain buys.",
+    blurb: "How each block's rewards move through the network.",
   },
   {
     to: "/chain/analytics",
     label: "Analytics",
-    blurb:
-      "Stake-flow sankey, concentration & emission trends, and registration economics — computed live from the chain-direct tiers.",
+    blurb: "Stake flow, concentration, emissions, and registration economics.",
   },
   {
     to: "/chain/runtime",
     label: "Runtime",
-    blurb:
-      "Spec-version upgrade history from the first-party blocks tier — every upgrade observed, newest first.",
+    blurb: "Runtime upgrade history, newest first.",
   },
 ] as const;
 
@@ -74,8 +66,8 @@ export function activeChainTab(pathname: string): ChainTab {
   return activeHubTab(CHAIN_TABS, pathname);
 }
 
-export function ChainTabs() {
-  return <HubTabs tabs={CHAIN_TABS} ariaLabel="Chain sections" />;
+export function ChainTabs({ className }: { className?: string }) {
+  return <HubTabs tabs={CHAIN_TABS} ariaLabel="Chain sections" className={className} />;
 }
 
 export const ChainTabActions = HubTabActions;

--- a/apps/ui/src/routes/-extrinsics-hash-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-hash-page.tsx
@@ -16,7 +16,14 @@ import {
   StatTile,
   TableState,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+  Panel,
+} from "@/components/metagraphed/primitives";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -121,7 +128,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
 
   if (!extrinsic) {
     return (
-      <>
+      <DataPageStage>
         <PageHeading
           eyebrow="Explorer"
           title={`Extrinsic ${shortHash(hash) ?? hash}`}
@@ -136,7 +143,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           paths={[`/api/v1/extrinsics/${sourceRef}`]}
           artifacts={[`/metagraph/extrinsics/${sourceRef}.json`]}
         />
-      </>
+      </DataPageStage>
     );
   }
 
@@ -150,7 +157,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
   });
 
   return (
-    <>
+    <DataPageStage>
       <PageMasthead
         eyebrow="Explorer · extrinsic"
         live
@@ -182,119 +189,125 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         caption="explorer / v1"
       />
 
-      <RelatedEntityChipRow>
-        {extrinsic.signer ? (
-          <Link
-            to="/accounts/$ss58"
-            params={{ ss58: extrinsic.signer }}
-            className={relatedEntityChipLinkClass}
-          >
-            <RelatedEntityChip label="signer" title="Signer account">
-              {shortSs58Chip(extrinsic.signer)}
-            </RelatedEntityChip>
-          </Link>
-        ) : null}
-        {extrinsic.block_number != null ? (
-          <Link
-            to="/blocks/$ref"
-            params={{ ref: String(extrinsic.block_number) }}
-            className={relatedEntityChipLinkClass}
-          >
-            <RelatedEntityChip label="block" title="Including block">
-              #{formatNumber(extrinsic.block_number)}
-            </RelatedEntityChip>
-          </Link>
-        ) : null}
-        {relatedNetuid != null ? (
-          <Link
-            to="/subnets/$netuid"
-            params={{ netuid: relatedNetuid }}
-            className={relatedEntityChipLinkClass}
-          >
-            <RelatedEntityChip label="subnet" title={`Subnet ${relatedNetuid}`}>
-              SN{relatedNetuid}
-            </RelatedEntityChip>
-          </Link>
-        ) : null}
-      </RelatedEntityChipRow>
+      <DataPageCanvas>
+        <DataPageModule>
+          <RelatedEntityChipRow>
+            {extrinsic.signer ? (
+              <Link
+                to="/accounts/$ss58"
+                params={{ ss58: extrinsic.signer }}
+                className={relatedEntityChipLinkClass}
+              >
+                <RelatedEntityChip label="signer" title="Signer account">
+                  {shortSs58Chip(extrinsic.signer)}
+                </RelatedEntityChip>
+              </Link>
+            ) : null}
+            {extrinsic.block_number != null ? (
+              <Link
+                to="/blocks/$ref"
+                params={{ ref: String(extrinsic.block_number) }}
+                className={relatedEntityChipLinkClass}
+              >
+                <RelatedEntityChip label="block" title="Including block">
+                  #{formatNumber(extrinsic.block_number)}
+                </RelatedEntityChip>
+              </Link>
+            ) : null}
+            {relatedNetuid != null ? (
+              <Link
+                to="/subnets/$netuid"
+                params={{ netuid: relatedNetuid }}
+                className={relatedEntityChipLinkClass}
+              >
+                <RelatedEntityChip label="subnet" title={`Subnet ${relatedNetuid}`}>
+                  SN{relatedNetuid}
+                </RelatedEntityChip>
+              </Link>
+            ) : null}
+          </RelatedEntityChipRow>
 
-      {realAccount ? (
-        <div className="mb-8 flex flex-wrap items-center gap-3 rounded border border-accent/30 bg-accent-surface px-4 py-3">
-          <UserCog className="size-4 shrink-0 text-accent" aria-hidden="true" />
-          <span className="text-sm text-ink">
-            Executed on behalf of{" "}
-            {/* #8372: inline prose, not a table cell/field row -- stays a plain
+          {realAccount ? (
+            <div className="mb-8 flex flex-wrap items-center gap-3 rounded border border-accent/30 bg-accent-surface px-4 py-3">
+              <UserCog className="size-4 shrink-0 text-accent" aria-hidden="true" />
+              <span className="text-sm text-ink">
+                Executed on behalf of{" "}
+                {/* #8372: inline prose, not a table cell/field row -- stays a plain
                 Link (resolveAddress, not AddressDisplay) so it doesn't grow a
                 CopyButton + hover-card here. That combination pushed this
                 banner past the 375px viewport (caught by
                 tests/e2e/responsive-overflow.spec.ts); the full address is
                 still one tap away via the account page this links to. */}
-            <Link
-              to="/accounts/$ss58"
-              params={{ ss58: realAccount }}
-              className="font-mono text-ink-strong hover:underline"
-            >
-              {resolveAddress(realAccount).display}
-            </Link>{" "}
-            — the account below only relayed this <code className="font-mono">Proxy.proxy</code>{" "}
-            call, it isn't the account the inner call actually acts as.
-          </span>
-        </div>
-      ) : null}
+                <Link
+                  to="/accounts/$ss58"
+                  params={{ ss58: realAccount }}
+                  className="font-mono text-ink-strong hover:underline"
+                >
+                  {resolveAddress(realAccount).display}
+                </Link>{" "}
+                — the account below only relayed this <code className="font-mono">Proxy.proxy</code>{" "}
+                call, it isn't the account the inner call actually acts as.
+              </span>
+            </div>
+          ) : null}
 
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
-        <StatTile
-          icon={Boxes}
-          eyebrow="Block"
-          value={extrinsic.block_number != null ? `#${formatNumber(extrinsic.block_number)}` : "—"}
-        />
-        <StatTile icon={FileText} eyebrow="Result" value={result} />
-        <StatTile
-          icon={Clock}
-          eyebrow="Observed"
-          value={<TimeAgo at={extrinsic.observed_at} />}
-          tone="accent"
-        />
-      </div>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+            <StatTile
+              icon={Boxes}
+              eyebrow="Block"
+              value={
+                extrinsic.block_number != null ? `#${formatNumber(extrinsic.block_number)}` : "—"
+              }
+            />
+            <StatTile icon={FileText} eyebrow="Result" value={result} />
+            <StatTile
+              icon={Clock}
+              eyebrow="Observed"
+              value={<TimeAgo at={extrinsic.observed_at} />}
+              tone="accent"
+            />
+          </div>
 
-      <SectionAnchor id="details" title="Extrinsic details" tone="accent">
-        <dl className="rounded border border-border bg-card divide-y divide-border">
-          <FieldRow label="Extrinsic hash">
-            {extrinsic.extrinsic_hash ? (
-              <CopyableCode
-                value={extrinsic.extrinsic_hash}
-                truncate={false}
-                className="max-w-full"
-              />
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
-          </FieldRow>
-          <FieldRow label="Block">
-            {extrinsic.block_number != null ? (
-              <Link
-                to="/blocks/$ref"
-                params={{ ref: String(extrinsic.block_number) }}
-                className="font-mono text-sm text-ink-strong hover:underline tabular-nums"
-              >
-                #{formatNumber(extrinsic.block_number)}
-              </Link>
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
-          </FieldRow>
-          <FieldRow label="Index in block">
-            <span className="font-mono text-sm text-ink tabular-nums">
-              {extrinsic.extrinsic_index != null ? formatNumber(extrinsic.extrinsic_index) : "—"}
-            </span>
-          </FieldRow>
-          <FieldRow label="Call">
-            <span className="font-mono text-sm text-ink-strong break-all">
-              {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
-            </span>
-          </FieldRow>
-          <FieldRow label="Signer">
-            {/* #6424: linked like every other ss58 on this page (see the events
+          <SectionAnchor id="details" title="Extrinsic details" tone="accent">
+            <dl className="rounded border border-border bg-card divide-y divide-border">
+              <FieldRow label="Extrinsic hash">
+                {extrinsic.extrinsic_hash ? (
+                  <CopyableCode
+                    value={extrinsic.extrinsic_hash}
+                    truncate={false}
+                    className="max-w-full"
+                  />
+                ) : (
+                  <span className="text-ink-muted">—</span>
+                )}
+              </FieldRow>
+              <FieldRow label="Block">
+                {extrinsic.block_number != null ? (
+                  <Link
+                    to="/blocks/$ref"
+                    params={{ ref: String(extrinsic.block_number) }}
+                    className="font-mono text-sm text-ink-strong hover:underline tabular-nums"
+                  >
+                    #{formatNumber(extrinsic.block_number)}
+                  </Link>
+                ) : (
+                  <span className="text-ink-muted">—</span>
+                )}
+              </FieldRow>
+              <FieldRow label="Index in block">
+                <span className="font-mono text-sm text-ink tabular-nums">
+                  {extrinsic.extrinsic_index != null
+                    ? formatNumber(extrinsic.extrinsic_index)
+                    : "—"}
+                </span>
+              </FieldRow>
+              <FieldRow label="Call">
+                <span className="font-mono text-sm text-ink-strong break-all">
+                  {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
+                </span>
+              </FieldRow>
+              <FieldRow label="Signer">
+                {/* #6424: linked like every other ss58 on this page (see the events
                 table below) -- untruncated, so the full value stays readable and
                 copyable exactly as it was. valueClassName="truncate min-w-0"
                 inside a min-w-0 flex row (#6427's convention, mirrored from
@@ -302,194 +315,196 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                 to the row's actual width instead of forcing the page wide --
                 the full address stays available via the copy button and the
                 link's title. */}
-            <span className="flex w-full min-w-0 items-center">
-              <AddressDisplay
-                ss58={extrinsic.signer}
-                truncate={false}
-                valueClassName="truncate min-w-0"
-                fallback={<span className="text-ink-muted">—</span>}
-                editable
-              />
-            </span>
-          </FieldRow>
-          <FieldRow label="Result">
-            <span className="font-mono text-sm text-ink">{result}</span>
-          </FieldRow>
-          <FieldRow label="Inclusion fee">
-            <TaoValue amount={extrinsic.fee_tao} precision={4} align="left" />
-          </FieldRow>
-          <FieldRow label="Tip">
-            <TaoValue amount={extrinsic.tip_tao} precision={4} align="left" />
-          </FieldRow>
-          <FieldRow label="Observed at">
-            <span className="font-mono mg-type-caption text-ink-muted">
-              <TimeAgo at={extrinsic.observed_at} />
-            </span>
-          </FieldRow>
-        </dl>
-      </SectionAnchor>
+                <span className="flex w-full min-w-0 items-center">
+                  <AddressDisplay
+                    ss58={extrinsic.signer}
+                    truncate={false}
+                    valueClassName="truncate min-w-0"
+                    fallback={<span className="text-ink-muted">—</span>}
+                    editable
+                  />
+                </span>
+              </FieldRow>
+              <FieldRow label="Result">
+                <span className="font-mono text-sm text-ink">{result}</span>
+              </FieldRow>
+              <FieldRow label="Inclusion fee">
+                <TaoValue amount={extrinsic.fee_tao} precision={4} align="left" />
+              </FieldRow>
+              <FieldRow label="Tip">
+                <TaoValue amount={extrinsic.tip_tao} precision={4} align="left" />
+              </FieldRow>
+              <FieldRow label="Observed at">
+                <span className="font-mono mg-type-caption text-ink-muted">
+                  <TimeAgo at={extrinsic.observed_at} />
+                </span>
+              </FieldRow>
+            </dl>
+          </SectionAnchor>
 
-      <SectionAnchor
-        id="call-args"
-        title="Call arguments"
-        subtitle="The decoded parameters passed to this extrinsic."
-      >
-        {renderCallArgs(callArgs, extrinsic.call_module, extrinsic.call_function)}
-        {callArgsOmitted > 0 ? (
-          <p className="mt-2 mg-type-data text-ink-muted">
-            Showing 64 of {formatNumber(callArgsTotal)} call args — {formatNumber(callArgsOmitted)}{" "}
-            more omitted.
-          </p>
-        ) : null}
-      </SectionAnchor>
+          <SectionAnchor
+            id="call-args"
+            title="Call arguments"
+            subtitle="The decoded parameters passed to this extrinsic."
+          >
+            {renderCallArgs(callArgs, extrinsic.call_module, extrinsic.call_function)}
+            {callArgsOmitted > 0 ? (
+              <p className="mt-2 mg-type-data text-ink-muted">
+                Showing 64 of {formatNumber(callArgsTotal)} call args —{" "}
+                {formatNumber(callArgsOmitted)} more omitted.
+              </p>
+            ) : null}
+          </SectionAnchor>
 
-      {callHash ? (
-        <SectionAnchor
-          id="multisig-chain"
-          title="Related Multisig calls"
-          subtitle="Other extrinsics approving or executing this same call_hash."
-          tone="accent"
-        >
-          {relatedQuery.isLoading ? (
-            <Skeleton className="h-16 w-full" />
-          ) : relatedQuery.isError ? (
-            // Without this branch a failed lookup left `data` undefined, so
-            // `relatedCalls` fell through to [] and rendered the same "no other
-            // extrinsics" copy as a genuinely empty result -- the one case where
-            // this page asserted something it hadn't actually learned (#6426).
-            <TableState
-              variant="error"
-              title="Couldn't load related Multisig calls"
-              description="The related-calls lookup is optional enrichment — the rest of this extrinsic's detail is unaffected."
-              error={relatedQuery.error}
-              onRetry={() => relatedQuery.refetch()}
-            />
-          ) : relatedCalls.length > 0 ? (
-            <ul className="flex flex-col gap-2">
-              {relatedCalls.map((e) => (
-                <li key={e.extrinsic_hash ?? `${e.block_number}-${e.extrinsic_index}`}>
-                  <Link
-                    to="/extrinsics/$hash"
-                    params={{ hash: e.extrinsic_hash ?? "" }}
-                    className="flex items-center gap-2 rounded border border-border bg-card px-3 py-2 text-sm hover:border-ink/30"
-                  >
-                    <Link2 className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
-                    <span className="font-mono text-ink-strong">
-                      {extrinsicCall(e.call_module, e.call_function)}
-                    </span>
-                    <span className="text-ink-muted">·</span>
-                    <span className="mg-type-data text-ink-muted">
-                      #{formatNumber(e.block_number ?? 0)}
-                    </span>
-                    <TimeAgo
-                      at={e.observed_at}
-                      className="ml-auto mg-type-caption text-ink-muted"
-                    />
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-sm text-ink-muted">
-              No other extrinsics reference this call_hash yet.
-            </p>
-          )}
-        </SectionAnchor>
-      ) : null}
+          {callHash ? (
+            <SectionAnchor
+              id="multisig-chain"
+              title="Related Multisig calls"
+              subtitle="Other extrinsics approving or executing this same call_hash."
+              tone="accent"
+            >
+              {relatedQuery.isLoading ? (
+                <Skeleton className="h-16 w-full" />
+              ) : relatedQuery.isError ? (
+                // Without this branch a failed lookup left `data` undefined, so
+                // `relatedCalls` fell through to [] and rendered the same "no other
+                // extrinsics" copy as a genuinely empty result -- the one case where
+                // this page asserted something it hadn't actually learned (#6426).
+                <TableState
+                  variant="error"
+                  title="Couldn't load related Multisig calls"
+                  description="The related-calls lookup is optional enrichment — the rest of this extrinsic's detail is unaffected."
+                  error={relatedQuery.error}
+                  onRetry={() => relatedQuery.refetch()}
+                />
+              ) : relatedCalls.length > 0 ? (
+                <ul className="flex flex-col gap-2">
+                  {relatedCalls.map((e) => (
+                    <li key={e.extrinsic_hash ?? `${e.block_number}-${e.extrinsic_index}`}>
+                      <Link
+                        to="/extrinsics/$hash"
+                        params={{ hash: e.extrinsic_hash ?? "" }}
+                        className="flex items-center gap-2 rounded border border-border bg-card px-3 py-2 text-sm hover:border-ink/30"
+                      >
+                        <Link2 className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
+                        <span className="font-mono text-ink-strong">
+                          {extrinsicCall(e.call_module, e.call_function)}
+                        </span>
+                        <span className="text-ink-muted">·</span>
+                        <span className="mg-type-data text-ink-muted">
+                          #{formatNumber(e.block_number ?? 0)}
+                        </span>
+                        <TimeAgo
+                          at={e.observed_at}
+                          className="ml-auto mg-type-caption text-ink-muted"
+                        />
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-ink-muted">
+                  No other extrinsics reference this call_hash yet.
+                </p>
+              )}
+            </SectionAnchor>
+          ) : null}
 
-      <SectionAnchor id="events" title="Emitted events" tone="accent">
-        {events.length > 0 ? (
-          <Panel as="div" flush className="overflow-x-auto">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-surface/40">
-                <tr>
-                  <th className="px-4 py-2.5">Block</th>
-                  <th className="px-4 py-2.5">Kind</th>
-                  <th className="px-4 py-2.5">Hotkey</th>
-                  <th className="px-4 py-2.5 text-right">Amount</th>
-                  <th className="px-4 py-2.5 text-right">Observed</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {events.map((ev, i) => (
-                  <tr
-                    key={`${ev.block_number}-${ev.event_index}-${i}`}
-                    className="hover:bg-surface/40"
-                  >
-                    <td className="px-4 py-2.5 font-mono mg-type-caption">
-                      {ev.block_number != null ? (
-                        <Link
-                          to="/blocks/$ref"
-                          params={{ ref: String(ev.block_number) }}
-                          className="text-ink hover:underline"
+          <SectionAnchor id="events" title="Emitted events" tone="accent">
+            {events.length > 0 ? (
+              <Panel as="div" flush className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead className="bg-surface/40">
+                    <tr>
+                      <th className="px-4 py-2.5">Block</th>
+                      <th className="px-4 py-2.5">Kind</th>
+                      <th className="px-4 py-2.5">Hotkey</th>
+                      <th className="px-4 py-2.5 text-right">Amount</th>
+                      <th className="px-4 py-2.5 text-right">Observed</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {events.map((ev, i) => (
+                      <tr
+                        key={`${ev.block_number}-${ev.event_index}-${i}`}
+                        className="hover:bg-surface/40"
+                      >
+                        <td className="px-4 py-2.5 font-mono mg-type-caption">
+                          {ev.block_number != null ? (
+                            <Link
+                              to="/blocks/$ref"
+                              params={{ ref: String(ev.block_number) }}
+                              className="text-ink hover:underline"
+                            >
+                              #{formatNumber(ev.block_number)}
+                            </Link>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                        <td
+                          className="px-4 py-2.5 mg-type-data text-ink-strong"
+                          title={ev.event_kind ?? undefined}
                         >
-                          #{formatNumber(ev.block_number)}
-                        </Link>
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                    <td
-                      className="px-4 py-2.5 mg-type-data text-ink-strong"
-                      title={ev.event_kind ?? undefined}
-                    >
-                      {eventKindLabel(ev.event_kind)}
-                    </td>
-                    <td className="px-4 py-2.5 mg-type-data text-ink-muted">
-                      <AddressDisplay ss58={ev.hotkey} compact fallback="—" />
-                    </td>
-                    <td className="px-4 py-2.5 text-right">
-                      <TaoValue amount={ev.amount_tao} precision={4} />
-                    </td>
-                    <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
-                      <TimeAgo at={ev.observed_at} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </Panel>
-        ) : (
-          <EmptyState
-            title="No emitted events"
-            description="No emitted events were indexed for this extrinsic."
+                          {eventKindLabel(ev.event_kind)}
+                        </td>
+                        <td className="px-4 py-2.5 mg-type-data text-ink-muted">
+                          <AddressDisplay ss58={ev.hotkey} compact fallback="—" />
+                        </td>
+                        <td className="px-4 py-2.5 text-right">
+                          <TaoValue amount={ev.amount_tao} precision={4} />
+                        </td>
+                        <td className="px-4 py-2.5 text-right mg-type-data text-ink-muted">
+                          <TimeAgo at={ev.observed_at} />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </Panel>
+            ) : (
+              <EmptyState
+                title="No emitted events"
+                description="No emitted events were indexed for this extrinsic."
+              />
+            )}
+            {eventsOmitted > 0 ? (
+              <p className="mt-2 mg-type-data text-ink-muted">
+                Showing 100 of {formatNumber(eventsTotal)} events — {formatNumber(eventsOmitted)}{" "}
+                more omitted.
+              </p>
+            ) : null}
+          </SectionAnchor>
+
+          <div className="mt-6">
+            <Link
+              to="/chain/extrinsics"
+              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
+            >
+              ← All extrinsics
+            </Link>
+          </div>
+
+          <SectionAnchor
+            id="call"
+            title="Call this endpoint"
+            subtitle="Copy a ready-to-run request for this extrinsic."
+          >
+            <EndpointSnippet
+              rows={[
+                { label: "extrinsic", path: `/api/v1/extrinsics/${sourceRef}` },
+                { label: "artifact", path: `/metagraph/extrinsics/${sourceRef}.json` },
+              ]}
+            />
+          </SectionAnchor>
+
+          <ApiSourceFooter
+            paths={[`/api/v1/extrinsics/${sourceRef}`]}
+            artifacts={[`/metagraph/extrinsics/${sourceRef}.json`]}
           />
-        )}
-        {eventsOmitted > 0 ? (
-          <p className="mt-2 mg-type-data text-ink-muted">
-            Showing 100 of {formatNumber(eventsTotal)} events — {formatNumber(eventsOmitted)} more
-            omitted.
-          </p>
-        ) : null}
-      </SectionAnchor>
-
-      <div className="mt-6">
-        <Link
-          to="/chain/extrinsics"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
-        >
-          ← All extrinsics
-        </Link>
-      </div>
-
-      <SectionAnchor
-        id="call"
-        title="Call this endpoint"
-        subtitle="Copy a ready-to-run request for this extrinsic."
-      >
-        <EndpointSnippet
-          rows={[
-            { label: "extrinsic", path: `/api/v1/extrinsics/${sourceRef}` },
-            { label: "artifact", path: `/metagraph/extrinsics/${sourceRef}.json` },
-          ]}
-        />
-      </SectionAnchor>
-
-      <ApiSourceFooter
-        paths={[`/api/v1/extrinsics/${sourceRef}`]}
-        artifacts={[`/metagraph/extrinsics/${sourceRef}.json`]}
-      />
-    </>
+        </DataPageModule>
+      </DataPageCanvas>
+    </DataPageStage>
   );
 }
 

--- a/apps/ui/src/routes/-extrinsics-index-page.tsx
+++ b/apps/ui/src/routes/-extrinsics-index-page.tsx
@@ -258,6 +258,8 @@ function ExtrinsicsTable() {
 
   return (
     <ListShell
+      presentation="canvas"
+      responsiveAt="lg"
       filters={filters}
       isEmpty={rows.length === 0}
       empty={emptyNode}

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -9,7 +9,6 @@ import {
   ExternalLink,
   TableState,
   PageSection,
-  SectionHeading,
   MethodologyCallout,
   BrandIcon,
   CurationChip,
@@ -18,7 +17,14 @@ import {
   MiniRadial,
   MobileCollapse,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageDisclosure,
+  DataPageHero,
+  DataPageStage,
+  Panel,
+} from "@/components/metagraphed/primitives";
 import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import { X, Search } from "lucide-react";
 import { IntegrabilityBoard } from "@/components/metagraphed/integrability-board";
@@ -52,170 +58,183 @@ const GAP_PAGE = 25;
 export function GapsPage() {
   return (
     <AppShell>
-      <PageMasthead
-        eyebrow="Operations"
-        live
-        title="Contribute"
-        description="The contributor work queue — which subnets are missing which public interfaces, and where a correction or addition helps most. Submit through the GitHub repo."
-        actions={
-          <ExternalLink href={GITHUB_REPO} className="text-xs">
-            github
-          </ExternalLink>
-        }
-      />
+      <DataPageStage>
+        <DataPageHero
+          id="contribute-title"
+          eyebrow="Operations"
+          live
+          title="Contribute."
+          description="A prioritized evidence queue for improving public Bittensor interfaces."
+          footer={
+            <>
+              <span>Changes are submitted through the public registry repository.</span>
+              <ExternalLink href={GITHUB_REPO} className="mg-page-quiet-action">
+                Open GitHub
+              </ExternalLink>
+            </>
+          }
+        />
 
-      <main className="space-y-20 md:space-y-24">
-        <AsyncPanel height="sm">
-          <GapsKpiStrip />
-        </AsyncPanel>
+        <DataPageCanvas variant="operations">
+          <AsyncPanel height="sm">
+            <GapsKpiStrip />
+          </AsyncPanel>
 
-        <AsyncPanel height="md">
-          <MissingKindsAtAGlance />
-        </AsyncPanel>
+          <AsyncPanel height="md">
+            <MissingKindsAtAGlance />
+          </AsyncPanel>
 
-        <AsyncPanel height="sm">
-          <GapsMethodology />
-        </AsyncPanel>
+          <DataPageDisclosure label="How priorities are calculated">
+            <AsyncPanel height="sm">
+              <GapsMethodology />
+            </AsyncPanel>
+          </DataPageDisclosure>
 
-        <section>
-          <SectionHeading title="Integrability scoreboard" />
+          <PageSection
+            id="integrability"
+            eyebrow="Readiness"
+            title="Integrability scoreboard"
+            description="A concise view of where a maintained interface will help most."
+          >
+            <AsyncPanel height="lg">
+              <IntegrabilityBoard />
+            </AsyncPanel>
+          </PageSection>
+
+          <PageSection
+            id="coverage-matrix"
+            eyebrow="Coverage"
+            title="What's actually missing"
+            description="Subnets × required public-interface kinds. Cells link straight to that subnet's surfaces tab."
+          >
+            <AsyncPanel height="lg">
+              <CoverageMatrix />
+            </AsyncPanel>
+          </PageSection>
+
           <AsyncPanel height="lg">
-            <IntegrabilityBoard />
+            <OpenGapsSection />
           </AsyncPanel>
-        </section>
 
-        <PageSection
-          id="coverage-matrix"
-          eyebrow="Coverage"
-          title="What's actually missing"
-          description="Subnets × required public-interface kinds. Cells link straight to that subnet's surfaces tab."
-        >
-          <AsyncPanel height="lg">
-            <CoverageMatrix />
-          </AsyncPanel>
-        </PageSection>
+          {/* These are valuable working queues, but are intentionally behind one
+              progressive-disclosure seam so they do not compete with the
+              contributor's first decision: what should I help with now? */}
+          <DataPageDisclosure label="Open detailed queues, intake, and evidence">
+            <PageSection
+              id="completeness-distribution"
+              eyebrow="Distribution"
+              title="Registry shape"
+              description="Histogram of completeness across every scored profile."
+            >
+              <AsyncPanel height="md">
+                <CompletenessHistogram />
+              </AsyncPanel>
+            </PageSection>
 
-        <PageSection
-          id="completeness-distribution"
-          eyebrow="Distribution"
-          title="Registry shape"
-          description="Histogram of completeness across every scored profile. Median and quartile markers show where the registry sits today."
-        >
-          <AsyncPanel height="md">
-            <CompletenessHistogram />
-          </AsyncPanel>
-        </PageSection>
+            {/* #10300: /candidates, /curation, /profiles and /source-snapshots
+                are the stages of registry intake, gathered here for people
+                working beyond the primary queue. */}
+            <PageSection
+              id="registry-pipeline"
+              eyebrow="Intake"
+              title="Registry pipeline"
+              description="Discovered, curated, profiled — and what each source actually said."
+            >
+              <RegistryPipelinePanel />
+            </PageSection>
 
-        <AsyncPanel height="lg">
-          <OpenGapsSection />
-        </AsyncPanel>
+            <PageSection
+              id="profile-completeness"
+              eyebrow="Coverage"
+              title="Profile completeness"
+              description="Per-subnet completeness across required public-interface kinds."
+            >
+              <AsyncPanel height="md">
+                <CompletenessList />
+              </AsyncPanel>
+            </PageSection>
 
-        {/* #10300: /candidates, /curation, /profiles and /source-snapshots were
-            all published and rendered nowhere. The issue listed them as
-            "plausibly API-only... but it should be a recorded decision, because
-            right now 'no page exists' and 'no page should exist' are
-            indistinguishable from the outside". This is that decision, made the
-            other way -- they are the four stages of registry intake, and this
-            is the console where someone asks where it has stalled. */}
-        <PageSection
-          id="registry-pipeline"
-          eyebrow="Intake"
-          title="Registry pipeline"
-          description="Discovered, curated, profiled — and the snapshot of what each source actually said."
-        >
-          <RegistryPipelinePanel />
-        </PageSection>
+            <PageSection
+              id="adapter-candidates"
+              eyebrow="Pilots"
+              title="Adapter candidates"
+              description="Subnets where a maintained adapter would unlock the most value."
+            >
+              <AsyncPanel height="md">
+                <AdapterCandidates />
+              </AsyncPanel>
+            </PageSection>
 
-        <PageSection
-          id="profile-completeness"
-          eyebrow="Coverage"
-          title="Profile completeness"
-          description="Per-subnet completeness across required public-interface kinds."
-        >
-          <AsyncPanel height="md">
-            <CompletenessList />
-          </AsyncPanel>
-        </PageSection>
+            <PageSection
+              id="enrichment-queue"
+              eyebrow="Queue"
+              title="Enrichment queue"
+              description="Registry entries awaiting verification or enrichment."
+            >
+              <AsyncPanel height="md">
+                <EnrichmentQueue />
+              </AsyncPanel>
+            </PageSection>
 
-        <PageSection
-          id="adapter-candidates"
-          eyebrow="Pilots"
-          title="Adapter candidates"
-          description="Subnets where a maintained adapter would unlock the highest registry value."
-        >
-          <AsyncPanel height="md">
-            <AdapterCandidates />
-          </AsyncPanel>
-        </PageSection>
+            <PageSection
+              id="enrichment-targets"
+              eyebrow="Targets"
+              title="Enrichment targets"
+              description="Specific surfaces to add per subnet, ranked by priority."
+            >
+              <AsyncPanel height="md">
+                <EnrichmentTargets />
+              </AsyncPanel>
+            </PageSection>
 
-        <PageSection
-          id="enrichment-queue"
-          eyebrow="Queue"
-          title="Enrichment queue"
-          description="Prioritized list of registry entries awaiting verification or enrichment."
-        >
-          <AsyncPanel height="md">
-            <EnrichmentQueue />
-          </AsyncPanel>
-        </PageSection>
+            <PageSection
+              id="enrichment-evidence"
+              eyebrow="Evidence"
+              title="Enrichment evidence"
+              description="Candidate evidence behind the enrichment queue."
+            >
+              <AsyncPanel height="md">
+                <EnrichmentEvidence />
+              </AsyncPanel>
+            </PageSection>
 
-        <PageSection
-          id="enrichment-targets"
-          eyebrow="Targets"
-          title="Enrichment targets"
-          description="Per-target contributor task board — the specific surfaces to add per subnet, ranked by priority."
-        >
-          <AsyncPanel height="md">
-            <EnrichmentTargets />
-          </AsyncPanel>
-        </PageSection>
+            <PageSection
+              id="attribution-candidates"
+              eyebrow="Unjudged"
+              title="Attribution candidates"
+              description="Unverified address leads found in published subnet pages."
+            >
+              <AsyncPanel height="md">
+                <AttributionCandidates />
+              </AsyncPanel>
+            </PageSection>
 
-        <PageSection
-          id="enrichment-evidence"
-          eyebrow="Evidence"
-          title="Enrichment evidence"
-          description="The detailed candidate evidence behind the enrichment queue — one level down from the summary above."
-        >
-          <AsyncPanel height="md">
-            <EnrichmentEvidence />
-          </AsyncPanel>
-        </PageSection>
+            <PageSection
+              id="gap-priorities"
+              eyebrow="Priorities"
+              title="Gap priorities"
+              description="Priority-scored per-subnet gaps, separate from the interface-facet queue."
+            >
+              <AsyncPanel height="md">
+                <GapPriorityList />
+              </AsyncPanel>
+            </PageSection>
+          </DataPageDisclosure>
+        </DataPageCanvas>
 
-        <PageSection
-          id="attribution-candidates"
-          eyebrow="Unjudged"
-          title="Attribution candidates"
-          description="Addresses the sweep found in the text of pages subnets publish, which nobody has judged yet. Each row is a LEAD, not an attribution — open the source and decide."
-        >
-          <AsyncPanel height="md">
-            <AttributionCandidates />
-          </AsyncPanel>
-        </PageSection>
-
-        <PageSection
-          id="gap-priorities"
-          eyebrow="Priorities"
-          title="Gap priorities"
-          description="Priority-scored per-subnet gap board — ranked separately from the interface-facet gaps above."
-        >
-          <AsyncPanel height="md">
-            <GapPriorityList />
-          </AsyncPanel>
-        </PageSection>
-      </main>
-
-      <ApiSourceFooter
-        paths={[
-          "/api/v1/gaps",
-          "/api/v1/review/profile-completeness",
-          "/api/v1/review/adapter-candidates",
-          "/api/v1/review/enrichment-queue",
-          "/api/v1/review/enrichment-targets",
-          "/api/v1/review/attribution-candidates",
-          "/api/v1/review/enrichment-evidence",
-          "/api/v1/review/gaps",
-        ]}
-      />
+        <ApiSourceFooter
+          paths={[
+            "/api/v1/gaps",
+            "/api/v1/review/profile-completeness",
+            "/api/v1/review/adapter-candidates",
+            "/api/v1/review/enrichment-queue",
+            "/api/v1/review/enrichment-targets",
+            "/api/v1/review/attribution-candidates",
+            "/api/v1/review/enrichment-evidence",
+            "/api/v1/review/gaps",
+          ]}
+        />
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-graphql-explorer-page.tsx
+++ b/apps/ui/src/routes/-graphql-explorer-page.tsx
@@ -4,7 +4,12 @@ import { CopyableCode } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { GraphiqlExplorer } from "@/components/metagraphed/graphiql-explorer";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import {
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+} from "@/components/metagraphed/primitives";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { toGraphqlSubscriptionUrl } from "@/lib/metagraphed/graphql-subscription-url";
 
@@ -17,50 +22,59 @@ const SUBSCRIPTION_URL = toGraphqlSubscriptionUrl(ENDPOINT_URL) ?? undefined;
 export function GraphqlExplorerPage() {
   return (
     <AppShell>
-      <Link
-        to="/docs/$"
-        params={{ _splat: "graphql" }}
-        className="inline-flex items-center gap-1.5 mg-type-label uppercase text-ink-muted transition-colors hover:text-ink-strong"
-      >
-        <ArrowLeft aria-hidden className="size-3.5" />
-        GraphQL docs
-      </Link>
-      <PageMasthead
-        eyebrow="GraphQL"
-        title="Explorer"
-        description="Schema-aware autocomplete, docs, and history against the live GraphQL endpoint — queries over HTTP, live chainEvents subscriptions over WebSocket. No API key."
-        hideBreadcrumbs
-        className="mt-2"
-      />
-
-      {/* Same CopyableCode row treatment as EndpointSnippet / ApiSourceFooter —
+      <DataPageStage>
+        <DataPageHero
+          id="graphql-explorer-title"
+          eyebrow="GraphQL"
+          live
+          title="Query the live registry."
+          description="Schema-aware autocomplete, docs, and history over HTTP — plus live chainEvents subscriptions over WebSocket. No API key."
+          actions={
+            <Link
+              to="/docs/$"
+              params={{ _splat: "graphql" }}
+              className="inline-flex min-h-11 items-center gap-1.5 border border-border px-3 py-1.5 mg-type-caption font-medium text-ink-muted transition-colors hover:border-accent/50 hover:text-ink-strong"
+            >
+              <ArrowLeft aria-hidden className="size-3.5" />
+              GraphQL docs
+            </Link>
+          }
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title="Compose and inspect."
+            caption="Endpoints stay copyable at the point of use; the explorer remains the one focused workspace below."
+          >
+            {/* Same CopyableCode row treatment as EndpointSnippet / ApiSourceFooter —
           one labeled chip per transport, each with its own copy control. */}
-      <div className="mt-4 space-y-2" data-testid="graphql-explorer-endpoints">
-        <CopyableCode
-          label="POST"
-          value={ENDPOINT_URL}
-          truncate={false}
-          className="w-full max-w-3xl"
-        />
-        {SUBSCRIPTION_URL ? (
-          <CopyableCode
-            label="WSS"
-            value={SUBSCRIPTION_URL}
-            truncate={false}
-            className="w-full max-w-3xl"
-          />
-        ) : null}
-      </div>
+            <div className="space-y-2" data-testid="graphql-explorer-endpoints">
+              <CopyableCode
+                label="POST"
+                value={ENDPOINT_URL}
+                truncate={false}
+                className="w-full max-w-3xl"
+              />
+              {SUBSCRIPTION_URL ? (
+                <CopyableCode
+                  label="WSS"
+                  value={SUBSCRIPTION_URL}
+                  truncate={false}
+                  className="w-full max-w-3xl"
+                />
+              ) : null}
+            </div>
 
-      <div className="mt-6">
-        <GraphiqlExplorer
-          endpoint={ENDPOINT_URL}
-          subscriptionUrl={SUBSCRIPTION_URL}
-          heightClassName="h-[70vh] min-h-[520px] max-h-[900px]"
-        />
-      </div>
-
-      <ApiSourceFooter paths={[GRAPHQL_ENDPOINT_PATH]} />
+            <div className="mt-6">
+              <GraphiqlExplorer
+                endpoint={ENDPOINT_URL}
+                subscriptionUrl={SUBSCRIPTION_URL}
+                heightClassName="h-[70vh] min-h-[520px] max-h-[900px]"
+              />
+            </div>
+          </DataPageModule>
+        </DataPageCanvas>
+        <ApiSourceFooter paths={[GRAPHQL_ENDPOINT_PATH]} />
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -10,12 +10,18 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { CaptureCurrencyPanel } from "@/components/metagraphed/capture-currency-panel";
 import { StaleBanner } from "@/components/metagraphed/states";
-import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageHero,
+  DataPageStage,
+  Panel,
+} from "@/components/metagraphed/primitives";
 import { IncidentCard } from "@/components/metagraphed/incident-card";
 import {
   HealthPill,
   TableState,
-  ActionBar,
+  MetaStrip,
   PageSection,
   TimeAgo,
   AnimatedNumber,
@@ -88,20 +94,11 @@ export function HealthPage() {
 
   return (
     <AppShell>
-      <AsyncPanel height="xl">
-        <HealthHero
-          interval={effectiveInterval}
-          controls={
-            <>
-              <ActionBar>
-                <Link
-                  to="/status"
-                  className="inline-flex items-center gap-1 rounded px-2 py-1 min-h-8 mg-type-caption font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-                >
-                  Public status
-                  <ArrowUpRight className="size-3" aria-hidden="true" />
-                </Link>
-              </ActionBar>
+      <DataPageStage>
+        <AsyncPanel height="xl">
+          <HealthHero
+            interval={effectiveInterval}
+            controls={
               <AutoRefreshControl
                 enabled={enabled}
                 visible={visible}
@@ -109,109 +106,109 @@ export function HealthPage() {
                 onToggle={() => setEnabled((v) => !v)}
                 onIntervalChange={setIntervalMs}
               />
-            </>
-          }
-        />
-      </AsyncPanel>
+            }
+          />
+        </AsyncPanel>
 
-      <main className="space-y-20 md:space-y-24">
-        <TimeRangeProvider>
+        <DataPageCanvas variant="operations">
+          <TimeRangeProvider>
+            <PageSection
+              id="status-board"
+              eyebrow="Status board"
+              title="Global health, at a glance"
+              description="Probe-derived state across every monitored surface."
+              toolbar={<TimeRangeScrub />}
+              className={sectionRing("status-board")}
+            >
+              <AsyncPanel height="lg">
+                <StatusBoard interval={effectiveInterval} />
+              </AsyncPanel>
+            </PageSection>
+
+            <PageSection
+              id="network-pulse"
+              eyebrow="Network pulse"
+              title="ok / warn / down distribution"
+              description="Aggregate status over the selected range, with incident markers per bucket."
+            >
+              <AsyncPanel height="lg">
+                <NetworkPulseBand />
+              </AsyncPanel>
+            </PageSection>
+
+            <PageSection
+              id="status-mosaic"
+              eyebrow="Endpoints"
+              title="Live status mosaic"
+              description="Every monitored endpoint, colored by latest probe state. Filter by state; click a tile to open."
+            >
+              <AsyncPanel height="lg">
+                <StatusMosaic />
+              </AsyncPanel>
+            </PageSection>
+          </TimeRangeProvider>
+
           <PageSection
-            id="status-board"
-            eyebrow="Status board"
-            title="Global health, at a glance"
-            description="Probe-derived state across every monitored surface."
-            toolbar={<TimeRangeScrub />}
-            className={sectionRing("status-board")}
+            id="subnet-matrix"
+            eyebrow="Coverage"
+            title="Subnet health matrix"
+            description="Every active subnet, colored by latest probe state. Click a cell to open."
+            className={sectionRing("subnet-matrix")}
           >
-            <AsyncPanel height="lg">
-              <StatusBoard interval={effectiveInterval} />
-            </AsyncPanel>
+            <SubnetHealthMatrix />
           </PageSection>
 
           <PageSection
-            id="network-pulse"
-            eyebrow="Network pulse"
-            title="ok / warn / down distribution"
-            description="Aggregate status over the selected range, with incident markers per bucket."
+            id="source-health"
+            eyebrow="Sources"
+            title="Source freshness"
+            description="Where the registry pulls evidence from and how fresh each source is."
+            className={sectionRing("source-health")}
           >
-            <AsyncPanel height="lg">
-              <NetworkPulseBand />
+            <AsyncPanel height="md">
+              <SourceHealth interval={effectiveInterval} />
             </AsyncPanel>
           </PageSection>
 
-          <PageSection
-            id="status-mosaic"
-            eyebrow="Endpoints"
-            title="Live status mosaic"
-            description="Every monitored endpoint, colored by latest probe state. Filter by state; click a tile to open."
-          >
-            <AsyncPanel height="lg">
-              <StatusMosaic />
-            </AsyncPanel>
-          </PageSection>
-        </TimeRangeProvider>
-
-        <PageSection
-          id="subnet-matrix"
-          eyebrow="Coverage"
-          title="Subnet health matrix"
-          description="Every active subnet, colored by latest probe state. Click a cell to open."
-          className={sectionRing("subnet-matrix")}
-        >
-          <SubnetHealthMatrix />
-        </PageSection>
-
-        <PageSection
-          id="source-health"
-          eyebrow="Sources"
-          title="Source freshness"
-          description="Where the registry pulls evidence from and how fresh each source is."
-          className={sectionRing("source-health")}
-        >
-          <AsyncPanel height="md">
-            <SourceHealth interval={effectiveInterval} />
-          </AsyncPanel>
-        </PageSection>
-
-        {/* #10300: /chain/indexer-lag and /health/failure-reasons were both
+          {/* #10300: /chain/indexer-lag and /health/failure-reasons were both
             published and rendered nowhere. The ops console is their home --
             "how current is our capture, and what is failing behind it" is the
             question this page exists to answer. */}
-        <PageSection
-          id="capture-currency"
-          eyebrow="Capture"
-          title="Capture currency & failure mix"
-          description="How far behind the chain head our indexing is, and what is actually going wrong with the probes."
-          className={sectionRing("capture-currency")}
-        >
-          <AsyncPanel height="md">
-            <CaptureCurrencyPanel />
-          </AsyncPanel>
-        </PageSection>
+          <PageSection
+            id="capture-currency"
+            eyebrow="Capture"
+            title="Capture currency & failure mix"
+            description="How far behind the chain head our indexing is, and what is actually going wrong with the probes."
+            className={sectionRing("capture-currency")}
+          >
+            <AsyncPanel height="md">
+              <CaptureCurrencyPanel />
+            </AsyncPanel>
+          </PageSection>
 
-        <PageSection
-          id="incidents"
-          eyebrow="Incidents"
-          title="Live & recent incidents"
-          description="Grouped by host. Ongoing incidents bubble to the top."
-          className={sectionRing("incidents")}
-        >
-          <AsyncPanel height="md">
-            <Incidents interval={effectiveInterval} />
-          </AsyncPanel>
-        </PageSection>
-      </main>
+          <PageSection
+            id="incidents"
+            eyebrow="Incidents"
+            title="Live & recent incidents"
+            description="Grouped by host. Ongoing incidents bubble to the top."
+            className={sectionRing("incidents")}
+          >
+            <AsyncPanel height="md">
+              <Incidents interval={effectiveInterval} />
+            </AsyncPanel>
+          </PageSection>
+        </DataPageCanvas>
 
-      <ApiSourceFooter
-        paths={[
-          "/api/v1/health",
-          "/api/v1/freshness",
-          "/api/v1/endpoint-incidents",
-          "/api/v1/chain/indexer-lag",
-          "/api/v1/health/failure-reasons",
-        ]}
-      />
+        <ApiSourceFooter
+          paths={[
+            "/api/v1/health",
+            "/api/v1/freshness",
+            "/api/v1/endpoint-incidents",
+            "/api/v1/chain/indexer-lag",
+            "/api/v1/health/failure-reasons",
+          ]}
+        />
+      </DataPageStage>
     </AppShell>
   );
 }
@@ -243,41 +240,42 @@ function HealthHero({
   const ongoing = incidents.filter((i) => !i.ended_at).length;
 
   return (
-    <PageMasthead
+    <DataPageHero
+      id="health-title"
       eyebrow="Operations"
       live
-      title="Health & freshness"
-      description={
+      title="Health & freshness."
+      description="Probe-derived status across monitored network surfaces."
+      actions={controls}
+      summary={
+        <MetaStrip
+          items={[
+            {
+              label: "24h uptime",
+              value: uptimePct != null ? uptimePct.toFixed(2) + "%" : "—",
+            },
+            { label: "Surfaces", value: <AnimatedNumber value={h?.total} /> },
+            { label: "Incidents", value: <AnimatedNumber value={ongoing} /> },
+            {
+              label: "Stale sources",
+              value: <AnimatedNumber value={f?.stale_count} />,
+              title: f?.sources ? `of ${f.sources.length} sources` : undefined,
+            },
+          ]}
+        />
+      }
+      footer={
         <>
-          Operational drill-down for maintainers — subnet matrix, endpoint mosaic, source freshness,
-          and live incidents. Probe-derived only; submissions cannot set uptime or incident state.
-          For plain-language uptime, see{" "}
-          <Link to="/status" className="text-accent-text underline-offset-2 hover:underline">
-            System status
+          <span>Submissions cannot set uptime or incident state.</span>
+          <Link
+            to="/status"
+            className="inline-flex items-center gap-1 text-accent hover:text-ink-strong hover:underline"
+          >
+            Public status
+            <ArrowUpRight className="size-3" aria-hidden="true" />
           </Link>
-          .
         </>
       }
-      actions={controls}
-      caption={<>health · {h?.total ?? "—"} surfaces</>}
-      kpis={[
-        {
-          label: "Uptime · 24h",
-          value: uptimePct != null ? uptimePct.toFixed(2) + "%" : "—",
-        },
-        { label: "OK", value: <AnimatedNumber value={h?.ok} />, hint: "surfaces" },
-        { label: "Warn", value: <AnimatedNumber value={h?.warn} /> },
-        { label: "Down", value: <AnimatedNumber value={h?.down} /> },
-        {
-          label: "Stale sources",
-          value: <AnimatedNumber value={f?.stale_count} />,
-          hint: f?.sources ? `of ${f.sources.length}` : undefined,
-        },
-        {
-          label: "Ongoing incidents",
-          value: <AnimatedNumber value={ongoing} />,
-        },
-      ]}
     />
   );
 }

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useState } from "react";
-import { ArrowUpRight, ChevronDown, Terminal } from "lucide-react";
+import { ArrowUpRight, ChevronDown, Search, Terminal } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { HomeWatchedModule } from "@/components/metagraphed/home-watched-module";
 import { EmptyState, ErrorState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
@@ -39,7 +39,6 @@ import { TimeRangeScrub } from "@/components/metagraphed/analytics/time-range-sc
 import { QuickActionsRow } from "@/components/metagraphed/quick-actions-row";
 import { RecentIdentityChanges } from "@/components/metagraphed/recent-identity-changes";
 import { ContinueExploring } from "@/components/metagraphed/continue-exploring";
-import { HeroFeatureRow } from "@/components/metagraphed/hero-feature-row";
 import { useHydrated } from "@/hooks/use-hydrated";
 
 import {
@@ -382,7 +381,7 @@ export function ChainHeadTip() {
     <Link
       to="/blocks/$ref"
       params={{ ref: String(head.block_number) }}
-      className="mg-fade-in mg-fade-in-delay-3 mt-4 inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-accent transition-colors"
+      className="mg-fade-in mg-fade-in-delay-3 inline-flex items-center gap-1.5 mg-type-data text-ink-muted hover:text-accent transition-colors"
     >
       <span className="mg-live-dot" />
       head #{formatNumber(head.block_number)} · <TimeAgo at={head.observed_at} />
@@ -399,14 +398,6 @@ function openCommandPalette() {
   );
 }
 
-// The hero's MCP connect one-liner. Static rather than agentResourcesQuery()'s
-// `mcp.install` (which HomeForAgentsModule below renders) on purpose: the hero
-// renders pre-hydration with no query dependency, and this recommends
-// /mcp/core — the 23-tool context-diet profile (#11164) — where `mcp.install`
-// teaches the full 240-tool /mcp catalog. Per-client setup lives at /docs/mcp.
-const MCP_CORE_INSTALL =
-  "claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp/core";
-
 function HomeHero() {
   const hydrated = useHydrated();
   const { data: subnetsData } = useQuery({
@@ -419,113 +410,72 @@ function HomeHero() {
       : 128;
 
   return (
-    <section className="mg-hero-slab relative overflow-hidden px-4 py-10 sm:px-6 md:py-16">
-      <div className="relative z-[var(--mg-z-sticky)] mx-auto grid max-w-6xl gap-8 md:gap-12 lg:grid-cols-[minmax(0,1.25fr)_minmax(16rem,0.75fr)] lg:items-end">
-        <div className="min-w-0 text-left">
-          <div className="mg-hero-caption mg-fade-in">Metagraph Terminal · Finney</div>
-          {/* eslint-disable-next-line no-restricted-syntax -- display-size hero heading (30/40/48px responsive); the mg-type-* scale tops out at caption-lg (13px) with no display tier, so there is no matching token (#8717 req 2 exception) */}
-          <h1 className="mg-fade-in mt-4 font-display text-[30px] sm:text-[40px] md:text-[48px] font-medium leading-[1.08] tracking-[-0.04em] text-ink-strong">
-            <span className="block">Find the signal.</span>
-            <span className="block text-accent">Verify the surface.</span>
+    <section className="mg-hero-slab relative overflow-hidden px-4 sm:px-6">
+      <div className="relative z-[var(--mg-z-sticky)] mx-auto max-w-6xl py-12 md:py-24">
+        <div className="relative max-w-4xl">
+          <div className="mg-hero-caption mg-fade-in">Finney · public registry</div>
+          {/* eslint-disable-next-line no-restricted-syntax -- display-size hero heading (38/52/64px responsive); the mg-type-* scale deliberately tops out at caption-lg, so there is no matching token (#8717 req 2 exception) */}
+          <h1 className="mg-fade-in mt-5 font-display text-[38px] sm:text-[52px] md:text-[64px] font-medium leading-[1.02] tracking-[-0.055em] text-ink-strong">
+            Find the signal.
+            <br />
+            Verify the surface.
           </h1>
-          <p className="mg-fade-in mg-fade-in-delay-1 mt-4 max-w-2xl text-sm md:text-base text-ink-muted leading-relaxed">
-            A public map of Bittensor subnets, chain activity, and interfaces — built to show what
-            is live, credible, and ready to use.
-          </p>
 
-          {/* Unified search shell: one plain-language primary task, no decorative chrome. */}
-          <div className="mg-fade-in mg-fade-in-delay-2 mt-8 w-full max-w-2xl">
-            {/* eslint-disable-next-line no-restricted-syntax -- not a card shell: this is the search field's flush query-trigger + Search-button row (items-stretch, overflow-hidden, focus-within/hover border states); <Panel> hardcodes its own content padding and can't express this composite input geometry (#8717 req 2 exception) */}
-            <div className="mg-focus-ring flex items-stretch overflow-hidden rounded-sm border border-border bg-card transition-colors focus-within:border-accent/80 hover:border-accent/60">
-              <button
-                type="button"
-                onClick={openCommandPalette}
-                aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
-                className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
+          {/* One reference field establishes the page's data character. It is
+              deliberately structural rather than another card, metric, or CTA. */}
+          <div aria-hidden className="mg-hero-dot-field" />
+
+          <div className="mg-fade-in mg-fade-in-delay-1 mt-16 max-w-xl md:mt-20">
+            <p className="text-sm leading-relaxed text-ink-muted md:text-base">
+              A public map of Bittensor subnets, chain activity, and interfaces — built to show what
+              is live, credible, and ready to use.
+            </p>
+
+            <button
+              type="button"
+              onClick={openCommandPalette}
+              aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
+              className="mg-focus-ring mt-8 flex min-h-12 w-full items-center gap-3 border-b border-ink-strong/30 pb-3 text-left text-sm text-ink-muted transition-colors hover:border-primary hover:text-ink-strong"
+            >
+              <Search className="size-4 shrink-0" aria-hidden="true" />
+              <span className="min-w-0 flex-1 truncate">
+                Search subnets, validators, endpoints, accounts…
+              </span>
+              <kbd className="hidden shrink-0 border border-border px-1.5 py-0.5 mg-type-caption text-ink-muted sm:inline-flex">
+                ⌘K
+              </kbd>
+              <span className="inline-flex size-8 shrink-0 items-center justify-center bg-primary text-primary-foreground">
+                <ArrowUpRight className="size-4" aria-hidden="true" />
+              </span>
+            </button>
+
+            <div className="mg-fade-in mg-fade-in-delay-2 mt-4 flex flex-wrap items-center gap-x-4 gap-y-3 mg-type-caption-lg">
+              <Link
+                to="/subnets"
+                className="mg-focus-ring inline-flex min-h-11 items-center gap-1.5 bg-primary px-4 py-2 font-medium text-primary-foreground transition-opacity hover:opacity-85"
               >
-                <svg
-                  aria-hidden="true"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.75"
-                  className="size-4 shrink-0 text-ink-muted"
-                >
-                  <circle cx="11" cy="11" r="7" />
-                  <path d="m20 20-3.5-3.5" strokeLinecap="round" />
-                </svg>
-                <span className="min-w-0 flex-1 truncate">
-                  Search subnets, validators, endpoints, accounts…
-                </span>
-                <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted">
-                  ⌘K
-                </kbd>
-              </button>
-              <button
-                type="button"
-                onClick={openCommandPalette}
-                aria-label="Open search"
-                className="flex size-12 shrink-0 items-center justify-center border-l border-border bg-primary-soft text-accent-text transition-colors hover:bg-accent hover:text-accent-foreground sm:h-auto sm:w-auto sm:px-4"
+                Explore {subnetCount} subnets
+                <ArrowUpRight className="size-3.5" />
+              </Link>
+              <Link
+                to="/apis/schemas"
+                className="mg-focus-ring inline-flex min-h-11 items-center text-accent-text underline decoration-current/40 underline-offset-4 transition-colors hover:text-ink-strong"
               >
-                <svg
-                  aria-hidden="true"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.75"
-                  className="size-4 sm:hidden"
-                >
-                  <circle cx="11" cy="11" r="7" />
-                  <path d="m20 20-3.5-3.5" strokeLinecap="round" />
-                </svg>
-                <span className="hidden text-sm font-medium sm:inline">Search</span>
-              </button>
+                Read the API
+              </Link>
             </div>
           </div>
 
-          <div className="mg-fade-in mg-fade-in-delay-3 mt-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4 mg-type-caption-lg">
-            <Link
-              to="/subnets"
-              className="mg-focus-ring inline-flex min-h-11 items-center gap-1.5 rounded bg-accent px-4 py-2 font-medium text-accent-foreground transition-opacity hover:opacity-90"
-            >
-              Explore all {subnetCount} subnets
-              <ArrowUpRight className="size-3.5" />
-            </Link>
-            <Link
-              to="/apis/schemas"
-              className="mg-focus-ring inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-4 py-2 font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
-            >
-              Read the API
-            </Link>
-          </div>
-          {/* inline-flex, not flex: this is a control shell (a copyable command
-            row), not a content panel — same distinction the card-shell lint
-            rule draws for segmented controls. */}
-          <div className="mg-fade-in mg-fade-in-delay-3 mt-4 inline-flex w-full max-w-xl items-center gap-2 rounded border border-border bg-card px-3 py-2">
-            <Terminal className="size-3.5 shrink-0 text-accent" aria-hidden />
-            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-left font-mono mg-type-caption-lg text-ink-muted">
-              {MCP_CORE_INSTALL}
-            </code>
-            <CopyButton value={MCP_CORE_INSTALL} label="MCP install command" />
-          </div>
-        </div>
-        <aside className="mg-fade-in mg-fade-in-delay-2 border-l-2 border-accent bg-card p-4 md:p-6">
-          <div className="mg-type-label text-ink-muted">Registry pulse</div>
-          <div className="mt-4 font-display text-4xl font-medium tracking-[-0.05em] text-ink-strong tabular-nums">
-            {formatNumber(subnetCount)}
-          </div>
-          <p className="mt-1 mg-type-caption-lg text-ink-muted">
-            active subnets mapped across chain data and public interfaces
-          </p>
-          <div className="mt-4 border-t border-border pt-4">
-            <div className="mg-type-label text-ink-muted">Chain head</div>
+          <div className="mg-fade-in mg-fade-in-delay-3 mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-3 mg-type-data text-ink-muted">
+            <span>
+              <strong className="font-medium text-ink-strong tabular-nums">
+                {formatNumber(subnetCount)}
+              </strong>{" "}
+              active subnets
+            </span>
             <ChainHeadTip />
           </div>
-        </aside>
-      </div>
-
-      <div className="relative z-[var(--mg-z-sticky)] mx-auto mt-10 max-w-6xl px-0 sm:px-2">
-        <HeroFeatureRow />
+        </div>
       </div>
     </section>
   );

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -7,7 +7,14 @@ import { HomeWatchedModule } from "@/components/metagraphed/home-watched-module"
 import { EmptyState, ErrorState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
 import { statPhase, type StatPhase } from "@/lib/metagraphed/stat-phase";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  Panel,
+} from "@/components/metagraphed/primitives";
 import {
   AccentBand,
   BrandIcon,
@@ -71,283 +78,266 @@ export function OverviewPage() {
   const [showMore, setShowMore] = useState(false);
   return (
     <AppShell flushTop>
-      <HomeHero />
+      <DataPageStage>
+        <HomeHero />
 
-      {/* #8249: the two new always-visible modules the redesign asked for --
-          "what's actually happening" and "how do I automate this" -- sit
-          right after the hero's throughput/live-subnets row, ahead of the
-          calmer "keep exploring" content below. Neither needs `showMore`:
-          they're small, single-panel, and exactly the kind of glance content
-          a first-time visitor benefits from seeing without an extra click. */}
-      <section className="mt-section-gap">
-        <SectionHeader
-          eyebrow="What changed"
-          live
-          title="What changed today."
-          description="New subnets, ownership transfers, runtime upgrades, notable stake moves, and resolved incidents — newest first."
-        />
-        <TimeRangeProvider>
-          <QueryErrorBoundary fallback={() => null}>
-            <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-              <WhatChangedFeed limit={7} />
-            </Suspense>
-          </QueryErrorBoundary>
-        </TimeRangeProvider>
-      </section>
-
-      <section className="mt-section-gap">
-        <SectionHeader
-          eyebrow="For agents"
-          title="Built for agents first."
-          description="Point any agent at this registry over MCP -- no key, no account."
-        />
-        <QueryErrorBoundary fallback={() => null}>
-          <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-            <HomeForAgentsModule />
-          </Suspense>
-        </QueryErrorBoundary>
-      </section>
-
-      {/* #8256: the watchlist is the site's only personalization, and until
-          now starring a subnet on /subnets had no payoff anywhere the user
-          actually lands. This sits above "keep exploring" because a returning
-          visitor's own stars beat a generic browse prompt -- and below the
-          two live modules, which a first-time visitor (no stars yet) needs
-          more. The module renders a one-line nudge, not a framed panel, when
-          nothing is starred. */}
-      <section className="mt-section-gap">
-        <SectionHeader
-          eyebrow="Watched"
-          title="Your watchlist."
-          description="Stars live in this browser — no account, nothing sent to us."
-        />
-        <HomeWatchedModule />
-      </section>
-
-      <ContinueExploring />
-
-      <section className="mt-section-gap">
-        <SectionHeader
-          eyebrow="What's tracked"
-          title="Every public surface, in one registry."
-          description="Glance counts live in the registry pulse ticker above — these are the sections to explore."
-          link={{ to: "/subnets", label: "Browse the registry" }}
-        />
-        <TrackedGrid />
-      </section>
-
-      {!showMore && (
-        <div className="mt-section-gap flex justify-center">
-          <button
-            type="button"
-            onClick={() => setShowMore(true)}
-            aria-expanded={false}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2.5 text-sm font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
+        <DataPageCanvas>
+          <DataPageModule
+            title="What changed today."
+            caption="New subnets, ownership transfers, runtime upgrades, notable stake moves, and resolved incidents — newest first."
           >
-            Show more of the registry
-            <ChevronDown className="size-4" />
-          </button>
-        </div>
-      )}
-      {showMore && (
-        <>
-          <LivePerformance />
+            <TimeRangeProvider>
+              <QueryErrorBoundary fallback={() => null}>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <WhatChangedFeed limit={7} />
+                </Suspense>
+              </QueryErrorBoundary>
+            </TimeRangeProvider>
+          </DataPageModule>
 
-          {/* #1124: live registry signal band — curation funnel + network pulse +
-          what-changed feed, scoped to a shared time range. Wired to real coverage/
-          health/changelog/incident data. */}
-          <ScrollReveal>
-            <section className="mt-section-gap">
-              <TimeRangeProvider>
-                <div className="mb-3 flex items-end justify-between gap-3">
-                  <SectionHeader
-                    inline
-                    eyebrow="Signal"
-                    live
-                    title="Live registry signal."
-                    description="Curation depth, network pulse, and the latest changes."
-                  />
-                  <TimeRangeScrub />
-                </div>
-                <div className="grid gap-4 lg:grid-cols-12">
-                  <AsyncPanel
-                    context="coverage funnel"
-                    fallback={<Skeleton className="h-72 lg:col-span-5" />}
-                    retryQueryKeys={[coverageQuery().queryKey]}
-                  >
-                    <div className="min-w-0 lg:col-span-5">
-                      <CoverageFunnel />
-                    </div>
-                  </AsyncPanel>
-                  <AsyncPanel
-                    context="network pulse"
-                    fallback={<Skeleton className="h-72 lg:col-span-7" />}
-                  >
-                    <div className="min-w-0 lg:col-span-7">
-                      <NetworkPulseBand />
-                    </div>
-                  </AsyncPanel>
-                  <AsyncPanel
-                    context="what changed"
-                    fallback={<Skeleton className="h-64 lg:col-span-12" />}
-                    retryQueryKeys={[changelogQuery().queryKey, endpointIncidentsQuery().queryKey]}
-                  >
-                    <div className="min-w-0 lg:col-span-12">
-                      <WhatChangedFeed />
-                    </div>
-                  </AsyncPanel>
-                </div>
-              </TimeRangeProvider>
-            </section>
-          </ScrollReveal>
+          <DataPageModule
+            title="Start with the question."
+            caption="Choose the part of Bittensor you need to inspect; each destination keeps the primary task in view."
+          >
+            <TrackedGrid />
+          </DataPageModule>
 
-          {/* #5: registry depth — completeness score distribution, surface-dimension
-          coverage, and the ranked enrichment queue. Wired to /api/v1/registry/summary
-          + /api/v1/coverage-depth. Each module renders inside its own error boundary
-          so a single artifact gap never blanks the whole section. */}
-          <ScrollReveal>
-            <section className="mt-section-gap">
-              <SectionHeader
-                eyebrow="Registry depth"
-                title="How complete is the registry?"
-                description="Completeness scores, surface-dimension coverage, and the highest-priority subnets to enrich next."
-              />
-              <div className="grid gap-4 lg:grid-cols-12">
-                <AsyncPanel
-                  context="registry score histogram"
-                  fallback={<Skeleton className="h-64 lg:col-span-7" />}
-                  retryQueryKeys={[registrySummaryQuery().queryKey]}
-                >
-                  <div className="min-w-0 lg:col-span-7">
-                    <RegistryScoreHistogram className="h-full" />
-                  </div>
-                </AsyncPanel>
-                <AsyncPanel
-                  context="dimension coverage heatmap"
-                  fallback={<Skeleton className="h-64 lg:col-span-5" />}
-                  retryQueryKeys={[registrySummaryQuery().queryKey]}
-                >
-                  <div className="min-w-0 lg:col-span-5">
-                    <DimensionCoverageHeatmap className="h-full" />
-                  </div>
-                </AsyncPanel>
-                <div className="min-w-0 lg:col-span-12">
-                  <div className="mb-3 mg-type-caption text-ink-muted">Enrichment queue</div>
-                  <AsyncPanel
-                    context="enrichment queue"
-                    fallback={<Skeleton className="h-64 w-full" />}
-                    retryQueryKeys={[coverageDepthQuery().queryKey]}
-                  >
-                    <EnrichmentQueueTable />
-                  </AsyncPanel>
+          <DataPageModule
+            title="Your workspace."
+            caption="Watch entities locally, continue a recent investigation, or connect an agent without an account."
+          >
+            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+              <div className="min-w-0">
+                <h3 className="mg-type-label text-ink-muted">Watched entities</h3>
+                <div className="mt-3">
+                  <HomeWatchedModule />
+                </div>
+                <ContinueExploring />
+              </div>
+              <div className="min-w-0">
+                <h3 className="mg-type-label text-ink-muted">For agents</h3>
+                <p className="mt-2 mg-type-caption text-ink-muted">
+                  Point any agent at this registry over MCP — no key, no account.
+                </p>
+                <div className="mt-3">
+                  <QueryErrorBoundary fallback={() => null}>
+                    <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+                      <HomeForAgentsModule />
+                    </Suspense>
+                  </QueryErrorBoundary>
                 </div>
               </div>
-            </section>
-          </ScrollReveal>
-
-          <LeaderboardsModule />
-          <QueryErrorBoundary fallback={() => null}>
-            <Suspense fallback={<Skeleton className="h-48 w-full mt-section-gap" />}>
-              <MoversBand />
-            </Suspense>
-          </QueryErrorBoundary>
-
-          <QuickActionsRow />
-
-          <section className="mt-section-gap">
-            <div className="flex items-end justify-between mb-6">
-              <SectionHeader inline eyebrow="Active subnets" live title="The live registry." />
-              <Link
-                to="/subnets"
-                className="inline-flex items-center gap-1 text-xs font-mono uppercase tracking-[0.18em] text-ink-muted hover:text-accent transition-colors group"
-              >
-                View all
-                <ArrowUpRight className="size-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-              </Link>
             </div>
-            <AsyncPanel
-              context="subnets"
-              fallback={<TableSkeleton />}
-              retryQueryKeys={[subnetsQuery({ limit: 12 }).queryKey]}
-            >
-              <SubnetPreviewTable />
-            </AsyncPanel>
-          </section>
+          </DataPageModule>
+        </DataPageCanvas>
 
-          {/* #3474: live network-wide feed of recent subnet-identity changes. */}
-          <section className="mt-section-gap">
-            <SectionHeader
-              eyebrow="Network activity"
-              title="Recent identity changes."
-              description="Subnet name, symbol, and profile edits observed on-chain across the network, newest first."
-            />
-            <QueryErrorBoundary>
-              <RecentIdentityChanges />
-            </QueryErrorBoundary>
-          </section>
-
-          <section className="mt-section-gap">
-            <SectionHeader
-              eyebrow="For developers"
-              title="Public, read-only, JSON-Schema canonical."
-              description="Every list and detail view in this app is also a documented API route. Same data, same envelope."
-            />
-            <Panel as="div" className="max-w-2xl">
-              <div className="mg-type-caption text-ink-muted mb-2">Try it</div>
-              <CopyableCode
-                value={`curl ${API_BASE}/api/v1/subnets`}
-                className="w-full mg-type-caption"
-                truncate={false}
-              />
-              <div className="mt-3 flex gap-4 text-xs">
-                <Link to="/apis/schemas" className="text-accent-text hover:underline">
-                  API reference →
-                </Link>
-                <ExternalLink
-                  href={`${API_BASE}/api/v1/openapi.json`}
-                  className="text-ink-muted hover:text-ink-strong"
-                >
-                  OpenAPI spec
-                </ExternalLink>
-              </div>
-            </Panel>
-          </section>
-
+        {!showMore && (
           <div className="mt-section-gap flex justify-center">
             <button
               type="button"
-              onClick={() => setShowMore(false)}
-              aria-expanded
-              className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2.5 text-sm font-medium text-ink-muted transition-colors hover:border-accent/60 hover:text-accent"
+              onClick={() => setShowMore(true)}
+              aria-expanded={false}
+              className="inline-flex min-h-11 items-center gap-2 border border-border bg-card px-4 py-2.5 mg-type-caption font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
             >
-              Show less
-              <ChevronDown className="size-4 rotate-180" />
+              Show more of the registry
+              <ChevronDown className="size-4" />
             </button>
           </div>
-        </>
-      )}
+        )}
+        {showMore && (
+          <>
+            <LivePerformance />
 
-      <AccentBand pattern className="mt-20">
-        <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
-          <div className="max-w-xl">
-            <div className="mg-type-caption text-ink-strong/70 mb-2">
-              All registry data is public
+            {/* #1124: live registry signal band — curation funnel + network pulse +
+          what-changed feed, scoped to a shared time range. Wired to real coverage/
+          health/changelog/incident data. */}
+            <ScrollReveal>
+              <section className="mt-section-gap">
+                <TimeRangeProvider>
+                  <div className="mb-3 flex items-end justify-between gap-3">
+                    <SectionHeader
+                      inline
+                      eyebrow="Signal"
+                      live
+                      title="Live registry signal."
+                      description="Curation depth, network pulse, and the latest changes."
+                    />
+                    <TimeRangeScrub />
+                  </div>
+                  <div className="grid gap-4 lg:grid-cols-12">
+                    <AsyncPanel
+                      context="coverage funnel"
+                      fallback={<Skeleton className="h-72 lg:col-span-5" />}
+                      retryQueryKeys={[coverageQuery().queryKey]}
+                    >
+                      <div className="min-w-0 lg:col-span-5">
+                        <CoverageFunnel />
+                      </div>
+                    </AsyncPanel>
+                    <AsyncPanel
+                      context="network pulse"
+                      fallback={<Skeleton className="h-72 lg:col-span-7" />}
+                    >
+                      <div className="min-w-0 lg:col-span-7">
+                        <NetworkPulseBand />
+                      </div>
+                    </AsyncPanel>
+                    <AsyncPanel
+                      context="what changed"
+                      fallback={<Skeleton className="h-64 lg:col-span-12" />}
+                      retryQueryKeys={[
+                        changelogQuery().queryKey,
+                        endpointIncidentsQuery().queryKey,
+                      ]}
+                    >
+                      <div className="min-w-0 lg:col-span-12">
+                        <WhatChangedFeed />
+                      </div>
+                    </AsyncPanel>
+                  </div>
+                </TimeRangeProvider>
+              </section>
+            </ScrollReveal>
+
+            {/* #5: registry depth — completeness score distribution, surface-dimension
+          coverage, and the ranked enrichment queue. Wired to /api/v1/registry/summary
+          + /api/v1/coverage-depth. Each module renders inside its own error boundary
+          so a single artifact gap never blanks the whole section. */}
+            <ScrollReveal>
+              <section className="mt-section-gap">
+                <SectionHeader
+                  eyebrow="Registry depth"
+                  title="How complete is the registry?"
+                  description="Completeness scores, surface-dimension coverage, and the highest-priority subnets to enrich next."
+                />
+                <div className="grid gap-4 lg:grid-cols-12">
+                  <AsyncPanel
+                    context="registry score histogram"
+                    fallback={<Skeleton className="h-64 lg:col-span-7" />}
+                    retryQueryKeys={[registrySummaryQuery().queryKey]}
+                  >
+                    <div className="min-w-0 lg:col-span-7">
+                      <RegistryScoreHistogram className="h-full" />
+                    </div>
+                  </AsyncPanel>
+                  <AsyncPanel
+                    context="dimension coverage heatmap"
+                    fallback={<Skeleton className="h-64 lg:col-span-5" />}
+                    retryQueryKeys={[registrySummaryQuery().queryKey]}
+                  >
+                    <div className="min-w-0 lg:col-span-5">
+                      <DimensionCoverageHeatmap className="h-full" />
+                    </div>
+                  </AsyncPanel>
+                  <div className="min-w-0 lg:col-span-12">
+                    <div className="mb-3 mg-type-caption text-ink-muted">Enrichment queue</div>
+                    <AsyncPanel
+                      context="enrichment queue"
+                      fallback={<Skeleton className="h-64 w-full" />}
+                      retryQueryKeys={[coverageDepthQuery().queryKey]}
+                    >
+                      <EnrichmentQueueTable />
+                    </AsyncPanel>
+                  </div>
+                </div>
+              </section>
+            </ScrollReveal>
+
+            <LeaderboardsModule />
+            <QueryErrorBoundary fallback={() => null}>
+              <Suspense fallback={<Skeleton className="h-48 w-full mt-section-gap" />}>
+                <MoversBand />
+              </Suspense>
+            </QueryErrorBoundary>
+
+            <QuickActionsRow />
+
+            <section className="mt-section-gap">
+              <div className="flex items-end justify-between mb-6">
+                <SectionHeader inline eyebrow="Active subnets" live title="The live registry." />
+                <Link
+                  to="/subnets"
+                  className="inline-flex items-center gap-1 text-xs font-mono uppercase tracking-[0.18em] text-ink-muted hover:text-accent transition-colors group"
+                >
+                  View all
+                  <ArrowUpRight className="size-3 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                </Link>
+              </div>
+              <AsyncPanel
+                context="subnets"
+                fallback={<TableSkeleton />}
+                retryQueryKeys={[subnetsQuery({ limit: 12 }).queryKey]}
+              >
+                <SubnetPreviewTable />
+              </AsyncPanel>
+            </section>
+
+            {/* #3474: live network-wide feed of recent subnet-identity changes. */}
+            <section className="mt-section-gap">
+              <SectionHeader
+                eyebrow="Network activity"
+                title="Recent identity changes."
+                description="Subnet name, symbol, and profile edits observed on-chain across the network, newest first."
+              />
+              <QueryErrorBoundary>
+                <RecentIdentityChanges />
+              </QueryErrorBoundary>
+            </section>
+
+            <section className="mt-section-gap">
+              <SectionHeader
+                eyebrow="For developers"
+                title="Public, read-only, JSON-Schema canonical."
+                description="Every list and detail view in this app is also a documented API route. Same data, same envelope."
+              />
+              <Panel as="div" className="max-w-2xl">
+                <div className="mg-type-caption text-ink-muted mb-2">Try it</div>
+                <CopyableCode
+                  value={`curl ${API_BASE}/api/v1/subnets`}
+                  className="w-full mg-type-caption"
+                  truncate={false}
+                />
+                <div className="mt-3 flex gap-4 text-xs">
+                  <Link to="/apis/schemas" className="text-accent-text hover:underline">
+                    API reference →
+                  </Link>
+                  <ExternalLink
+                    href={`${API_BASE}/api/v1/openapi.json`}
+                    className="text-ink-muted hover:text-ink-strong"
+                  >
+                    OpenAPI spec
+                  </ExternalLink>
+                </div>
+              </Panel>
+            </section>
+
+            <div className="mt-section-gap flex justify-center">
+              <button
+                type="button"
+                onClick={() => setShowMore(false)}
+                aria-expanded
+                className="inline-flex min-h-11 items-center gap-2 border border-border bg-card px-4 py-2.5 mg-type-caption font-medium text-ink-muted transition-colors hover:border-accent/60 hover:text-accent"
+              >
+                Show less
+                <ChevronDown className="size-4 rotate-180" />
+              </button>
             </div>
-            <h2 className="font-display text-2xl md:text-3xl font-semibold text-ink-strong tracking-tight">
-              Browse the full Bittensor registry.
-            </h2>
+          </>
+        )}
+
+        <section className="mg-page-callout">
+          <div>
+            <span className="mg-page-kicker">Public chain data</span>
+            <h2>Browse the full Bittensor registry.</h2>
           </div>
-          <Link
-            to="/subnets"
-            className="inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-4 py-2.5 text-sm font-medium text-paper hover:opacity-90 transition-opacity self-start md:self-auto"
-          >
+          <Link to="/subnets" className="mg-page-primary-action">
             Open subnets
             <ArrowUpRight className="size-3.5" />
           </Link>
-        </div>
-      </AccentBand>
-      {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
-      <HubSections path="/" />
+        </section>
+        {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
+        <HubSections path="/" />
+      </DataPageStage>
     </AppShell>
   );
 }
@@ -410,74 +400,56 @@ function HomeHero() {
       : 128;
 
   return (
-    <section className="mg-hero-slab relative overflow-hidden px-4 sm:px-6">
-      <div className="relative z-[var(--mg-z-sticky)] mx-auto max-w-6xl py-12 md:py-24">
-        <div className="relative max-w-4xl">
-          <div className="mg-hero-caption mg-fade-in">Finney · public registry</div>
-          {/* eslint-disable-next-line no-restricted-syntax -- display-size hero heading (38/52/64px responsive); the mg-type-* scale deliberately tops out at caption-lg, so there is no matching token (#8717 req 2 exception) */}
-          <h1 className="mg-fade-in mt-5 font-display text-[38px] sm:text-[52px] md:text-[64px] font-medium leading-[1.02] tracking-[-0.055em] text-ink-strong">
-            Find the signal.
-            <br />
-            Verify the surface.
-          </h1>
-
-          {/* One reference field establishes the page's data character. It is
-              deliberately structural rather than another card, metric, or CTA. */}
-          <div aria-hidden className="mg-hero-dot-field" />
-
-          <div className="mg-fade-in mg-fade-in-delay-1 mt-16 max-w-xl md:mt-20">
-            <p className="text-sm leading-relaxed text-ink-muted md:text-base">
-              A public map of Bittensor subnets, chain activity, and interfaces — built to show what
-              is live, credible, and ready to use.
-            </p>
-
-            <button
-              type="button"
-              onClick={openCommandPalette}
-              aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
-              className="mg-focus-ring mt-8 flex min-h-12 w-full items-center gap-3 border-b border-ink-strong/30 pb-3 text-left text-sm text-ink-muted transition-colors hover:border-primary hover:text-ink-strong"
-            >
-              <Search className="size-4 shrink-0" aria-hidden="true" />
-              <span className="min-w-0 flex-1 truncate">
-                Search subnets, validators, endpoints, accounts…
-              </span>
-              <kbd className="hidden shrink-0 border border-border px-1.5 py-0.5 mg-type-caption text-ink-muted sm:inline-flex">
-                ⌘K
-              </kbd>
-              <span className="inline-flex size-8 shrink-0 items-center justify-center bg-primary text-primary-foreground">
-                <ArrowUpRight className="size-4" aria-hidden="true" />
-              </span>
-            </button>
-
-            <div className="mg-fade-in mg-fade-in-delay-2 mt-4 flex flex-wrap items-center gap-x-4 gap-y-3 mg-type-caption-lg">
-              <Link
-                to="/subnets"
-                className="mg-focus-ring inline-flex min-h-11 items-center gap-1.5 bg-primary px-4 py-2 font-medium text-primary-foreground transition-opacity hover:opacity-85"
-              >
-                Explore {subnetCount} subnets
-                <ArrowUpRight className="size-3.5" />
-              </Link>
-              <Link
-                to="/apis/schemas"
-                className="mg-focus-ring inline-flex min-h-11 items-center text-accent-text underline decoration-current/40 underline-offset-4 transition-colors hover:text-ink-strong"
-              >
-                Read the API
-              </Link>
-            </div>
-          </div>
-
-          <div className="mg-fade-in mg-fade-in-delay-3 mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-3 mg-type-data text-ink-muted">
-            <span>
-              <strong className="font-medium text-ink-strong tabular-nums">
-                {formatNumber(subnetCount)}
-              </strong>{" "}
-              active subnets
-            </span>
-            <ChainHeadTip />
-          </div>
-        </div>
+    <DataPageHero
+      id="home-title"
+      variant="landing"
+      live
+      eyebrow="Finney · public registry"
+      title={
+        <>
+          Find the signal.
+          <br />
+          Verify the surface.
+        </>
+      }
+      description="A public map of Bittensor subnets, chain activity, and interfaces — built to show what is live, credible, and ready to use."
+      footer={
+        <>
+          <span>
+            <strong className="font-medium text-ink-strong tabular-nums">
+              {formatNumber(subnetCount)}
+            </strong>{" "}
+            active subnets
+          </span>
+          <ChainHeadTip />
+        </>
+      }
+    >
+      <button
+        type="button"
+        onClick={openCommandPalette}
+        aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
+        className="mg-focus-ring mg-page-command"
+      >
+        <Search className="size-4 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 truncate">Search subnets, validators, endpoints, accounts…</span>
+        <kbd className="hidden shrink-0 border border-border px-1.5 py-0.5 mg-type-caption text-ink-muted sm:inline-flex">
+          ⌘K
+        </kbd>
+        <span className="mg-page-command-mark" aria-hidden="true">
+          <ArrowUpRight className="size-4" />
+        </span>
+      </button>
+      <div className="mg-page-action-row">
+        <Link to="/subnets" className="mg-focus-ring mg-page-primary-action">
+          Explore {subnetCount} subnets
+          <ArrowUpRight className="size-3.5" />
+        </Link>
+        <Link to="/apis/schemas" className="mg-focus-ring mg-page-quiet-action">
+          Read the API
+        </Link>
       </div>
-    </section>
+    </DataPageHero>
   );
 }
 
@@ -614,11 +586,7 @@ function TrackedGrid() {
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {items.map((item) => (
-        <Link
-          key={item.label}
-          to={item.to}
-          className="mg-hover-lift group rounded border border-border bg-card p-6 flex flex-col"
-        >
+        <Link key={item.label} to={item.to} className="mg-page-route-link group flex flex-col">
           <div className="mg-type-caption text-ink-muted">{item.label}</div>
           <p className="mt-3 text-sm text-ink-strong leading-relaxed flex-1">{item.desc}</p>
           <span className="mt-4 inline-flex items-center gap-1 mg-type-caption text-ink-muted group-hover:text-accent transition-colors">

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -419,94 +419,109 @@ function HomeHero() {
       : 128;
 
   return (
-    <section className="mg-hero-slab relative overflow-hidden px-4 py-12 sm:px-6 md:py-20">
-      <div className="relative z-[var(--mg-z-sticky)] mx-auto flex max-w-4xl flex-col items-center text-center">
-        {/* eslint-disable-next-line no-restricted-syntax -- display-size hero heading (30/40/48px responsive); the mg-type-* scale tops out at caption-lg (13px) with no display tier, so there is no matching token (#8717 req 2 exception) */}
-        <h1 className="mg-fade-in mt-2 font-display text-[30px] sm:text-[40px] md:text-[48px] font-semibold leading-[1.08] text-ink-strong">
-          <span className="block">Bittensor,</span>
-          <span className="block text-accent">de-mystified.</span>
-        </h1>
-        <p className="mg-fade-in mg-fade-in-delay-1 mt-4 max-w-xl text-base md:text-lg text-ink-muted leading-relaxed">
-          One search bar for every subnet, endpoint, and account — and yes, it&rsquo;s all a live
-          API.
-        </p>
+    <section className="mg-hero-slab relative overflow-hidden px-4 py-10 sm:px-6 md:py-16">
+      <div className="relative z-[var(--mg-z-sticky)] mx-auto grid max-w-6xl gap-8 md:gap-12 lg:grid-cols-[minmax(0,1.25fr)_minmax(16rem,0.75fr)] lg:items-end">
+        <div className="min-w-0 text-left">
+          <div className="mg-hero-caption mg-fade-in">Metagraph Terminal · Finney</div>
+          {/* eslint-disable-next-line no-restricted-syntax -- display-size hero heading (30/40/48px responsive); the mg-type-* scale tops out at caption-lg (13px) with no display tier, so there is no matching token (#8717 req 2 exception) */}
+          <h1 className="mg-fade-in mt-4 font-display text-[30px] sm:text-[40px] md:text-[48px] font-medium leading-[1.08] tracking-[-0.04em] text-ink-strong">
+            <span className="block">Find the signal.</span>
+            <span className="block text-accent">Verify the surface.</span>
+          </h1>
+          <p className="mg-fade-in mg-fade-in-delay-1 mt-4 max-w-2xl text-sm md:text-base text-ink-muted leading-relaxed">
+            A public map of Bittensor subnets, chain activity, and interfaces — built to show what
+            is live, credible, and ready to use.
+          </p>
 
-        {/* Unified search field: query trigger on the left, mint Search button flush right. */}
-        <div className="mg-fade-in mg-fade-in-delay-2 mt-8 w-full max-w-2xl">
-          {/* eslint-disable-next-line no-restricted-syntax -- not a card shell: this is the search field's flush query-trigger + Search-button row (items-stretch, overflow-hidden, rounded-2xl, focus-within/hover border states); <Panel> hardcodes `rounded border` and can't express this composite input geometry (#8717 req 2 exception) */}
-          <div className="mg-focus-ring flex items-stretch overflow-hidden rounded-2xl border border-border bg-card transition-colors focus-within:border-accent/60 hover:border-accent/40">
-            <button
-              type="button"
-              onClick={openCommandPalette}
-              aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
-              className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
-            >
-              <svg
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.75"
-                className="size-4 shrink-0 text-ink-muted"
+          {/* Unified search shell: one plain-language primary task, no decorative chrome. */}
+          <div className="mg-fade-in mg-fade-in-delay-2 mt-8 w-full max-w-2xl">
+            {/* eslint-disable-next-line no-restricted-syntax -- not a card shell: this is the search field's flush query-trigger + Search-button row (items-stretch, overflow-hidden, focus-within/hover border states); <Panel> hardcodes its own content padding and can't express this composite input geometry (#8717 req 2 exception) */}
+            <div className="mg-focus-ring flex items-stretch overflow-hidden rounded-sm border border-border bg-card transition-colors focus-within:border-accent/80 hover:border-accent/60">
+              <button
+                type="button"
+                onClick={openCommandPalette}
+                aria-label="Search subnets, validators, endpoints, accounts. Opens command palette (⌘K)"
+                className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3.5 text-left text-sm text-ink-muted transition-colors hover:text-ink"
               >
-                <circle cx="11" cy="11" r="7" />
-                <path d="m20 20-3.5-3.5" strokeLinecap="round" />
-              </svg>
-              <span className="min-w-0 flex-1 truncate">
-                Search subnets, validators, endpoints, accounts…
-              </span>
-              <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted">
-                ⌘K
-              </kbd>
-            </button>
-            <button
-              type="button"
-              onClick={openCommandPalette}
-              aria-label="Open search"
-              className="flex size-12 shrink-0 items-center justify-center border-l border-border bg-primary-soft text-accent-text transition-colors hover:bg-accent hover:text-accent-foreground sm:h-auto sm:w-auto sm:px-4"
-            >
-              <svg
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.75"
-                className="size-4 sm:hidden"
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.75"
+                  className="size-4 shrink-0 text-ink-muted"
+                >
+                  <circle cx="11" cy="11" r="7" />
+                  <path d="m20 20-3.5-3.5" strokeLinecap="round" />
+                </svg>
+                <span className="min-w-0 flex-1 truncate">
+                  Search subnets, validators, endpoints, accounts…
+                </span>
+                <kbd className="hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-paper px-1.5 py-0.5 mg-type-caption text-ink-muted">
+                  ⌘K
+                </kbd>
+              </button>
+              <button
+                type="button"
+                onClick={openCommandPalette}
+                aria-label="Open search"
+                className="flex size-12 shrink-0 items-center justify-center border-l border-border bg-primary-soft text-accent-text transition-colors hover:bg-accent hover:text-accent-foreground sm:h-auto sm:w-auto sm:px-4"
               >
-                <circle cx="11" cy="11" r="7" />
-                <path d="m20 20-3.5-3.5" strokeLinecap="round" />
-              </svg>
-              <span className="hidden text-sm font-medium sm:inline">Search</span>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.75"
+                  className="size-4 sm:hidden"
+                >
+                  <circle cx="11" cy="11" r="7" />
+                  <path d="m20 20-3.5-3.5" strokeLinecap="round" />
+                </svg>
+                <span className="hidden text-sm font-medium sm:inline">Search</span>
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div className="mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-col items-center gap-3 sm:flex-row sm:gap-4 mg-type-caption-lg">
-          <Link
-            to="/subnets"
-            className="mg-focus-ring inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 font-medium text-accent-foreground transition-opacity hover:opacity-90"
-          >
-            Explore all {subnetCount} subnets
-            <ArrowUpRight className="size-3.5" />
-          </Link>
-          <Link
-            to="/apis/schemas"
-            className="mg-focus-ring inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
-          >
-            Read the API
-          </Link>
-        </div>
-        {/* inline-flex, not flex: this is a control shell (a copyable command
+          <div className="mg-fade-in mg-fade-in-delay-3 mt-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4 mg-type-caption-lg">
+            <Link
+              to="/subnets"
+              className="mg-focus-ring inline-flex min-h-11 items-center gap-1.5 rounded bg-accent px-4 py-2 font-medium text-accent-foreground transition-opacity hover:opacity-90"
+            >
+              Explore all {subnetCount} subnets
+              <ArrowUpRight className="size-3.5" />
+            </Link>
+            <Link
+              to="/apis/schemas"
+              className="mg-focus-ring inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-4 py-2 font-medium text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
+            >
+              Read the API
+            </Link>
+          </div>
+          {/* inline-flex, not flex: this is a control shell (a copyable command
             row), not a content panel — same distinction the card-shell lint
             rule draws for segmented controls. */}
-        <div className="mg-fade-in mg-fade-in-delay-3 mt-6 inline-flex w-full max-w-xl items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
-          <Terminal className="size-3.5 shrink-0 text-accent" aria-hidden />
-          <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-left font-mono mg-type-caption-lg text-ink-muted">
-            {MCP_CORE_INSTALL}
-          </code>
-          <CopyButton value={MCP_CORE_INSTALL} label="MCP install command" />
+          <div className="mg-fade-in mg-fade-in-delay-3 mt-4 inline-flex w-full max-w-xl items-center gap-2 rounded border border-border bg-card px-3 py-2">
+            <Terminal className="size-3.5 shrink-0 text-accent" aria-hidden />
+            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-left font-mono mg-type-caption-lg text-ink-muted">
+              {MCP_CORE_INSTALL}
+            </code>
+            <CopyButton value={MCP_CORE_INSTALL} label="MCP install command" />
+          </div>
         </div>
-        <ChainHeadTip />
+        <aside className="mg-fade-in mg-fade-in-delay-2 border-l-2 border-accent bg-card p-4 md:p-6">
+          <div className="mg-type-label text-ink-muted">Registry pulse</div>
+          <div className="mt-4 font-display text-4xl font-medium tracking-[-0.05em] text-ink-strong tabular-nums">
+            {formatNumber(subnetCount)}
+          </div>
+          <p className="mt-1 mg-type-caption-lg text-ink-muted">
+            active subnets mapped across chain data and public interfaces
+          </p>
+          <div className="mt-4 border-t border-border pt-4">
+            <div className="mg-type-label text-ink-muted">Chain head</div>
+            <ChainHeadTip />
+          </div>
+        </aside>
       </div>
 
       <div className="relative z-[var(--mg-z-sticky)] mx-auto mt-10 max-w-6xl px-0 sm:px-2">
@@ -652,7 +667,7 @@ function TrackedGrid() {
         <Link
           key={item.label}
           to={item.to}
-          className="mg-hover-lift group rounded-xl border border-border bg-card p-6 flex flex-col"
+          className="mg-hover-lift group rounded border border-border bg-card p-6 flex flex-col"
         >
           <div className="mg-type-caption text-ink-muted">{item.label}</div>
           <p className="mt-3 text-sm text-ink-strong leading-relaxed flex-1">{item.desc}</p>

--- a/apps/ui/src/routes/-providers-slug-page.tsx
+++ b/apps/ui/src/routes/-providers-slug-page.tsx
@@ -3,7 +3,6 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, RECOVERY, StaleBanner } from "@/components/metagraphed/states";
-import { Panel } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   BrandIcon,
@@ -12,7 +11,15 @@ import {
   SectionAnchor,
   ShareButton,
 } from "@jsonbored/ui-kit";
-import { AsyncPanel, PageMasthead, TabStrip } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+  Panel,
+  TabStrip,
+} from "@/components/metagraphed/primitives";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
 import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
@@ -80,7 +87,7 @@ function ProviderShell({ slug }: { slug: string }) {
     });
 
   return (
-    <>
+    <DataPageStage>
       {/* No breadcrumb row here: the app-shell's own row is the single
           canonical trail (#7853). AppShell's `crumbLabel` prop carries the
           provider's display name this used to render redundantly. */}
@@ -107,52 +114,68 @@ function ProviderShell({ slug }: { slug: string }) {
           </Panel>
         }
       />
-      {shouldShowProviderSlugSubtitle(p?.name, slug) ? (
-        <div className="-mt-2 mb-3 mg-type-data text-ink-muted">{slug}</div>
-      ) : null}
+      <DataPageCanvas>
+        <DataPageModule
+          title="Provider footprint."
+          caption="Endpoints, ownership context, and evidence stay in one reading flow; use the tabs to narrow the task without losing the operational summary."
+        >
+          {shouldShowProviderSlugSubtitle(p?.name, slug) ? (
+            <div className="-mt-2 mb-3 mg-type-data text-ink-muted">{slug}</div>
+          ) : null}
 
-      <div className="mg-kpi-strip">
-        <ProviderPulseTile label="Endpoints" value={formatNumber(summary?.endpoint_count)} />
-        <ProviderPulseTile label="Monitored" value={formatNumber(summary?.monitored_count)} />
-        <ProviderPulseTile label="Healthy" value={formatNumber(summary?.by_status?.ok)} tone="ok" />
-        <ProviderPulseTile
-          label="Pool eligible"
-          value={formatNumber(summary?.pool_eligible_count)}
-        />
-      </div>
-      {stale ? (
-        <StaleBanner
-          generatedAt={meta?.generated_at}
-          refreshQueryKeys={[providerQuery(slug).queryKey, providerEndpointsQuery(slug).queryKey]}
-        />
-      ) : null}
+          <div className="mg-kpi-strip">
+            <ProviderPulseTile label="Endpoints" value={formatNumber(summary?.endpoint_count)} />
+            <ProviderPulseTile label="Monitored" value={formatNumber(summary?.monitored_count)} />
+            <ProviderPulseTile
+              label="Healthy"
+              value={formatNumber(summary?.by_status?.ok)}
+              tone="ok"
+            />
+            <ProviderPulseTile
+              label="Pool eligible"
+              value={formatNumber(summary?.pool_eligible_count)}
+            />
+          </div>
+          {stale ? (
+            <StaleBanner
+              generatedAt={meta?.generated_at}
+              refreshQueryKeys={[
+                providerQuery(slug).queryKey,
+                providerEndpointsQuery(slug).queryKey,
+              ]}
+            />
+          ) : null}
 
-      <TabStrip
-        items={TABS.map((item) =>
-          item.id === "endpoints" ? { ...item, meta: summary?.endpoint_count } : item,
-        )}
-        value={tab}
-        onChange={setTab}
-        ariaLabel="Provider profile sections"
-        className="mt-4 overflow-x-auto"
-      />
+          <TabStrip
+            items={TABS.map((item) =>
+              item.id === "endpoints" ? { ...item, meta: summary?.endpoint_count } : item,
+            )}
+            value={tab}
+            onChange={setTab}
+            ariaLabel="Provider profile sections"
+            className="mt-4 overflow-x-auto"
+          />
 
-      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_17rem]">
-        <div className="min-w-0 space-y-6">
-          {tab === "overview" ? <OverviewPanel slug={slug} /> : null}
-          {tab === "endpoints" ? <EndpointsPanel slug={slug} /> : null}
-          {tab === "subnets" ? <SubnetsServedPanel slug={slug} /> : null}
-          {tab === "evidence" ? <EvidencePanel provider={p} /> : null}
-        </div>
+          <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_17rem]">
+            <div className="min-w-0 space-y-6">
+              {tab === "overview" ? <OverviewPanel slug={slug} /> : null}
+              {tab === "endpoints" ? <EndpointsPanel slug={slug} /> : null}
+              {tab === "subnets" ? <SubnetsServedPanel slug={slug} /> : null}
+              {tab === "evidence" ? <EvidencePanel provider={p} /> : null}
+            </div>
 
-        <aside className="space-y-3 border-t border-border pt-4 lg:sticky lg:top-32 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0 self-start">
-          {summary?.by_kind ? <BreakdownCard title="By kind" data={summary.by_kind} /> : null}
-          {summary?.by_status ? <BreakdownCard title="By status" data={summary.by_status} /> : null}
-          {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
-        </aside>
-      </div>
+            <aside className="space-y-3 border-t border-border pt-4 lg:sticky lg:top-32 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0 self-start">
+              {summary?.by_kind ? <BreakdownCard title="By kind" data={summary.by_kind} /> : null}
+              {summary?.by_status ? (
+                <BreakdownCard title="By status" data={summary.by_status} />
+              ) : null}
+              {summary?.by_layer ? (
+                <BreakdownCard title="By layer" data={summary.by_layer} />
+              ) : null}
+            </aside>
+          </div>
 
-      {/*
+          {/*
         #11351: the same flywheel #8329 built for subnet teams, on the 138
         provider pages that never had it. /api/v1/providers/{slug}/badge.svg has
         always existed and nothing pointed an operator at it.
@@ -161,12 +184,14 @@ function ProviderShell({ slug }: { slug: string }) {
         earns an inbound link -- measured 2026-08-15, 0 of 115 reachable subnet
         READMEs mention metagraph.sh.
       */}
-      <UptimeBadgeEmbed entity="providers" id={slug} name={p.name ?? undefined} />
+          <UptimeBadgeEmbed entity="providers" id={slug} name={p.name ?? undefined} />
+        </DataPageModule>
+      </DataPageCanvas>
 
       <ApiSourceFooter
         paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
       />
-    </>
+    </DataPageStage>
   );
 }
 

--- a/apps/ui/src/routes/-revenue-page.tsx
+++ b/apps/ui/src/routes/-revenue-page.tsx
@@ -2,12 +2,29 @@ import { useMemo } from "react";
 import type { RevenueSearch } from "./revenue";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { Chip, StatTile } from "@jsonbored/ui-kit";
+import {
+  Chip,
+  DefinitionList,
+  ListShell,
+  MetaStrip,
+  MetricGrid,
+  StatTile,
+} from "@jsonbored/ui-kit";
 import { Route } from "./revenue";
-import { chainRevenueCoverageQuery } from "@/lib/metagraphed/queries";
-import { Panel } from "@/components/metagraphed/primitives";
-import { Skeleton, ErrorState } from "@/components/metagraphed/states";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import {
+  DataPageCanvas,
+  DataPageDisclosure,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  FilterSelect,
+  GhostButton,
+  Panel,
+} from "@/components/metagraphed/primitives";
+import { Skeleton, ErrorState, EmptyState } from "@/components/metagraphed/states";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
+import { chainRevenueCoverageQuery } from "@/lib/metagraphed/queries";
 import {
   COVERAGE_SORT_FIELDS,
   HEADLINE_TIERS,
@@ -25,36 +42,70 @@ import {
   usdLabel,
 } from "@/lib/metagraphed/revenue-panel-model";
 
-/**
- * #10478: every subnet's coverage, in one table.
- *
- * THE ORDERING IS WHERE THIS PAGE CAN DO HARM. Sorting `null` as `0` would rank
- * 127 subnets as the worst performers on the network — a claim about each of
- * them at once, and one the data does not support. So unmeasured subnets are
- * never ranked: they sit in their own group below the table, labelled as what
- * they are. The rule lives in coverage-leaderboard-model.ts, where it is tested.
- *
- * The provenance filter shows every tier by default, with counts, because the
- * count is how a reader learns the headline-eligible set is two subnets wide.
- */
-
-const TH = "px-4 py-3 text-left mg-type-caption text-ink-muted";
+const TABLE_HEAD = "mg-table-head-pinned px-4 py-2.5 text-left mg-type-label text-ink-muted";
+const MOBILE_SORT_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "revenue_usd:desc", label: "Revenue · high to low" },
+  { value: "revenue_usd:asc", label: "Revenue · low to high" },
+  { value: "coverage_ratio:desc", label: "Coverage · high to low" },
+  { value: "coverage_ratio:asc", label: "Coverage · low to high" },
+  { value: "subsidy_multiple:desc", label: "Subsidy · high to low" },
+  { value: "subsidy_multiple:asc", label: "Subsidy · low to high" },
+  { value: "emission_usd:desc", label: "Emission · high to low" },
+  { value: "emission_usd:asc", label: "Emission · low to high" },
+  { value: "netuid:asc", label: "Subnet ID · low to high" },
+  { value: "netuid:desc", label: "Subnet ID · high to low" },
+];
 
 function ProvenanceCell({ provenance }: { provenance: string | null }) {
   const eligible = HEADLINE_TIERS.has(provenance ?? "");
   return <Chip tone={eligible ? "accent" : "muted"}>{tierLabel(provenance)}</Chip>;
 }
 
-function SubnetCell({ row }: { row: CoverageRow }) {
+function SubnetCell({ row, compact = false }: { row: CoverageRow; compact?: boolean }) {
   return (
     <Link
       to="/subnets/$netuid"
       params={{ netuid: row.netuid }}
-      className="font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
+      className={
+        compact
+          ? "block truncate font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
+          : "font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
+      }
+      title={row.name ? `SN${row.netuid} · ${row.name}` : `SN${row.netuid}`}
     >
       SN{row.netuid}
       {row.name ? <span className="ml-2 font-sans text-ink-muted">{row.name}</span> : null}
     </Link>
+  );
+}
+
+/**
+ * The touch view has the same truth conditions as the wide table, but leads
+ * with the two decisions people make on a small screen: which subnet, and how
+ * much observed revenue covers its emission. Supporting figures stay present
+ * without forcing a six-column table into a horizontal gesture.
+ */
+function RevenueCard({ row }: { row: CoverageRow }) {
+  return (
+    <Panel as="article" dense>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <SubnetCell row={row} compact />
+          <p className="mt-1 mg-type-data text-ink-muted">Observed external revenue</p>
+        </div>
+        <ProvenanceCell provenance={row.provenance} />
+      </div>
+      <DefinitionList
+        layout="grid"
+        className="mt-4"
+        items={[
+          { term: "Revenue", detail: usdLabel(row.revenue_usd) ?? "—" },
+          { term: "Coverage", detail: coverageLabel(row.coverage_ratio) },
+          { term: "Emission", detail: usdLabel(row.emission_usd) ?? "—" },
+          { term: "Subsidy", detail: subsidyLabel(row.subsidy_multiple) },
+        ]}
+      />
+    </Panel>
   );
 }
 
@@ -86,187 +137,285 @@ export function RevenuePage() {
       }),
     });
 
-  if (q.isError) {
-    return <ErrorState error={q.error} onRetry={() => q.refetch()} context="revenue coverage" />;
-  }
-  if (q.isLoading) return <Skeleton className="h-96 w-full" />;
-
   const sortField = COVERAGE_SORT_FIELDS.includes(search.sort)
     ? search.sort
     : ("revenue_usd" as CoverageSortField);
+  const headlineEligible = rows.filter((row) => HEADLINE_TIERS.has(row.provenance ?? "")).length;
+  const hasLoadedData = !q.isLoading && !q.isError;
 
-  return (
-    <div className="space-y-6">
-      <div className="grid gap-3 sm:grid-cols-3">
-        <StatTile
-          eyebrow="Subnets measured"
-          value={String(measured.length)}
-          hint="With an observable external revenue figure"
-        />
-        <StatTile
-          eyebrow="Not observed"
-          value={String(notObserved.length)}
-          hint="No readable public figure — not measured, not judged"
-        />
-        <StatTile
-          eyebrow="Headline-eligible"
-          value={String(rows.filter((r) => HEADLINE_TIERS.has(r.provenance ?? "")).length)}
-          hint="Chain-verified or probe-derived"
-        />
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="mg-type-caption text-ink-muted">Provenance</span>
-        <button
-          type="button"
-          onClick={() => navigate({ search: (p) => ({ ...p, provenance: "" }) })}
-          className={`rounded-full border px-3 py-1 mg-type-caption ${
-            search.provenance ? "border-border/80 text-ink-muted" : "border-accent text-ink-strong"
-          }`}
-        >
-          All ({rows.length})
-        </button>
-        {options.map((option) => (
-          <button
+  const filters = (
+    <div className="flex w-full flex-wrap items-center gap-2 py-2">
+      <span className="mr-1 mg-type-label text-ink-muted">Evidence</span>
+      <GhostButton
+        size="sm"
+        appearance="terminal"
+        tone={search.provenance ? "default" : "accent"}
+        aria-pressed={!search.provenance}
+        onClick={() => navigate({ search: (prev) => ({ ...prev, provenance: "" }) })}
+      >
+        All <span className="text-ink-muted">{rows.length}</span>
+      </GhostButton>
+      {options.map((option) => {
+        const selected = search.provenance === option.value;
+        return (
+          <GhostButton
             key={option.value}
-            type="button"
+            size="sm"
+            appearance="terminal"
+            tone={selected ? "accent" : "default"}
+            aria-pressed={selected}
             onClick={() =>
               navigate({
-                search: (p) => ({ ...p, provenance: option.value }),
+                search: (prev) => ({ ...prev, provenance: option.value }),
               })
             }
-            className={`rounded-full border px-3 py-1 mg-type-caption ${
-              search.provenance === option.value
-                ? "border-accent text-ink-strong"
-                : "border-border/80 text-ink-muted"
-            }`}
           >
-            {tierLabel(option.value === "none" ? null : option.value)} ({option.count})
-            {option.headlineEligible ? " ★" : ""}
-          </button>
-        ))}
-      </div>
-
-      <div className="overflow-x-auto rounded-2xl border border-border/80">
-        <table className="w-full min-w-[52rem]">
-          <thead>
-            <tr className="border-b border-border/80">
-              <th className={TH} aria-sort={ariaSort(sortField === "netuid", search.dir)}>
-                <SortHeader
-                  label="Subnet"
-                  field="netuid"
-                  active={sortField === "netuid"}
-                  order={search.dir}
-                  onSort={onSort}
-                />
-              </th>
-              <th className={TH}>Provenance</th>
-              <th
-                className={`${TH} text-right`}
-                aria-sort={ariaSort(sortField === "emission_usd", search.dir)}
-              >
-                <SortHeader
-                  label="Emission"
-                  field="emission_usd"
-                  active={sortField === "emission_usd"}
-                  order={search.dir}
-                  onSort={onSort}
-                  align="right"
-                />
-              </th>
-              <th
-                className={`${TH} text-right`}
-                aria-sort={ariaSort(sortField === "revenue_usd", search.dir)}
-              >
-                <SortHeader
-                  label="Revenue"
-                  field="revenue_usd"
-                  active={sortField === "revenue_usd"}
-                  order={search.dir}
-                  onSort={onSort}
-                  align="right"
-                />
-              </th>
-              <th
-                className={`${TH} text-right`}
-                aria-sort={ariaSort(sortField === "coverage_ratio", search.dir)}
-              >
-                <SortHeader
-                  label="Coverage"
-                  field="coverage_ratio"
-                  active={sortField === "coverage_ratio"}
-                  order={search.dir}
-                  onSort={onSort}
-                  align="right"
-                />
-              </th>
-              <th
-                className={`${TH} text-right`}
-                aria-sort={ariaSort(sortField === "subsidy_multiple", search.dir)}
-              >
-                <SortHeader
-                  label="Subsidy"
-                  field="subsidy_multiple"
-                  active={sortField === "subsidy_multiple"}
-                  order={search.dir}
-                  onSort={onSort}
-                  align="right"
-                />
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {measured.map((row) => (
-              <tr key={row.netuid} className="border-b border-border/40">
-                <td className="px-4 py-3">
-                  <SubnetCell row={row} />
-                </td>
-                <td className="px-4 py-3">
-                  <ProvenanceCell provenance={row.provenance} />
-                </td>
-                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
-                  {usdLabel(row.emission_usd) ?? "—"}
-                </td>
-                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
-                  {usdLabel(row.revenue_usd) ?? "—"}
-                </td>
-                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
-                  {coverageLabel(row.coverage_ratio)}
-                </td>
-                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
-                  {subsidyLabel(row.subsidy_multiple)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {notObserved.length > 0 ? (
-        <div className="space-y-2">
-          {/* Visually distinct and OUTSIDE the ranked table, because ordering
-              these by a figure nobody measured is the defect this page exists
-              not to have. */}
-          <Panel as="div" dense bodyClassName="mg-type-caption text-ink-muted">
-            {notObservedNote(notObserved.length, rows.length)}
-          </Panel>
-          <div className="flex flex-wrap gap-2">
-            {notObserved.map((row) => (
-              <span key={row.netuid} className="rounded-full border border-border/60 px-3 py-1">
-                <SubnetCell row={row} />
-              </span>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      <Link
-        to="/docs/$"
-        params={{ _splat: "revenue-coverage" }}
-        className="mg-type-caption text-accent hover:underline"
-      >
-        How the ratio is derived, and what it does not mean
-      </Link>
+            {tierLabel(option.value === "none" ? null : option.value)}
+            <span className="text-ink-muted">{option.count}</span>
+            {option.headlineEligible ? <span aria-label="headline eligible">★</span> : null}
+          </GhostButton>
+        );
+      })}
+      <label className="flex min-w-[13rem] flex-1 flex-col gap-1 lg:hidden">
+        <span className="mg-type-caption text-ink-muted">Sort observed rows</span>
+        <FilterSelect
+          aria-label="Sort coverage leaderboard"
+          value={`${sortField}:${search.dir}`}
+          onChange={(event) => {
+            const [field, dir] = event.target.value.split(":");
+            if (!COVERAGE_SORT_FIELDS.includes(field as CoverageSortField)) return;
+            navigate({
+              search: (prev) => ({
+                ...prev,
+                sort: field as CoverageSortField,
+                dir: dir === "asc" ? "asc" : "desc",
+              }),
+            });
+          }}
+        >
+          {MOBILE_SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </FilterSelect>
+      </label>
     </div>
+  );
+
+  const emptyNode = (
+    <EmptyState
+      title="No observed figures in this view"
+      description="Try another evidence tier. Subnets without an observable external-revenue figure remain separate and never receive a rank."
+    />
+  );
+
+  return (
+    <AppShell>
+      <DataPageStage>
+        <DataPageHero
+          variant="directory"
+          id="revenue-coverage-title"
+          eyebrow="Network economics"
+          live
+          title="Revenue coverage."
+          description="Observable external revenue, set against the TAO each subnet receives in emission."
+          summary={
+            hasLoadedData ? (
+              <MetaStrip
+                items={[
+                  { label: "Measured", value: measured.length },
+                  { label: "Not observed", value: notObserved.length },
+                  { label: "Headline-ready", value: headlineEligible },
+                ]}
+              />
+            ) : undefined
+          }
+          footer={
+            <>
+              <span>Absence is not zero — only observed figures are ranked.</span>
+              <Link
+                to="/docs/$"
+                params={{ _splat: "revenue-coverage" }}
+                className="text-accent hover:text-ink-strong hover:underline"
+              >
+                Methodology
+              </Link>
+            </>
+          }
+        />
+
+        <DataPageCanvas>
+          <DataPageModule
+            kind="question"
+            title="What is measured"
+            caption="Publicly observable external revenue is the entry condition; the coverage ratio is never inferred from a missing figure."
+          >
+            {q.isLoading ? (
+              <Skeleton className="h-28 w-full" />
+            ) : q.isError ? (
+              <ErrorState error={q.error} onRetry={() => q.refetch()} context="revenue coverage" />
+            ) : (
+              <MetricGrid cols={{ base: 1, sm: 3 }} gap="sm">
+                <StatTile
+                  eyebrow="Measured"
+                  value={String(measured.length)}
+                  hint="observable figure"
+                />
+                <StatTile
+                  eyebrow="Not observed"
+                  value={String(notObserved.length)}
+                  hint="separate, never ranked"
+                />
+                <StatTile
+                  eyebrow="Headline-ready"
+                  value={String(headlineEligible)}
+                  hint="verified or probe-derived"
+                  tone="accent"
+                />
+              </MetricGrid>
+            )}
+          </DataPageModule>
+
+          {!q.isError ? (
+            <DataPageModule
+              kind="question"
+              title="Coverage leaderboard"
+              caption="Sort the observed set by revenue, emission, coverage, or subsidy. A missing value is not a score."
+            >
+              {q.isLoading ? (
+                <Skeleton className="h-96 w-full" />
+              ) : (
+                <ListShell
+                  presentation="canvas"
+                  responsiveAt="lg"
+                  filters={filters}
+                  isEmpty={measured.length === 0}
+                  empty={emptyNode}
+                  cards={measured.map((row) => (
+                    <RevenueCard key={row.netuid} row={row} />
+                  ))}
+                  table={
+                    <table className="w-full min-w-[52rem] text-left text-sm">
+                      <thead>
+                        <tr>
+                          <th
+                            className={TABLE_HEAD}
+                            aria-sort={ariaSort(sortField === "netuid", search.dir)}
+                          >
+                            <SortHeader
+                              label="Subnet"
+                              field="netuid"
+                              active={sortField === "netuid"}
+                              order={search.dir}
+                              onSort={onSort}
+                            />
+                          </th>
+                          <th className={TABLE_HEAD}>Evidence</th>
+                          <th
+                            className={`${TABLE_HEAD} text-right`}
+                            aria-sort={ariaSort(sortField === "emission_usd", search.dir)}
+                          >
+                            <SortHeader
+                              label="Emission"
+                              field="emission_usd"
+                              active={sortField === "emission_usd"}
+                              order={search.dir}
+                              onSort={onSort}
+                              align="right"
+                            />
+                          </th>
+                          <th
+                            className={`${TABLE_HEAD} text-right`}
+                            aria-sort={ariaSort(sortField === "revenue_usd", search.dir)}
+                          >
+                            <SortHeader
+                              label="Revenue"
+                              field="revenue_usd"
+                              active={sortField === "revenue_usd"}
+                              order={search.dir}
+                              onSort={onSort}
+                              align="right"
+                            />
+                          </th>
+                          <th
+                            className={`${TABLE_HEAD} text-right`}
+                            aria-sort={ariaSort(sortField === "coverage_ratio", search.dir)}
+                          >
+                            <SortHeader
+                              label="Coverage"
+                              field="coverage_ratio"
+                              active={sortField === "coverage_ratio"}
+                              order={search.dir}
+                              onSort={onSort}
+                              align="right"
+                            />
+                          </th>
+                          <th
+                            className={`${TABLE_HEAD} text-right`}
+                            aria-sort={ariaSort(sortField === "subsidy_multiple", search.dir)}
+                          >
+                            <SortHeader
+                              label="Subsidy"
+                              field="subsidy_multiple"
+                              active={sortField === "subsidy_multiple"}
+                              order={search.dir}
+                              onSort={onSort}
+                              align="right"
+                            />
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-border">
+                        {measured.map((row) => (
+                          <tr key={row.netuid} className="mg-row-accent hover:bg-surface/40">
+                            <td className="px-4 py-3">
+                              <SubnetCell row={row} />
+                            </td>
+                            <td className="px-4 py-3">
+                              <ProvenanceCell provenance={row.provenance} />
+                            </td>
+                            <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                              {usdLabel(row.emission_usd) ?? "—"}
+                            </td>
+                            <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                              {usdLabel(row.revenue_usd) ?? "—"}
+                            </td>
+                            <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                              {coverageLabel(row.coverage_ratio)}
+                            </td>
+                            <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                              {subsidyLabel(row.subsidy_multiple)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  }
+                />
+              )}
+            </DataPageModule>
+          ) : null}
+
+          {hasLoadedData && notObserved.length > 0 ? (
+            <DataPageModule
+              kind="operations"
+              title="Not observed"
+              caption={notObservedNote(notObserved.length, rows.length)}
+            >
+              <DataPageDisclosure label={`Show ${notObserved.length} unmeasured subnets`}>
+                <ul className="grid grid-cols-2 gap-x-4 gap-y-2 pb-1 sm:grid-cols-3 lg:grid-cols-4">
+                  {notObserved.map((row) => (
+                    <li key={row.netuid} className="min-w-0 border-l border-border pl-2">
+                      <SubnetCell row={row} compact />
+                    </li>
+                  ))}
+                </ul>
+              </DataPageDisclosure>
+            </DataPageModule>
+          ) : null}
+        </DataPageCanvas>
+      </DataPageStage>
+    </AppShell>
   );
 }

--- a/apps/ui/src/routes/-settings-page.tsx
+++ b/apps/ui/src/routes/-settings-page.tsx
@@ -1,5 +1,10 @@
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import {
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+} from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { WebhookSubscriptionManager } from "@/components/metagraphed/webhook-subscription-manager";
 import { ApiKeysManager } from "@/components/metagraphed/api-keys-manager";
@@ -14,35 +19,44 @@ export function SettingsPage() {
   const kpis = buildSettingsHeroKpis();
   return (
     <AppShell>
-      <PageMasthead
-        eyebrow="Developer"
-        live
-        title="Developer settings"
-        description="Your watchlist's export/import, self-service webhook subscription management against the public subscription API (no account model), wallet-connected API key management for gated fullnode access, and your own verified chain alert triggers."
-        caption={<>webhooks / v1</>}
-        kpis={kpis}
-      />
-      {/* #8384: install affordance renders nothing when there's nothing to
+      <DataPageStage>
+        <PageMasthead
+          eyebrow="Developer"
+          live
+          title="Developer settings"
+          description="Your watchlist's export/import, self-service webhook subscription management against the public subscription API (no account model), wallet-connected API key management for gated fullnode access, and your own verified chain alert triggers."
+          caption={<>webhooks / v1</>}
+          kpis={kpis}
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title="Your local workspace."
+            caption="Portable browser-local state, developer credentials, webhooks, and the alerts you have configured."
+          >
+            {/* #8384: install affordance renders nothing when there's nothing to
           offer (already installed, dismissed, unsupported browser). */}
-      <InstallAppRow />
-      {/* #8256: no account model means stars live in one browser. A JSON
+            <InstallAppRow />
+            {/* #8256: no account model means stars live in one browser. A JSON
           file is the whole portability story -- no server, no sync. */}
-      <WatchlistPortability />
-      {/* #8484: private, local-first labels for your own addresses —
+            <WatchlistPortability />
+            {/* #8484: private, local-first labels for your own addresses —
           distinct store from the watchlist, same portability posture. */}
-      <AddressLabelPortability />
-      <ApiKeysManager />
-      <AlertsManager />
-      {/* #10300: the UI could always CREATE an alert trigger and never read one
+            <AddressLabelPortability />
+            <ApiKeysManager />
+            <AlertsManager />
+            {/* #10300: the UI could always CREATE an alert trigger and never read one
           back, so "is it still active, and has it ever fired" had no answer.
           GET /api/v1/alerts/triggers/{id} was published and rendered nowhere. */}
-      <div className="mt-6">
-        <AlertTriggerLookup />
-      </div>
-      <WebhookSubscriptionManager />
-      <ApiSourceFooter
-        paths={["/api/v1/webhooks/subscriptions", "/api/v1/keys", "/api/v1/watch/triggers"]}
-      />
+            <div className="mt-6">
+              <AlertTriggerLookup />
+            </div>
+            <WebhookSubscriptionManager />
+          </DataPageModule>
+        </DataPageCanvas>
+        <ApiSourceFooter
+          paths={["/api/v1/webhooks/subscriptions", "/api/v1/keys", "/api/v1/watch/triggers"]}
+        />
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-status-page.tsx
+++ b/apps/ui/src/routes/-status-page.tsx
@@ -8,15 +8,16 @@ import { ArrowUpRight, ChevronDown } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { SelfHealthVerdict } from "@/components/metagraphed/self-health-verdict";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { AsyncPanel, Panel } from "@/components/metagraphed/primitives";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import {
-  CopyableCode,
-  ExternalLink,
-  SectionHeading,
-  TimeAgo,
-  AnimatedNumber,
-} from "@jsonbored/ui-kit";
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  Panel,
+} from "@/components/metagraphed/primitives";
+import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { CopyableCode, ExternalLink, TimeAgo, AnimatedNumber } from "@jsonbored/ui-kit";
 import { healthQuery, globalIncidentsQuery, incidentsFeedQuery } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { classNames, humaniseSeconds } from "@/lib/metagraphed/format";
@@ -46,95 +47,101 @@ export function StatusPage() {
   useRegistryEvents();
   return (
     <AppShell>
-      <PageHeading
-        eyebrow="Public status"
-        title="System status"
-        description="Is Metagraphed up? That question, answered first — then what we're seeing across the subnet surfaces we track. Probe-derived only; nobody can self-report their own health here."
-        right={
-          <Link
-            to="/health"
-            className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1.5 mg-type-caption font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
+      <DataPageStage>
+        <DataPageHero
+          id="status-title"
+          eyebrow="Public status"
+          live
+          title="System status."
+          description="Is Metagraphed up? That question is answered first, followed by the probe-derived state of the subnet surfaces we track."
+          actions={
+            <Link
+              to="/health"
+              className="inline-flex min-h-11 items-center gap-1 border border-border px-3 py-1.5 mg-type-caption font-medium text-ink-muted transition-colors hover:border-accent/50 hover:text-ink-strong"
+            >
+              Ops console
+              <ArrowUpRight className="size-3" aria-hidden="true" />
+            </Link>
+          }
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title="Current operating state."
+            caption="Metagraphed's own components only — third-party endpoint trouble cannot turn this into a false platform outage."
           >
-            Ops console
-            <ArrowUpRight className="size-3" aria-hidden="true" />
-          </Link>
-        }
-      />
-      <div className="space-y-section">
-        {/* #8250: the verdict is scoped to OUR components and nothing else.
+            {/* #8250: the verdict is scoped to OUR components and nothing else.
             The old one derived "Partial outage" from the third-party surface
             counts below, so 3 of 617 someone-else's endpoints being down
             painted a red banner that read as "metagraphed is down" -- on the
             one page whose entire job is answering that accurately. */}
-        <AsyncPanel
-          context="status verdict"
-          fallback={<Skeleton className="h-40 w-full" />}
-          retryQueryKeys={[healthQuery().queryKey]}
-        >
-          <SelfHealthVerdict />
-        </AsyncPanel>
+            <AsyncPanel
+              context="status verdict"
+              fallback={<Skeleton className="h-40 w-full" />}
+              retryQueryKeys={[healthQuery().queryKey]}
+            >
+              <SelfHealthVerdict />
+            </AsyncPanel>
+          </DataPageModule>
 
-        <section>
-          <SectionHeading
-            title="Recent incidents"
-            intro="Probe-detected downtime across the subnet surfaces we track, newest first."
-          />
-          <AsyncPanel context="recent incidents" fallback={<Skeleton className="h-32 w-full" />}>
-            <RecentIncidents />
-          </AsyncPanel>
-        </section>
-
-        <section>
-          <SectionHeading
-            title="Subscribe"
-            intro="The same downtime stream as a feed — RSS, Atom, or JSON Feed."
-          />
-          <AsyncPanel
-            context="incidents feed"
-            fallback={<Skeleton className="h-32 w-full" />}
-            retryQueryKeys={[incidentsFeedQuery().queryKey]}
+          <DataPageModule
+            title="Recent incidents."
+            caption="Probe-detected downtime across the subnet surfaces we track, newest first."
           >
-            <IncidentsFeedSubscribe />
-          </AsyncPanel>
-        </section>
+            <AsyncPanel context="recent incidents" fallback={<Skeleton className="h-32 w-full" />}>
+              <RecentIncidents />
+            </AsyncPanel>
+          </DataPageModule>
 
-        {/* #8250: the per-day probe drill-down (96,395px) and the per-provider
+          <DataPageModule
+            title="Subscribe."
+            caption="The same downtime stream as RSS, Atom, or JSON Feed."
+          >
+            <AsyncPanel
+              context="incidents feed"
+              fallback={<Skeleton className="h-32 w-full" />}
+              retryQueryKeys={[incidentsFeedQuery().queryKey]}
+            >
+              <IncidentsFeedSubscribe />
+            </AsyncPanel>
+          </DataPageModule>
+
+          {/* #8250: the per-day probe drill-down (96,395px) and the per-provider
             source-health rollup (11,251px) left this page -- together they were
             94% of its 115,233px height, and neither answers "is it up". Both
             are operational drill-downs and now live only on the ops console
             they were always duplicating. The per-subnet view lives on each
             subnet's own API tab. */}
-        <section>
-          <SectionHeading
-            title="Go deeper"
-            intro="Per-day probe results, per-provider verification, the live mosaic and the full surface ledger are operational views — they live on the ops console."
-          />
-          <div className="flex flex-wrap gap-2">
-            <Link
-              to="/health"
-              className="inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:border-accent/40"
-            >
-              Ops console
-              <ArrowUpRight className="size-3" aria-hidden="true" />
-            </Link>
-            <Link
-              to="/apis/endpoints"
-              className="inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 mg-type-caption font-medium text-ink-strong hover:border-accent/40"
-            >
-              Browse all surfaces
-              <ArrowUpRight className="size-3" aria-hidden="true" />
-            </Link>
-          </div>
-        </section>
-      </div>
-      <ApiSourceFooter
-        paths={[
-          "/api/v1/self-health",
-          "/api/v1/health",
-          "/api/v1/incidents",
-          "/api/v1/feeds/incidents",
-        ]}
-      />
+          <DataPageModule
+            title="Go deeper."
+            caption="Per-day probe results, verification, the live mosaic, and the surface ledger live in the operational console."
+          >
+            <div className="flex flex-wrap gap-2">
+              <Link
+                to="/health"
+                className="inline-flex min-h-11 items-center gap-1.5 border border-border px-3 py-1.5 mg-type-caption font-medium text-ink-strong transition-colors hover:border-accent/50"
+              >
+                Ops console
+                <ArrowUpRight className="size-3" aria-hidden="true" />
+              </Link>
+              <Link
+                to="/apis/endpoints"
+                className="inline-flex min-h-11 items-center gap-1.5 border border-border px-3 py-1.5 mg-type-caption font-medium text-ink-strong transition-colors hover:border-accent/50"
+              >
+                Browse all surfaces
+                <ArrowUpRight className="size-3" aria-hidden="true" />
+              </Link>
+            </div>
+          </DataPageModule>
+        </DataPageCanvas>
+        <ApiSourceFooter
+          paths={[
+            "/api/v1/self-health",
+            "/api/v1/health",
+            "/api/v1/incidents",
+            "/api/v1/feeds/incidents",
+          ]}
+        />
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-subnets-category-page.tsx
+++ b/apps/ui/src/routes/-subnets-category-page.tsx
@@ -3,7 +3,10 @@ import { Link, useParams } from "@tanstack/react-router";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
   AsyncPanel,
-  PageMasthead,
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
   Panel,
   TableSkeleton,
 } from "@/components/metagraphed/primitives";
@@ -121,15 +124,25 @@ export function SubnetCategoryPage() {
   const copy = categoryCopy(slug);
   return (
     <AppShell>
-      <PageMasthead
-        live
-        eyebrow="Category"
-        title={`${copy.label} subnets`}
-        description={copy.summary}
-      />
-      <AsyncPanel context="subnet-category" fallback={<TableSkeleton rows={8} columns={4} />}>
-        <CategoryTable slug={slug} />
-      </AsyncPanel>
+      <DataPageStage>
+        <DataPageHero
+          id="subnet-category-title"
+          eyebrow="Registry category"
+          live
+          title={`${copy.label} subnets.`}
+          description={copy.summary}
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title={`Compare ${copy.label.toLowerCase()} work.`}
+            caption="The category view turns a registry label into a compact, evidence-backed comparison."
+          >
+            <AsyncPanel context="subnet-category" fallback={<TableSkeleton rows={8} columns={4} />}>
+              <CategoryTable slug={slug} />
+            </AsyncPanel>
+          </DataPageModule>
+        </DataPageCanvas>
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -24,10 +24,14 @@ import {
   StickyToolbar,
   TableSkeleton,
   useColumnVisibility,
+  DataPageCanvas,
+  DataPageDisclosure,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
   type ColumnDef,
   type FilterChipItem,
   type HealthStatus,
-  PageMasthead,
 } from "@/components/metagraphed/primitives";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -58,12 +62,7 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useInView } from "@/hooks/use-in-view";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
-import {
-  ariaSort,
-  FilterChip,
-  ResetFiltersButton,
-  SortHeader,
-} from "@/components/metagraphed/table-controls";
+import { ariaSort, FilterChip, SortHeader } from "@/components/metagraphed/table-controls";
 import { SubnetsSavedViews } from "@/components/metagraphed/subnets-saved-views";
 import {
   SubnetsCompareDrawer,
@@ -90,7 +89,7 @@ import {
   formatSubnetAge,
 } from "@/lib/metagraphed/format";
 import { SubnetCategoryLinks } from "@/components/metagraphed/subnet-category-links";
-import { HubSections, hubLede } from "@/components/metagraphed/hub-prose";
+import { HubSections } from "@/components/metagraphed/hub-prose";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { joinEconomics, joinHealth, matchesQuery, sortBy } from "@/lib/metagraphed/url-state";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -190,31 +189,12 @@ function joinCatalog(
 export function SubnetsPage() {
   const search = useSearch({ from: "/subnets/" }) as SubnetsSearch;
   const navigate = useNavigate({ from: "/subnets/" });
-  const filtersActive =
-    !!search.q ||
-    !!search.sort ||
-    !!search.curation ||
-    !!search.health ||
-    !!search.serviceKind ||
-    !!search.readiness ||
-    !!search.kind ||
-    !!search.stale ||
-    !!search.domain ||
-    !!search.watched ||
-    // #6270: defaults to true, so hiding the root is what makes it "active" —
-    // without this the Reset button stays disabled while a filter is applied.
-    !search.includeRoot;
-  const onReset = () =>
-    navigate({
-      search: { view: search.view },
-      replace: true,
-    });
   const setView = (v: ViewMode) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, view: v }),
       replace: true,
     });
-  const isMobile = useIsMobile();
+  const isMobile = useIsMobile(1024);
   const effectiveDensity: Density =
     search.density === "compact" || search.density === "comfortable"
       ? search.density
@@ -237,146 +217,126 @@ export function SubnetsPage() {
       replace: true,
       resetScroll: false,
     });
-  const subnetsCsvUrl = buildUrl("/api/v1/subnets", { limit: SUBNETS_ALL_LIMIT });
   return (
     <AppShell>
-      <PageMasthead
-        live
-        title="Subnets"
-        // #11320: from HUB_COPY, not a second hand-written string. This slot
-        // and <meta name="description"> were separately authored copies of the
-        // same fact -- the shape that let /apis ship a title and an og:title
-        // naming the page differently.
-        description={hubLede("/subnets")}
-        actions={
-          /* Display/export are useful desktop controls, but on phone and
-             tablet they previously became an unexplained row of icons before
-             the directory task. Narrow layouts expose the same choices as
-             named controls in the Filters sheet below. */
-          <div className="hidden lg:flex flex-wrap items-center gap-2">
-            {search.section === "registry" ? (
-              <>
-                <ViewModeToggle value={search.view} onChange={setView} />
-                {search.view === "table" ? (
-                  <DensityToggle value={effectiveDensity} onChange={setDensity} />
-                ) : null}
-              </>
-            ) : null}
-            <ActionBar>
-              {search.section === "rankings" ? (
-                <LeaderboardsCsvExportMenu win={search.window} />
-              ) : (
-                <>
-                  <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
-                  <DownloadCsvButton url={subnetsCsvUrl} bare />
-                </>
-              )}
-              <ShareButton bare />
-            </ActionBar>
-          </div>
-        }
-      />
-      {/* #8248: masthead trim -- the old nine meta-cards (SubnetsHighlights +
-          a 5-tile SubnetsStatStrip) pushed the table ~1,700px down on mobile
-          and led with an incident card, before any actionable content. Ops
-          signals (incidents/drift/pilot counts) now live only on their owning
-          pages (/apis/endpoints, /status); this page keeps at most 4 inline
-          facts a reader of a SUBNET list actually wants first. */}
-      {/* #8311: /leaderboards folded in here. Every board ranks subnets, so a
-          separate top-level route for them was an IA accident. A section tab
-          rather than a `view` mode -- see subnets.index.tsx for why. */}
-      <SectionTabs section={search.section} onChange={setSection} />
+      <DataPageStage>
+        <DataPageHero
+          id="subnets-title"
+          eyebrow="Network registry"
+          live
+          title="Subnets."
+          description="Live subnet economics, public surfaces, and probe health."
+          footer={
+            <AsyncPanel context="subnets summary" fallback={<PanelSkeleton height="xs" />}>
+              <SubnetsCompactStats />
+            </AsyncPanel>
+          }
+        />
 
-      {search.section === "rankings" ? (
-        <LeaderboardsSection win={search.window} onWindowChange={setWindow} />
-      ) : (
-        <>
-          <AsyncPanel
-            context="subnets summary"
-            fallback={<PanelSkeleton height="xs" className="mb-4" />}
-          >
-            <SubnetsCompactStats />
-          </AsyncPanel>
-          <SubnetsSavedViews />
-          <AsyncPanel
-            context="subnets"
-            fallback={
-              <TableSkeleton
-                rows={search.view === "table" ? 10 : 6}
-                columns={search.view === "table" ? 8 : 4}
-                density={effectiveDensity}
-              />
-            }
-          >
-            <SubnetsTable
-              view={search.view}
-              density={effectiveDensity}
-              onViewChange={setView}
-              onDensityChange={setDensity}
-            />
-          </AsyncPanel>
-          <AsyncPanel
-            context="domains rollup"
-            fallback={<PanelSkeleton height="sm" className="mt-6" />}
-          >
-            <SubnetsDomainsRollup />
-          </AsyncPanel>
-          {/* #8311: /domains folded in. The chips above are a filter; this is
-              the taxonomy itself -- members, stake, emission share and
-              within-domain concentration per domain. Collapsed by default so
-              it costs nothing to the reader who came for the table, and its
-              query doesn't fire until opened. */}
-          <SubnetsDomainsTaxonomy />
-          {/* #10300: network-wide registration/deregistration was published
-              and rendered nowhere. It belongs beside the registry table --
-              "which subnets came and went" is the same question the table
-              answers as a snapshot. */}
-          <section className="mt-8">
-            <h2 className="mb-2 mg-type-label text-ink-muted">Registration churn</h2>
-            <NetworkSubnetLifecycle />
-          </section>
-          {/* #11204: the table above virtualizes, so its server-rendered HTML
-              carries anchors for ~30 of 129 subnets and the other 99 pages had
-              no internal link anywhere on the site. This is the complete index
-              — see the component for why it is not a duplicate of the table. */}
-          <AsyncPanel
-            context="subnet index"
-            fallback={<PanelSkeleton height="sm" className="mt-8" />}
-          >
-            <SubnetIndexDirectory />
-          </AsyncPanel>
-        </>
-      )}
-      <ApiSourceFooter
-        paths={
-          search.section === "rankings"
-            ? [
-                "/api/v1/registry/leaderboards",
-                "/api/v1/chain/weights",
-                "/api/v1/chain/deregistrations",
-                "/api/v1/economics",
-              ]
-            : ["/api/v1/subnets", "/api/v1/domains", "/api/v1/chain/subnet-lifecycle"]
-        }
-        artifacts={search.section === "rankings" ? undefined : ["/metagraph/subnets.json"]}
-      />
-      {/*
-        #11316 / #11342: REAL anchors, not prose naming a path. Sitemap-only is
-        the profile that lands a URL in "Crawled - currently not indexed"
-        (#11277), and every faceted page needs an inbound link from the hub it
-        filters. The category list is derived from the rendered rows, so a
-        category the registry stops deriving stops being linked.
-      */}
-      <SubnetCategoryLinks />
-      <p className="mt-8 mg-type-caption text-ink-muted">
-        Looking for the ones you can integrate with?{" "}
-        <Link to="/subnets/with-api" className="text-accent-text hover:underline">
-          Subnets publishing a machine-readable API spec
-        </Link>
-        .
-      </p>
-      {/* Below the table on purpose -- see hub-prose.tsx. */}
-      <HubSections path="/subnets" />
+        <DataPageCanvas>
+          {/* Rankings is a sibling task, not a separate destination. */}
+          <SectionTabs
+            className="mg-directory-tabs"
+            section={search.section}
+            onChange={setSection}
+          />
+
+          {search.section === "rankings" ? (
+            <DataPageModule
+              title="Subnet rankings."
+              caption="Compare live subnet leaders without leaving the registry."
+              actions={
+                <ActionBar>
+                  <LeaderboardsCsvExportMenu win={search.window} />
+                  <ShareButton bare />
+                </ActionBar>
+              }
+            >
+              <LeaderboardsSection win={search.window} onWindowChange={setWindow} />
+            </DataPageModule>
+          ) : (
+            <>
+              <DataPageModule
+                title="Live registry."
+                caption="Search, compare, and open a subnet dossier."
+              >
+                <SubnetsSavedViews />
+                <AsyncPanel
+                  context="subnets"
+                  fallback={
+                    <TableSkeleton
+                      rows={search.view === "table" ? 10 : 6}
+                      columns={search.view === "table" ? 8 : 4}
+                      density={effectiveDensity}
+                    />
+                  }
+                >
+                  <SubnetsTable
+                    view={search.view}
+                    density={effectiveDensity}
+                    onViewChange={setView}
+                    onDensityChange={setDensity}
+                  />
+                </AsyncPanel>
+              </DataPageModule>
+
+              {/* Secondary context is available when useful, but no longer
+                  delays the directory task or turns the first scroll into a
+                  wall of equal-weight cards. */}
+              <DataPageModule
+                title="Registry context."
+                caption="Domain coverage, churn, and the complete linked index."
+              >
+                <DataPageDisclosure label="Explore registry context">
+                  <AsyncPanel context="domains rollup" fallback={<PanelSkeleton height="sm" />}>
+                    <SubnetsDomainsRollup />
+                  </AsyncPanel>
+                  <SubnetsDomainsTaxonomy />
+                  <section className="mt-8">
+                    <h3 className="mb-2 mg-type-label text-ink-muted">Registration churn</h3>
+                    <NetworkSubnetLifecycle />
+                  </section>
+                  {/* The virtualized table intentionally only mounts visible
+                      rows. This complete link index preserves access to every
+                      subnet detail URL without duplicating the primary list. */}
+                  <AsyncPanel
+                    context="subnet index"
+                    fallback={<PanelSkeleton height="sm" className="mt-8" />}
+                  >
+                    <SubnetIndexDirectory />
+                  </AsyncPanel>
+                </DataPageDisclosure>
+              </DataPageModule>
+            </>
+          )}
+        </DataPageCanvas>
+
+        <ApiSourceFooter
+          paths={
+            search.section === "rankings"
+              ? [
+                  "/api/v1/registry/leaderboards",
+                  "/api/v1/chain/weights",
+                  "/api/v1/chain/deregistrations",
+                  "/api/v1/economics",
+                ]
+              : ["/api/v1/subnets", "/api/v1/domains", "/api/v1/chain/subnet-lifecycle"]
+          }
+          artifacts={search.section === "rankings" ? undefined : ["/metagraph/subnets.json"]}
+        />
+        {/* Real anchors for faceted routes remain in the document for readers
+            and crawlers, but follow the main directory rather than competing
+            with it above the fold. */}
+        <SubnetCategoryLinks />
+        <p className="mt-8 mg-type-caption text-ink-muted">
+          Looking for the ones you can integrate with?{" "}
+          <Link to="/subnets/with-api" className="text-accent-text hover:underline">
+            Subnets publishing a machine-readable API spec
+          </Link>
+          .
+        </p>
+        <HubSections path="/subnets" />
+      </DataPageStage>
       <SubnetsCompareDrawer />
       <BackToTop />
     </AppShell>
@@ -424,7 +384,7 @@ function SubnetsCompactStats() {
       </>
     );
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 mg-type-data text-ink-muted">
+    <div className="mg-directory-summary">
       <span>
         <span className="font-medium text-ink-strong">{formatNumber(active)}</span> active
         {total ? ` of ${formatNumber(total)}` : ""}
@@ -982,9 +942,8 @@ function SubnetsTable({
     </div>
   );
 
-  // The filter-sheet badge needs to represent every refinement it now owns at
-  // phone/tablet widths — not just the five dropdowns it originally held.
-  // Search remains outside the sheet, so it deliberately is not counted here.
+  // The control sheet owns both display and filter refinements. Search stays
+  // in the command rail, so it deliberately is not counted in its badge.
   const filterSheetCount =
     (search.health ? 1 : 0) +
     (search.curation ? 1 : 0) +
@@ -1000,8 +959,8 @@ function SubnetsTable({
     : "Root subnet hidden — click to show it again";
   const subnetsCsvUrl = buildUrl("/api/v1/subnets", { limit: SUBNETS_ALL_LIMIT });
 
-  const mobileRefinements = (
-    <div className="flex flex-col gap-3 border-b border-border pb-4 lg:hidden">
+  const directoryRefinements = (
+    <div className="flex flex-col gap-3 border-b border-border pb-4">
       <div className="flex flex-col gap-2">
         <span className="mg-type-label uppercase text-ink-muted">Display</span>
         <ViewModeToggle
@@ -1166,10 +1125,10 @@ function SubnetsTable({
         </QueryBar>
         <FilterSheet
           className="mg-subnets-filter-sheet shrink-0 [&>button]:min-h-11"
-          label="Filters"
+          label="Controls"
           activeCount={filterSheetCount}
         >
-          {mobileRefinements}
+          {directoryRefinements}
           {secondaryFilters}
         </FilterSheet>
       </div>
@@ -1312,6 +1271,8 @@ function SubnetsTable({
     <div id="subnets-list" className="relative">
       <QueryProgress active={isFetching} position="sticky" />
       <ListShell
+        presentation="canvas"
+        responsiveAt="lg"
         filters={filters}
         isEmpty={rows.length === 0}
         isStale={isFetching}
@@ -2346,15 +2307,17 @@ function SurfacesCell({ subnet, density = "comfortable" }: { subnet: Subnet; den
 function SectionTabs({
   section,
   onChange,
+  className,
 }: {
   section: "registry" | "rankings";
   onChange: (s: "registry" | "rankings") => void;
+  className?: string;
 }) {
   return (
     <div
       role="tablist"
       aria-label="Subnets sections"
-      className="mb-4 flex items-center gap-1 border-b border-border"
+      className={classNames("mb-4 flex items-center gap-1 border-b border-border", className)}
     >
       {(
         [

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -249,7 +249,11 @@ export function SubnetsPage() {
         // naming the page differently.
         description={hubLede("/subnets")}
         actions={
-          <>
+          /* Display/export are useful desktop controls, but on phone and
+             tablet they previously became an unexplained row of icons before
+             the directory task. Narrow layouts expose the same choices as
+             named controls in the Filters sheet below. */
+          <div className="hidden lg:flex flex-wrap items-center gap-2">
             {search.section === "registry" ? (
               <>
                 <ViewModeToggle value={search.view} onChange={setView} />
@@ -269,7 +273,7 @@ export function SubnetsPage() {
               )}
               <ShareButton bare />
             </ActionBar>
-          </>
+          </div>
         }
       />
       {/* #8248: masthead trim -- the old nine meta-cards (SubnetsHighlights +
@@ -304,7 +308,12 @@ export function SubnetsPage() {
               />
             }
           >
-            <SubnetsTable view={search.view} density={effectiveDensity} />
+            <SubnetsTable
+              view={search.view}
+              density={effectiveDensity}
+              onViewChange={setView}
+              onDensityChange={setDensity}
+            />
           </AsyncPanel>
           <AsyncPanel
             context="domains rollup"
@@ -529,7 +538,7 @@ function ExcludeToggle({
       aria-pressed={hidden}
       title={title}
       className={classNames(
-        "mg-type-caption inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 transition-colors",
+        "mg-type-caption inline-flex min-h-11 items-center gap-1.5 rounded border px-2 py-1 transition-colors lg:min-h-9",
         hidden
           ? "border-accent/40 bg-accent/10 text-accent"
           : "border-border bg-card text-ink-muted hover:text-ink-strong",
@@ -542,7 +551,17 @@ function ExcludeToggle({
   );
 }
 
-function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; density?: Density }) {
+function SubnetsTable({
+  view,
+  density = "comfortable",
+  onViewChange,
+  onDensityChange,
+}: {
+  view: ViewMode;
+  density?: Density;
+  onViewChange: (view: ViewMode) => void;
+  onDensityChange: (density: Density) => void;
+}) {
   const search = useSearch({ from: "/subnets/" }) as SubnetsSearch;
   const navigate = useNavigate({ from: "/subnets/" });
   const columns = useColumnVisibility("subnets", SUBNET_COLUMNS);
@@ -858,6 +877,12 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     (search.watched ? 1 : 0) +
     (!search.includeRoot ? 1 : 0);
 
+  const resetDirectoryFilters = () =>
+    navigate({
+      search: { view: search.view },
+      replace: true,
+    });
+
   const resultCount = rows.length;
   const totalCount = total ?? all.length;
 
@@ -899,7 +924,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   };
 
   const secondaryFilters = (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 [&>label]:min-h-11">
       <FilterChip
         label="Health"
         ariaLabel="Filter by exact health state"
@@ -945,30 +970,161 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         onChange={(v) => setSearch({ kind: v })}
         options={kindOptions}
       />
+      {activeFilterCount > 0 ? (
+        <button
+          type="button"
+          onClick={resetDirectoryFilters}
+          className="inline-flex min-h-11 items-center justify-center rounded border border-border bg-card px-3 py-2 mg-type-caption font-medium text-ink-muted transition-colors hover:border-accent/40 hover:text-ink-strong"
+        >
+          Clear all filters
+        </button>
+      ) : null}
     </div>
   );
 
-  const secondaryFilterCount =
-    (search.health && search.health !== "unhealthy" ? 1 : 0) +
+  // The filter-sheet badge needs to represent every refinement it now owns at
+  // phone/tablet widths — not just the five dropdowns it originally held.
+  // Search remains outside the sheet, so it deliberately is not counted here.
+  const filterSheetCount =
+    (search.health ? 1 : 0) +
     (search.curation ? 1 : 0) +
     (search.readiness ? 1 : 0) +
     (search.serviceKind ? 1 : 0) +
-    (search.kind ? 1 : 0);
+    (search.kind ? 1 : 0) +
+    (search.watched ? 1 : 0) +
+    (!search.includeRoot ? 1 : 0);
+
+  const rootToggleLabel = search.includeRoot ? "Hide root" : "Show root";
+  const rootToggleTitle = search.includeRoot
+    ? `Showing the root subnet — click to hide ${rootCount} root netuid${rootCount === 1 ? "" : "s"}`
+    : "Root subnet hidden — click to show it again";
+  const subnetsCsvUrl = buildUrl("/api/v1/subnets", { limit: SUBNETS_ALL_LIMIT });
+
+  const mobileRefinements = (
+    <div className="flex flex-col gap-3 border-b border-border pb-4 lg:hidden">
+      <div className="flex flex-col gap-2">
+        <span className="mg-type-label uppercase text-ink-muted">Display</span>
+        <ViewModeToggle
+          value={view}
+          onChange={onViewChange}
+          className="w-full [&>div>button>span]:inline"
+        />
+        {view === "table" ? (
+          <DensityToggle
+            value={density}
+            onChange={onDensityChange}
+            className="w-full [&>div>button>span]:inline"
+          />
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="mg-type-label uppercase text-ink-muted">Export &amp; share</span>
+        <div className="grid grid-cols-2 gap-2">
+          <DownloadCsvButton
+            url={subnetsCsvUrl}
+            className="w-full justify-center rounded [&>span]:!inline"
+          />
+          <ShareButton className="w-full justify-center rounded [&>span]:!inline" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="mg-type-label uppercase text-ink-muted">Quick views</span>
+        <div className="grid grid-cols-2 gap-2" role="group" aria-label="Quick filter">
+          {quickTabOptions.map((option) => {
+            const active = quickTab === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => onQuickTab(option.value)}
+                aria-pressed={active}
+                className={classNames(
+                  "inline-flex min-h-11 items-center justify-center rounded border px-3 py-2 mg-type-caption font-medium transition-colors",
+                  option.value === "new" && "col-span-2",
+                  active
+                    ? "border-accent/40 bg-accent/10 text-accent-text"
+                    : "border-border bg-card text-ink-muted hover:border-accent/40 hover:text-ink-strong",
+                )}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="mg-type-label uppercase text-ink-muted">View options</span>
+        <ExcludeToggle
+          hidden={!search.includeRoot}
+          onToggle={() => setSearch({ includeRoot: !search.includeRoot })}
+          label={rootToggleLabel}
+          count={rootCount}
+          title={rootToggleTitle}
+        />
+        {view === "table" ? (
+          <>
+            <div className="flex flex-col gap-1.5">
+              <span className="mg-type-caption text-ink-muted">Sparkline window</span>
+              <div
+                className="grid grid-cols-3 gap-2"
+                role="group"
+                aria-label="Trend window for row sparklines"
+              >
+                {(["7d", "30d", "90d"] as const).map((window) => {
+                  const active = trendWindow === window;
+                  return (
+                    <button
+                      key={window}
+                      type="button"
+                      onClick={() => setTrendWindow(window)}
+                      aria-pressed={active}
+                      className={classNames(
+                        "inline-flex min-h-11 items-center justify-center rounded border px-2 py-2 mg-type-caption font-medium transition-colors",
+                        active
+                          ? "border-accent/40 bg-accent/10 text-accent-text"
+                          : "border-border bg-card text-ink-muted hover:border-accent/40 hover:text-ink-strong",
+                      )}
+                    >
+                      {window}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="mg-type-caption text-ink-muted">Visible table columns</span>
+              <ColumnCustomizer
+                columns={SUBNET_COLUMNS}
+                isVisible={columns.isVisible}
+                onToggle={columns.toggle}
+                onReset={columns.reset}
+                className="[&>button]:min-h-11"
+              />
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
 
   const filters = (
-    <div className="flex w-full flex-col gap-0 min-w-0">
+    <div className="mg-subnets-directory-controls flex w-full flex-col gap-0 min-w-0">
       <div className="flex w-full items-center gap-2 min-w-0">
-        <QueryBar className="flex-1 min-w-0">
+        <QueryBar className="flex-1 min-w-0 min-h-12 lg:min-h-0">
           <QueryBar.Search
             value={search.q}
             onChange={(v) => setSearch({ q: v })}
             placeholder="Search by netuid, name, or symbol"
             shortcut
             debounceMs={200}
+            className="min-h-11 lg:min-h-0"
           />
 
           <QueryBar.Divider />
-          <div className="hidden sm:flex items-center">
+          <div className="hidden lg:flex items-center">
             <SegmentedToggle
               options={quickTabOptions}
               value={quickTab}
@@ -977,17 +1133,13 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
               className="border-0 bg-transparent"
             />
           </div>
-          <QueryBar.Utility className="ml-auto">
+          <QueryBar.Utility className="ml-auto hidden lg:flex">
             <ExcludeToggle
               hidden={!search.includeRoot}
               onToggle={() => setSearch({ includeRoot: !search.includeRoot })}
-              label="Hide root"
+              label={rootToggleLabel}
               count={rootCount}
-              title={
-                search.includeRoot
-                  ? `Showing the root subnet — click to hide ${rootCount} root netuid${rootCount === 1 ? "" : "s"}`
-                  : "Root subnet hidden — click to show it again"
-              }
+              title={rootToggleTitle}
             />
             {view === "table" ? (
               <>
@@ -1012,7 +1164,12 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
             ) : null}
           </QueryBar.Utility>
         </QueryBar>
-        <FilterSheet label="Filters" activeCount={secondaryFilterCount}>
+        <FilterSheet
+          className="mg-subnets-filter-sheet shrink-0 [&>button]:min-h-11"
+          label="Filters"
+          activeCount={filterSheetCount}
+        >
+          {mobileRefinements}
           {secondaryFilters}
         </FilterSheet>
       </div>
@@ -1021,15 +1178,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         total={totalCount}
         noun="subnets"
         activeCount={activeFilterCount}
-        onReset={
-          activeFilterCount > 0
-            ? () =>
-                navigate({
-                  search: { view: search.view },
-                  replace: true,
-                })
-            : undefined
-        }
+        onReset={activeFilterCount > 0 ? resetDirectoryFilters : undefined}
       />
       {(() => {
         const chipItems: FilterChipItem[] = [];
@@ -1116,15 +1265,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           <FilterChipRow
             items={chipItems}
             onRemove={clearKey}
-            onClearAll={
-              chipItems.length > 1
-                ? () =>
-                    navigate({
-                      search: { view: search.view },
-                      replace: true,
-                    })
-                : undefined
-            }
+            onClearAll={chipItems.length > 1 ? resetDirectoryFilters : undefined}
           />
         );
       })()}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -22,6 +22,9 @@ import {
 import {
   AsyncPanel,
   CopyLinkButton,
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
   MobileCollapse,
   Panel,
   ResponsiveTable,
@@ -267,61 +270,64 @@ function ProfileShell({ netuid }: { netuid: number }) {
   ].filter(Boolean).length;
 
   return (
-    <TimeRangeProvider>
-      <SubnetWindowProvider>
-        <SubnetFilterProvider>
-          <SubnetMasthead
-            netuid={netuid}
-            profile={profile}
-            generatedAt={meta?.generated_at}
-            stale={stale}
-            evidenceCount={evidenceCount}
-            refreshQueryKeys={[
-              subnetProfileQuery(netuid).queryKey,
-              subnetSurfacesQuery(netuid).queryKey,
-              subnetEndpointsQuery(netuid).queryKey,
-              subnetHealthQuery(netuid).queryKey,
-              subnetCandidatesQuery(netuid).queryKey,
-            ]}
-            refreshLabel="Refresh health now"
-          />
+    <DataPageStage variant="profile">
+      <TimeRangeProvider>
+        <SubnetWindowProvider>
+          <SubnetFilterProvider>
+            <SubnetMasthead
+              netuid={netuid}
+              profile={profile}
+              generatedAt={meta?.generated_at}
+              stale={stale}
+              evidenceCount={evidenceCount}
+              refreshQueryKeys={[
+                subnetProfileQuery(netuid).queryKey,
+                subnetSurfacesQuery(netuid).queryKey,
+                subnetEndpointsQuery(netuid).queryKey,
+                subnetHealthQuery(netuid).queryKey,
+                subnetCandidatesQuery(netuid).queryKey,
+              ]}
+              refreshLabel="Refresh health now"
+            />
 
-          <SubnetValidatorsPreview netuid={netuid} />
+            <DataPageCanvas variant="profile">
+              <DataPageModule kind="profile">
+                <SubnetValidatorsPreview netuid={netuid} />
 
-          <div className="mt-4">
-            <MethodologyCallout generatedAt={meta?.generated_at} windowLabel="7d" />
-          </div>
+                <div className="mt-4">
+                  <MethodologyCallout generatedAt={meta?.generated_at} windowLabel="7d" />
+                </div>
 
-          <div className="mt-2">
-            <ProfileTabs
-              tabs={tabsWithCounts}
-              defaultTab="overview"
-              trailing={
-                <>
-                  {/* Star (#8256) pins this subnet to your homepage; Follow
+                <div className="mt-2">
+                  <ProfileTabs
+                    tabs={tabsWithCounts}
+                    defaultTab="overview"
+                    trailing={
+                      <>
+                        {/* Star (#8256) pins this subnet to your homepage; Follow
                       (#8257) hands you a feed or webhook. Complementary, not
                       alternatives: one is for you, the other is for a machine. */}
-                  <WatchStarButton kind="subnet" id={netuid} label={`SN${netuid}`} />
-                  <WatchEntitySheet netuid={netuid} name={profile?.name ?? undefined} />
-                  <SubnetWindowToggle />
-                  {/* Restored, not removed: CopyLinkButton was imported here and
+                        <WatchStarButton kind="subnet" id={netuid} label={`SN${netuid}`} />
+                        <WatchEntitySheet netuid={netuid} name={profile?.name ?? undefined} />
+                        <SubnetWindowToggle />
+                        {/* Restored, not removed: CopyLinkButton was imported here and
                       never rendered, and subnet detail had NO share affordance at
                       all while every comparable page has one (#8294). */}
-                  <CopyLinkButton />
-                  <SubnetCompareDrawer netuid={netuid} />
-                </>
-              }
-            />
-          </div>
+                        <CopyLinkButton />
+                        <SubnetCompareDrawer netuid={netuid} />
+                      </>
+                    }
+                  />
+                </div>
 
-          <div className="mt-6 min-w-0 space-y-8">
-            {tab === "overview" ? <OverviewPanel netuid={netuid} profile={profile} /> : null}
-            {tab === "api" ? <ApiEndpointsPanel netuid={netuid} /> : null}
-            {tab === "metagraph" ? <MetagraphPanel netuid={netuid} /> : null}
-            {tab === "economics" ? <EconomicsTabPanel netuid={netuid} /> : null}
-            {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
-            {tab === "governance" ? <GovernancePanel netuid={netuid} /> : null}
-            {/*
+                <div className="mt-6 min-w-0 space-y-8">
+                  {tab === "overview" ? <OverviewPanel netuid={netuid} profile={profile} /> : null}
+                  {tab === "api" ? <ApiEndpointsPanel netuid={netuid} /> : null}
+                  {tab === "metagraph" ? <MetagraphPanel netuid={netuid} /> : null}
+                  {tab === "economics" ? <EconomicsTabPanel netuid={netuid} /> : null}
+                  {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
+                  {tab === "governance" ? <GovernancePanel netuid={netuid} /> : null}
+                  {/*
               #11351: the badge embed also renders here, on the DEFAULT view.
               It has lived inside ApiEndpointsPanel since #8329 — reachable only
               at ?tab=api, behind a tab bar that is not even in the server-
@@ -333,40 +339,43 @@ function ProfileShell({ netuid }: { netuid: number }) {
               deliberately not being done, discoverability is the only lever
               left, so it goes where an operator actually lands.
             */}
-            {tab === "overview" ? <UptimeBadgeEmbed entity="subnets" id={netuid} /> : null}
-            {tab === "about" ? <AboutPanel netuid={netuid} profile={profile} /> : null}
-          </div>
+                  {tab === "overview" ? <UptimeBadgeEmbed entity="subnets" id={netuid} /> : null}
+                  {tab === "about" ? <AboutPanel netuid={netuid} profile={profile} /> : null}
+                </div>
 
-          {/* #6558: the backend accepts netuid-scoped alert triggers, but only the
+                {/* #6558: the backend accepts netuid-scoped alert triggers, but only the
               validator page exposed a Watch UI. Extend the same pattern here.
               Outside the tab switch, so it's reachable from any tab -- same as the
               "Watch this validator" section on the validator page. */}
-          <div className="mt-8">
-            <SectionAnchor
-              id="watch"
-              title="Watch this subnet"
-              subtitle="Alert on on-chain activity for this subnet, via the existing chain alert-triggers API."
-              tone="accent"
-            >
-              <WatchSubnetAlert netuid={netuid} />
-            </SectionAnchor>
-          </div>
+                <div className="mt-8">
+                  <SectionAnchor
+                    id="watch"
+                    title="Watch this subnet"
+                    subtitle="Alert on on-chain activity for this subnet, via the existing chain alert-triggers API."
+                    tone="accent"
+                  >
+                    <WatchSubnetAlert netuid={netuid} />
+                  </SectionAnchor>
+                </div>
 
-          {/* #6432: outside the tab switch, so the way back is there whichever
+                {/* #6432: outside the tab switch, so the way back is there whichever
               tab a reader ends on -- this profile is the longest page in the app
               and the masthead breadcrumb is far behind by the time they finish.
               Same placement/styling as blocks.$ref.tsx and extrinsics.$hash.tsx. */}
-          <div className="mt-6">
-            <Link
-              to="/subnets"
-              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
-            >
-              ← All subnets
-            </Link>
-          </div>
-        </SubnetFilterProvider>
-      </SubnetWindowProvider>
-    </TimeRangeProvider>
+                <div className="mt-6">
+                  <Link
+                    to="/subnets"
+                    className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
+                  >
+                    ← All subnets
+                  </Link>
+                </div>
+              </DataPageModule>
+            </DataPageCanvas>
+          </SubnetFilterProvider>
+        </SubnetWindowProvider>
+      </TimeRangeProvider>
+    </DataPageStage>
   );
 }
 

--- a/apps/ui/src/routes/-subnets-with-api-page.tsx
+++ b/apps/ui/src/routes/-subnets-with-api-page.tsx
@@ -3,7 +3,10 @@ import { Link } from "@tanstack/react-router";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
   AsyncPanel,
-  PageMasthead,
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
   Panel,
   TableSkeleton,
 } from "@/components/metagraphed/primitives";
@@ -126,16 +129,29 @@ function WithApiTable() {
 export function SubnetsWithApiPage() {
   return (
     <AppShell>
-      <PageMasthead
-        live
-        eyebrow="Capability"
-        title="Subnets with an API spec"
-        description={hubLede("/subnets/with-api")}
-      />
-      <AsyncPanel context="subnets-with-api" fallback={<TableSkeleton rows={10} columns={4} />}>
-        <WithApiTable />
-      </AsyncPanel>
-      <HubSections path="/subnets/with-api" />
+      <DataPageStage>
+        <DataPageHero
+          id="subnets-api-spec-title"
+          eyebrow="Capability index"
+          live
+          title="Subnets with an API spec."
+          description={hubLede("/subnets/with-api")}
+        />
+        <DataPageCanvas>
+          <DataPageModule
+            title="Integrate from a real contract."
+            caption="Each row has a published machine-readable specification; readiness and probe status remain visible without a crowded dashboard."
+          >
+            <AsyncPanel
+              context="subnets-with-api"
+              fallback={<TableSkeleton rows={10} columns={4} />}
+            >
+              <WithApiTable />
+            </AsyncPanel>
+          </DataPageModule>
+        </DataPageCanvas>
+        <HubSections path="/subnets/with-api" />
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-surfaces-page.tsx
+++ b/apps/ui/src/routes/-surfaces-page.tsx
@@ -352,12 +352,15 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
             debounceMs={200}
           />
           <QueryBar.Divider />
-          <div className="hidden md:contents">{secondaryFilters}</div>
+          {/* A ruled data canvas is intentionally narrower than the old
+              full-page toolbar. Keep the three selectors in the shared sheet
+              through tablet so the search task retains usable width. */}
+          <div className="hidden lg:contents">{secondaryFilters}</div>
           <QueryBar.Utility className="ml-auto">
             <PageSizeSelect value={search.limit} onChange={(n) => setSearch({ limit: n })} />
           </QueryBar.Utility>
         </QueryBar>
-        <FilterSheet className="md:hidden" label="Filters" activeCount={secondaryFilterCount}>
+        <FilterSheet className="lg:hidden" label="Filters" activeCount={secondaryFilterCount}>
           {secondaryFilters}
         </FilterSheet>
       </div>

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -15,7 +15,13 @@ import {
   SegmentedToggle,
   Chip,
 } from "@jsonbored/ui-kit";
-import { PageMasthead, AsyncPanel } from "@/components/metagraphed/primitives";
+import {
+  AsyncPanel,
+  DataPageCanvas,
+  DataPageModule,
+  DataPageStage,
+  PageMasthead,
+} from "@/components/metagraphed/primitives";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { WatchStarButton } from "@/components/metagraphed/watch-star-button";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
@@ -383,7 +389,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
   );
 
   return (
-    <>
+    <DataPageStage variant="profile">
       <PageMasthead
         eyebrow="Explorer · validator"
         live
@@ -486,157 +492,161 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         caption="explorer / v1"
       />
 
-      {/* #6430: the endpoint is schema-stable, so a mistyped or never-registered
+      <DataPageCanvas variant="profile">
+        <DataPageModule kind="profile">
+          {/* #6430: the endpoint is schema-stable, so a mistyped or never-registered
           hotkey resolves to a zeroed aggregate and renders a page of zeros that
           looks exactly like a real validator holding nothing. Say so up front. */}
-      {isUnrecognizedValidator(detail) ? (
-        <div
-          role="status"
-          className="mb-8 flex items-start gap-3 rounded-2xl border border-health-warn/40 bg-health-warn/5 px-4 py-3"
-        >
-          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-health-warn" aria-hidden />
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-ink-strong">
-              This hotkey isn&apos;t a registered validator
-            </p>
-            <p className="mt-1 max-w-2xl mg-type-caption-lg text-ink-muted">
-              The address is a valid ss58, but it has never been seen validating on any subnet —
-              every figure below reads zero for that reason, not because the validator is idle. It
-              may be mistyped, or a coldkey rather than a hotkey.
-            </p>
-          </div>
-        </div>
-      ) : null}
+          {isUnrecognizedValidator(detail) ? (
+            <div
+              role="status"
+              className="mb-8 flex items-start gap-3 rounded-2xl border border-health-warn/40 bg-health-warn/5 px-4 py-3"
+            >
+              <TriangleAlert className="mt-0.5 size-4 shrink-0 text-health-warn" aria-hidden />
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-ink-strong">
+                  This hotkey isn&apos;t a registered validator
+                </p>
+                <p className="mt-1 max-w-2xl mg-type-caption-lg text-ink-muted">
+                  The address is a valid ss58, but it has never been seen validating on any subnet —
+                  every figure below reads zero for that reason, not because the validator is idle.
+                  It may be mistyped, or a coldkey rather than a hotkey.
+                </p>
+              </div>
+            </div>
+          ) : null}
 
-      {/* #8251: KPI band of exactly six — Total stake · Est. APY (one tile
+          {/* #8251: KPI band of exactly six — Total stake · Est. APY (one tile
           with a 7/30/90 toggle) · Take · Active subnets · Nominators · Avg
           val-trust. Total emission and Max trust left the band (emission is a
           per-subnet story now told in the performance tab; max-trust
           duplicated avg-trust's signal); the old separate three-card APY
           section is gone — this tile IS the one APY block on the page.
           Mobile is the required 2×3 grid. */}
-      <div className="mb-12 grid grid-cols-2 gap-4 xl:grid-cols-3 2xl:grid-cols-6">
-        <StatTile
-          icon={Coins}
-          eyebrow="Total stake"
-          value={taoCompact(detail.total_stake_tao)}
-          // Root (netuid 0) is TAO-denominated with no price exposure; alpha
-          // is the sum across every other subnet's own alpha token (#2550).
-          hint={`Root ${taoCompact(detail.root_stake_tao)} · Alpha ${taoCompact(detail.alpha_stake_tao)}`}
-          truncate={false}
-          tone="accent"
-          className="rounded-2xl border-accent/25 mg-glass-opaque p-4 mg-card-glow-accent"
-        />
-        <ApyKpiTile hotkey={hotkey} take={detail.take} snapshotApy={snapshotApy} />
-        <StatTile
-          icon={Percent}
-          eyebrow="Take rate"
-          value={formatTakePct(detail.take)}
-          hint="commission kept from delegators"
-          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
-        />
-        <StatTile
-          icon={Boxes}
-          eyebrow="Active subnets"
-          value={formatNumber(detail.subnet_count)}
-          hint="validator memberships"
-          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
-        />
-        <StatTile
-          icon={Users}
-          eyebrow="Nominators"
-          value={detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"}
-          hint="distinct coldkeys delegated"
-          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
-        />
-        <StatTile
-          icon={Gauge}
-          eyebrow="Avg validator trust"
-          value={scoreStr(detail.avg_validator_trust)}
-          hint="mean across subnets"
-          className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
-        />
-      </div>
+          <div className="mb-12 grid grid-cols-2 gap-4 xl:grid-cols-3 2xl:grid-cols-6">
+            <StatTile
+              icon={Coins}
+              eyebrow="Total stake"
+              value={taoCompact(detail.total_stake_tao)}
+              // Root (netuid 0) is TAO-denominated with no price exposure; alpha
+              // is the sum across every other subnet's own alpha token (#2550).
+              hint={`Root ${taoCompact(detail.root_stake_tao)} · Alpha ${taoCompact(detail.alpha_stake_tao)}`}
+              truncate={false}
+              tone="accent"
+              className="rounded-2xl border-accent/25 mg-glass-opaque p-4 mg-card-glow-accent"
+            />
+            <ApyKpiTile hotkey={hotkey} take={detail.take} snapshotApy={snapshotApy} />
+            <StatTile
+              icon={Percent}
+              eyebrow="Take rate"
+              value={formatTakePct(detail.take)}
+              hint="commission kept from delegators"
+              className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
+            />
+            <StatTile
+              icon={Boxes}
+              eyebrow="Active subnets"
+              value={formatNumber(detail.subnet_count)}
+              hint="validator memberships"
+              className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
+            />
+            <StatTile
+              icon={Users}
+              eyebrow="Nominators"
+              value={detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"}
+              hint="distinct coldkeys delegated"
+              className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
+            />
+            <StatTile
+              icon={Gauge}
+              eyebrow="Avg validator trust"
+              value={scoreStr(detail.avg_validator_trust)}
+              hint="mean across subnets"
+              className="rounded-2xl border-border/80 mg-glass-opaque p-4 mg-card-glow"
+            />
+          </div>
 
-      <ProfileTabs tabs={[...TABS]} defaultTab="subnets" />
+          <ProfileTabs tabs={[...TABS]} defaultTab="subnets" />
 
-      <div className="mt-6 min-w-0 space-y-8">
-        {tab === "subnets" ? (
-          <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
-            <SubnetPerformanceTab subnets={detail.subnets} />
-          </SectionAnchor>
-        ) : null}
-        {tab === "nominators" ? (
-          <SectionAnchor
-            id="nominators"
-            title="Nominators"
-            subtitle="Derived from stake-delegation events"
-            tone="muted"
-          >
-            <AsyncPanel
-              context="nominators"
-              fallback={<Skeleton className="h-64 w-full" />}
-              retryQueryKeys={[metagraphedQueryKey("validator-nominators", hotkey)]}
+          <div className="mt-6 min-w-0 space-y-8">
+            {tab === "subnets" ? (
+              <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
+                <SubnetPerformanceTab subnets={detail.subnets} />
+              </SectionAnchor>
+            ) : null}
+            {tab === "nominators" ? (
+              <SectionAnchor
+                id="nominators"
+                title="Nominators"
+                subtitle="Derived from stake-delegation events"
+                tone="muted"
+              >
+                <AsyncPanel
+                  context="nominators"
+                  fallback={<Skeleton className="h-64 w-full" />}
+                  retryQueryKeys={[metagraphedQueryKey("validator-nominators", hotkey)]}
+                >
+                  <NominatorsSection hotkey={hotkey} />
+                </AsyncPanel>
+              </SectionAnchor>
+            ) : null}
+            {tab === "history" ? (
+              <SectionAnchor
+                id="history"
+                title="Stake & rewards over time"
+                subtitle="Daily snapshots"
+                tone="ink"
+              >
+                <ValidatorHistoryChart hotkey={hotkey} />
+              </SectionAnchor>
+            ) : null}
+          </div>
+
+          <div className="mt-8">
+            <SectionAnchor
+              id="watch"
+              title="Watch this validator"
+              subtitle="Alert on new delegations or stake, via the existing chain alert-triggers API."
+              tone="accent"
             >
-              <NominatorsSection hotkey={hotkey} />
-            </AsyncPanel>
-          </SectionAnchor>
-        ) : null}
-        {tab === "history" ? (
+              <WatchValidatorAlert hotkey={hotkey} />
+            </SectionAnchor>
+          </div>
+
+          {/* #6432: same placement blocks.$ref.tsx and extrinsics.$hash.tsx use. */}
+          <div className="mt-6">
+            <Link
+              to="/validators"
+              className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
+            >
+              ← All validators
+            </Link>
+          </div>
+
           <SectionAnchor
-            id="history"
-            title="Stake & rewards over time"
-            subtitle="Daily snapshots"
-            tone="ink"
+            id="call"
+            title="Call this endpoint"
+            subtitle="Copy a ready-to-run request for this validator."
           >
-            <ValidatorHistoryChart hotkey={hotkey} />
+            <EndpointSnippet
+              rows={[
+                { label: "summary", path: `/api/v1/validators/${sourceRef}` },
+                { label: "nominators", path: `/api/v1/validators/${sourceRef}/nominators` },
+                { label: "history", path: `/api/v1/validators/${sourceRef}/history` },
+              ]}
+            />
           </SectionAnchor>
-        ) : null}
-      </div>
 
-      <div className="mt-8">
-        <SectionAnchor
-          id="watch"
-          title="Watch this validator"
-          subtitle="Alert on new delegations or stake, via the existing chain alert-triggers API."
-          tone="accent"
-        >
-          <WatchValidatorAlert hotkey={hotkey} />
-        </SectionAnchor>
-      </div>
-
-      {/* #6432: same placement blocks.$ref.tsx and extrinsics.$hash.tsx use. */}
-      <div className="mt-6">
-        <Link
-          to="/validators"
-          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 mg-type-caption font-medium hover:border-ink/30"
-        >
-          ← All validators
-        </Link>
-      </div>
-
-      <SectionAnchor
-        id="call"
-        title="Call this endpoint"
-        subtitle="Copy a ready-to-run request for this validator."
-      >
-        <EndpointSnippet
-          rows={[
-            { label: "summary", path: `/api/v1/validators/${sourceRef}` },
-            { label: "nominators", path: `/api/v1/validators/${sourceRef}/nominators` },
-            { label: "history", path: `/api/v1/validators/${sourceRef}/history` },
-          ]}
-        />
-      </SectionAnchor>
-
-      <ApiSourceFooter
-        paths={[
-          `/api/v1/validators/${sourceRef}`,
-          `/api/v1/validators/${sourceRef}/nominators`,
-          `/api/v1/validators/${sourceRef}/history`,
-        ]}
-      />
-    </>
+          <ApiSourceFooter
+            paths={[
+              `/api/v1/validators/${sourceRef}`,
+              `/api/v1/validators/${sourceRef}/nominators`,
+              `/api/v1/validators/${sourceRef}/history`,
+            ]}
+          />
+        </DataPageModule>
+      </DataPageCanvas>
+    </DataPageStage>
   );
 }
 

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -8,15 +8,21 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import {
   ShareButton,
   DownloadCsvButton,
-  ActionBar,
   DensityToggle,
   MiniStack,
   type Density,
 } from "@jsonbored/ui-kit";
 import {
   AsyncPanel,
-  PageMasthead,
+  DataPageCanvas,
+  DataPageDisclosure,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  FilterSheet,
+  GhostButton,
   Panel,
+  QueryBar,
   TableSkeleton,
 } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -25,7 +31,7 @@ import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/stat
 import { API_BASE } from "@/lib/metagraphed/config";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
-import { formatNumber, isStaleFreshness, classNames } from "@/lib/metagraphed/format";
+import { isStaleFreshness, classNames } from "@/lib/metagraphed/format";
 import { matchesQuery, sortBy } from "@/lib/metagraphed/url-state";
 import { groupByOperator } from "@/lib/metagraphed/group-validators";
 import { useWatchlist } from "@/lib/metagraphed/watchlist";
@@ -38,8 +44,8 @@ import {
   ValidatorsCompareDrawer,
   ValidatorCompareToggle,
 } from "@/components/metagraphed/validators-compare-drawer";
-import { HubSections, hubLede } from "@/components/metagraphed/hub-prose";
-import { SortHeader, ariaSort, SearchInput } from "@/components/metagraphed/table-controls";
+import { HubSections } from "@/components/metagraphed/hub-prose";
+import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import { TableColGroup } from "@jsonbored/ui-kit";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 import { useMeasuredRowHeight } from "@/hooks/use-measured-row-height";
@@ -59,13 +65,6 @@ export function ValidatorsPage() {
   const search = useSearch({ from: "/validators/" }) as ValidatorsSearch;
   const navigate = useNavigate({ from: "/validators/" });
   const density = search.density ?? "comfortable";
-  // Mirror the sibling ranked-list pages (subnets/blocks/surfaces): export the
-  // current view as CSV. DownloadCsvButton appends `format=csv`; the backend's
-  // handleGlobalValidators already serves it (#5482).
-  const validatorsCsvUrl = buildUrl("/api/v1/validators", {
-    sort: "total_stake",
-    limit: ALL_VALIDATORS_LIMIT,
-  });
   const onDensityChange = (d: Density) =>
     navigate({
       search: (prev: Record<string, unknown>) => ({ ...prev, density: d }),
@@ -73,42 +72,44 @@ export function ValidatorsPage() {
     });
   return (
     <AppShell>
-      <PageMasthead
-        eyebrow="Directory"
-        live
-        title="Validators"
-        // #11320: from HUB_COPY -- this slot and the meta description were two
-        // separately written copies of the same fact.
-        description={hubLede("/validators")}
-        actions={
-          <>
-            <ActionBar>
-              <DownloadCsvButton url={validatorsCsvUrl} bare />
-              <ShareButton bare />
-            </ActionBar>
-          </>
-        }
-      />
-      <ValidatorGuide />
-      <AsyncPanel
-        context="validators"
-        fallback={<TableSkeleton rows={10} columns={8} />}
-        retryQueryKeys={[
-          validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false })
-            .queryKey,
-        ]}
-      >
-        <ValidatorsDirectory density={density} onDensityChange={onDensityChange} />
-      </AsyncPanel>
-      {/* #10300: the cross-subnet "where is it cheapest to start validating"
-          ranking was published and rendered nowhere. */}
-      <section className="mt-8">
-        <ValidatorEconomicsRanking />
-      </section>
-      <ApiSourceFooter paths={["/api/v1/validators", "/api/v1/validators/economics"]} />
+      <DataPageStage>
+        <DataPageHero
+          id="validators-title"
+          eyebrow="Network operators"
+          live
+          title="Validators."
+          description="Search the live validator set by operator or key."
+        />
+        <DataPageCanvas>
+          <DataPageModule title="Directory." caption="Stake, ownership, and on-chain economics.">
+            <AsyncPanel
+              context="validators"
+              fallback={<TableSkeleton rows={10} columns={8} />}
+              retryQueryKeys={[
+                validatorsQuery({
+                  sort: "total_stake",
+                  limit: ALL_VALIDATORS_LIMIT,
+                  subnets: false,
+                }).queryKey,
+              ]}
+            >
+              <ValidatorsDirectory density={density} onDensityChange={onDensityChange} />
+            </AsyncPanel>
+            <DataPageDisclosure label="How to read this directory">
+              <ValidatorGuide />
+            </DataPageDisclosure>
+          </DataPageModule>
+          <DataPageModule
+            title="Entry economics."
+            caption="Current stake thresholds across the network."
+          >
+            <ValidatorEconomicsRanking />
+          </DataPageModule>
+        </DataPageCanvas>
+        <ApiSourceFooter paths={["/api/v1/validators", "/api/v1/validators/economics"]} />
+        <HubSections path="/validators" />
+      </DataPageStage>
       <ValidatorsCompareDrawer />
-      {/* Below the table on purpose -- see hub-prose.tsx. */}
-      <HubSections path="/validators" />
     </AppShell>
   );
 }
@@ -141,6 +142,14 @@ function ValidatorsDirectory({
   // permanently was the wrong default.
   const columns = useColumnVisibility("validators", VALIDATOR_COLUMNS);
   const visibleColumns = VALIDATOR_COLUMNS.filter((c) => columns.isVisible(c.id));
+  // Keep the route-level actions local to the directory instrument. The hero
+  // names the page; the command rail is where a reader searches, adjusts the
+  // table, exports, or shares the exact view they are looking at.
+  const validatorsCsvUrl = buildUrl("/api/v1/validators", {
+    sort: "total_stake",
+    limit: ALL_VALIDATORS_LIMIT,
+  });
+  const activeFilterCount = search.watched ? 1 : 0;
 
   const setSearch = (patch: Record<string, unknown>) =>
     navigate({
@@ -209,6 +218,68 @@ function ValidatorsDirectory({
       ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1]!.end
       : 0;
 
+  const directoryRefinements = (
+    <>
+      <div className="flex flex-col gap-2">
+        <span className="mg-type-label uppercase text-ink-muted">Directory</span>
+        <GhostButton
+          onClick={() => setSearch({ grouped: !grouped })}
+          aria-pressed={grouped}
+          title="Cluster an operator's validator keys under one entry"
+          tone={grouped ? "accent" : "default"}
+          appearance="terminal"
+          className="w-full justify-between"
+        >
+          Group by operator
+        </GhostButton>
+        {watchlist.count > 0 ? (
+          <GhostButton
+            onClick={() => setSearch({ watched: !search.watched })}
+            aria-pressed={search.watched}
+            tone={search.watched ? "accent" : "default"}
+            appearance="terminal"
+            className="w-full justify-between"
+            icon={
+              <Star
+                className={classNames("size-3.5", search.watched && "fill-accent text-accent")}
+                aria-hidden
+              />
+            }
+          >
+            Watched · {watchlist.count}
+          </GhostButton>
+        ) : null}
+      </div>
+
+      <div className="hidden flex-col gap-2 border-t border-border pt-4 lg:flex">
+        <span className="mg-type-label uppercase text-ink-muted">Table</span>
+        <DensityToggle
+          value={density}
+          onChange={onDensityChange}
+          className="w-full [&>div]:w-full [&>div>button]:flex-1 [&>div>button>span]:inline"
+        />
+        <ColumnCustomizer
+          columns={VALIDATOR_COLUMNS}
+          isVisible={columns.isVisible}
+          onToggle={columns.toggle}
+          onReset={columns.reset}
+          className="[&>button]:w-full [&>button]:justify-between"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 border-t border-border pt-4">
+        <span className="mg-type-label uppercase text-ink-muted">Export &amp; share</span>
+        <div className="grid grid-cols-2 gap-2">
+          <DownloadCsvButton
+            url={validatorsCsvUrl}
+            className="w-full justify-center rounded [&>span]:!inline"
+          />
+          <ShareButton className="w-full justify-center rounded [&>span]:!inline" />
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <div className="space-y-3">
       {isStaleFreshness(generatedAt) ? (
@@ -221,64 +292,36 @@ function ValidatorsDirectory({
         />
       ) : null}
 
-      <div className="flex flex-wrap items-center gap-2">
-        <SearchInput
-          value={search.q}
-          onChange={(v) => setSearch({ q: v })}
-          placeholder="Search by operator, hotkey, or coldkey"
-          className="w-full sm:w-80"
-        />
-        {/* #8256: only offered once something is starred -- an always-visible
-            filter that can only ever return nothing is furniture. */}
-        <button
-          type="button"
-          onClick={() => setSearch({ grouped: !grouped })}
-          aria-pressed={grouped}
-          title="Cluster an operator's validator keys under one entry"
-          className={classNames(
-            "inline-flex min-h-9 items-center gap-1.5 rounded border px-2.5 py-1 mg-type-caption font-medium transition-colors",
-            grouped
-              ? "border-accent/40 bg-accent/10 text-accent-text"
-              : "border-border bg-card text-ink-muted hover:border-accent/40 hover:text-ink-strong",
-          )}
-        >
-          Group by operator
-        </button>
-        {watchlist.count > 0 ? (
-          <button
-            type="button"
-            onClick={() => setSearch({ watched: !search.watched })}
-            aria-pressed={search.watched}
-            className={classNames(
-              "inline-flex min-h-9 items-center gap-1.5 rounded border px-2.5 py-1 mg-type-caption font-medium transition-colors",
-              search.watched
-                ? "border-accent/40 bg-accent/10 text-accent-text"
-                : "border-border bg-card text-ink-muted hover:border-accent/40 hover:text-ink-strong",
-            )}
-          >
-            <Star
-              className={classNames("size-3.5", search.watched && "fill-accent text-accent")}
-              aria-hidden
+      <div className="mg-directory-toolbar flex w-full flex-col gap-0 min-w-0">
+        <div className="flex w-full items-center gap-2 min-w-0">
+          <QueryBar className="min-h-11 lg:min-h-0" ariaLabel="Search validators">
+            <QueryBar.Search
+              value={search.q}
+              onChange={(v) => setSearch({ q: v })}
+              placeholder="Search operator, hotkey, or coldkey"
+              debounceMs={150}
+              className="min-h-11 lg:min-h-0"
             />
-            Watched · {watchlist.count}
-          </button>
-        ) : null}
-        <span className="mg-type-data text-ink-muted">
-          {formatNumber(rows.length)} of {formatNumber(all.length)} validators
-        </span>
-        <div className="ml-auto flex items-center gap-2">
-          <ColumnCustomizer
-            columns={VALIDATOR_COLUMNS}
-            isVisible={columns.isVisible}
-            onToggle={columns.toggle}
-            onReset={columns.reset}
-          />
-          <DensityToggle value={density} onChange={onDensityChange} />
+          </QueryBar>
+          <FilterSheet
+            className="shrink-0 [&>button]:min-h-11 lg:[&>button]:min-h-9"
+            label="Controls"
+            activeCount={activeFilterCount}
+          >
+            {directoryRefinements}
+          </FilterSheet>
         </div>
+        <QueryBar.MetaRow
+          count={rows.length}
+          total={all.length}
+          noun="validators"
+          activeCount={activeFilterCount}
+          onReset={search.watched ? () => setSearch({ watched: false }) : undefined}
+        />
       </div>
 
       {rows.length > 0 ? (
-        <div className="hidden md:block rounded-md border border-border">
+        <div className="mg-directory-table hidden lg:block border border-border">
           {/* ONE scroll container carrying BOTH sets of styling.
               This was split into single-axis wrappers (#8314) because a
               combined overflow-auto div left the extra columns
@@ -415,7 +458,7 @@ function ValidatorsDirectory({
       {rows.length > 0 ? (
         <ValidatorCardList
           validators={rows.slice(0, 50)}
-          className="grid gap-3 sm:grid-cols-2 md:hidden"
+          className="grid gap-3 sm:grid-cols-2 lg:hidden"
         />
       ) : null}
 
@@ -424,11 +467,10 @@ function ValidatorsDirectory({
   );
 }
 
-// #8251: the concentration story, calmed. The old full-bleed flat-mint
-// treemap (the loudest visual element on the site) retires; in its place, ONE
-// accent moment — a top-10 stacked horizontal dominance bar — and the
-// stake-intensity heatmap matrix survives behind a collapsed "Concentration
-// detail" disclosure instead of rendering unconditionally.
+// #8251: the concentration story stays calm, but each top operator needs a
+// stable categorical color. Mint remains an interface/focus signal; a single
+// mint stack for ten different operators makes the chart impossible to scan.
+// The stake-intensity heatmap remains behind an explicit disclosure.
 function ConcentrationSection({ validators }: { validators: GlobalValidator[] }) {
   const [showDetail, setShowDetail] = useState(false);
   const ranked = useMemo(
@@ -446,13 +488,23 @@ function ConcentrationSection({ validators }: { validators: GlobalValidator[] })
     v.coldkey_identity?.has_identity && v.coldkey_identity.name
       ? v.coldkey_identity.name
       : (v.hotkey.slice(0, 6) ?? "validator");
+  const seriesColors = [
+    "var(--chart-1)",
+    "var(--chart-2)",
+    "var(--chart-3)",
+    "var(--chart-4)",
+    "var(--chart-5)",
+    "var(--chart-6)",
+    "var(--chart-7)",
+    "var(--chart-8)",
+    "var(--chart-9)",
+    "var(--chart-10)",
+  ];
   const segments = [
     ...top.map((v, i) => ({
       label: label(v),
       value: (v.stake_dominance ?? 0) * 100,
-      // One accent moment: interpolate opacity down the ranking rather than
-      // introducing a second hue.
-      color: `color-mix(in oklab, var(--accent) ${100 - i * 8}%, var(--border))`,
+      color: seriesColors[i % seriesColors.length]!,
     })),
     { label: "everyone else", value: rest * 100, color: "var(--border)" },
   ];

--- a/apps/ui/src/routes/apis.tsx
+++ b/apps/ui/src/routes/apis.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import {
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+} from "@/components/metagraphed/primitives";
 import { ApisTabs, activeApisTab } from "./-apis-hub";
 
 /**
@@ -8,8 +13,8 @@ import { ApisTabs, activeApisTab } from "./-apis-hub";
  * public-interface surface, which was split across /surfaces, /endpoints,
  * /schemas and /providers.
  *
- * The masthead and tab strip render once here rather than per page, the same
- * shape the Chain hub established (#8244).
+ * The shared title field and tab strip establish one clear entry point before
+ * each data task, rather than giving every API route its own competing intro.
  *
  * Provider detail (/providers/$slug) deliberately keeps its own URL — only
  * index pages consolidate.
@@ -20,9 +25,21 @@ function ApisHubLayout() {
 
   return (
     <AppShell>
-      <PageMasthead title="APIs" description={tab.blurb} pathname={pathname} live />
-      <ApisTabs />
-      <Outlet />
+      <DataPageStage>
+        <DataPageHero
+          id="apis-title"
+          eyebrow="Public interfaces"
+          live
+          title={`${tab.label}.`}
+          description={tab.blurb}
+        />
+        <DataPageCanvas>
+          <ApisTabs className="mg-data-hub-tabs" />
+          <DataPageModule>
+            <Outlet />
+          </DataPageModule>
+        </DataPageCanvas>
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/chain.tsx
+++ b/apps/ui/src/routes/chain.tsx
@@ -19,10 +19,15 @@ import { ChainTabs, activeChainTab } from "./-chain-hub";
 function ChainHubLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const tab = activeChainTab(pathname);
+  // Analytics owns a dedicated, spacious data hero. Keeping the generic
+  // compact Chain masthead above it creates two competing introductions.
+  const hasDedicatedHero = pathname === "/chain/analytics";
 
   return (
     <AppShell>
-      <PageMasthead title="Chain" description={tab.blurb} pathname={pathname} live />
+      {!hasDedicatedHero ? (
+        <PageMasthead title="Chain" description={tab.blurb} pathname={pathname} live />
+      ) : null}
       <ChainTabs />
       <Outlet />
     </AppShell>

--- a/apps/ui/src/routes/chain.tsx
+++ b/apps/ui/src/routes/chain.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageMasthead } from "@/components/metagraphed/primitives";
+import {
+  DataPageCanvas,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+} from "@/components/metagraphed/primitives";
 import { ChainTabs, activeChainTab } from "./-chain-hub";
 
 /**
@@ -8,9 +13,9 @@ import { ChainTabs, activeChainTab } from "./-chain-hub";
  * top-level routes (/explorer, /blocks, /extrinsics, /events, /sudo,
  * /admin-changes, /runtime, plus their shared preamble duplication).
  *
- * The masthead and tab strip render once here rather than per page, which is
- * most of the point: each old route rebuilt its own heading, breadcrumb and
- * stat preamble, and several rebuilt each other's stats too.
+ * The title field and tab strip render once here rather than per page. Every
+ * tab gets the same reading order: orient, choose a chain task, then inspect
+ * its data — rather than rebuilding a heading and a card wall on every route.
  *
  * Detail routes (/blocks/$ref, /extrinsics/$hash) deliberately keep their own
  * URLs — only the index pages consolidate, so every existing deep link, share
@@ -23,13 +28,34 @@ function ChainHubLayout() {
   // compact Chain masthead above it creates two competing introductions.
   const hasDedicatedHero = pathname === "/chain/analytics";
 
+  if (hasDedicatedHero) {
+    return (
+      <AppShell>
+        <DataPageStage variant="tabs">
+          <ChainTabs className="mg-data-hub-tabs" />
+        </DataPageStage>
+        <Outlet />
+      </AppShell>
+    );
+  }
+
   return (
     <AppShell>
-      {!hasDedicatedHero ? (
-        <PageMasthead title="Chain" description={tab.blurb} pathname={pathname} live />
-      ) : null}
-      <ChainTabs />
-      <Outlet />
+      <DataPageStage>
+        <DataPageHero
+          id="chain-title"
+          eyebrow="Chain explorer"
+          live
+          title={`${tab.label}.`}
+          description={tab.blurb}
+        />
+        <DataPageCanvas>
+          <ChainTabs className="mg-data-hub-tabs" />
+          <DataPageModule>
+            <Outlet />
+          </DataPageModule>
+        </DataPageCanvas>
+      </DataPageStage>
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/leaderboards-csv-export-menu.test.ts
+++ b/apps/ui/src/routes/leaderboards-csv-export-menu.test.ts
@@ -35,13 +35,19 @@ function csvMenuSource() {
 
 describe("leaderboards ActionBar CSV export", () => {
   it("renders exactly one CSV-export trigger in the rankings ActionBar, not one per board", () => {
-    const actionBar = host.slice(host.indexOf("<ActionBar>"), host.indexOf("</ActionBar>"));
+    const rankingsStart = host.indexOf('{search.section === "rankings" ? (');
+    const rankingsBranch = host.slice(rankingsStart, host.indexOf(") : (", rankingsStart));
+    const actionBar = rankingsBranch.slice(
+      rankingsBranch.indexOf("<ActionBar>"),
+      rankingsBranch.indexOf("</ActionBar>"),
+    );
     expect(actionBar).toContain("<LeaderboardsCsvExportMenu");
     // Exactly one menu element -- not one per board.
     expect(actionBar.match(/<LeaderboardsCsvExportMenu/g)?.length).toBe(1);
-    // The subnets CSV button is the registry section's, and must not render
-    // alongside the menu in the rankings section.
-    expect(actionBar).toContain('search.section === "rankings"');
+    // The rankings branch owns this single menu; the registry's export lives
+    // in its local Controls sheet instead of alongside the rankings action.
+    expect(rankingsBranch).toContain('search.section === "rankings"');
+    expect(actionBar).not.toContain("DownloadCsvButton");
   });
 
   it("no longer imports DownloadCsvButton -- replaced entirely by the menu", () => {

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -195,7 +195,145 @@
 
 /* Compact page masthead — data-explorer counterpart to .mg-hero-slab. */
 .mg-masthead {
+  position: relative;
+  isolation: isolate;
+  min-height: 10.5rem;
+  padding-top: clamp(2rem, 4vw, 3.25rem) !important;
+  padding-bottom: clamp(1.5rem, 3vw, 2.5rem) !important;
+  overflow: hidden;
   background: transparent;
+}
+.mg-masthead::before {
+  position: absolute;
+  z-index: -1;
+  top: 1.15rem;
+  right: -1rem;
+  width: min(62%, 34rem);
+  height: 7.5rem;
+  border: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--ink-strong) 14%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 4px 4px;
+  content: "";
+  mask-image: linear-gradient(90deg, transparent, #000 22%, #000 82%, transparent);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 22%, #000 82%, transparent);
+}
+.mg-masthead h1 {
+  max-width: 15ch;
+  font-size: clamp(2rem, 4.2vw, 3.5rem) !important;
+  font-weight: 500 !important;
+  letter-spacing: -0.065em !important;
+  line-height: 0.94 !important;
+}
+.mg-route-frame {
+  width: min(100%, 68rem);
+  margin-inline: auto;
+}
+.mg-page-heading {
+  position: relative;
+  min-height: 9.5rem;
+  padding: clamp(2rem, 4vw, 3.25rem) 0 clamp(1.5rem, 3vw, 2.5rem);
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+}
+.mg-page-heading::before {
+  position: absolute;
+  top: 1.25rem;
+  right: -1rem;
+  width: min(60%, 32rem);
+  height: 6.75rem;
+  border: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--ink-strong) 14%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 4px 4px;
+  content: "";
+  mask-image: linear-gradient(90deg, transparent, #000 22%, #000 82%, transparent);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 22%, #000 82%, transparent);
+}
+.mg-page-heading > * {
+  position: relative;
+}
+.mg-page-heading h1 {
+  max-width: 15ch;
+  font-size: clamp(2rem, 4.2vw, 3.5rem) !important;
+  font-weight: 500 !important;
+  letter-spacing: -0.065em !important;
+  line-height: 0.94 !important;
+}
+.mg-route-section,
+.mg-detail-section {
+  padding-top: clamp(1.5rem, 3.5vw, 2.5rem);
+  border-top: 1px solid var(--border);
+}
+.mg-route-section > :first-child,
+.mg-detail-section > :first-child {
+  margin-top: 0;
+}
+.mg-route-section .mg-section-rule::before {
+  display: none;
+}
+.mg-route-heading {
+  padding-bottom: var(--mg-space-md);
+  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-static-section {
+  padding-top: var(--mg-space-lg);
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-static-section + .mg-static-section {
+  margin-top: var(--mg-space-lg);
+}
+.mg-static-section:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+.mg-profile-tabs {
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem) !important;
+}
+.mg-profile-tabs ul {
+  gap: clamp(1rem, 3vw, 2rem);
+}
+.mg-profile-tabs button {
+  border-radius: 0 !important;
+}
+.mg-profile-tabs button[aria-selected="true"]::after {
+  border-radius: 0 !important;
+}
+.mg-route-frame .mg-panel {
+  border-radius: 0;
+  box-shadow: none;
+}
+@media (max-width: 639.98px) {
+  .mg-page-heading {
+    min-height: 0;
+    padding-top: var(--mg-space-xl);
+  }
+  .mg-page-heading::before {
+    top: 1.25rem;
+    right: 0;
+    width: 100%;
+    height: 6rem;
+    opacity: 0.6;
+  }
+  .mg-page-heading h1 {
+    font-size: clamp(2.25rem, 12vw, 3.35rem) !important;
+  }
+  .mg-route-section,
+  .mg-detail-section {
+    padding-top: var(--mg-space-xl);
+  }
+}
+.mg-masthead > div {
+  position: relative;
+}
+.mg-masthead .mg-masthead-kpi {
+  background: color-mix(in oklab, var(--paper) 82%, transparent);
 }
 .mg-masthead-kpi {
   display: grid;
@@ -218,7 +356,78 @@
   padding-left: 1rem;
   border-left: 1px solid var(--border);
 }
+.mg-subnet-masthead {
+  position: relative;
+  isolation: isolate;
+  min-height: 15rem;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 4vw, 3rem) clamp(1.5rem, 3vw, 2.5rem);
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+}
+.mg-subnet-masthead::before {
+  position: absolute;
+  z-index: -1;
+  top: clamp(2.25rem, 5vw, 3.5rem);
+  right: -1rem;
+  width: min(65%, 38rem);
+  height: 8.5rem;
+  border: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--ink-strong) 14%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 4px 4px;
+  content: "";
+  mask-image: linear-gradient(90deg, transparent, #000 20%, #000 84%, transparent);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 20%, #000 84%, transparent);
+}
+.mg-subnet-masthead > * {
+  position: relative;
+}
+.mg-subnet-masthead h1 {
+  max-width: 14ch;
+  font-size: clamp(2.4rem, 5vw, 4.25rem) !important;
+  font-weight: 500 !important;
+  letter-spacing: -0.065em !important;
+  line-height: 0.94 !important;
+}
+.mg-subnet-masthead .mg-subnet-kpi-grid {
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: color-mix(in oklab, var(--paper) 84%, transparent);
+}
 @media (max-width: 639.98px) {
+  .mg-masthead {
+    min-height: 0;
+    padding-top: var(--mg-space-xl) !important;
+  }
+  .mg-masthead::before {
+    top: 1.25rem;
+    right: 0;
+    width: 100%;
+    height: 6.5rem;
+    opacity: 0.6;
+  }
+  .mg-masthead h1 {
+    font-size: clamp(2.25rem, 12vw, 3.35rem) !important;
+  }
+  .mg-subnet-masthead {
+    min-height: 0;
+    padding: var(--mg-space-xl) 0 var(--mg-space-lg);
+  }
+  .mg-subnet-masthead::before {
+    top: 1.5rem;
+    right: 0;
+    width: 100%;
+    height: 7rem;
+    opacity: 0.6;
+  }
+  .mg-subnet-masthead h1 {
+    font-size: clamp(2.35rem, 12vw, 3.5rem) !important;
+  }
   .mg-masthead-kpi > * + * {
     padding-left: 0;
     border-left: 0;
@@ -265,416 +474,5 @@
   .mg-shimmer-sweep,
   .mg-query-progress-track {
     animation: none;
-  }
-}
-
-/* ============================================================
- * Network Data — a continuous analytics document, not a dashboard wall.
- *
- * The page intentionally borrows the calm, vertically paced data-reading
- * rhythm of a modern research terminal: a single quiet field in the hero,
- * one constrained canvas, and one analytical question per ruled module.
- * Metagraphed mint stays the product/live focus; the shared chart prism is
- * only for category tracking inside the visuals.
- * ============================================================ */
-.mg-data-stage {
-  width: min(100%, 68rem);
-  margin-inline: auto;
-  padding-bottom: var(--mg-space-3xl);
-}
-.mg-data-hero {
-  position: relative;
-  isolation: isolate;
-  min-height: 23rem;
-  padding: clamp(3rem, 8vw, 6.5rem) clamp(1rem, 4vw, 3rem) clamp(2.5rem, 5vw, 4rem);
-  overflow: hidden;
-}
-.mg-data-hero-field {
-  position: absolute;
-  z-index: -1;
-  right: 0;
-  top: clamp(2rem, 5vw, 4rem);
-  width: min(72%, 45rem);
-  height: min(17rem, 58%);
-  border: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
-  background-image: radial-gradient(
-    circle at 1px 1px,
-    color-mix(in oklab, var(--ink-strong) 16%, transparent) 1px,
-    transparent 0
-  );
-  background-size: 4px 4px;
-  mask-image: linear-gradient(90deg, transparent 0, #000 26%, #000 82%, transparent 100%);
-  -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 26%, #000 82%, transparent 100%);
-}
-.mg-data-hero-content {
-  position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(15rem, 0.8fr);
-  align-items: end;
-  gap: clamp(2rem, 8vw, 8rem);
-  min-height: 16rem;
-}
-.mg-data-kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.25rem 0.45rem;
-  border: 1px solid var(--border);
-  color: var(--ink-muted);
-  background: color-mix(in oklab, var(--paper) 85%, transparent);
-  font-size: var(--mg-type-micro);
-  font-weight: 600;
-  letter-spacing: var(--mg-tracking-micro);
-  line-height: 1.25;
-  text-transform: uppercase;
-}
-.mg-data-kicker-dot {
-  width: 0.45rem;
-  height: 0.45rem;
-  flex: 0 0 auto;
-  border-radius: 999px;
-  background: var(--brand-green);
-  box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
-  animation: mg-data-live-signal 2.4s ease-out infinite;
-}
-@keyframes mg-data-live-signal {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
-  }
-  45% {
-    box-shadow: 0 0 0 0.32rem color-mix(in oklab, var(--brand-green) 22%, transparent);
-  }
-}
-.mg-data-hero h1 {
-  max-width: 10ch;
-  margin: var(--mg-space-md) 0 0;
-  color: var(--ink-strong);
-  font-family: var(--font-display);
-  font-size: clamp(3.25rem, 8.5vw, 6.75rem);
-  font-weight: 500;
-  letter-spacing: -0.07em;
-  line-height: 0.86;
-}
-.mg-data-hero-detail {
-  display: grid;
-  justify-items: start;
-  gap: var(--mg-space-lg);
-  padding-bottom: 0.2rem;
-}
-.mg-data-hero-detail p {
-  max-width: 31rem;
-  margin: 0;
-  color: var(--ink-muted);
-  font-size: clamp(0.82rem, 1.5vw, 0.95rem);
-  line-height: 1.7;
-}
-.mg-data-window {
-  display: inline-flex;
-  border: 1px solid var(--border);
-  background: color-mix(in oklab, var(--paper) 86%, transparent);
-}
-.mg-data-window-button {
-  position: relative;
-  min-height: 2.35rem;
-  padding: 0.5rem 0.8rem;
-  color: var(--ink-muted);
-  font-family: var(--font-sans);
-  font-size: var(--mg-type-caption);
-  font-weight: 500;
-  line-height: 1;
-  transition:
-    color 160ms ease,
-    background-color 160ms ease;
-}
-.mg-data-window-button + .mg-data-window-button {
-  border-left: 1px solid var(--border);
-}
-.mg-data-window-button::after {
-  position: absolute;
-  right: 0.65rem;
-  bottom: 0.42rem;
-  left: 0.65rem;
-  height: 1.5px;
-  background: transparent;
-  content: "";
-}
-.mg-data-window-button.is-active {
-  color: var(--ink-strong);
-  background: color-mix(in oklab, var(--brand-green) 8%, transparent);
-}
-.mg-data-window-button.is-active::after {
-  background: var(--brand-green);
-}
-.mg-data-canvas {
-  border-right: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  border-left: 1px solid var(--border);
-}
-.mg-data-module {
-  padding: clamp(1.5rem, 4vw, 2.75rem) clamp(1rem, 4vw, 3rem);
-  border-top: 1px solid var(--border);
-}
-.mg-data-module-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--mg-space-lg);
-}
-.mg-data-module-title {
-  max-width: 54rem;
-  margin: 0;
-  color: var(--ink-muted);
-  font-family: var(--font-display);
-  font-size: clamp(0.94rem, 2vw, 1.15rem);
-  font-weight: 400;
-  letter-spacing: -0.025em;
-  line-height: 1.55;
-}
-.mg-data-module-title strong {
-  color: var(--ink-strong);
-  font-weight: 600;
-}
-.mg-data-module-title span {
-  margin-left: 0.35em;
-}
-.mg-data-module-action {
-  flex: 0 0 auto;
-}
-.mg-data-module-chart,
-.mg-data-module-body {
-  margin-top: clamp(1.25rem, 3vw, 2rem);
-}
-.mg-data-module-footer {
-  margin-top: var(--mg-space-lg);
-  padding-top: var(--mg-space-sm);
-  border-top: 1px solid var(--border);
-  color: var(--ink-muted);
-  font-size: var(--mg-type-caption);
-  line-height: 1.55;
-}
-.mg-data-module--stake-flow .mg-data-module-chart {
-  margin-top: clamp(1.5rem, 4vw, 2.5rem);
-}
-.mg-data-plot-grid {
-  display: flex;
-  align-items: center;
-  min-width: 0;
-  overflow: hidden;
-  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
-  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
-  background-image: radial-gradient(
-    circle at 1px 1px,
-    color-mix(in oklab, var(--ink-strong) 11%, transparent) 1px,
-    transparent 0
-  );
-  background-size: 5px 5px;
-}
-.mg-data-measure-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-.mg-data-measure-grid--4 {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-.mg-data-measure {
-  min-width: 0;
-  padding: var(--mg-space-md);
-}
-.mg-data-measure + .mg-data-measure {
-  border-left: 1px solid var(--border);
-}
-.mg-data-measure > :first-child {
-  color: var(--ink-muted);
-  font-size: var(--mg-type-micro);
-  font-weight: 600;
-  letter-spacing: var(--mg-tracking-label);
-  line-height: 1.35;
-  text-transform: uppercase;
-}
-.mg-data-measure > :last-child {
-  margin-top: 0.45rem;
-  overflow: hidden;
-  color: var(--ink-strong);
-  font-family: var(--font-display);
-  font-size: clamp(1rem, 2.4vw, 1.45rem);
-  font-weight: 500;
-  letter-spacing: -0.045em;
-  line-height: 1.05;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.mg-data-rank-list {
-  margin: var(--mg-space-xl) 0 0;
-  padding: 0;
-  border-top: 1px solid var(--border);
-  list-style: none;
-}
-.mg-data-rank-list > li + li {
-  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
-}
-.mg-data-rank-row {
-  display: grid;
-  grid-template-columns: 2.3rem minmax(4.5rem, 0.75fr) minmax(8rem, 2fr) max-content;
-  align-items: center;
-  gap: var(--mg-space-sm);
-  min-width: 0;
-  padding: 0.78rem 0;
-  color: inherit;
-  text-decoration: none;
-  transition:
-    background-color 160ms ease,
-    color 160ms ease;
-}
-.mg-data-rank-index {
-  color: var(--ink-subtle);
-  font-size: var(--mg-type-micro);
-}
-.mg-data-rank-label {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--ink-strong);
-  font-size: var(--mg-type-caption);
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.mg-data-rank-track {
-  height: 0.28rem;
-  overflow: hidden;
-  background: color-mix(in oklab, var(--ink-strong) 8%, transparent);
-}
-.mg-data-rank-fill {
-  display: block;
-  height: 100%;
-}
-.mg-data-rank-value {
-  display: grid;
-  justify-items: end;
-  color: var(--ink-strong);
-  font-size: var(--mg-type-caption);
-  line-height: 1.15;
-  text-align: right;
-  white-space: nowrap;
-}
-.mg-data-rank-value small {
-  margin-top: 0.2rem;
-  color: var(--ink-muted);
-  font-size: var(--mg-type-micro);
-}
-.mg-data-module-note {
-  max-width: 56rem;
-  margin: var(--mg-space-md) 0 0;
-  color: var(--ink-muted);
-  font-size: var(--mg-type-caption);
-  line-height: 1.55;
-}
-.mg-data-module-note + .mg-data-module-note {
-  margin-top: var(--mg-space-xs);
-}
-.mg-data-wide-chart {
-  margin-bottom: var(--mg-space-xl);
-  padding: var(--mg-space-md) 0;
-  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
-  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
-}
-.mg-data-loading {
-  padding: clamp(1rem, 4vw, 3rem);
-  border-top: 1px solid var(--border);
-}
-@media (hover: hover) {
-  .mg-data-window-button:hover {
-    color: var(--ink-strong);
-    background: color-mix(in oklab, var(--ink-strong) 4%, transparent);
-  }
-  .mg-data-rank-row:hover {
-    background: color-mix(in oklab, var(--brand-green) 5%, transparent);
-  }
-}
-@media (max-width: 640px) {
-  .mg-data-stage {
-    width: 100%;
-  }
-  .mg-data-hero {
-    min-height: 0;
-    padding: var(--mg-space-2xl) 0 var(--mg-space-xl);
-  }
-  .mg-data-hero-field {
-    top: 1.75rem;
-    width: 100%;
-    height: 11rem;
-    opacity: 0.65;
-  }
-  .mg-data-hero-content {
-    display: block;
-    min-height: 0;
-  }
-  .mg-data-hero h1 {
-    margin-top: var(--mg-space-sm);
-    font-size: clamp(3.3rem, 16vw, 4.75rem);
-  }
-  .mg-data-hero-detail {
-    gap: var(--mg-space-md);
-    margin-top: var(--mg-space-2xl);
-  }
-  .mg-data-canvas {
-    margin-inline: calc(-1 * var(--mg-gutter-x));
-    border-right: 0;
-    border-left: 0;
-  }
-  .mg-data-module {
-    padding: var(--mg-space-xl) var(--mg-gutter-x);
-  }
-  .mg-data-module-heading {
-    display: block;
-  }
-  .mg-data-module-action {
-    margin-top: var(--mg-space-sm);
-  }
-  .mg-data-module-title span {
-    display: inline;
-  }
-  .mg-data-measure-grid,
-  .mg-data-measure-grid--4 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-  .mg-data-measure-grid--3 > :last-child {
-    grid-column: span 2;
-  }
-  .mg-data-measure + .mg-data-measure {
-    border-left: 0;
-  }
-  .mg-data-measure:nth-child(even) {
-    border-left: 1px solid var(--border);
-  }
-  .mg-data-measure-grid--3 > :last-child {
-    border-top: 1px solid var(--border);
-  }
-  .mg-data-measure-grid--4 > :nth-child(n + 3) {
-    border-top: 1px solid var(--border);
-  }
-  .mg-data-rank-row {
-    grid-template-columns: 1.7rem minmax(3.8rem, 0.68fr) minmax(3rem, 1fr) max-content;
-    gap: var(--mg-space-xs);
-  }
-  .mg-data-rank-value {
-    font-size: var(--mg-type-data-sm);
-  }
-  .mg-data-wide-chart {
-    margin-bottom: var(--mg-space-lg);
-  }
-  .mg-data-loading {
-    padding: var(--mg-space-xl) var(--mg-gutter-x);
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .mg-data-kicker-dot {
-    animation: none;
-  }
-  .mg-data-window-button,
-  .mg-data-rank-row {
-    transition: none;
   }
 }

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -267,3 +267,414 @@
     animation: none;
   }
 }
+
+/* ============================================================
+ * Network Data — a continuous analytics document, not a dashboard wall.
+ *
+ * The page intentionally borrows the calm, vertically paced data-reading
+ * rhythm of a modern research terminal: a single quiet field in the hero,
+ * one constrained canvas, and one analytical question per ruled module.
+ * Metagraphed mint stays the product/live focus; the shared chart prism is
+ * only for category tracking inside the visuals.
+ * ============================================================ */
+.mg-data-stage {
+  width: min(100%, 68rem);
+  margin-inline: auto;
+  padding-bottom: var(--mg-space-3xl);
+}
+.mg-data-hero {
+  position: relative;
+  isolation: isolate;
+  min-height: 23rem;
+  padding: clamp(3rem, 8vw, 6.5rem) clamp(1rem, 4vw, 3rem) clamp(2.5rem, 5vw, 4rem);
+  overflow: hidden;
+}
+.mg-data-hero-field {
+  position: absolute;
+  z-index: -1;
+  right: 0;
+  top: clamp(2rem, 5vw, 4rem);
+  width: min(72%, 45rem);
+  height: min(17rem, 58%);
+  border: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--ink-strong) 16%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 4px 4px;
+  mask-image: linear-gradient(90deg, transparent 0, #000 26%, #000 82%, transparent 100%);
+  -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 26%, #000 82%, transparent 100%);
+}
+.mg-data-hero-content {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(15rem, 0.8fr);
+  align-items: end;
+  gap: clamp(2rem, 8vw, 8rem);
+  min-height: 16rem;
+}
+.mg-data-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--border);
+  color: var(--ink-muted);
+  background: color-mix(in oklab, var(--paper) 85%, transparent);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-micro);
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.mg-data-kicker-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--brand-green);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  animation: mg-data-live-signal 2.4s ease-out infinite;
+}
+@keyframes mg-data-live-signal {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  }
+  45% {
+    box-shadow: 0 0 0 0.32rem color-mix(in oklab, var(--brand-green) 22%, transparent);
+  }
+}
+.mg-data-hero h1 {
+  max-width: 10ch;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(3.25rem, 8.5vw, 6.75rem);
+  font-weight: 500;
+  letter-spacing: -0.07em;
+  line-height: 0.86;
+}
+.mg-data-hero-detail {
+  display: grid;
+  justify-items: start;
+  gap: var(--mg-space-lg);
+  padding-bottom: 0.2rem;
+}
+.mg-data-hero-detail p {
+  max-width: 31rem;
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: clamp(0.82rem, 1.5vw, 0.95rem);
+  line-height: 1.7;
+}
+.mg-data-window {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--paper) 86%, transparent);
+}
+.mg-data-window-button {
+  position: relative;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.8rem;
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: var(--mg-type-caption);
+  font-weight: 500;
+  line-height: 1;
+  transition:
+    color 160ms ease,
+    background-color 160ms ease;
+}
+.mg-data-window-button + .mg-data-window-button {
+  border-left: 1px solid var(--border);
+}
+.mg-data-window-button::after {
+  position: absolute;
+  right: 0.65rem;
+  bottom: 0.42rem;
+  left: 0.65rem;
+  height: 1.5px;
+  background: transparent;
+  content: "";
+}
+.mg-data-window-button.is-active {
+  color: var(--ink-strong);
+  background: color-mix(in oklab, var(--brand-green) 8%, transparent);
+}
+.mg-data-window-button.is-active::after {
+  background: var(--brand-green);
+}
+.mg-data-canvas {
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+}
+.mg-data-module {
+  padding: clamp(1.5rem, 4vw, 2.75rem) clamp(1rem, 4vw, 3rem);
+  border-top: 1px solid var(--border);
+}
+.mg-data-module-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--mg-space-lg);
+}
+.mg-data-module-title {
+  max-width: 54rem;
+  margin: 0;
+  color: var(--ink-muted);
+  font-family: var(--font-display);
+  font-size: clamp(0.94rem, 2vw, 1.15rem);
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.55;
+}
+.mg-data-module-title strong {
+  color: var(--ink-strong);
+  font-weight: 600;
+}
+.mg-data-module-title span {
+  margin-left: 0.35em;
+}
+.mg-data-module-action {
+  flex: 0 0 auto;
+}
+.mg-data-module-chart,
+.mg-data-module-body {
+  margin-top: clamp(1.25rem, 3vw, 2rem);
+}
+.mg-data-module-footer {
+  margin-top: var(--mg-space-lg);
+  padding-top: var(--mg-space-sm);
+  border-top: 1px solid var(--border);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-data-module--stake-flow .mg-data-module-chart {
+  margin-top: clamp(1.5rem, 4vw, 2.5rem);
+}
+.mg-data-plot-grid {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--ink-strong) 11%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 5px 5px;
+}
+.mg-data-measure-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.mg-data-measure-grid--4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.mg-data-measure {
+  min-width: 0;
+  padding: var(--mg-space-md);
+}
+.mg-data-measure + .mg-data-measure {
+  border-left: 1px solid var(--border);
+}
+.mg-data-measure > :first-child {
+  color: var(--ink-muted);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-label);
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+.mg-data-measure > :last-child {
+  margin-top: 0.45rem;
+  overflow: hidden;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(1rem, 2.4vw, 1.45rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-data-rank-list {
+  margin: var(--mg-space-xl) 0 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+  list-style: none;
+}
+.mg-data-rank-list > li + li {
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-data-rank-row {
+  display: grid;
+  grid-template-columns: 2.3rem minmax(4.5rem, 0.75fr) minmax(8rem, 2fr) max-content;
+  align-items: center;
+  gap: var(--mg-space-sm);
+  min-width: 0;
+  padding: 0.78rem 0;
+  color: inherit;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+.mg-data-rank-index {
+  color: var(--ink-subtle);
+  font-size: var(--mg-type-micro);
+}
+.mg-data-rank-label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink-strong);
+  font-size: var(--mg-type-caption);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-data-rank-track {
+  height: 0.28rem;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--ink-strong) 8%, transparent);
+}
+.mg-data-rank-fill {
+  display: block;
+  height: 100%;
+}
+.mg-data-rank-value {
+  display: grid;
+  justify-items: end;
+  color: var(--ink-strong);
+  font-size: var(--mg-type-caption);
+  line-height: 1.15;
+  text-align: right;
+  white-space: nowrap;
+}
+.mg-data-rank-value small {
+  margin-top: 0.2rem;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-micro);
+}
+.mg-data-module-note {
+  max-width: 56rem;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-data-module-note + .mg-data-module-note {
+  margin-top: var(--mg-space-xs);
+}
+.mg-data-wide-chart {
+  margin-bottom: var(--mg-space-xl);
+  padding: var(--mg-space-md) 0;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-data-loading {
+  padding: clamp(1rem, 4vw, 3rem);
+  border-top: 1px solid var(--border);
+}
+@media (hover: hover) {
+  .mg-data-window-button:hover {
+    color: var(--ink-strong);
+    background: color-mix(in oklab, var(--ink-strong) 4%, transparent);
+  }
+  .mg-data-rank-row:hover {
+    background: color-mix(in oklab, var(--brand-green) 5%, transparent);
+  }
+}
+@media (max-width: 640px) {
+  .mg-data-stage {
+    width: 100%;
+  }
+  .mg-data-hero {
+    min-height: 0;
+    padding: var(--mg-space-2xl) 0 var(--mg-space-xl);
+  }
+  .mg-data-hero-field {
+    top: 1.75rem;
+    width: 100%;
+    height: 11rem;
+    opacity: 0.65;
+  }
+  .mg-data-hero-content {
+    display: block;
+    min-height: 0;
+  }
+  .mg-data-hero h1 {
+    margin-top: var(--mg-space-sm);
+    font-size: clamp(3.3rem, 16vw, 4.75rem);
+  }
+  .mg-data-hero-detail {
+    gap: var(--mg-space-md);
+    margin-top: var(--mg-space-2xl);
+  }
+  .mg-data-canvas {
+    margin-inline: calc(-1 * var(--mg-gutter-x));
+    border-right: 0;
+    border-left: 0;
+  }
+  .mg-data-module {
+    padding: var(--mg-space-xl) var(--mg-gutter-x);
+  }
+  .mg-data-module-heading {
+    display: block;
+  }
+  .mg-data-module-action {
+    margin-top: var(--mg-space-sm);
+  }
+  .mg-data-module-title span {
+    display: inline;
+  }
+  .mg-data-measure-grid,
+  .mg-data-measure-grid--4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .mg-data-measure-grid--3 > :last-child {
+    grid-column: span 2;
+  }
+  .mg-data-measure + .mg-data-measure {
+    border-left: 0;
+  }
+  .mg-data-measure:nth-child(even) {
+    border-left: 1px solid var(--border);
+  }
+  .mg-data-measure-grid--3 > :last-child {
+    border-top: 1px solid var(--border);
+  }
+  .mg-data-measure-grid--4 > :nth-child(n + 3) {
+    border-top: 1px solid var(--border);
+  }
+  .mg-data-rank-row {
+    grid-template-columns: 1.7rem minmax(3.8rem, 0.68fr) minmax(3rem, 1fr) max-content;
+    gap: var(--mg-space-xs);
+  }
+  .mg-data-rank-value {
+    font-size: var(--mg-type-data-sm);
+  }
+  .mg-data-wide-chart {
+    margin-bottom: var(--mg-space-lg);
+  }
+  .mg-data-loading {
+    padding: var(--mg-space-xl) var(--mg-gutter-x);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mg-data-kicker-dot {
+    animation: none;
+  }
+  .mg-data-window-button,
+  .mg-data-rank-row {
+    transition: none;
+  }
+}

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -116,6 +116,24 @@
   height: 0;
 }
 
+/* The subnet directory's sheet is the whole refinement surface below lg.
+   Its close affordance must be as easy to hit as the controls it contains.
+   This stays route-scoped because FilterSheet's desktop compactness remains
+   appropriate for the other, denser directories. */
+.mg-subnets-filter-sheet [aria-label="Close filters"] {
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+}
+
+/* FilterSheet's modal is rendered beside the trigger. Backdrop filters create
+   a containing block for a fixed descendant, so leaving the list toolbar's
+   blur on would constrain the sheet to that toolbar instead of the viewport.
+   The nearly opaque paper background preserves the same visual treatment. */
+.sticky:has(.mg-subnets-directory-controls) {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
 /* The subnets table header used to be styled here, by a bespoke
    `.mg-subnets-sticky-head` rule that pinned it with
    `top: var(--mg-sticky-offset)` -- the app-header stack height (131px live),

--- a/apps/ui/tests/e2e/capture-pr-screenshots.ts
+++ b/apps/ui/tests/e2e/capture-pr-screenshots.ts
@@ -128,7 +128,11 @@ function run(cmd, args, opts = {}) {
       `${cmd} ${args.join(" ")} failed (${result.status}):\n${result.stderr || result.stdout}`,
     );
   }
-  return result.stdout.trim();
+  // `stdio: "inherit"` deliberately streams long-lived install output to the
+  // caller, which means Node leaves `stdout` as `null`. The helper is also
+  // used for commands whose output is meaningful, so normalize just this
+  // no-capture case rather than forcing every caller through a second runner.
+  return (result.stdout ?? "").trim();
 }
 
 /** Prefers `origin/main` over local `main` -- a long-lived local checkout's

--- a/apps/ui/tests/e2e/capture-pr-screenshots.ts
+++ b/apps/ui/tests/e2e/capture-pr-screenshots.ts
@@ -261,36 +261,20 @@ function removeWorktree(worktreeDir) {
   }
 }
 
-async function setTheme(page, baseUrl, theme) {
-  await page.goto(`${baseUrl}/`, { waitUntil: "domcontentloaded" });
-  await page.evaluate(({ key, value }) => localStorage.setItem(key, value), {
-    key: THEME_STORAGE_KEY,
-    value: theme,
-  });
-}
-
-/** `networkidle` is the right wait condition (it's what lets a late-mounting
- * chart or a client-side non-suspense query settle before capture -- see
- * capture-operational-status-screenshots.ts), but a just-spawned dev
- * server's first hit on a route pays Vite's cold transform/optimize cost on
- * top of the app's own data fetches, occasionally blowing past a single
- * timeout. Retry once, then fall back to the cheaper `load` condition plus a
- * fixed settle wait rather than failing the whole capture run outright. */
+/** Dev-mode Vite keeps a hot-module websocket open. Waiting for
+ * `networkidle` therefore turns a visual capture into a multi-minute timeout
+ * on some machines even though the document is completely usable. Wait for
+ * the actual document instead; the fixed settle waits in `captureVariant`
+ * deliberately cover late client-side charts and queries. */
 async function gotoRoute(page, url) {
   try {
-    await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
+    await page.goto(url, { waitUntil: "load", timeout: 30_000 });
     return;
   } catch (err) {
-    console.warn(`networkidle wait failed for ${url}, retrying once: ${err.message}`);
+    console.warn(`load wait failed for ${url}, falling back to DOMContentLoaded: ${err.message}`);
   }
-  try {
-    await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
-    return;
-  } catch (err) {
-    console.warn(`networkidle retry failed for ${url}, falling back to "load": ${err.message}`);
-  }
-  await page.goto(url, { waitUntil: "load", timeout: 60_000 });
-  await page.waitForTimeout(2000);
+  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 });
+  await page.waitForTimeout(500);
 }
 
 /** Scrolls `sectionId` into view, accounting for the sticky masthead's live
@@ -328,13 +312,19 @@ async function captureVariant({
   prefix,
 }) {
   for (const viewport of VIEWPORTS) {
-    const context = await browser.newContext({
-      viewport: { width: viewport.width, height: viewport.height },
-    });
-    const page = await context.newPage();
-
     for (const theme of THEMES) {
-      await setTheme(page, baseUrl, theme);
+      // Seed the preference before the document executes. Apart from avoiding
+      // a visible light-to-dark flash, this deliberately avoids a second
+      // root-page navigation between screenshots -- a costly and occasionally
+      // flaky request while two cold Vite servers are compiling in parallel.
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      await context.addInitScript(({ key, value }) => window.localStorage.setItem(key, value), {
+        key: THEME_STORAGE_KEY,
+        value: theme,
+      });
+      const page = await context.newPage();
       await gotoRoute(page, `${baseUrl}${route}`);
       // Let async, non-suspense queries (identity/balance/etc. -- anything
       // fetched client-side post-hydration) resolve before scrolling and
@@ -350,7 +340,12 @@ async function captureVariant({
       // every glyph shifts, which is exactly the noise a before/after
       // comparison must not have (responsive-overflow.spec.ts blocks on this
       // for the same reason -- see #4876). Block until the swap has happened.
-      await page.evaluate(() => document.fonts.ready);
+      await page.evaluate(() =>
+        Promise.race([
+          document.fonts.ready,
+          new Promise((resolve) => window.setTimeout(resolve, 5_000)),
+        ]),
+      );
 
       if (section) {
         const found = await scrollToSection(page, section);
@@ -364,8 +359,8 @@ async function captureVariant({
       const file = path.join(outDir, `${name}.png`);
       await page.screenshot({ path: file, fullPage: false });
       console.log(`wrote ${file}`);
+      await context.close();
     }
-    await context.close();
   }
 }
 

--- a/apps/ui/tests/e2e/subnets-directory-controls.spec.ts
+++ b/apps/ui/tests/e2e/subnets-directory-controls.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test, type Page } from "@playwright/test";
+import { DATED_ENDPOINT_PATTERNS, findHarFixture, harPathForRoute } from "./har-path.ts";
+import { gotoThroughRestart } from "./server-restart.ts";
+
+const ROUTE = "/subnets";
+const HAR_PATH = harPathForRoute(ROUTE);
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+] as const;
+
+async function openSubnets(page: Page, viewport: (typeof VIEWPORTS)[number]) {
+  await page.routeFromHAR(HAR_PATH, {
+    url: "**/api.metagraph.sh/**",
+    notFound: "fallback",
+    update: false,
+  });
+  for (const pattern of DATED_ENDPOINT_PATTERNS) {
+    const fixture = findHarFixture(HAR_PATH, pattern);
+    if (fixture) await page.route(pattern, (route) => route.fulfill(fixture));
+  }
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await gotoThroughRestart(page, ROUTE);
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 5000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  await page.evaluate(() => document.fonts.ready);
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`keeps subnet search usable at ${viewport.name} (${viewport.width}px)`, async ({ page }) => {
+    await openSubnets(page, viewport);
+
+    const search = page.getByRole("textbox", {
+      name: "Search by netuid, name, or symbol",
+    });
+    await expect(search).toBeVisible();
+    const searchBox = await search.boundingBox();
+    expect(searchBox?.width, `search width at ${viewport.width}px`).toBeGreaterThanOrEqual(180);
+
+    if (viewport.width < 1024) {
+      expect(
+        searchBox?.height,
+        `mobile search target at ${viewport.width}px`,
+      ).toBeGreaterThanOrEqual(44);
+
+      const filters = page.getByRole("button", { name: "Filters", exact: true });
+      const filterBox = await filters.boundingBox();
+      expect(filterBox?.height, `filter target at ${viewport.width}px`).toBeGreaterThanOrEqual(44);
+
+      await filters.click();
+      const dialog = page.getByRole("dialog", { name: "Filters" });
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByText("Display", { exact: true })).toBeVisible();
+      await expect(dialog.getByText("Export & share", { exact: true })).toBeVisible();
+      await expect(dialog.getByRole("button", { name: "Download CSV" })).toBeVisible();
+      await expect(
+        dialog.getByRole("button", { name: "Copy link with current filters, sort, and page" }),
+      ).toBeVisible();
+      await expect(dialog.getByText("Quick views", { exact: true })).toBeVisible();
+      await expect(dialog.getByText("View options", { exact: true })).toBeVisible();
+
+      const hasApi = dialog.getByRole("button", { name: "Has API", exact: true });
+      await hasApi.click();
+      await expect(hasApi).toHaveAttribute("aria-pressed", "true");
+      await expect(dialog.getByRole("button", { name: "Clear all filters" })).toBeVisible();
+
+      const close = dialog.getByRole("button", { name: "Close filters" });
+      const closeBox = await close.boundingBox();
+      expect(closeBox?.height, `filter close target at ${viewport.width}px`).toBeGreaterThanOrEqual(
+        44,
+      );
+      await close.click();
+      await expect(dialog).toBeHidden();
+    }
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,6 +1692,15 @@
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@fuma-translate/react": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@fuma-translate/react/-/react-1.0.2.tgz",
@@ -20876,6 +20885,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "@radix-ui/react-accordion": "^1.2.20",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-hover-card": "^1.1.23",

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -536,7 +536,7 @@ function Panel({
     {
       ...rest,
       className: classNames(
-        "rounded-sm border",
+        "mg-panel rounded-sm border",
         toneStyle.border,
         tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,
@@ -2035,6 +2035,20 @@ function KeyChip({
     ] })
   );
 }
+var RESPONSIVE_CLASSES = {
+  md: {
+    filter: "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5",
+    cards: "md:hidden space-y-2",
+    table: "hidden md:block",
+    footer: "md:hidden mt-3"
+  },
+  lg: {
+    filter: "sticky lg:static z-[var(--mg-z-raised)] -mx-4 lg:mx-0 mb-3 border-b border-border lg:border lg:rounded lg:bg-card px-3 py-2 lg:p-2.5",
+    cards: "lg:hidden space-y-2",
+    table: "hidden lg:block",
+    footer: "lg:hidden mt-3"
+  }
+};
 function ListShell({
   filters,
   cards,
@@ -2044,16 +2058,23 @@ function ListShell({
   isEmpty,
   isStale,
   viewportRef,
-  stickyHeader = true
+  stickyHeader = true,
+  presentation = "panel",
+  responsiveAt = "md"
 }) {
-  const tableCard = "rounded border border-border bg-card overflow-hidden";
+  const responsive = RESPONSIVE_CLASSES[responsiveAt];
+  const tableCard = classNames(
+    "mg-list-table-card overflow-hidden",
+    presentation === "canvas" ? "mg-list-table-card--canvas" : "rounded border border-border bg-card"
+  );
   const viewportClass = stickyHeader ? "mg-table-scroll mg-list-viewport" : "mg-table-scroll overflow-x-auto";
-  return /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+  return /* @__PURE__ */ jsxRuntime.jsxs("div", { "data-mg-list-shell": true, "data-presentation": presentation, children: [
     /* @__PURE__ */ jsxRuntime.jsx(
       "div",
       {
         className: classNames(
-          // Sticky below `md`, in normal flow at and above it. Offset reads
+          // Sticky below the responsive breakpoint, in normal flow at and
+          // above it. Offset reads
           // --mg-sticky-offset (published by AppShell to match real header +
           // ticker height) with a fallback.
           //
@@ -2072,10 +2093,9 @@ function ListShell({
           // (`#subnets-list > div > div:first-child { position: static }`,
           // at >=1024px only, which is why tablet still showed the overlap).
           // That override is deleted; this is the general rule.
-          "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
+          responsive.filter,
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
-          "border-b border-border md:border md:rounded md:bg-card",
-          "px-3 py-2 md:p-2.5"
+          presentation === "canvas" ? "mg-list-filter-bar--canvas" : void 0
         ),
         style: {
           top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
@@ -2092,12 +2112,12 @@ function ListShell({
       // attribute is what makes that state observable.
       /* @__PURE__ */ jsxRuntime.jsx("div", { "data-mg-list-empty": "", children: empty })
     ) : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
-      cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
-      /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
+      cards ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: responsive.cards, children: cards }) : null,
+      /* @__PURE__ */ jsxRuntime.jsx("div", { className: cards ? responsive.table : void 0, children: /* @__PURE__ */ jsxRuntime.jsxs("div", { className: tableCard, children: [
         /* @__PURE__ */ jsxRuntime.jsx("div", { ref: viewportRef, className: viewportClass, children: table }),
         footer
       ] }) }),
-      cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "md:hidden mt-3", children: footer }) : null
+      cards && footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: responsive.footer, children: footer }) : null
     ] })
   ] });
 }
@@ -2217,6 +2237,165 @@ function PageHero({
           k.chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
         ] }, k.label)) }) : null
       ]
+    }
+  );
+}
+function DataPageStage({
+  children,
+  className,
+  variant = "default"
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    "div",
+    {
+      className: classNames(
+        "mg-page-stage",
+        variant !== "default" ? `mg-page-stage--${variant}` : void 0,
+        className
+      ),
+      children
+    }
+  );
+}
+function DataPageHero({
+  eyebrow,
+  title,
+  description,
+  summary,
+  actions,
+  children,
+  footer,
+  live = false,
+  id,
+  className,
+  variant = "directory"
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    "section",
+    {
+      className: classNames(
+        "mg-page-hero",
+        `mg-page-hero--${variant}`,
+        className
+      ),
+      "aria-labelledby": id,
+      children: [
+        /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-hero-field", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-page-hero-content", children: [
+          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-page-hero-copy", children: [
+            eyebrow ? /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "mg-page-kicker", children: [
+              live ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-page-kicker-dot", "aria-hidden": "true" }) : null,
+              eyebrow
+            ] }) : null,
+            /* @__PURE__ */ jsxRuntime.jsx("h1", { id, children: title }),
+            description ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-hero-description", children: description }) : null,
+            children ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-hero-body", children }) : null,
+            summary ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-hero-summary", children: summary }) : null
+          ] }),
+          actions ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-hero-actions", children: actions }) : null
+        ] }),
+        footer ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-hero-footer", children: footer }) : null
+      ]
+    }
+  );
+}
+function DataPageCanvas({
+  children,
+  className,
+  variant = "default"
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    "div",
+    {
+      className: classNames(
+        "mg-page-canvas",
+        variant !== "default" ? `mg-page-canvas--${variant}` : void 0,
+        className
+      ),
+      children
+    }
+  );
+}
+function DataPageModule({
+  title,
+  caption,
+  actions,
+  children,
+  className,
+  id,
+  kind = "task"
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    "section",
+    {
+      id,
+      className: classNames(
+        "mg-page-module",
+        `mg-page-module--${kind}`,
+        className
+      ),
+      children: [
+        title || caption || actions ? /* @__PURE__ */ jsxRuntime.jsxs("header", { className: "mg-page-module-heading", children: [
+          /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+            title ? /* @__PURE__ */ jsxRuntime.jsx("h2", { className: "mg-page-module-title", children: title }) : null,
+            caption ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mg-page-module-caption", children: caption }) : null
+          ] }),
+          actions ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-module-actions", children: actions }) : null
+        ] }) : null,
+        /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-page-module-body", children })
+      ]
+    }
+  );
+}
+function DataPageDisclosure({
+  label,
+  children,
+  className,
+  open = false
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    "details",
+    {
+      className: classNames("mg-page-disclosure", className),
+      open,
+      children: [
+        /* @__PURE__ */ jsxRuntime.jsx("summary", { children: label }),
+        /* @__PURE__ */ jsxRuntime.jsx("div", { children })
+      ]
+    }
+  );
+}
+function DataPageWindowTabs({
+  label,
+  options,
+  value,
+  onValueChange,
+  className
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    "div",
+    {
+      role: "tablist",
+      "aria-label": label,
+      className: classNames("mg-data-window", className),
+      children: options.map((option) => {
+        const selected = option.value === value;
+        return /* @__PURE__ */ jsxRuntime.jsx(
+          "button",
+          {
+            type: "button",
+            role: "tab",
+            "aria-selected": selected,
+            onClick: () => onValueChange(option.value),
+            className: classNames(
+              "mg-data-window-button mg-focus-ring",
+              selected && "is-active"
+            ),
+            children: option.label
+          },
+          option.value
+        );
+      })
     }
   );
 }
@@ -2357,7 +2536,7 @@ function PageSection({
       id,
       "data-section-anchor": id ? "" : void 0,
       className: classNames(
-        "mg-section",
+        "mg-section mg-route-section",
         tone === "muted" && "rounded-xl bg-surface-2/40 px-4 md:px-8 py-8 md:py-10",
         className
       ),
@@ -2465,7 +2644,7 @@ function SectionAnchor({
       id,
       "data-section-anchor": true,
       className: classNames(
-        "mg-section scroll-mt-32",
+        "mg-section mg-detail-section scroll-mt-32",
         tone && classNames(
           "relative pl-3 before:content-[''] before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:rounded-full before:opacity-70",
           TONE_CLASS[tone]
@@ -2516,7 +2695,7 @@ function SectionHeading({
     "div",
     {
       className: classNames(
-        "mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between",
+        "mg-route-heading mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between",
         className
       ),
       children: [
@@ -5409,6 +5588,7 @@ var GhostButton = React3.forwardRef(
   function GhostButton2({
     size = "sm",
     tone = "default",
+    appearance = "soft",
     icon,
     iconRight,
     className,
@@ -5422,7 +5602,8 @@ var GhostButton = React3.forwardRef(
         ref,
         type: type ?? "button",
         className: cn(
-          "inline-flex items-center justify-center gap-1.5 rounded-md border bg-card transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "inline-flex items-center justify-center gap-1.5 border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          appearance === "terminal" ? "rounded-none bg-transparent" : "rounded-md bg-card",
           SIZE[size],
           TONE2[tone],
           className
@@ -6622,6 +6803,12 @@ exports.CopyIconToggle = CopyIconToggle;
 exports.CopyableCode = CopyableCode;
 exports.CurationChip = CurationChip;
 exports.DailyRollupFreshness = DailyRollupFreshness;
+exports.DataPageCanvas = DataPageCanvas;
+exports.DataPageDisclosure = DataPageDisclosure;
+exports.DataPageHero = DataPageHero;
+exports.DataPageModule = DataPageModule;
+exports.DataPageStage = DataPageStage;
+exports.DataPageWindowTabs = DataPageWindowTabs;
 exports.DefinitionList = DefinitionList;
 exports.DensityToggle = DensityToggle;
 exports.Dialog = Dialog;

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -536,7 +536,7 @@ function Panel({
     {
       ...rest,
       className: classNames(
-        "rounded border",
+        "rounded-sm border",
         toneStyle.border,
         tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3282,10 +3282,10 @@ function BarMini({
             className: "grid grid-cols-[5.5rem_1fr_auto] items-center gap-2",
             children: [
               /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-type-caption text-ink-muted truncate", children: d.label }),
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "relative h-1.5 rounded-full bg-surface overflow-hidden", children: /* @__PURE__ */ jsxRuntime.jsx(
+              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "relative h-1.5 bg-surface overflow-hidden", children: /* @__PURE__ */ jsxRuntime.jsx(
                 "span",
                 {
-                  className: "absolute inset-y-0 left-0 rounded-full",
+                  className: "absolute inset-y-0 left-0",
                   style: {
                     width: `${pct}%`,
                     background: d.color ?? "var(--accent)"

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -67,7 +67,7 @@
   src: url("./JetBrains-Mono-600-normal-KWGKDJVK.woff2") format("woff2");
 }
 @custom-variant dark (&:is(.dark *));
-@theme inline { --radius-sm: calc(var(--radius) - 4px); --radius-md: calc(var(--radius) - 2px); --radius-lg: var(--radius); --radius-xl: calc(var(--radius) + 4px); --color-background: var(--background); --color-foreground: var(--foreground); --color-paper: var(--paper); --color-surface: var(--surface); --color-surface-2: var(--surface-2); --color-ink: var(--ink); --color-ink-strong: var(--ink-strong); --color-ink-muted: var(--ink-muted); --color-ink-subtle: var(--ink-subtle); --color-ink-subtle-text: var(--ink-subtle-text); --color-card: var(--card); --color-card-foreground: var(--card-foreground); --color-popover: var(--popover); --color-popover-foreground: var(--popover-foreground); --color-primary: var(--primary); --color-primary-foreground: var(--primary-foreground); --color-primary-soft: var(--primary-soft); --color-secondary: var(--secondary); --color-secondary-foreground: var(--secondary-foreground); --color-muted: var(--muted); --color-muted-foreground: var(--muted-foreground); --color-accent: var(--accent); --color-accent-foreground: var(--accent-foreground); --color-accent-text: var(--accent-text); --color-destructive: var(--destructive); --color-destructive-foreground: var(--destructive-foreground); --color-border: var(--border); --color-input: var(--input); --color-ring: var(--ring); --color-health-ok: var(--health-ok); --color-health-warn: var(--health-warn); --color-health-warn-text: var(--health-warn-text); --color-health-bad: var(--health-bad); --color-health-down: var(--health-down); --color-health-unknown: var(--health-unknown); --color-curation-native: var(--curation-native); --color-curation-verified: var(--curation-verified); --color-curation-pilot: var(--curation-pilot); --color-curation-candidate: var(--curation-candidate); --color-curation-seeded: var(--curation-seeded); --color-curation-machine: var(--curation-machine); --color-curation-adapter: var(--curation-adapter); --color-chart-1: var(--chart-1); --color-chart-2: var(--chart-2); --color-chart-3: var(--chart-3); --color-chart-4: var(--chart-4); --color-chart-5: var(--chart-5); --color-chart-6: var(--chart-6); --font-display: "IBM Plex Mono", "Space Grotesk", ui-monospace, monospace; --font-sans: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-mono: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-prose: "DM Sans", ui-sans-serif, system-ui, sans-serif; --spacing-section: 3rem; --color-accent-surface: color-mix(in oklab, var(--accent) 6%, transparent); --spacing-nav: 3.25rem; --spacing-section-gap: 4rem; --spacing-shell-max: 1400px; }
+@theme inline { --radius-sm: calc(var(--radius) - 4px); --radius-md: calc(var(--radius) - 2px); --radius-lg: var(--radius); --radius-xl: calc(var(--radius) + 4px); --color-background: var(--background); --color-foreground: var(--foreground); --color-paper: var(--paper); --color-surface: var(--surface); --color-surface-2: var(--surface-2); --color-ink: var(--ink); --color-ink-strong: var(--ink-strong); --color-ink-muted: var(--ink-muted); --color-ink-subtle: var(--ink-subtle); --color-ink-subtle-text: var(--ink-subtle-text); --color-card: var(--card); --color-card-foreground: var(--card-foreground); --color-popover: var(--popover); --color-popover-foreground: var(--popover-foreground); --color-primary: var(--primary); --color-primary-foreground: var(--primary-foreground); --color-primary-soft: var(--primary-soft); --color-secondary: var(--secondary); --color-secondary-foreground: var(--secondary-foreground); --color-muted: var(--muted); --color-muted-foreground: var(--muted-foreground); --color-accent: var(--accent); --color-accent-foreground: var(--accent-foreground); --color-accent-text: var(--accent-text); --color-destructive: var(--destructive); --color-destructive-foreground: var(--destructive-foreground); --color-border: var(--border); --color-input: var(--input); --color-ring: var(--ring); --color-health-ok: var(--health-ok); --color-health-warn: var(--health-warn); --color-health-warn-text: var(--health-warn-text); --color-health-bad: var(--health-bad); --color-health-down: var(--health-down); --color-health-unknown: var(--health-unknown); --color-curation-native: var(--curation-native); --color-curation-verified: var(--curation-verified); --color-curation-pilot: var(--curation-pilot); --color-curation-candidate: var(--curation-candidate); --color-curation-seeded: var(--curation-seeded); --color-curation-machine: var(--curation-machine); --color-curation-adapter: var(--curation-adapter); --color-chart-1: var(--chart-1); --color-chart-2: var(--chart-2); --color-chart-3: var(--chart-3); --color-chart-4: var(--chart-4); --color-chart-5: var(--chart-5); --color-chart-6: var(--chart-6); --color-chart-7: var(--chart-7); --color-chart-8: var(--chart-8); --color-chart-9: var(--chart-9); --color-chart-10: var(--chart-10); --color-chart-11: var(--chart-11); --font-display: "IBM Plex Mono", "Space Grotesk", ui-monospace, monospace; --font-sans: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-mono: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-prose: "DM Sans", ui-sans-serif, system-ui, sans-serif; --spacing-section: 3rem; --color-accent-surface: color-mix(in oklab, var(--accent) 6%, transparent); --spacing-nav: 3.25rem; --spacing-section-gap: 4rem; --spacing-shell-max: 1400px; }
 :root {
   --radius: 0.25rem;
   --brand-green: #30ffc0;
@@ -113,12 +113,17 @@
   --curation-seeded: #b46b00;
   --curation-machine: #7562c6;
   --curation-adapter: #b24f8c;
-  --chart-1: #b52cce;
-  --chart-2: #7450d8;
-  --chart-3: #386fdb;
-  --chart-4: #078ab5;
-  --chart-5: #5d9200;
-  --chart-6: #d76000;
+  --chart-1: #a82ab7;
+  --chart-2: #785cd0;
+  --chart-3: #556ad4;
+  --chart-4: #1e78bc;
+  --chart-5: #0089a1;
+  --chart-6: #007a6a;
+  --chart-7: #057353;
+  --chart-8: #5d9200;
+  --chart-9: #a96d00;
+  --chart-10: #c55600;
+  --chart-11: #bf4b55;
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 13%, transparent);
   --claude-brand: oklch(0.67 0.13 39);
@@ -291,12 +296,17 @@
   --curation-seeded: #e8bb63;
   --curation-machine: #b49aff;
   --curation-adapter: #e79ac9;
-  --chart-1: #e45dff;
-  --chart-2: #9b7bff;
-  --chart-3: #5a8eff;
-  --chart-4: #22c9e4;
-  --chart-5: #a8e31b;
-  --chart-6: #ff9000;
+  --chart-1: #ed6aff;
+  --chart-2: #a684ff;
+  --chart-3: #7c86ff;
+  --chart-4: #51a2ff;
+  --chart-5: #00d3f2;
+  --chart-6: #00d5be;
+  --chart-7: #00bc7d;
+  --chart-8: #9ae600;
+  --chart-9: #ffb900;
+  --chart-10: #ff8904;
+  --chart-11: #ff6467;
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 15%, transparent);
 }
@@ -1238,6 +1248,982 @@ html[data-density=compact] .bg-card > table td {
 @media (prefers-reduced-motion: reduce) {
   .mg-query-shell,
   .mg-ghost-trigger {
+    transition: none;
+  }
+}
+:root {
+  --mg-page-max: 68rem;
+  --mg-page-gutter: clamp(1rem, 4vw, 3rem);
+  --mg-page-module-y: clamp(1.25rem, 3.5vw, 2.5rem);
+  --mg-page-rule: color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  --mg-page-field-dot: color-mix(in oklab, var(--ink-strong) 16%, transparent);
+  --mg-page-command-height: 3rem;
+}
+.mg-page-stage {
+  width: min(100%, var(--mg-page-max));
+  margin-inline: auto;
+  padding-bottom: var(--mg-space-3xl);
+}
+.mg-page-stage--tabs {
+  padding-bottom: 0;
+}
+.mg-page-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--paper) 88%, transparent);
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-micro);
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.mg-page-kicker-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--brand-green);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  animation: mg-page-live-signal 2.4s ease-out infinite;
+}
+@keyframes mg-page-live-signal {
+  0%, 100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  }
+  45% {
+    box-shadow: 0 0 0 0.32rem color-mix(in oklab, var(--brand-green) 22%, transparent);
+  }
+}
+.mg-page-hero {
+  position: relative;
+  isolation: isolate;
+  min-height: 15.5rem;
+  padding: clamp(2.5rem, 6vw, 4.5rem) var(--mg-page-gutter) clamp(2rem, 4vw, 3rem);
+  overflow: hidden;
+}
+.mg-page-hero-field {
+  position: absolute;
+  z-index: -1;
+  top: clamp(1.75rem, 4vw, 3rem);
+  right: -1rem;
+  width: min(66%, 39rem);
+  height: min(12rem, 65%);
+  border: 1px solid var(--mg-page-rule);
+  background-image:
+    radial-gradient(
+      circle at 1px 1px,
+      var(--mg-page-field-dot) 1px,
+      transparent 0);
+  background-size: 4px 4px;
+  mask-image:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      #000 20%,
+      #000 84%,
+      transparent 100%);
+  -webkit-mask-image:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      #000 20%,
+      #000 84%,
+      transparent 100%);
+}
+.mg-page-hero-content {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(13rem, 0.85fr);
+  align-items: end;
+  gap: clamp(2rem, 8vw, 8rem);
+  min-height: 10.5rem;
+}
+.mg-page-hero-copy {
+  min-width: 0;
+}
+.mg-page-hero h1 {
+  max-width: 12ch;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(2.7rem, 5.8vw, 4.7rem);
+  font-weight: 500;
+  letter-spacing: -0.07em;
+  line-height: 0.9;
+}
+.mg-page-hero-description {
+  max-width: 37rem;
+  margin-top: var(--mg-space-lg);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption-lg);
+  line-height: 1.7;
+}
+.mg-page-hero-body {
+  margin-top: var(--mg-space-xl);
+}
+.mg-page-hero-summary {
+  margin-top: var(--mg-space-lg);
+}
+.mg-page-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--mg-space-sm);
+  padding-bottom: 0.15rem;
+}
+.mg-page-hero-footer {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--mg-space-xs) var(--mg-space-lg);
+  margin-top: var(--mg-space-xl);
+  padding-top: var(--mg-space-sm);
+  border-top: 1px solid var(--border);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+}
+.mg-page-hero--landing {
+  min-height: 22.5rem;
+  padding-top: clamp(2.75rem, 6vw, 4.75rem);
+}
+.mg-page-hero--landing .mg-page-hero-content {
+  display: block;
+  min-height: 17rem;
+}
+.mg-page-hero--landing .mg-page-hero-copy {
+  max-width: 43rem;
+}
+.mg-page-hero--landing h1 {
+  max-width: 12ch;
+  font-size: clamp(3rem, 5.8vw, 4.9rem);
+  letter-spacing: -0.078em;
+  line-height: 0.88;
+}
+.mg-page-hero--landing .mg-page-hero-field {
+  top: clamp(4.5rem, 9vw, 6.5rem);
+  width: min(72%, 46rem);
+  height: min(16rem, 48%);
+}
+.mg-page-hero--analytics {
+  min-height: 20rem;
+}
+.mg-page-command {
+  display: flex;
+  min-height: var(--mg-page-command-height);
+  width: 100%;
+  align-items: center;
+  gap: var(--mg-space-sm);
+  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 30%, transparent);
+  padding-bottom: var(--mg-space-sm);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-body);
+  text-align: left;
+  transition: border-color 140ms ease-out, color 140ms ease-out;
+}
+.mg-page-command:hover,
+.mg-page-command:focus-visible {
+  border-color: var(--brand-green);
+  color: var(--ink-strong);
+}
+.mg-page-command > :nth-child(2) {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.mg-page-command-mark {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  background: var(--brand-green);
+  color: #08110e;
+}
+.mg-page-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--mg-space-sm) var(--mg-space-lg);
+  margin-top: var(--mg-space-md);
+}
+.mg-page-primary-action {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: var(--mg-space-xs);
+  padding: 0.55rem 0.85rem;
+  background: var(--brand-green);
+  color: #08110e;
+  font-size: var(--mg-type-caption-lg);
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 140ms ease-out, transform 140ms ease-out;
+}
+.mg-page-primary-action:hover {
+  background: color-mix(in oklab, var(--brand-green) 84%, #ffffff);
+}
+.mg-page-primary-action:active {
+  transform: translateY(1px);
+}
+.mg-page-quiet-action {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  color: var(--accent-text);
+  font-size: var(--mg-type-caption-lg);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, currentColor 40%, transparent);
+  text-underline-offset: 0.28rem;
+  transition: color 140ms ease-out;
+}
+.mg-page-quiet-action:hover {
+  color: var(--ink-strong);
+}
+.mg-page-canvas {
+  --mg-list-canvas-bleed: calc(-1 * var(--mg-page-gutter));
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+}
+.mg-page-canvas--profile {
+  border-top: 1px solid var(--border);
+}
+.mg-page-canvas--operations > * {
+  padding: clamp(1.25rem, 3.5vw, 2.5rem) var(--mg-page-gutter);
+}
+.mg-page-canvas--operations > * + * {
+  border-top: 1px solid var(--border);
+}
+.mg-page-canvas--operations .mg-route-section {
+  border-top: 0;
+}
+.mg-page-stage--profile .mg-masthead,
+.mg-page-stage--profile .mg-subnet-masthead {
+  margin-bottom: 0 !important;
+}
+.mg-page-module {
+  min-width: 0;
+  padding: var(--mg-page-module-y) var(--mg-page-gutter);
+  border-top: 1px solid var(--border);
+}
+.mg-page-module--profile {
+  padding-top: var(--mg-page-module-y);
+}
+.mg-page-module--profile > .mg-page-module-body {
+  min-width: 0;
+}
+.mg-page-module--profile .mg-detail-section:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+.mg-page-module--profile .mg-masthead-kpi,
+.mg-page-module--profile .mg-data-measure-grid {
+  border-radius: 0;
+}
+.mg-page-module-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--mg-space-lg);
+}
+.mg-page-module-title {
+  margin: 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(0.98rem, 2vw, 1.15rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.4;
+}
+.mg-page-module-caption {
+  max-width: 52rem;
+  margin: var(--mg-space-xs) 0 0;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-page-module-actions {
+  flex: 0 0 auto;
+}
+.mg-page-module-body {
+  min-width: 0;
+}
+.mg-page-module-heading + .mg-page-module-body {
+  margin-top: var(--mg-space-lg);
+}
+.mg-page-module--question .mg-page-module-title::after {
+  content: ".";
+  color: var(--brand-green);
+}
+.mg-page-module--operations .mg-page-module-title {
+  font-size: var(--mg-type-caption-lg);
+  letter-spacing: var(--mg-tracking-label);
+  text-transform: uppercase;
+}
+.mg-page-disclosure {
+  margin-top: var(--mg-space-lg);
+  border-top: 1px solid var(--border);
+}
+.mg-page-disclosure > summary {
+  display: flex;
+  min-height: 2.75rem;
+  cursor: pointer;
+  align-items: center;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-label);
+  list-style: none;
+  text-transform: uppercase;
+}
+.mg-page-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+.mg-page-disclosure > summary::after {
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-left: auto;
+  border-right: 1px solid var(--ink-muted);
+  border-bottom: 1px solid var(--ink-muted);
+  content: "";
+  transform: rotate(45deg) translateY(-0.15rem);
+  transition: transform 160ms ease;
+}
+.mg-page-disclosure[open] > summary::after {
+  transform: rotate(225deg) translate(-0.15rem, -0.1rem);
+}
+.mg-page-disclosure > div {
+  padding-bottom: var(--mg-space-md);
+}
+.mg-list-filter-bar--canvas {
+  margin-inline: var(--mg-list-canvas-bleed);
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: color-mix(in oklab, var(--paper) 93%, transparent);
+  padding-inline: var(--mg-page-gutter);
+}
+.mg-list-table-card--canvas {
+  margin-inline: var(--mg-list-canvas-bleed);
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: transparent;
+}
+.mg-list-table-card--canvas .mg-table-scroll {
+  border-top: 1px solid var(--mg-page-rule);
+}
+.mg-directory-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem 0.9rem;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.35;
+}
+.mg-directory-summary strong {
+  color: var(--ink-strong);
+  font-weight: 600;
+}
+.mg-directory-summary [aria-hidden=true] {
+  color: var(--border);
+}
+.mg-directory-tabs,
+.mg-data-hub-tabs {
+  margin: 0 !important;
+  padding: 0 var(--mg-page-gutter);
+  border-top: 1px solid var(--border);
+  border-bottom: 0;
+}
+.mg-directory-tabs button,
+.mg-data-hub-tabs button {
+  border-radius: 0;
+}
+.mg-directory-tabs button[aria-selected=true]::after,
+.mg-data-hub-tabs button[aria-selected=true]::after {
+  border-radius: 0;
+}
+.mg-directory-toolbar {
+  margin-inline: var(--mg-list-canvas-bleed);
+  padding-inline: var(--mg-page-gutter);
+}
+.mg-directory-table {
+  margin-inline: var(--mg-list-canvas-bleed);
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: transparent;
+}
+.mg-directory-table .mg-table-scroll {
+  border-top: 1px solid var(--mg-page-rule);
+}
+.mg-page-route-link {
+  min-height: 9rem;
+  padding: var(--mg-space-lg) 0;
+  border-top: 1px solid var(--border);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    background-color 140ms ease-out,
+    color 140ms ease-out,
+    padding 140ms ease-out;
+}
+.mg-page-route-link p {
+  max-width: 20rem;
+}
+.mg-page-route-link > span {
+  color: var(--ink-muted);
+}
+.mg-page-callout {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--mg-space-lg);
+  margin-top: var(--mg-space-3xl);
+  padding: var(--mg-space-xl) 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.mg-page-callout h2 {
+  max-width: 12ch;
+  margin: var(--mg-space-sm) 0 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(1.55rem, 4vw, 2.75rem);
+  font-weight: 500;
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+@media (hover: hover) {
+  .mg-page-route-link:hover {
+    padding-left: var(--mg-space-sm);
+    background: color-mix(in oklab, var(--brand-green) 5%, transparent);
+    color: var(--ink-strong);
+  }
+  .mg-page-route-link:hover > span {
+    color: var(--accent);
+  }
+  .mg-page-disclosure > summary:hover {
+    color: var(--ink-strong);
+  }
+}
+@media (max-width: 640px) {
+  .mg-page-stage {
+    width: 100%;
+  }
+  .mg-page-hero,
+  .mg-page-hero--landing,
+  .mg-page-hero--analytics {
+    min-height: 0;
+    padding: var(--mg-space-2xl) 0 var(--mg-space-xl);
+  }
+  .mg-page-hero-content,
+  .mg-page-hero--landing .mg-page-hero-content {
+    display: block;
+    min-height: 0;
+  }
+  .mg-page-hero-field,
+  .mg-page-hero--landing .mg-page-hero-field {
+    top: 2.1rem;
+    right: 0;
+    width: 100%;
+    height: 9rem;
+    opacity: 0.64;
+  }
+  .mg-page-hero h1,
+  .mg-page-hero--landing h1 {
+    font-size: clamp(2.7rem, 12.5vw, 4rem);
+    line-height: 0.91;
+  }
+  .mg-page-hero-actions {
+    margin-top: var(--mg-space-xl);
+  }
+  .mg-page-canvas {
+    margin-inline: calc(-1 * var(--mg-gutter-x, 1rem));
+    border-right: 0;
+    border-left: 0;
+  }
+  .mg-page-module {
+    padding: var(--mg-space-xl) var(--mg-gutter-x, 1rem);
+  }
+  .mg-page-canvas--operations > * {
+    padding: var(--mg-space-xl) var(--mg-gutter-x, 1rem);
+  }
+  .mg-page-module-heading {
+    display: block;
+  }
+  .mg-page-module-actions {
+    margin-top: var(--mg-space-sm);
+  }
+  .mg-page-callout {
+    display: block;
+  }
+  .mg-page-callout .mg-page-primary-action {
+    margin-top: var(--mg-space-lg);
+  }
+  .mg-list-filter-bar--canvas,
+  .mg-list-table-card--canvas,
+  .mg-directory-toolbar,
+  .mg-directory-table {
+    margin-inline: calc(-1 * var(--mg-gutter-x, 1rem));
+    padding-inline: var(--mg-gutter-x, 1rem);
+  }
+  .mg-list-table-card--canvas,
+  .mg-directory-table {
+    padding-inline: 0;
+  }
+  .mg-directory-tabs,
+  .mg-data-hub-tabs {
+    padding-inline: var(--mg-gutter-x, 1rem);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mg-page-kicker-dot {
+    animation: none;
+  }
+  .mg-page-command,
+  .mg-page-primary-action,
+  .mg-page-quiet-action,
+  .mg-page-route-link,
+  .mg-page-disclosure > summary::after {
+    transition: none;
+  }
+}
+.mg-data-stage {
+  width: min(100%, 68rem);
+  margin-inline: auto;
+  padding-bottom: var(--mg-space-3xl);
+}
+.mg-data-hero {
+  position: relative;
+  isolation: isolate;
+  min-height: 23rem;
+  padding: clamp(3rem, 8vw, 6.5rem) clamp(1rem, 4vw, 3rem) clamp(2.5rem, 5vw, 4rem);
+  overflow: hidden;
+}
+.mg-data-hero-field {
+  position: absolute;
+  z-index: -1;
+  right: 0;
+  top: clamp(2rem, 5vw, 4rem);
+  width: min(72%, 45rem);
+  height: min(17rem, 58%);
+  border: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  background-image:
+    radial-gradient(
+      circle at 1px 1px,
+      color-mix(in oklab, var(--ink-strong) 16%, transparent) 1px,
+      transparent 0);
+  background-size: 4px 4px;
+  mask-image:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      #000 26%,
+      #000 82%,
+      transparent 100%);
+  -webkit-mask-image:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      #000 26%,
+      #000 82%,
+      transparent 100%);
+}
+.mg-data-hero-content {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(15rem, 0.8fr);
+  align-items: end;
+  gap: clamp(2rem, 8vw, 8rem);
+  min-height: 16rem;
+}
+.mg-data-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--border);
+  color: var(--ink-muted);
+  background: color-mix(in oklab, var(--paper) 85%, transparent);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-micro);
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.mg-data-kicker-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--brand-green);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  animation: mg-data-live-signal 2.4s ease-out infinite;
+}
+@keyframes mg-data-live-signal {
+  0%, 100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  }
+  45% {
+    box-shadow: 0 0 0 0.32rem color-mix(in oklab, var(--brand-green) 22%, transparent);
+  }
+}
+.mg-data-hero h1 {
+  max-width: 10ch;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(3.25rem, 8.5vw, 6.75rem);
+  font-weight: 500;
+  letter-spacing: -0.07em;
+  line-height: 0.86;
+}
+.mg-data-hero-detail {
+  display: grid;
+  justify-items: start;
+  gap: var(--mg-space-lg);
+  padding-bottom: 0.2rem;
+}
+.mg-data-hero-detail p {
+  max-width: 31rem;
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: clamp(0.82rem, 1.5vw, 0.95rem);
+  line-height: 1.7;
+}
+.mg-data-window {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--paper) 86%, transparent);
+}
+.mg-data-window-button {
+  position: relative;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.8rem;
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: var(--mg-type-caption);
+  font-weight: 500;
+  line-height: 1;
+  transition: color 160ms ease, background-color 160ms ease;
+}
+.mg-data-window-button + .mg-data-window-button {
+  border-left: 1px solid var(--border);
+}
+.mg-data-window-button::after {
+  position: absolute;
+  right: 0.65rem;
+  bottom: 0.42rem;
+  left: 0.65rem;
+  height: 1.5px;
+  background: transparent;
+  content: "";
+}
+.mg-data-window-button.is-active {
+  color: var(--ink-strong);
+  background: color-mix(in oklab, var(--brand-green) 8%, transparent);
+}
+.mg-data-window-button.is-active::after {
+  background: var(--brand-green);
+}
+.mg-data-canvas {
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+}
+.mg-data-module {
+  padding: clamp(1.5rem, 4vw, 2.75rem) clamp(1rem, 4vw, 3rem);
+  border-top: 1px solid var(--border);
+}
+.mg-data-module-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--mg-space-lg);
+}
+.mg-data-module-title {
+  max-width: 54rem;
+  margin: 0;
+  color: var(--ink-muted);
+  font-family: var(--font-display);
+  font-size: clamp(0.94rem, 2vw, 1.15rem);
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.55;
+}
+.mg-data-module-title strong {
+  color: var(--ink-strong);
+  font-weight: 600;
+}
+.mg-data-module-title span {
+  margin-left: 0.35em;
+}
+.mg-data-module-action {
+  flex: 0 0 auto;
+}
+.mg-data-module-chart,
+.mg-data-module-body {
+  margin-top: clamp(1.25rem, 3vw, 2rem);
+}
+.mg-data-module-footer {
+  margin-top: var(--mg-space-lg);
+  padding-top: var(--mg-space-sm);
+  border-top: 1px solid var(--border);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-data-module--stake-flow .mg-data-module-chart {
+  margin-top: clamp(1.5rem, 4vw, 2.5rem);
+}
+.mg-data-plot-grid {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  background-image:
+    radial-gradient(
+      circle at 1px 1px,
+      color-mix(in oklab, var(--ink-strong) 11%, transparent) 1px,
+      transparent 0);
+  background-size: 5px 5px;
+}
+.mg-data-measure-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.mg-data-measure-grid--4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.mg-data-measure {
+  min-width: 0;
+  padding: var(--mg-space-md);
+}
+.mg-data-measure + .mg-data-measure {
+  border-left: 1px solid var(--border);
+}
+.mg-data-measure > :first-child {
+  color: var(--ink-muted);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-label);
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+.mg-data-measure > :last-child {
+  margin-top: 0.45rem;
+  overflow: hidden;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(1rem, 2.4vw, 1.45rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-data-measure dd small {
+  display: block;
+  margin-top: 0.28rem;
+  overflow: hidden;
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: var(--mg-type-micro);
+  font-weight: 400;
+  letter-spacing: normal;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-live-block-rail {
+  padding: var(--mg-space-md) 0;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
+}
+.mg-data-rank-list {
+  margin: var(--mg-space-xl) 0 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+  list-style: none;
+}
+.mg-data-rank-list > li + li {
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-data-rank-row {
+  display: grid;
+  grid-template-columns: 2.3rem minmax(4.5rem, 0.75fr) minmax(8rem, 2fr) max-content;
+  align-items: center;
+  gap: var(--mg-space-sm);
+  min-width: 0;
+  padding: 0.78rem 0;
+  color: inherit;
+  text-decoration: none;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+.mg-data-rank-index {
+  color: var(--ink-subtle);
+  font-size: var(--mg-type-micro);
+}
+.mg-data-rank-label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink-strong);
+  font-size: var(--mg-type-caption);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-data-rank-track {
+  height: 0.28rem;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--ink-strong) 8%, transparent);
+}
+.mg-data-rank-fill {
+  display: block;
+  height: 100%;
+}
+.mg-data-rank-value {
+  display: grid;
+  justify-items: end;
+  color: var(--ink-strong);
+  font-size: var(--mg-type-caption);
+  line-height: 1.15;
+  text-align: right;
+  white-space: nowrap;
+}
+.mg-data-rank-value small {
+  margin-top: 0.2rem;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-micro);
+}
+.mg-data-module-note {
+  max-width: 56rem;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-data-module-note + .mg-data-module-note {
+  margin-top: var(--mg-space-xs);
+}
+.mg-data-wide-chart {
+  margin-bottom: var(--mg-space-xl);
+  padding: var(--mg-space-md) 0;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-data-loading {
+  padding: clamp(1rem, 4vw, 3rem);
+  border-top: 1px solid var(--border);
+}
+@media (hover: hover) {
+  .mg-data-window-button:hover {
+    color: var(--ink-strong);
+    background: color-mix(in oklab, var(--ink-strong) 4%, transparent);
+  }
+  .mg-data-rank-row:hover {
+    background: color-mix(in oklab, var(--brand-green) 5%, transparent);
+  }
+}
+@media (max-width: 640px) {
+  .mg-data-stage {
+    width: 100%;
+  }
+  .mg-data-hero {
+    min-height: 0;
+    padding: var(--mg-space-2xl) 0 var(--mg-space-xl);
+  }
+  .mg-data-hero-field {
+    top: 1.75rem;
+    width: 100%;
+    height: 11rem;
+    opacity: 0.65;
+  }
+  .mg-data-hero-content {
+    display: block;
+    min-height: 0;
+  }
+  .mg-data-hero h1 {
+    margin-top: var(--mg-space-sm);
+    font-size: clamp(3.3rem, 16vw, 4.75rem);
+  }
+  .mg-data-hero-detail {
+    gap: var(--mg-space-md);
+    margin-top: var(--mg-space-2xl);
+  }
+  .mg-data-canvas {
+    margin-inline: calc(-1 * var(--mg-gutter-x));
+    border-right: 0;
+    border-left: 0;
+  }
+  .mg-data-module {
+    padding: var(--mg-space-xl) var(--mg-gutter-x);
+  }
+  .mg-data-module-heading {
+    display: block;
+  }
+  .mg-data-module-action {
+    margin-top: var(--mg-space-sm);
+  }
+  .mg-data-module-title span {
+    display: inline;
+  }
+  .mg-data-measure-grid,
+  .mg-data-measure-grid--4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .mg-data-measure-grid--3 > :last-child {
+    grid-column: span 2;
+  }
+  .mg-data-measure + .mg-data-measure {
+    border-left: 0;
+  }
+  .mg-data-measure:nth-child(even) {
+    border-left: 1px solid var(--border);
+  }
+  .mg-data-measure-grid--3 > :last-child {
+    border-top: 1px solid var(--border);
+  }
+  .mg-data-measure-grid--4 > :nth-child(n+3) {
+    border-top: 1px solid var(--border);
+  }
+  .mg-data-rank-row {
+    grid-template-columns: 1.7rem minmax(3.8rem, 0.68fr) minmax(3rem, 1fr) max-content;
+    gap: var(--mg-space-xs);
+  }
+  .mg-data-rank-value {
+    font-size: var(--mg-type-data-sm);
+  }
+  .mg-data-wide-chart {
+    margin-bottom: var(--mg-space-lg);
+  }
+  .mg-data-module--stake-flow svg text {
+    display: none;
+  }
+  .mg-data-loading {
+    padding: var(--mg-space-xl) var(--mg-gutter-x);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mg-data-kicker-dot {
+    animation: none;
+  }
+  .mg-data-window-button,
+  .mg-data-rank-row {
     transition: none;
   }
 }

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -70,7 +70,8 @@
 @theme inline { --radius-sm: calc(var(--radius) - 4px); --radius-md: calc(var(--radius) - 2px); --radius-lg: var(--radius); --radius-xl: calc(var(--radius) + 4px); --color-background: var(--background); --color-foreground: var(--foreground); --color-paper: var(--paper); --color-surface: var(--surface); --color-surface-2: var(--surface-2); --color-ink: var(--ink); --color-ink-strong: var(--ink-strong); --color-ink-muted: var(--ink-muted); --color-ink-subtle: var(--ink-subtle); --color-ink-subtle-text: var(--ink-subtle-text); --color-card: var(--card); --color-card-foreground: var(--card-foreground); --color-popover: var(--popover); --color-popover-foreground: var(--popover-foreground); --color-primary: var(--primary); --color-primary-foreground: var(--primary-foreground); --color-primary-soft: var(--primary-soft); --color-secondary: var(--secondary); --color-secondary-foreground: var(--secondary-foreground); --color-muted: var(--muted); --color-muted-foreground: var(--muted-foreground); --color-accent: var(--accent); --color-accent-foreground: var(--accent-foreground); --color-accent-text: var(--accent-text); --color-destructive: var(--destructive); --color-destructive-foreground: var(--destructive-foreground); --color-border: var(--border); --color-input: var(--input); --color-ring: var(--ring); --color-health-ok: var(--health-ok); --color-health-warn: var(--health-warn); --color-health-warn-text: var(--health-warn-text); --color-health-bad: var(--health-bad); --color-health-down: var(--health-down); --color-health-unknown: var(--health-unknown); --color-curation-native: var(--curation-native); --color-curation-verified: var(--curation-verified); --color-curation-pilot: var(--curation-pilot); --color-curation-candidate: var(--curation-candidate); --color-curation-seeded: var(--curation-seeded); --color-curation-machine: var(--curation-machine); --color-curation-adapter: var(--curation-adapter); --color-chart-1: var(--chart-1); --color-chart-2: var(--chart-2); --color-chart-3: var(--chart-3); --color-chart-4: var(--chart-4); --color-chart-5: var(--chart-5); --color-chart-6: var(--chart-6); --font-display: "IBM Plex Mono", "Space Grotesk", ui-monospace, monospace; --font-sans: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-mono: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-prose: "DM Sans", ui-sans-serif, system-ui, sans-serif; --spacing-section: 3rem; --color-accent-surface: color-mix(in oklab, var(--accent) 6%, transparent); --spacing-nav: 3.25rem; --spacing-section-gap: 4rem; --spacing-shell-max: 1400px; }
 :root {
   --radius: 0.25rem;
-  --paper: #f7f7f4;
+  --brand-green: #30ffc0;
+  --paper: #f8f8f5;
   --surface: #ffffff;
   --surface-2: #eeeeeb;
   --ink: #383838;
@@ -84,16 +85,16 @@
   --card-foreground: var(--ink-strong);
   --popover: var(--surface);
   --popover-foreground: var(--ink-strong);
-  --primary: #1f6feb;
-  --primary-foreground: #ffffff;
+  --primary: var(--brand-green);
+  --primary-foreground: #08110e;
   --primary-soft: color-mix(in oklab, var(--primary) 10%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface-2);
   --muted-foreground: var(--ink-muted);
-  --accent: #1f6feb;
+  --accent: #087b5d;
   --accent-foreground: #ffffff;
-  --accent-text: #1857b7;
+  --accent-text: #087b5d;
   --destructive: #c93f3c;
   --destructive-foreground: #ffffff;
   --border: color-mix(in oklab, var(--ink-strong) 8%, transparent);
@@ -106,20 +107,20 @@
   --health-down: #c93f3c;
   --health-unknown: #737373;
   --curation-native: var(--ink-strong);
-  --curation-verified: #1f6feb;
-  --curation-pilot: #4f77c8;
+  --curation-verified: #087b5d;
+  --curation-pilot: #2d806c;
   --curation-candidate: var(--ink-muted);
   --curation-seeded: #b46b00;
   --curation-machine: #7562c6;
   --curation-adapter: #b24f8c;
-  --chart-1: #3679e8;
+  --chart-1: #119b76;
   --chart-2: #8562d7;
   --chart-3: #d56b25;
   --chart-4: #bd4e92;
   --chart-5: #9c7b11;
   --chart-6: #6f7b87;
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
-  --mg-cadence-color: color-mix(in oklab, var(--accent) 20%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 13%, transparent);
   --claude-brand: oklch(0.67 0.13 39);
 }
 :root {
@@ -262,16 +263,16 @@
   --card-foreground: var(--ink-strong);
   --popover: var(--surface-2);
   --popover-foreground: var(--ink-strong);
-  --primary: #72a6ff;
-  --primary-foreground: #0d0d0d;
+  --primary: var(--brand-green);
+  --primary-foreground: #08110e;
   --primary-soft: color-mix(in oklab, var(--primary) 12%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface);
   --muted-foreground: var(--ink-muted);
-  --accent: #72a6ff;
+  --accent: var(--brand-green);
   --accent-foreground: #0d0d0d;
-  --accent-text: #9bbdff;
+  --accent-text: var(--brand-green);
   --destructive: #fb7974;
   --destructive-foreground: #161616;
   --border: color-mix(in oklab, var(--ink-strong) 11%, transparent);
@@ -284,20 +285,20 @@
   --health-down: #fb7974;
   --health-unknown: #8b8b8b;
   --curation-native: var(--ink-strong);
-  --curation-verified: #72a6ff;
-  --curation-pilot: #91b4ef;
+  --curation-verified: var(--brand-green);
+  --curation-pilot: #78d7bb;
   --curation-candidate: var(--ink-muted);
   --curation-seeded: #e8bb63;
   --curation-machine: #b49aff;
   --curation-adapter: #e79ac9;
-  --chart-1: #75a9ff;
+  --chart-1: var(--brand-green);
   --chart-2: #b69bff;
   --chart-3: #ffad72;
   --chart-4: #ec9bcf;
   --chart-5: #e9ca68;
   --chart-6: #a6adb7;
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
-  --mg-cadence-color: color-mix(in oklab, var(--accent) 28%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 15%, transparent);
 }
 @layer base {
   * {
@@ -315,18 +316,11 @@
     overflow-x: clip;
   }
   body {
-    background-image:
-      linear-gradient(
-        to right,
-        var(--mg-grid-color) 1px,
-        transparent 1px),
-      linear-gradient(
-        to bottom,
-        var(--mg-grid-color) 1px,
-        transparent 1px);
-    background-size: 32px 32px, 32px 32px;
-    background-position: 0 0, 0 0;
-    background-attachment: fixed;
+    background-image: none;
+  }
+  :where(a, button, input, select, textarea, summary):focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
   }
   html.theme-transition,
   html.theme-transition * {
@@ -517,33 +511,55 @@ html[data-density=compact] .bg-card > table td {
 }
 .mg-hero-slab {
   position: relative;
-  background-color: color-mix(in oklab, var(--surface) 52%, transparent);
-  background-image:
-    linear-gradient(
-      to right,
-      var(--mg-cadence-color) 1px,
-      transparent 1px),
-    linear-gradient(
-      to bottom,
-      var(--mg-cadence-color) 1px,
-      transparent 1px);
-  background-size: 16px 16px;
+  background: transparent;
   border-bottom: 1px solid var(--border);
   border-radius: 0;
-  border-top: 1px solid color-mix(in oklab, var(--accent) 68%, transparent);
 }
 .mg-hero-slab::before {
   content: none;
+}
+.mg-hero-dot-field {
+  position: absolute;
+  z-index: 0;
+  top: clamp(7.5rem, 11vw, 10.5rem);
+  right: 0;
+  left: clamp(1rem, 13vw, 10rem);
+  height: clamp(5rem, 10vw, 8rem);
+  pointer-events: none;
+  background-image: radial-gradient(var(--mg-cadence-color) 0.7px, transparent 0.85px);
+  background-size: 7px 7px;
+  mask-image:
+    linear-gradient(
+      to right,
+      transparent,
+      #000 8%,
+      #000 92%,
+      transparent);
+  -webkit-mask-image:
+    linear-gradient(
+      to right,
+      transparent,
+      #000 8%,
+      #000 92%,
+      transparent);
+}
+@media (max-width: 767px) {
+  .mg-hero-dot-field {
+    top: 8.5rem;
+    right: 0;
+    left: 0;
+    height: 4rem;
+  }
 }
 .mg-accent-band {
   background: var(--surface-2);
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
-  box-shadow: inset 2px 0 0 var(--accent);
+  box-shadow: inset 0 2px 0 var(--primary);
 }
 .mg-dot-grid {
-  background-image: radial-gradient(color-mix(in oklab, var(--accent) 36%, transparent) 1px, transparent 1px);
-  background-size: 14px 14px;
+  background-image: radial-gradient(var(--mg-cadence-color) 1px, transparent 1px);
+  background-size: 8px 8px;
 }
 .mg-kpi-strip {
   display: grid;

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -113,12 +113,12 @@
   --curation-seeded: #b46b00;
   --curation-machine: #7562c6;
   --curation-adapter: #b24f8c;
-  --chart-1: #119b76;
-  --chart-2: #8562d7;
-  --chart-3: #d56b25;
-  --chart-4: #bd4e92;
-  --chart-5: #9c7b11;
-  --chart-6: #6f7b87;
+  --chart-1: #b52cce;
+  --chart-2: #7450d8;
+  --chart-3: #386fdb;
+  --chart-4: #078ab5;
+  --chart-5: #5d9200;
+  --chart-6: #d76000;
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 13%, transparent);
   --claude-brand: oklch(0.67 0.13 39);
@@ -291,12 +291,12 @@
   --curation-seeded: #e8bb63;
   --curation-machine: #b49aff;
   --curation-adapter: #e79ac9;
-  --chart-1: var(--brand-green);
-  --chart-2: #b69bff;
-  --chart-3: #ffad72;
-  --chart-4: #ec9bcf;
-  --chart-5: #e9ca68;
-  --chart-6: #a6adb7;
+  --chart-1: #e45dff;
+  --chart-2: #9b7bff;
+  --chart-3: #5a8eff;
+  --chart-4: #22c9e4;
+  --chart-5: #a8e31b;
+  --chart-6: #ff9000;
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 15%, transparent);
 }

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -1,3 +1,7 @@
+@import "@fontsource/ibm-plex-mono/latin-400.css";
+@import "@fontsource/ibm-plex-mono/latin-500.css";
+@import "@fontsource/ibm-plex-mono/latin-600.css";
+
 /* src/styles.css */
 @font-face {
   font-family: "Space Grotesk";
@@ -63,60 +67,59 @@
   src: url("./JetBrains-Mono-600-normal-KWGKDJVK.woff2") format("woff2");
 }
 @custom-variant dark (&:is(.dark *));
-@theme inline { --radius-sm: calc(var(--radius) - 4px); --radius-md: calc(var(--radius) - 2px); --radius-lg: var(--radius); --radius-xl: calc(var(--radius) + 4px); --color-background: var(--background); --color-foreground: var(--foreground); --color-paper: var(--paper); --color-surface: var(--surface); --color-surface-2: var(--surface-2); --color-ink: var(--ink); --color-ink-strong: var(--ink-strong); --color-ink-muted: var(--ink-muted); --color-ink-subtle: var(--ink-subtle); --color-ink-subtle-text: var(--ink-subtle-text); --color-card: var(--card); --color-card-foreground: var(--card-foreground); --color-popover: var(--popover); --color-popover-foreground: var(--popover-foreground); --color-primary: var(--primary); --color-primary-foreground: var(--primary-foreground); --color-primary-soft: var(--primary-soft); --color-secondary: var(--secondary); --color-secondary-foreground: var(--secondary-foreground); --color-muted: var(--muted); --color-muted-foreground: var(--muted-foreground); --color-accent: var(--accent); --color-accent-foreground: var(--accent-foreground); --color-accent-text: var(--accent-text); --color-destructive: var(--destructive); --color-destructive-foreground: var(--destructive-foreground); --color-border: var(--border); --color-input: var(--input); --color-ring: var(--ring); --color-health-ok: var(--health-ok); --color-health-warn: var(--health-warn); --color-health-warn-text: var(--health-warn-text); --color-health-bad: var(--health-bad); --color-health-down: var(--health-down); --color-health-unknown: var(--health-unknown); --color-curation-native: var(--curation-native); --color-curation-verified: var(--curation-verified); --color-curation-pilot: var(--curation-pilot); --color-curation-candidate: var(--curation-candidate); --color-curation-seeded: var(--curation-seeded); --color-curation-machine: var(--curation-machine); --color-curation-adapter: var(--curation-adapter); --color-chart-1: var(--chart-1); --color-chart-2: var(--chart-2); --color-chart-3: var(--chart-3); --color-chart-4: var(--chart-4); --color-chart-5: var(--chart-5); --color-chart-6: var(--chart-6); --font-display: "Space Grotesk", ui-sans-serif, system-ui, sans-serif; --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif; --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; --spacing-section: 3rem; --color-accent-surface: color-mix(in oklab, var(--accent) 6%, transparent); --spacing-nav: 3.5rem; --spacing-section-gap: 4rem; --spacing-shell-max: 1400px; }
+@theme inline { --radius-sm: calc(var(--radius) - 4px); --radius-md: calc(var(--radius) - 2px); --radius-lg: var(--radius); --radius-xl: calc(var(--radius) + 4px); --color-background: var(--background); --color-foreground: var(--foreground); --color-paper: var(--paper); --color-surface: var(--surface); --color-surface-2: var(--surface-2); --color-ink: var(--ink); --color-ink-strong: var(--ink-strong); --color-ink-muted: var(--ink-muted); --color-ink-subtle: var(--ink-subtle); --color-ink-subtle-text: var(--ink-subtle-text); --color-card: var(--card); --color-card-foreground: var(--card-foreground); --color-popover: var(--popover); --color-popover-foreground: var(--popover-foreground); --color-primary: var(--primary); --color-primary-foreground: var(--primary-foreground); --color-primary-soft: var(--primary-soft); --color-secondary: var(--secondary); --color-secondary-foreground: var(--secondary-foreground); --color-muted: var(--muted); --color-muted-foreground: var(--muted-foreground); --color-accent: var(--accent); --color-accent-foreground: var(--accent-foreground); --color-accent-text: var(--accent-text); --color-destructive: var(--destructive); --color-destructive-foreground: var(--destructive-foreground); --color-border: var(--border); --color-input: var(--input); --color-ring: var(--ring); --color-health-ok: var(--health-ok); --color-health-warn: var(--health-warn); --color-health-warn-text: var(--health-warn-text); --color-health-bad: var(--health-bad); --color-health-down: var(--health-down); --color-health-unknown: var(--health-unknown); --color-curation-native: var(--curation-native); --color-curation-verified: var(--curation-verified); --color-curation-pilot: var(--curation-pilot); --color-curation-candidate: var(--curation-candidate); --color-curation-seeded: var(--curation-seeded); --color-curation-machine: var(--curation-machine); --color-curation-adapter: var(--curation-adapter); --color-chart-1: var(--chart-1); --color-chart-2: var(--chart-2); --color-chart-3: var(--chart-3); --color-chart-4: var(--chart-4); --color-chart-5: var(--chart-5); --color-chart-6: var(--chart-6); --font-display: "IBM Plex Mono", "Space Grotesk", ui-monospace, monospace; --font-sans: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-mono: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace; --font-prose: "DM Sans", ui-sans-serif, system-ui, sans-serif; --spacing-section: 3rem; --color-accent-surface: color-mix(in oklab, var(--accent) 6%, transparent); --spacing-nav: 3.25rem; --spacing-section-gap: 4rem; --spacing-shell-max: 1400px; }
 :root {
-  --radius: 0.75rem;
-  --paper: oklch(0.975 0.006 95);
-  --surface: oklch(1 0 0);
-  --surface-2: oklch(0.945 0.008 95);
-  --ink: oklch(0.32 0.012 200);
-  --ink-strong: oklch(0.2 0.012 200);
-  --ink-muted: oklch(0.52 0.012 200);
-  --ink-subtle: oklch(0.74 0.008 200);
-  --ink-subtle-text: oklch(0.54 0.008 200);
+  --radius: 0.25rem;
+  --paper: #f7f7f4;
+  --surface: #ffffff;
+  --surface-2: #eeeeeb;
+  --ink: #383838;
+  --ink-strong: #161616;
+  --ink-muted: #686868;
+  --ink-subtle: #a3a3a3;
+  --ink-subtle-text: #686868;
   --background: var(--paper);
   --foreground: var(--ink-strong);
   --card: var(--surface);
   --card-foreground: var(--ink-strong);
   --popover: var(--surface);
   --popover-foreground: var(--ink-strong);
-  --primary: oklch(0.74 0.15 168);
-  --primary-foreground: oklch(0.2 0.012 200);
-  --primary-soft: color-mix(in oklab, oklch(0.74 0.15 168) 12%, var(--paper));
+  --primary: #1f6feb;
+  --primary-foreground: #ffffff;
+  --primary-soft: color-mix(in oklab, var(--primary) 10%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface-2);
   --muted-foreground: var(--ink-muted);
-  --accent: oklch(0.74 0.15 168);
-  --accent-foreground: oklch(0.2 0.012 200);
-  --accent-text: oklch(0.515 0.15 168);
-  --destructive: oklch(0.58 0.22 28);
-  --destructive-foreground: oklch(1 0 0);
+  --accent: #1f6feb;
+  --accent-foreground: #ffffff;
+  --accent-text: #1857b7;
+  --destructive: #c93f3c;
+  --destructive-foreground: #ffffff;
   --border: color-mix(in oklab, var(--ink-strong) 8%, transparent);
   --input: color-mix(in oklab, var(--ink-strong) 12%, transparent);
   --ring: color-mix(in oklab, var(--accent) 45%, transparent);
-  --health-ok: oklch( 0.68 0.16 160 );
-  --health-warn: oklch(0.72 0.16 75);
-  --health-warn-text: oklch(0.55 0.12 80);
-  --health-bad: oklch( 0.66 0.18 50 );
-  --health-down: oklch(0.58 0.22 28);
-  --health-unknown: oklch(0.66 0.01 200);
+  --health-ok: #16824a;
+  --health-warn: #a56100;
+  --health-warn-text: #8a5000;
+  --health-bad: #c86400;
+  --health-down: #c93f3c;
+  --health-unknown: #737373;
   --curation-native: var(--ink-strong);
-  --curation-verified: oklch( 0.68 0.16 160 );
-  --curation-pilot: oklch(0.6 0.15 150);
+  --curation-verified: #1f6feb;
+  --curation-pilot: #4f77c8;
   --curation-candidate: var(--ink-muted);
-  --curation-seeded: oklch( 0.64 0.15 80 );
-  --curation-machine: oklch(0.54 0.14 250);
-  --curation-adapter: oklch(0.62 0.15 305);
-  --chart-1: oklch(0.64 0.13 250);
-  --chart-2: oklch(0.72 0.13 168);
-  --chart-3: oklch(0.76 0.12 80);
-  --chart-4: oklch(0.62 0.15 305);
-  --chart-5: oklch(0.66 0.14 350);
-  --chart-6: oklch(0.66 0.02 220);
-  --mg-dot-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
-  --mg-dot-size: 24px;
-  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 3.5%, transparent);
+  --curation-seeded: #b46b00;
+  --curation-machine: #7562c6;
+  --curation-adapter: #b24f8c;
+  --chart-1: #3679e8;
+  --chart-2: #8562d7;
+  --chart-3: #d56b25;
+  --chart-4: #bd4e92;
+  --chart-5: #9c7b11;
+  --chart-6: #6f7b87;
+  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--accent) 20%, transparent);
   --claude-brand: oklch(0.67 0.13 39);
 }
 :root {
@@ -245,57 +248,56 @@
   background: color-mix(in oklab, var(--card) 95%, transparent);
 }
 .dark {
-  --paper: oklch(0.14 0.003 250);
-  --surface: oklch(0.175 0.003 250);
-  --surface-2: oklch(0.215 0.004 250);
-  --ink: oklch(0.86 0.005 250);
-  --ink-strong: oklch(0.96 0.006 250);
-  --ink-muted: oklch(0.64 0.005 250);
-  --ink-subtle: oklch(0.42 0.004 250);
-  --ink-subtle-text: oklch(0.61 0.01 200);
+  --paper: #161616;
+  --surface: #1e1e1e;
+  --surface-2: #303030;
+  --ink: #d4d4d4;
+  --ink-strong: #ffffff;
+  --ink-muted: #a3a3a3;
+  --ink-subtle: #707070;
+  --ink-subtle-text: #b3b3b3;
   --background: var(--paper);
   --foreground: var(--ink-strong);
   --card: var(--surface);
   --card-foreground: var(--ink-strong);
   --popover: var(--surface-2);
   --popover-foreground: var(--ink-strong);
-  --primary: oklch(0.85 0.14 168);
-  --primary-foreground: oklch(0.14 0.003 250);
-  --primary-soft: color-mix(in oklab, oklch(0.85 0.14 168) 10%, var(--paper));
+  --primary: #72a6ff;
+  --primary-foreground: #0d0d0d;
+  --primary-soft: color-mix(in oklab, var(--primary) 12%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface);
   --muted-foreground: var(--ink-muted);
-  --accent: oklch(0.85 0.14 168);
-  --accent-foreground: oklch(0.14 0.003 250);
-  --accent-text: var(--accent);
-  --destructive: oklch(0.7 0.22 28);
-  --destructive-foreground: oklch(0.14 0.003 250);
+  --accent: #72a6ff;
+  --accent-foreground: #0d0d0d;
+  --accent-text: #9bbdff;
+  --destructive: #fb7974;
+  --destructive-foreground: #161616;
   --border: color-mix(in oklab, var(--ink-strong) 11%, transparent);
   --input: color-mix(in oklab, var(--ink-strong) 16%, transparent);
   --ring: color-mix(in oklab, var(--accent) 50%, transparent);
-  --health-ok: oklch(0.85 0.14 168);
-  --health-warn: oklch(0.82 0.15 75);
-  --health-warn-text: var(--health-warn);
-  --health-bad: oklch( 0.75 0.18 52 );
-  --health-down: oklch(0.72 0.2 28);
-  --health-unknown: oklch(0.52 0.005 250);
+  --health-ok: #54d98a;
+  --health-warn: #f4b65f;
+  --health-warn-text: #f4b65f;
+  --health-bad: #fb9a4c;
+  --health-down: #fb7974;
+  --health-unknown: #8b8b8b;
   --curation-native: var(--ink-strong);
-  --curation-verified: oklch(0.85 0.14 168);
-  --curation-pilot: oklch(0.8 0.14 150);
+  --curation-verified: #72a6ff;
+  --curation-pilot: #91b4ef;
   --curation-candidate: var(--ink-muted);
-  --curation-seeded: oklch( 0.78 0.14 80 );
-  --curation-machine: oklch(0.76 0.12 250);
-  --curation-adapter: oklch(0.78 0.13 305);
-  --chart-1: oklch(0.76 0.12 250);
-  --chart-2: oklch(0.85 0.13 168);
-  --chart-3: oklch(0.84 0.12 80);
-  --chart-4: oklch(0.76 0.14 305);
-  --chart-5: oklch(0.8 0.13 350);
-  --chart-6: oklch(0.62 0.02 220);
-  --mg-dot-color: color-mix(in oklab, var(--ink-strong) 10%, transparent);
-  --mg-dot-size: 26px;
-  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 5%, transparent);
+  --curation-seeded: #e8bb63;
+  --curation-machine: #b49aff;
+  --curation-adapter: #e79ac9;
+  --chart-1: #75a9ff;
+  --chart-2: #b69bff;
+  --chart-3: #ffad72;
+  --chart-4: #ec9bcf;
+  --chart-5: #e9ca68;
+  --chart-6: #a6adb7;
+  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--accent) 28%, transparent);
 }
 @layer base {
   * {
@@ -306,7 +308,7 @@
     background-color: var(--color-paper);
     color: var(--color-ink-strong);
     font-family: var(--font-sans);
-    font-feature-settings: "ss01", "cv11";
+    font-feature-settings: "zero", "ss01";
     font-variant-numeric: tabular-nums;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -314,7 +316,6 @@
   }
   body {
     background-image:
-      radial-gradient(var(--mg-dot-color) 1px, transparent 1px),
       linear-gradient(
         to right,
         var(--mg-grid-color) 1px,
@@ -322,21 +323,9 @@
       linear-gradient(
         to bottom,
         var(--mg-grid-color) 1px,
-        transparent 1px),
-      radial-gradient(
-        ellipse 110% 60% at 50% 0%,
-        color-mix(in oklab, var(--accent) 5%, transparent) 0%,
-        transparent 70%);
-    background-size:
-      var(--mg-dot-size) var(--mg-dot-size),
-      96px 96px,
-      96px 96px,
-      100% 100%;
-    background-position:
-      0 0,
-      0 0,
-      0 0,
-      0 0;
+        transparent 1px);
+    background-size: 32px 32px, 32px 32px;
+    background-position: 0 0, 0 0;
     background-attachment: fixed;
   }
   html.theme-transition,
@@ -528,21 +517,32 @@ html[data-density=compact] .bg-card > table td {
 }
 .mg-hero-slab {
   position: relative;
-  background: transparent;
-  border: 0;
+  background-color: color-mix(in oklab, var(--surface) 52%, transparent);
+  background-image:
+    linear-gradient(
+      to right,
+      var(--mg-cadence-color) 1px,
+      transparent 1px),
+    linear-gradient(
+      to bottom,
+      var(--mg-cadence-color) 1px,
+      transparent 1px);
+  background-size: 16px 16px;
+  border-bottom: 1px solid var(--border);
   border-radius: 0;
-  border-top: 1px solid color-mix(in oklab, var(--accent) 55%, transparent);
+  border-top: 1px solid color-mix(in oklab, var(--accent) 68%, transparent);
 }
 .mg-hero-slab::before {
   content: none;
 }
 .mg-accent-band {
-  background: color-mix(in oklab, var(--accent) 6%, var(--paper));
-  border-top: 1px solid color-mix(in oklab, var(--accent) 35%, transparent);
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 .mg-dot-grid {
-  background-image: radial-gradient(color-mix(in oklab, var(--accent) 30%, transparent) 1px, transparent 1px);
+  background-image: radial-gradient(color-mix(in oklab, var(--accent) 36%, transparent) 1px, transparent 1px);
   background-size: 14px 14px;
 }
 .mg-kpi-strip {
@@ -578,14 +578,14 @@ html[data-density=compact] .bg-card > table td {
   width: 0.45rem;
   height: 0.45rem;
   border-radius: 9999px;
-  background: var(--accent);
+  background: var(--health-ok);
 }
 .mg-live-dot::after {
   content: "";
   position: absolute;
   inset: -3px;
   border-radius: 9999px;
-  background: var(--accent);
+  background: var(--health-ok);
   opacity: 0.3;
   animation: mg-pulse 1.8s ease-in-out infinite;
 }
@@ -703,10 +703,7 @@ html[data-density=compact] .bg-card > table td {
 .mg-mega-surface {
   background: var(--paper);
   border: 1px solid var(--border);
-  box-shadow:
-    0 1px 0 var(--border) inset,
-    0 24px 60px -20px color-mix(in oklab, var(--ink-strong) 22%, transparent),
-    0 2px 8px -2px color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  box-shadow: 0 1px 0 var(--border) inset;
 }
 .mg-mega-scrim {
   position: fixed;
@@ -809,10 +806,10 @@ html[data-density=compact] .bg-card > table td {
   background-color: color-mix(in oklab, var(--accent) 8%, var(--surface));
 }
 .mg-card-glow {
-  box-shadow: 0 24px 80px -58px color-mix(in oklab, var(--ink-strong) 45%, transparent);
+  box-shadow: 0 1px 0 var(--border);
 }
 .mg-card-glow-accent {
-  box-shadow: 0 24px 80px -52px color-mix(in oklab, var(--accent) 45%, transparent);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 .mg-skel-crossfade > * {
   transition: opacity 200ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -972,8 +969,8 @@ html[data-density=compact] .bg-card > table td {
   transition: background-color 220ms ease, border-color 220ms ease;
 }
 .mg-header[data-scrolled=true] {
-  background-color: color-mix(in oklab, var(--paper) 88%, transparent);
-  border-bottom-color: color-mix(in oklab, var(--ink-strong) 14%, transparent);
+  background-color: var(--paper);
+  border-bottom-color: var(--border);
 }
 .mg-glyph-rule {
   display: flex;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3253,10 +3253,10 @@ function BarMini({
             className: "grid grid-cols-[5.5rem_1fr_auto] items-center gap-2",
             children: [
               /* @__PURE__ */ jsx("span", { className: "mg-type-caption text-ink-muted truncate", children: d.label }),
-              /* @__PURE__ */ jsx("span", { className: "relative h-1.5 rounded-full bg-surface overflow-hidden", children: /* @__PURE__ */ jsx(
+              /* @__PURE__ */ jsx("span", { className: "relative h-1.5 bg-surface overflow-hidden", children: /* @__PURE__ */ jsx(
                 "span",
                 {
-                  className: "absolute inset-y-0 left-0 rounded-full",
+                  className: "absolute inset-y-0 left-0",
                   style: {
                     width: `${pct}%`,
                     background: d.color ?? "var(--accent)"

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -507,7 +507,7 @@ function Panel({
     {
       ...rest,
       className: classNames(
-        "rounded-sm border",
+        "mg-panel rounded-sm border",
         toneStyle.border,
         tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,
@@ -2006,6 +2006,20 @@ function KeyChip({
     ] })
   );
 }
+var RESPONSIVE_CLASSES = {
+  md: {
+    filter: "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5",
+    cards: "md:hidden space-y-2",
+    table: "hidden md:block",
+    footer: "md:hidden mt-3"
+  },
+  lg: {
+    filter: "sticky lg:static z-[var(--mg-z-raised)] -mx-4 lg:mx-0 mb-3 border-b border-border lg:border lg:rounded lg:bg-card px-3 py-2 lg:p-2.5",
+    cards: "lg:hidden space-y-2",
+    table: "hidden lg:block",
+    footer: "lg:hidden mt-3"
+  }
+};
 function ListShell({
   filters,
   cards,
@@ -2015,16 +2029,23 @@ function ListShell({
   isEmpty,
   isStale,
   viewportRef,
-  stickyHeader = true
+  stickyHeader = true,
+  presentation = "panel",
+  responsiveAt = "md"
 }) {
-  const tableCard = "rounded border border-border bg-card overflow-hidden";
+  const responsive = RESPONSIVE_CLASSES[responsiveAt];
+  const tableCard = classNames(
+    "mg-list-table-card overflow-hidden",
+    presentation === "canvas" ? "mg-list-table-card--canvas" : "rounded border border-border bg-card"
+  );
   const viewportClass = stickyHeader ? "mg-table-scroll mg-list-viewport" : "mg-table-scroll overflow-x-auto";
-  return /* @__PURE__ */ jsxs("div", { children: [
+  return /* @__PURE__ */ jsxs("div", { "data-mg-list-shell": true, "data-presentation": presentation, children: [
     /* @__PURE__ */ jsx(
       "div",
       {
         className: classNames(
-          // Sticky below `md`, in normal flow at and above it. Offset reads
+          // Sticky below the responsive breakpoint, in normal flow at and
+          // above it. Offset reads
           // --mg-sticky-offset (published by AppShell to match real header +
           // ticker height) with a fallback.
           //
@@ -2043,10 +2064,9 @@ function ListShell({
           // (`#subnets-list > div > div:first-child { position: static }`,
           // at >=1024px only, which is why tablet still showed the overlap).
           // That override is deleted; this is the general rule.
-          "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
+          responsive.filter,
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
-          "border-b border-border md:border md:rounded md:bg-card",
-          "px-3 py-2 md:p-2.5"
+          presentation === "canvas" ? "mg-list-filter-bar--canvas" : void 0
         ),
         style: {
           top: "calc(var(--mg-sticky-offset, 3.5rem) + var(--mg-tabs-h, 0px))"
@@ -2063,12 +2083,12 @@ function ListShell({
       // attribute is what makes that state observable.
       /* @__PURE__ */ jsx("div", { "data-mg-list-empty": "", children: empty })
     ) : /* @__PURE__ */ jsxs("div", { className: isStale ? "opacity-70 transition-opacity" : void 0, children: [
-      cards ? /* @__PURE__ */ jsx("div", { className: "md:hidden space-y-2", children: cards }) : null,
-      /* @__PURE__ */ jsx("div", { className: cards ? "hidden md:block" : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
+      cards ? /* @__PURE__ */ jsx("div", { className: responsive.cards, children: cards }) : null,
+      /* @__PURE__ */ jsx("div", { className: cards ? responsive.table : void 0, children: /* @__PURE__ */ jsxs("div", { className: tableCard, children: [
         /* @__PURE__ */ jsx("div", { ref: viewportRef, className: viewportClass, children: table }),
         footer
       ] }) }),
-      cards && footer ? /* @__PURE__ */ jsx("div", { className: "md:hidden mt-3", children: footer }) : null
+      cards && footer ? /* @__PURE__ */ jsx("div", { className: responsive.footer, children: footer }) : null
     ] })
   ] });
 }
@@ -2188,6 +2208,165 @@ function PageHero({
           k.chart ? /* @__PURE__ */ jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
         ] }, k.label)) }) : null
       ]
+    }
+  );
+}
+function DataPageStage({
+  children,
+  className,
+  variant = "default"
+}) {
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      className: classNames(
+        "mg-page-stage",
+        variant !== "default" ? `mg-page-stage--${variant}` : void 0,
+        className
+      ),
+      children
+    }
+  );
+}
+function DataPageHero({
+  eyebrow,
+  title,
+  description,
+  summary,
+  actions,
+  children,
+  footer,
+  live = false,
+  id,
+  className,
+  variant = "directory"
+}) {
+  return /* @__PURE__ */ jsxs(
+    "section",
+    {
+      className: classNames(
+        "mg-page-hero",
+        `mg-page-hero--${variant}`,
+        className
+      ),
+      "aria-labelledby": id,
+      children: [
+        /* @__PURE__ */ jsx("div", { className: "mg-page-hero-field", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxs("div", { className: "mg-page-hero-content", children: [
+          /* @__PURE__ */ jsxs("div", { className: "mg-page-hero-copy", children: [
+            eyebrow ? /* @__PURE__ */ jsxs("span", { className: "mg-page-kicker", children: [
+              live ? /* @__PURE__ */ jsx("span", { className: "mg-page-kicker-dot", "aria-hidden": "true" }) : null,
+              eyebrow
+            ] }) : null,
+            /* @__PURE__ */ jsx("h1", { id, children: title }),
+            description ? /* @__PURE__ */ jsx("div", { className: "mg-page-hero-description", children: description }) : null,
+            children ? /* @__PURE__ */ jsx("div", { className: "mg-page-hero-body", children }) : null,
+            summary ? /* @__PURE__ */ jsx("div", { className: "mg-page-hero-summary", children: summary }) : null
+          ] }),
+          actions ? /* @__PURE__ */ jsx("div", { className: "mg-page-hero-actions", children: actions }) : null
+        ] }),
+        footer ? /* @__PURE__ */ jsx("div", { className: "mg-page-hero-footer", children: footer }) : null
+      ]
+    }
+  );
+}
+function DataPageCanvas({
+  children,
+  className,
+  variant = "default"
+}) {
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      className: classNames(
+        "mg-page-canvas",
+        variant !== "default" ? `mg-page-canvas--${variant}` : void 0,
+        className
+      ),
+      children
+    }
+  );
+}
+function DataPageModule({
+  title,
+  caption,
+  actions,
+  children,
+  className,
+  id,
+  kind = "task"
+}) {
+  return /* @__PURE__ */ jsxs(
+    "section",
+    {
+      id,
+      className: classNames(
+        "mg-page-module",
+        `mg-page-module--${kind}`,
+        className
+      ),
+      children: [
+        title || caption || actions ? /* @__PURE__ */ jsxs("header", { className: "mg-page-module-heading", children: [
+          /* @__PURE__ */ jsxs("div", { children: [
+            title ? /* @__PURE__ */ jsx("h2", { className: "mg-page-module-title", children: title }) : null,
+            caption ? /* @__PURE__ */ jsx("p", { className: "mg-page-module-caption", children: caption }) : null
+          ] }),
+          actions ? /* @__PURE__ */ jsx("div", { className: "mg-page-module-actions", children: actions }) : null
+        ] }) : null,
+        /* @__PURE__ */ jsx("div", { className: "mg-page-module-body", children })
+      ]
+    }
+  );
+}
+function DataPageDisclosure({
+  label,
+  children,
+  className,
+  open = false
+}) {
+  return /* @__PURE__ */ jsxs(
+    "details",
+    {
+      className: classNames("mg-page-disclosure", className),
+      open,
+      children: [
+        /* @__PURE__ */ jsx("summary", { children: label }),
+        /* @__PURE__ */ jsx("div", { children })
+      ]
+    }
+  );
+}
+function DataPageWindowTabs({
+  label,
+  options,
+  value,
+  onValueChange,
+  className
+}) {
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      role: "tablist",
+      "aria-label": label,
+      className: classNames("mg-data-window", className),
+      children: options.map((option) => {
+        const selected = option.value === value;
+        return /* @__PURE__ */ jsx(
+          "button",
+          {
+            type: "button",
+            role: "tab",
+            "aria-selected": selected,
+            onClick: () => onValueChange(option.value),
+            className: classNames(
+              "mg-data-window-button mg-focus-ring",
+              selected && "is-active"
+            ),
+            children: option.label
+          },
+          option.value
+        );
+      })
     }
   );
 }
@@ -2328,7 +2507,7 @@ function PageSection({
       id,
       "data-section-anchor": id ? "" : void 0,
       className: classNames(
-        "mg-section",
+        "mg-section mg-route-section",
         tone === "muted" && "rounded-xl bg-surface-2/40 px-4 md:px-8 py-8 md:py-10",
         className
       ),
@@ -2436,7 +2615,7 @@ function SectionAnchor({
       id,
       "data-section-anchor": true,
       className: classNames(
-        "mg-section scroll-mt-32",
+        "mg-section mg-detail-section scroll-mt-32",
         tone && classNames(
           "relative pl-3 before:content-[''] before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:rounded-full before:opacity-70",
           TONE_CLASS[tone]
@@ -2487,7 +2666,7 @@ function SectionHeading({
     "div",
     {
       className: classNames(
-        "mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between",
+        "mg-route-heading mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between",
         className
       ),
       children: [
@@ -5380,6 +5559,7 @@ var GhostButton = forwardRef(
   function GhostButton2({
     size = "sm",
     tone = "default",
+    appearance = "soft",
     icon,
     iconRight,
     className,
@@ -5393,7 +5573,8 @@ var GhostButton = forwardRef(
         ref,
         type: type ?? "button",
         className: cn(
-          "inline-flex items-center justify-center gap-1.5 rounded-md border bg-card transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "inline-flex items-center justify-center gap-1.5 border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          appearance === "terminal" ? "rounded-none bg-transparent" : "rounded-md bg-card",
           SIZE[size],
           TONE2[tone],
           className
@@ -6563,4 +6744,4 @@ function RoutePending({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, SankeyMini, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StackedAreaMini, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableColGroup, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, columnWidths, defaultVisible, fmtYield, isScrolledPast, layoutSankey, layoutStackedArea, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, ChartSkeleton, Chip, ClaudeIcon, ColumnCustomizer, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DataPageCanvas, DataPageDisclosure, DataPageHero, DataPageModule, DataPageStage, DataPageWindowTabs, DefinitionList, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Divider, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EmptyState, EntityHero, ExternalLink, FilterChipRow, FilterField, FilterInput, FilterSelect, FilterSheet, FilterToolbar, FreshnessIndicator, GhostButton, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, Indicator, InfoTooltip, Kbd, KeyChip, ListShell, LiveTickerProvider, LoadMore, LoadingPill, McpToolsList, MetaStrip, MethodologyCallout, MetricGrid, MiniRadial, MiniStack, MobileCollapse, NoDataSpark, OpenAIIcon, PageActions, PageHero, PageSection, PagerBar, PagerFooter, Panel, PanelError, PanelHeader, PanelSkeleton, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProvenanceChip, QueryBar, QueryProgress, ReadinessGauge, RealtimeFreshness, ResponsiveTable, ReviewChip, RoutePending, SCOPES, SHARE_COPIED_EVENT, SankeyMini, ScrollReveal, ScrollShadow, SectionAnchor, SectionHeading, SectionLabel, SegmentedToggle, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StackedAreaMini, StatTile, StatWithSpark, StatusBadge, StickyToolbar, TabStrip, TableColGroup, TableSkeleton, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, classNames, cn, columnWidths, defaultVisible, fmtYield, isScrolledPast, layoutSankey, layoutStackedArea, nextTabIndex, prefetchBrandIcon, rovingTabIndex, safeExternalUrl, tierFreshnessLabel, useColumnVisibility, useLiveTicker, useQueryBarContext, useRovingTablist, useScrolled };

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -507,7 +507,7 @@ function Panel({
     {
       ...rest,
       className: classNames(
-        "rounded border",
+        "rounded-sm border",
         toneStyle.border,
         tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -38,6 +38,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "@radix-ui/react-accordion": "^1.2.20",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-hover-card": "^1.1.23",

--- a/packages/ui-kit/src/components/metagraphed/charts/bar-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/bar-mini.tsx
@@ -51,9 +51,9 @@ export function BarMini({
             <span className="mg-type-caption text-ink-muted truncate">
               {d.label}
             </span>
-            <span className="relative h-1.5 rounded-full bg-surface overflow-hidden">
+            <span className="relative h-1.5 bg-surface overflow-hidden">
               <span
-                className="absolute inset-y-0 left-0 rounded-full"
+                className="absolute inset-y-0 left-0"
                 style={{
                   width: `${pct}%`,
                   background: d.color ?? "var(--accent)",

--- a/packages/ui-kit/src/components/metagraphed/data-page.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/data-page.test.ts
@@ -1,0 +1,85 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  DataPageCanvas,
+  DataPageDisclosure,
+  DataPageHero,
+  DataPageModule,
+  DataPageStage,
+  DataPageWindowTabs,
+} from "./data-page";
+
+describe("data page primitives", () => {
+  it("renders a focused live hero and continuous canvas", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        DataPageStage,
+        null,
+        createElement(DataPageHero, {
+          eyebrow: "Network registry",
+          title: "Subnets.",
+          description: "Browse live network data.",
+          live: true,
+          id: "subnets-title",
+          footer: createElement("span", null, "128 active"),
+        }),
+        createElement(
+          DataPageCanvas,
+          null,
+          createElement(DataPageModule, {
+            title: "Browse",
+            caption: "Ranked by stake.",
+            children: "Rows",
+          }),
+        ),
+      ),
+    );
+
+    expect(html).toContain('class="mg-page-stage"');
+    expect(html).toContain('aria-labelledby="subnets-title"');
+    expect(html).toContain("mg-page-kicker-dot");
+    expect(html).toContain('class="mg-page-canvas"');
+    expect(html).toContain('class="mg-page-module mg-page-module--task"');
+    expect(html).toContain("Ranked by stake.");
+  });
+
+  it("supports a quiet disclosure instead of adding explanatory page density", () => {
+    const html = renderToStaticMarkup(
+      createElement(DataPageDisclosure, {
+        label: "How this is measured",
+        children: "Methodology",
+      }),
+    );
+
+    expect(html).toContain("mg-page-disclosure");
+    expect(html).toContain("How this is measured");
+    expect(html).toContain("Methodology");
+  });
+
+  it("offers an operations canvas without forcing routes to own a layout class", () => {
+    const html = renderToStaticMarkup(
+      createElement(DataPageCanvas, { variant: "operations", children: "Live health" }),
+    );
+
+    expect(html).toContain("mg-page-canvas--operations");
+  });
+
+  it("keeps a time-window choice inside the analytical module grammar", () => {
+    const html = renderToStaticMarkup(
+      createElement(DataPageWindowTabs, {
+        label: "Analytics time window",
+        options: [
+          { value: "7d", label: "7 days" },
+          { value: "30d", label: "30 days" },
+        ],
+        value: "7d",
+        onValueChange: () => undefined,
+      }),
+    );
+
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain("mg-data-window");
+    expect(html).toContain('aria-selected="true"');
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/data-page.tsx
+++ b/packages/ui-kit/src/components/metagraphed/data-page.tsx
@@ -1,0 +1,257 @@
+import type { ReactNode } from "react";
+import { classNames } from "@/lib/format";
+
+/**
+ * Shared frame for explorer, directory, dossier, and analytics routes.
+ *
+ * These are deliberately structural primitives: they establish the same
+ * reading rhythm without forcing every route into the same content template.
+ */
+export type DataPageStageVariant = "default" | "profile" | "tabs";
+export type DataPageHeroVariant = "directory" | "landing" | "analytics";
+export type DataPageCanvasVariant = "default" | "profile" | "operations";
+export type DataPageModuleKind = "task" | "question" | "operations" | "profile";
+
+export interface DataPageWindowOption<T extends string> {
+  value: T;
+  label: ReactNode;
+}
+
+export function DataPageStage({
+  children,
+  className,
+  variant = "default",
+}: {
+  children: ReactNode;
+  className?: string;
+  variant?: DataPageStageVariant;
+}) {
+  return (
+    <div
+      className={classNames(
+        "mg-page-stage",
+        variant !== "default" ? `mg-page-stage--${variant}` : undefined,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface DataPageHeroProps {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  /** A short, in-context operational fact. Never a card wall. */
+  summary?: ReactNode;
+  /** Export, share, or view controls; visually secondary to the task. */
+  actions?: ReactNode;
+  /** Primary task control, such as the homepage command field. */
+  children?: ReactNode;
+  /** Freshness or identity facts that follow the task, not the title. */
+  footer?: ReactNode;
+  live?: boolean;
+  id?: string;
+  className?: string;
+  variant?: DataPageHeroVariant;
+}
+
+/**
+ * A title field with a single restrained activity lattice. The lattice is an
+ * orientation cue, not a substitute for a chart, and appears across routes so
+ * a directory, landing page, and data report feel like one product.
+ */
+export function DataPageHero({
+  eyebrow,
+  title,
+  description,
+  summary,
+  actions,
+  children,
+  footer,
+  live = false,
+  id,
+  className,
+  variant = "directory",
+}: DataPageHeroProps) {
+  return (
+    <section
+      className={classNames(
+        "mg-page-hero",
+        `mg-page-hero--${variant}`,
+        className,
+      )}
+      aria-labelledby={id}
+    >
+      <div className="mg-page-hero-field" aria-hidden="true" />
+      <div className="mg-page-hero-content">
+        <div className="mg-page-hero-copy">
+          {eyebrow ? (
+            <span className="mg-page-kicker">
+              {live ? (
+                <span className="mg-page-kicker-dot" aria-hidden="true" />
+              ) : null}
+              {eyebrow}
+            </span>
+          ) : null}
+          <h1 id={id}>{title}</h1>
+          {description ? (
+            <div className="mg-page-hero-description">{description}</div>
+          ) : null}
+          {children ? (
+            <div className="mg-page-hero-body">{children}</div>
+          ) : null}
+          {summary ? (
+            <div className="mg-page-hero-summary">{summary}</div>
+          ) : null}
+        </div>
+        {actions ? <div className="mg-page-hero-actions">{actions}</div> : null}
+      </div>
+      {footer ? <div className="mg-page-hero-footer">{footer}</div> : null}
+    </section>
+  );
+}
+
+/** A ruled canvas that turns related modules into one continuous reading surface. */
+export function DataPageCanvas({
+  children,
+  className,
+  variant = "default",
+}: {
+  children: ReactNode;
+  className?: string;
+  variant?: DataPageCanvasVariant;
+}) {
+  return (
+    <div
+      className={classNames(
+        "mg-page-canvas",
+        variant !== "default" ? `mg-page-canvas--${variant}` : undefined,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface DataPageModuleProps {
+  title?: ReactNode;
+  caption?: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  id?: string;
+  kind?: DataPageModuleKind;
+}
+
+/**
+ * One task or one analytical question. Rules, alignment, and type establish
+ * grouping; routes should not turn each task into its own rounded card.
+ */
+export function DataPageModule({
+  title,
+  caption,
+  actions,
+  children,
+  className,
+  id,
+  kind = "task",
+}: DataPageModuleProps) {
+  return (
+    <section
+      id={id}
+      className={classNames(
+        "mg-page-module",
+        `mg-page-module--${kind}`,
+        className,
+      )}
+    >
+      {title || caption || actions ? (
+        <header className="mg-page-module-heading">
+          <div>
+            {title ? <h2 className="mg-page-module-title">{title}</h2> : null}
+            {caption ? (
+              <p className="mg-page-module-caption">{caption}</p>
+            ) : null}
+          </div>
+          {actions ? (
+            <div className="mg-page-module-actions">{actions}</div>
+          ) : null}
+        </header>
+      ) : null}
+      <div className="mg-page-module-body">{children}</div>
+    </section>
+  );
+}
+
+/** A quiet, keyboard-native disclosure for methodology and advanced context. */
+export function DataPageDisclosure({
+  label,
+  children,
+  className,
+  open = false,
+}: {
+  label: ReactNode;
+  children: ReactNode;
+  className?: string;
+  open?: boolean;
+}) {
+  return (
+    <details
+      className={classNames("mg-page-disclosure", className)}
+      open={open}
+    >
+      <summary>{label}</summary>
+      <div>{children}</div>
+    </details>
+  );
+}
+
+/**
+ * A compact time/filter rail for a single analytical question. It deliberately
+ * stays local to the plot it controls, rather than becoming a competing page
+ * toolbar.
+ */
+export function DataPageWindowTabs<T extends string>({
+  label,
+  options,
+  value,
+  onValueChange,
+  className,
+}: {
+  label: string;
+  options: readonly DataPageWindowOption<T>[];
+  value: T;
+  onValueChange: (value: T) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label={label}
+      className={classNames("mg-data-window", className)}
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onValueChange(option.value)}
+            className={classNames(
+              "mg-data-window-button mg-focus-ring",
+              selected && "is-active",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui-kit/src/components/metagraphed/ghost-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/ghost-button.tsx
@@ -3,10 +3,13 @@ import { cn } from "@/lib/utils";
 
 export type GhostButtonSize = "sm" | "md" | "lg";
 export type GhostButtonTone = "default" | "accent" | "warn" | "down";
+export type GhostButtonAppearance = "soft" | "terminal";
 
 export type GhostButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: GhostButtonSize;
   tone?: GhostButtonTone;
+  /** `terminal` is the square-edged control treatment for data rails. */
+  appearance?: GhostButtonAppearance;
   icon?: ReactNode;
   iconRight?: ReactNode;
 };
@@ -37,6 +40,7 @@ export const GhostButton = forwardRef<HTMLButtonElement, GhostButtonProps>(
     {
       size = "sm",
       tone = "default",
+      appearance = "soft",
       icon,
       iconRight,
       className,
@@ -51,7 +55,10 @@ export const GhostButton = forwardRef<HTMLButtonElement, GhostButtonProps>(
         ref={ref}
         type={type ?? "button"}
         className={cn(
-          "inline-flex items-center justify-center gap-1.5 rounded-md border bg-card transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "inline-flex items-center justify-center gap-1.5 border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          appearance === "terminal"
+            ? "rounded-none bg-transparent"
+            : "rounded-md bg-card",
           SIZE[size],
           TONE[tone],
           className,

--- a/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.test.ts
@@ -49,9 +49,11 @@ describe("ListShell sticky table wrappers", () => {
     );
   });
 
-  it("keeps the card wrapper's rounded-corner clipping the same for both modes", () => {
-    expect(source).toContain(
-      'const tableCard = "rounded border border-border bg-card overflow-hidden";',
-    );
+  it("owns canvas presentation and the mobile-to-table breakpoint in the primitive", () => {
+    expect(source).toContain('presentation = "panel"');
+    expect(source).toContain('responsiveAt = "md"');
+    expect(source).toContain('presentation === "canvas"');
+    expect(source).toContain('"mg-list-table-card--canvas"');
+    expect(source).toContain("RESPONSIVE_CLASSES[responsiveAt]");
   });
 });

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -3,14 +3,32 @@ import { AlertCircle, RefreshCw } from "lucide-react";
 import { classNames } from "@/lib/format";
 import { Skeleton } from "./skeleton";
 
+const RESPONSIVE_CLASSES = {
+  md: {
+    filter:
+      "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5",
+    cards: "md:hidden space-y-2",
+    table: "hidden md:block",
+    footer: "md:hidden mt-3",
+  },
+  lg: {
+    filter:
+      "sticky lg:static z-[var(--mg-z-raised)] -mx-4 lg:mx-0 mb-3 border-b border-border lg:border lg:rounded lg:bg-card px-3 py-2 lg:p-2.5",
+    cards: "lg:hidden space-y-2",
+    table: "hidden lg:block",
+    footer: "lg:hidden mt-3",
+  },
+} as const;
+
 /**
  * Shared responsive shell for list/table routes.
  *
  * - `filters` renders inside a sticky filter bar that hugs the app header on
  *   mobile and remains visible while the user scrolls a long list.
- * - `cards` renders on viewports < md and provides a tap-friendly card
- *   fallback for tabular data.
- * - `table` renders on viewports >= md with horizontal scroll for overflow.
+ * - `cards` renders below the configured responsive breakpoint and provides a
+ *   tap-friendly fallback for tabular data.
+ * - `table` renders at and above that breakpoint with horizontal scroll for
+ *   overflow.
  *
  * The table's <thead> sticks against the bounded viewport this shell puts
  * around it, so consumers pin their header with `sticky top-0` and nothing
@@ -34,6 +52,8 @@ export function ListShell({
   isStale,
   viewportRef,
   stickyHeader = true,
+  presentation = "panel",
+  responsiveAt = "md",
 }: {
   filters: ReactNode;
   cards?: ReactNode;
@@ -65,8 +85,22 @@ export function ListShell({
    * passes `false` -- the exact behaviour it opted out of.
    */
   stickyHeader?: boolean;
+  /**
+   * `canvas` lets a directory become part of a continuous data document.
+   * The shell owns its flush table edges and toolbar bleed so routes do not
+   * repair them with negative-margin selectors.
+   */
+  presentation?: "panel" | "canvas";
+  /** Keep touch-first cards through tablet when a table has many columns. */
+  responsiveAt?: "md" | "lg";
 }) {
-  const tableCard = "rounded border border-border bg-card overflow-hidden";
+  const responsive = RESPONSIVE_CLASSES[responsiveAt];
+  const tableCard = classNames(
+    "mg-list-table-card overflow-hidden",
+    presentation === "canvas"
+      ? "mg-list-table-card--canvas"
+      : "rounded border border-border bg-card",
+  );
   // .mg-table-scroll brings the edge-fade + thin scrollbar; .mg-list-viewport
   // brings the height cap, both overflow axes and overscroll containment. They
   // belong on the SAME element (see the note below).
@@ -74,10 +108,11 @@ export function ListShell({
     ? "mg-table-scroll mg-list-viewport"
     : "mg-table-scroll overflow-x-auto";
   return (
-    <div>
+    <div data-mg-list-shell data-presentation={presentation}>
       <div
         className={classNames(
-          // Sticky below `md`, in normal flow at and above it. Offset reads
+          // Sticky below the responsive breakpoint, in normal flow at and
+          // above it. Offset reads
           // --mg-sticky-offset (published by AppShell to match real header +
           // ticker height) with a fallback.
           //
@@ -96,10 +131,9 @@ export function ListShell({
           // (`#subnets-list > div > div:first-child { position: static }`,
           // at >=1024px only, which is why tablet still showed the overlap).
           // That override is deleted; this is the general rule.
-          "sticky md:static z-[var(--mg-z-raised)] -mx-4 md:mx-0 mb-3",
+          responsive.filter,
           "bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80",
-          "border-b border-border md:border md:rounded md:bg-card",
-          "px-3 py-2 md:p-2.5",
+          presentation === "canvas" ? "mg-list-filter-bar--canvas" : undefined,
         )}
         // --mg-sticky-offset is the app header (published by AppShell);
         // --mg-tabs-h is the page's sticky tab strip, 0 when there isn't one.
@@ -122,8 +156,8 @@ export function ListShell({
         <div data-mg-list-empty="">{empty}</div>
       ) : (
         <div className={isStale ? "opacity-70 transition-opacity" : undefined}>
-          {cards ? <div className="md:hidden space-y-2">{cards}</div> : null}
-          <div className={cards ? "hidden md:block" : undefined}>
+          {cards ? <div className={responsive.cards}>{cards}</div> : null}
+          <div className={cards ? responsive.table : undefined}>
             <div className={tableCard}>
               {/* ONE scroll container, both axes. These used to be two
                   nested divs -- .mg-table-scroll for x, an inner bounded div
@@ -141,7 +175,7 @@ export function ListShell({
             </div>
           </div>
           {cards && footer ? (
-            <div className="md:hidden mt-3">{footer}</div>
+            <div className={responsive.footer}>{footer}</div>
           ) : null}
         </div>
       )}

--- a/packages/ui-kit/src/components/metagraphed/page-section.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-section.tsx
@@ -42,7 +42,7 @@ export function PageSection({
       id={id}
       data-section-anchor={id ? "" : undefined}
       className={classNames(
-        "mg-section",
+        "mg-section mg-route-section",
         tone === "muted" &&
           "rounded-xl bg-surface-2/40 px-4 md:px-8 py-8 md:py-10",
         className,

--- a/packages/ui-kit/src/components/metagraphed/panel.tsx
+++ b/packages/ui-kit/src/components/metagraphed/panel.tsx
@@ -89,7 +89,7 @@ export function Panel({
     <Cmp
       {...rest}
       className={classNames(
-        "rounded border",
+        "rounded-sm border",
         toneStyle.border,
         tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,

--- a/packages/ui-kit/src/components/metagraphed/panel.tsx
+++ b/packages/ui-kit/src/components/metagraphed/panel.tsx
@@ -89,7 +89,7 @@ export function Panel({
     <Cmp
       {...rest}
       className={classNames(
-        "rounded-sm border",
+        "mg-panel rounded-sm border",
         toneStyle.border,
         tintBorderOnly ? "bg-card" : toneStyle.bg,
         interactive ? "mg-hover-lift" : null,

--- a/packages/ui-kit/src/components/metagraphed/section-anchor.tsx
+++ b/packages/ui-kit/src/components/metagraphed/section-anchor.tsx
@@ -58,7 +58,7 @@ export function SectionAnchor({
       id={id}
       data-section-anchor
       className={classNames(
-        "mg-section scroll-mt-32",
+        "mg-section mg-detail-section scroll-mt-32",
         tone &&
           classNames(
             "relative pl-3 before:content-[''] before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:rounded-full before:opacity-70",

--- a/packages/ui-kit/src/components/metagraphed/section-heading.tsx
+++ b/packages/ui-kit/src/components/metagraphed/section-heading.tsx
@@ -32,7 +32,7 @@ export function SectionHeading({
   return (
     <div
       className={classNames(
-        "mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between",
+        "mg-route-heading mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between",
         className,
       )}
     >

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -125,6 +125,19 @@ export { KeyChip } from "@/components/metagraphed/key-chip";
 export { ListShell, LoadMore } from "@/components/metagraphed/list-shell";
 export { PageHero } from "@/components/metagraphed/page-hero";
 export {
+  DataPageStage,
+  DataPageHero,
+  DataPageCanvas,
+  DataPageModule,
+  DataPageDisclosure,
+  DataPageWindowTabs,
+  type DataPageStageVariant,
+  type DataPageHeroVariant,
+  type DataPageCanvasVariant,
+  type DataPageModuleKind,
+  type DataPageWindowOption,
+} from "@/components/metagraphed/data-page";
+export {
   type EntityHeroProps,
   type EntityHeroStat,
   EntityHero,
@@ -306,6 +319,7 @@ export {
   type GhostButtonProps,
   type GhostButtonSize,
   type GhostButtonTone,
+  type GhostButtonAppearance,
 } from "@/components/metagraphed/ghost-button";
 export {
   PagerFooter,

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -256,13 +256,16 @@
   --curation-machine: #7562c6;
   --curation-adapter: #b24f8c;
 
-  /* Arbitrary chart series, intentionally distinct from health and trust. */
-  --chart-1: #119b76;
-  --chart-2: #8562d7;
-  --chart-3: #d56b25;
-  --chart-4: #bd4e92;
-  --chart-5: #9c7b11;
-  --chart-6: #6f7b87;
+  /* Arbitrary chart series, intentionally distinct from health and trust.
+     This is the data prism: a deliberately ordered magenta → violet → blue
+     → cyan → lime → orange ramp. It is for comparable categories only;
+     health, direction, and verification still use their semantic tokens. */
+  --chart-1: #b52cce;
+  --chart-2: #7450d8;
+  --chart-3: #386fdb;
+  --chart-4: #078ab5;
+  --chart-5: #5d9200;
+  --chart-6: #d76000;
 
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 13%, transparent);
@@ -584,12 +587,15 @@
   --curation-machine: #b49aff;
   --curation-adapter: #e79ac9;
 
-  --chart-1: var(--brand-green);
-  --chart-2: #b69bff;
-  --chart-3: #ffad72;
-  --chart-4: #ec9bcf;
-  --chart-5: #e9ca68;
-  --chart-6: #a6adb7;
+  /* The dark data prism deliberately keeps Metagraphed mint out of the
+     categorical ramp. Mint remains the unmistakable product/action and live
+     focus color; this ordered palette makes overlapping data legible. */
+  --chart-1: #e45dff;
+  --chart-2: #9b7bff;
+  --chart-3: #5a8eff;
+  --chart-4: #22c9e4;
+  --chart-5: #a8e31b;
+  --chart-6: #ff9000;
 
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 15%, transparent);

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -174,6 +174,11 @@
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
   --color-chart-6: var(--chart-6);
+  --color-chart-7: var(--chart-7);
+  --color-chart-8: var(--chart-8);
+  --color-chart-9: var(--chart-9);
+  --color-chart-10: var(--chart-10);
+  --color-chart-11: var(--chart-11);
 
   --font-display: "IBM Plex Mono", "Space Grotesk", ui-monospace, monospace;
   --font-sans: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace;
@@ -260,12 +265,17 @@
      This is the data prism: a deliberately ordered magenta → violet → blue
      → cyan → lime → orange ramp. It is for comparable categories only;
      health, direction, and verification still use their semantic tokens. */
-  --chart-1: #b52cce;
-  --chart-2: #7450d8;
-  --chart-3: #386fdb;
-  --chart-4: #078ab5;
-  --chart-5: #5d9200;
-  --chart-6: #d76000;
+  --chart-1: #a82ab7;
+  --chart-2: #785cd0;
+  --chart-3: #556ad4;
+  --chart-4: #1e78bc;
+  --chart-5: #0089a1;
+  --chart-6: #007a6a;
+  --chart-7: #057353;
+  --chart-8: #5d9200;
+  --chart-9: #a96d00;
+  --chart-10: #c55600;
+  --chart-11: #bf4b55;
 
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 13%, transparent);
@@ -590,12 +600,17 @@
   /* The dark data prism deliberately keeps Metagraphed mint out of the
      categorical ramp. Mint remains the unmistakable product/action and live
      focus color; this ordered palette makes overlapping data legible. */
-  --chart-1: #e45dff;
-  --chart-2: #9b7bff;
-  --chart-3: #5a8eff;
-  --chart-4: #22c9e4;
-  --chart-5: #a8e31b;
-  --chart-6: #ff9000;
+  --chart-1: #ed6aff;
+  --chart-2: #a684ff;
+  --chart-3: #7c86ff;
+  --chart-4: #51a2ff;
+  --chart-5: #00d3f2;
+  --chart-6: #00d5be;
+  --chart-7: #00bc7d;
+  --chart-8: #9ae600;
+  --chart-9: #ffb900;
+  --chart-10: #ff8904;
+  --chart-11: #ff6467;
 
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
   --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 15%, transparent);
@@ -1760,6 +1775,1046 @@ html[data-density="compact"] .bg-card > table td {
 @media (prefers-reduced-motion: reduce) {
   .mg-query-shell,
   .mg-ghost-trigger {
+    transition: none;
+  }
+}
+
+/* ============================================================
+ * Terminal page grammar
+ *
+ * Shared explorer layout primitives. They make a page read as one quiet data
+ * document: a title field, a clear primary task, and ruled evidence modules.
+ * The rules intentionally use neutral structure; mint signals product action,
+ * selection, and live focus while the chart prism stays inside data visuals.
+ * ============================================================ */
+:root {
+  --mg-page-max: 68rem;
+  --mg-page-gutter: clamp(1rem, 4vw, 3rem);
+  --mg-page-module-y: clamp(1.25rem, 3.5vw, 2.5rem);
+  --mg-page-rule: color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  --mg-page-field-dot: color-mix(in oklab, var(--ink-strong) 16%, transparent);
+  --mg-page-command-height: 3rem;
+}
+
+.mg-page-stage {
+  width: min(100%, var(--mg-page-max));
+  margin-inline: auto;
+  padding-bottom: var(--mg-space-3xl);
+}
+.mg-page-stage--tabs {
+  padding-bottom: 0;
+}
+
+.mg-page-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--paper) 88%, transparent);
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-micro);
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.mg-page-kicker-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--brand-green);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  animation: mg-page-live-signal 2.4s ease-out infinite;
+}
+@keyframes mg-page-live-signal {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  }
+  45% {
+    box-shadow: 0 0 0 0.32rem
+      color-mix(in oklab, var(--brand-green) 22%, transparent);
+  }
+}
+
+.mg-page-hero {
+  position: relative;
+  isolation: isolate;
+  min-height: 15.5rem;
+  padding: clamp(2.5rem, 6vw, 4.5rem) var(--mg-page-gutter)
+    clamp(2rem, 4vw, 3rem);
+  overflow: hidden;
+}
+.mg-page-hero-field {
+  position: absolute;
+  z-index: -1;
+  top: clamp(1.75rem, 4vw, 3rem);
+  right: -1rem;
+  width: min(66%, 39rem);
+  height: min(12rem, 65%);
+  border: 1px solid var(--mg-page-rule);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    var(--mg-page-field-dot) 1px,
+    transparent 0
+  );
+  background-size: 4px 4px;
+  mask-image: linear-gradient(
+    90deg,
+    transparent 0,
+    #000 20%,
+    #000 84%,
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    transparent 0,
+    #000 20%,
+    #000 84%,
+    transparent 100%
+  );
+}
+.mg-page-hero-content {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(13rem, 0.85fr);
+  align-items: end;
+  gap: clamp(2rem, 8vw, 8rem);
+  min-height: 10.5rem;
+}
+.mg-page-hero-copy {
+  min-width: 0;
+}
+.mg-page-hero h1 {
+  max-width: 12ch;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(2.7rem, 5.8vw, 4.7rem);
+  font-weight: 500;
+  letter-spacing: -0.07em;
+  line-height: 0.9;
+}
+.mg-page-hero-description {
+  max-width: 37rem;
+  margin-top: var(--mg-space-lg);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption-lg);
+  line-height: 1.7;
+}
+.mg-page-hero-body {
+  margin-top: var(--mg-space-xl);
+}
+.mg-page-hero-summary {
+  margin-top: var(--mg-space-lg);
+}
+.mg-page-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--mg-space-sm);
+  padding-bottom: 0.15rem;
+}
+.mg-page-hero-footer {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--mg-space-xs) var(--mg-space-lg);
+  margin-top: var(--mg-space-xl);
+  padding-top: var(--mg-space-sm);
+  border-top: 1px solid var(--border);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+}
+
+/* The landing variant preserves an expressive thesis without turning it into
+   a billboard. The display cap is intentional: the hero should leave room for
+   the first live output on common laptop screens. */
+.mg-page-hero--landing {
+  min-height: 22.5rem;
+  padding-top: clamp(2.75rem, 6vw, 4.75rem);
+}
+.mg-page-hero--landing .mg-page-hero-content {
+  display: block;
+  min-height: 17rem;
+}
+.mg-page-hero--landing .mg-page-hero-copy {
+  max-width: 43rem;
+}
+.mg-page-hero--landing h1 {
+  max-width: 12ch;
+  font-size: clamp(3rem, 5.8vw, 4.9rem);
+  letter-spacing: -0.078em;
+  line-height: 0.88;
+}
+.mg-page-hero--landing .mg-page-hero-field {
+  top: clamp(4.5rem, 9vw, 6.5rem);
+  width: min(72%, 46rem);
+  height: min(16rem, 48%);
+}
+.mg-page-hero--analytics {
+  min-height: 20rem;
+}
+
+.mg-page-command {
+  display: flex;
+  min-height: var(--mg-page-command-height);
+  width: 100%;
+  align-items: center;
+  gap: var(--mg-space-sm);
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--ink-strong) 30%, transparent);
+  padding-bottom: var(--mg-space-sm);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-body);
+  text-align: left;
+  transition:
+    border-color 140ms ease-out,
+    color 140ms ease-out;
+}
+.mg-page-command:hover,
+.mg-page-command:focus-visible {
+  border-color: var(--brand-green);
+  color: var(--ink-strong);
+}
+.mg-page-command > :nth-child(2) {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.mg-page-command-mark {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  background: var(--brand-green);
+  color: #08110e;
+}
+.mg-page-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--mg-space-sm) var(--mg-space-lg);
+  margin-top: var(--mg-space-md);
+}
+.mg-page-primary-action {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: var(--mg-space-xs);
+  padding: 0.55rem 0.85rem;
+  background: var(--brand-green);
+  color: #08110e;
+  font-size: var(--mg-type-caption-lg);
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    background-color 140ms ease-out,
+    transform 140ms ease-out;
+}
+.mg-page-primary-action:hover {
+  background: color-mix(in oklab, var(--brand-green) 84%, #ffffff);
+}
+.mg-page-primary-action:active {
+  transform: translateY(1px);
+}
+.mg-page-quiet-action {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  color: var(--accent-text);
+  font-size: var(--mg-type-caption-lg);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, currentColor 40%, transparent);
+  text-underline-offset: 0.28rem;
+  transition: color 140ms ease-out;
+}
+.mg-page-quiet-action:hover {
+  color: var(--ink-strong);
+}
+
+.mg-page-canvas {
+  --mg-list-canvas-bleed: calc(-1 * var(--mg-page-gutter));
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+}
+.mg-page-canvas--profile {
+  border-top: 1px solid var(--border);
+}
+.mg-page-canvas--operations > * {
+  padding: clamp(1.25rem, 3.5vw, 2.5rem) var(--mg-page-gutter);
+}
+.mg-page-canvas--operations > * + * {
+  border-top: 1px solid var(--border);
+}
+.mg-page-canvas--operations .mg-route-section {
+  border-top: 0;
+}
+.mg-page-stage--profile .mg-masthead,
+.mg-page-stage--profile .mg-subnet-masthead {
+  margin-bottom: 0 !important;
+}
+.mg-page-module {
+  min-width: 0;
+  padding: var(--mg-page-module-y) var(--mg-page-gutter);
+  border-top: 1px solid var(--border);
+}
+.mg-page-module--profile {
+  padding-top: var(--mg-page-module-y);
+}
+.mg-page-module--profile > .mg-page-module-body {
+  min-width: 0;
+}
+.mg-page-module--profile .mg-detail-section:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+.mg-page-module--profile .mg-masthead-kpi,
+.mg-page-module--profile .mg-data-measure-grid {
+  border-radius: 0;
+}
+.mg-page-module-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--mg-space-lg);
+}
+.mg-page-module-title {
+  margin: 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(0.98rem, 2vw, 1.15rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.4;
+}
+.mg-page-module-caption {
+  max-width: 52rem;
+  margin: var(--mg-space-xs) 0 0;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-page-module-actions {
+  flex: 0 0 auto;
+}
+.mg-page-module-body {
+  min-width: 0;
+}
+.mg-page-module-heading + .mg-page-module-body {
+  margin-top: var(--mg-space-lg);
+}
+.mg-page-module--question .mg-page-module-title::after {
+  content: ".";
+  color: var(--brand-green);
+}
+.mg-page-module--operations .mg-page-module-title {
+  font-size: var(--mg-type-caption-lg);
+  letter-spacing: var(--mg-tracking-label);
+  text-transform: uppercase;
+}
+
+.mg-page-disclosure {
+  margin-top: var(--mg-space-lg);
+  border-top: 1px solid var(--border);
+}
+.mg-page-disclosure > summary {
+  display: flex;
+  min-height: 2.75rem;
+  cursor: pointer;
+  align-items: center;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-label);
+  list-style: none;
+  text-transform: uppercase;
+}
+.mg-page-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+.mg-page-disclosure > summary::after {
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-left: auto;
+  border-right: 1px solid var(--ink-muted);
+  border-bottom: 1px solid var(--ink-muted);
+  content: "";
+  transform: rotate(45deg) translateY(-0.15rem);
+  transition: transform 160ms ease;
+}
+.mg-page-disclosure[open] > summary::after {
+  transform: rotate(225deg) translate(-0.15rem, -0.1rem);
+}
+.mg-page-disclosure > div {
+  padding-bottom: var(--mg-space-md);
+}
+
+/* A directory's controls and output are one instrument, not two floating
+   cards. `ListShell` owns this presentation variant and therefore avoids
+   route-specific negative-margin fixes. */
+.mg-list-filter-bar--canvas {
+  margin-inline: var(--mg-list-canvas-bleed);
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: color-mix(in oklab, var(--paper) 93%, transparent);
+  padding-inline: var(--mg-page-gutter);
+}
+.mg-list-table-card--canvas {
+  margin-inline: var(--mg-list-canvas-bleed);
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: transparent;
+}
+.mg-list-table-card--canvas .mg-table-scroll {
+  border-top: 1px solid var(--mg-page-rule);
+}
+
+.mg-directory-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem 0.9rem;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.35;
+}
+.mg-directory-summary strong {
+  color: var(--ink-strong);
+  font-weight: 600;
+}
+.mg-directory-summary [aria-hidden="true"] {
+  color: var(--border);
+}
+.mg-directory-tabs,
+.mg-data-hub-tabs {
+  margin: 0 !important;
+  padding: 0 var(--mg-page-gutter);
+  border-top: 1px solid var(--border);
+  border-bottom: 0;
+}
+.mg-directory-tabs button,
+.mg-data-hub-tabs button {
+  border-radius: 0;
+}
+.mg-directory-tabs button[aria-selected="true"]::after,
+.mg-data-hub-tabs button[aria-selected="true"]::after {
+  border-radius: 0;
+}
+.mg-directory-toolbar {
+  margin-inline: var(--mg-list-canvas-bleed);
+  padding-inline: var(--mg-page-gutter);
+}
+.mg-directory-table {
+  margin-inline: var(--mg-list-canvas-bleed);
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: transparent;
+}
+.mg-directory-table .mg-table-scroll {
+  border-top: 1px solid var(--mg-page-rule);
+}
+
+.mg-page-route-link {
+  min-height: 9rem;
+  padding: var(--mg-space-lg) 0;
+  border-top: 1px solid var(--border);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    background-color 140ms ease-out,
+    color 140ms ease-out,
+    padding 140ms ease-out;
+}
+.mg-page-route-link p {
+  max-width: 20rem;
+}
+.mg-page-route-link > span {
+  color: var(--ink-muted);
+}
+.mg-page-callout {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--mg-space-lg);
+  margin-top: var(--mg-space-3xl);
+  padding: var(--mg-space-xl) 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.mg-page-callout h2 {
+  max-width: 12ch;
+  margin: var(--mg-space-sm) 0 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(1.55rem, 4vw, 2.75rem);
+  font-weight: 500;
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+
+@media (hover: hover) {
+  .mg-page-route-link:hover {
+    padding-left: var(--mg-space-sm);
+    background: color-mix(in oklab, var(--brand-green) 5%, transparent);
+    color: var(--ink-strong);
+  }
+  .mg-page-route-link:hover > span {
+    color: var(--accent);
+  }
+  .mg-page-disclosure > summary:hover {
+    color: var(--ink-strong);
+  }
+}
+
+@media (max-width: 640px) {
+  .mg-page-stage {
+    width: 100%;
+  }
+  .mg-page-hero,
+  .mg-page-hero--landing,
+  .mg-page-hero--analytics {
+    min-height: 0;
+    padding: var(--mg-space-2xl) 0 var(--mg-space-xl);
+  }
+  .mg-page-hero-content,
+  .mg-page-hero--landing .mg-page-hero-content {
+    display: block;
+    min-height: 0;
+  }
+  .mg-page-hero-field,
+  .mg-page-hero--landing .mg-page-hero-field {
+    top: 2.1rem;
+    right: 0;
+    width: 100%;
+    height: 9rem;
+    opacity: 0.64;
+  }
+  .mg-page-hero h1,
+  .mg-page-hero--landing h1 {
+    font-size: clamp(2.7rem, 12.5vw, 4rem);
+    line-height: 0.91;
+  }
+  .mg-page-hero-actions {
+    margin-top: var(--mg-space-xl);
+  }
+  .mg-page-canvas {
+    margin-inline: calc(-1 * var(--mg-gutter-x, 1rem));
+    border-right: 0;
+    border-left: 0;
+  }
+  .mg-page-module {
+    padding: var(--mg-space-xl) var(--mg-gutter-x, 1rem);
+  }
+  .mg-page-canvas--operations > * {
+    padding: var(--mg-space-xl) var(--mg-gutter-x, 1rem);
+  }
+  .mg-page-module-heading {
+    display: block;
+  }
+  .mg-page-module-actions {
+    margin-top: var(--mg-space-sm);
+  }
+  .mg-page-callout {
+    display: block;
+  }
+  .mg-page-callout .mg-page-primary-action {
+    margin-top: var(--mg-space-lg);
+  }
+  .mg-list-filter-bar--canvas,
+  .mg-list-table-card--canvas,
+  .mg-directory-toolbar,
+  .mg-directory-table {
+    margin-inline: calc(-1 * var(--mg-gutter-x, 1rem));
+    padding-inline: var(--mg-gutter-x, 1rem);
+  }
+  .mg-list-table-card--canvas,
+  .mg-directory-table {
+    padding-inline: 0;
+  }
+  .mg-directory-tabs,
+  .mg-data-hub-tabs {
+    padding-inline: var(--mg-gutter-x, 1rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mg-page-kicker-dot {
+    animation: none;
+  }
+  .mg-page-command,
+  .mg-page-primary-action,
+  .mg-page-quiet-action,
+  .mg-page-route-link,
+  .mg-page-disclosure > summary::after {
+    transition: none;
+  }
+}
+/* ============================================================
+ * Network Data — a continuous analytics document, not a dashboard wall.
+ *
+ * The page intentionally borrows the calm, vertically paced data-reading
+ * rhythm of a modern research terminal: a single quiet field in the hero,
+ * one constrained canvas, and one analytical question per ruled module.
+ * Metagraphed mint stays the product/live focus; the shared chart prism is
+ * only for category tracking inside the visuals.
+ * ============================================================ */
+.mg-data-stage {
+  width: min(100%, 68rem);
+  margin-inline: auto;
+  padding-bottom: var(--mg-space-3xl);
+}
+.mg-data-hero {
+  position: relative;
+  isolation: isolate;
+  min-height: 23rem;
+  padding: clamp(3rem, 8vw, 6.5rem) clamp(1rem, 4vw, 3rem)
+    clamp(2.5rem, 5vw, 4rem);
+  overflow: hidden;
+}
+.mg-data-hero-field {
+  position: absolute;
+  z-index: -1;
+  right: 0;
+  top: clamp(2rem, 5vw, 4rem);
+  width: min(72%, 45rem);
+  height: min(17rem, 58%);
+  border: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--ink-strong) 16%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 4px 4px;
+  mask-image: linear-gradient(
+    90deg,
+    transparent 0,
+    #000 26%,
+    #000 82%,
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    transparent 0,
+    #000 26%,
+    #000 82%,
+    transparent 100%
+  );
+}
+.mg-data-hero-content {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(15rem, 0.8fr);
+  align-items: end;
+  gap: clamp(2rem, 8vw, 8rem);
+  min-height: 16rem;
+}
+.mg-data-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--border);
+  color: var(--ink-muted);
+  background: color-mix(in oklab, var(--paper) 85%, transparent);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-micro);
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.mg-data-kicker-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--brand-green);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  animation: mg-data-live-signal 2.4s ease-out infinite;
+}
+@keyframes mg-data-live-signal {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-green) 0%, transparent);
+  }
+  45% {
+    box-shadow: 0 0 0 0.32rem
+      color-mix(in oklab, var(--brand-green) 22%, transparent);
+  }
+}
+.mg-data-hero h1 {
+  max-width: 10ch;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(3.25rem, 8.5vw, 6.75rem);
+  font-weight: 500;
+  letter-spacing: -0.07em;
+  line-height: 0.86;
+}
+.mg-data-hero-detail {
+  display: grid;
+  justify-items: start;
+  gap: var(--mg-space-lg);
+  padding-bottom: 0.2rem;
+}
+.mg-data-hero-detail p {
+  max-width: 31rem;
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: clamp(0.82rem, 1.5vw, 0.95rem);
+  line-height: 1.7;
+}
+.mg-data-window {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--paper) 86%, transparent);
+}
+.mg-data-window-button {
+  position: relative;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.8rem;
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: var(--mg-type-caption);
+  font-weight: 500;
+  line-height: 1;
+  transition:
+    color 160ms ease,
+    background-color 160ms ease;
+}
+.mg-data-window-button + .mg-data-window-button {
+  border-left: 1px solid var(--border);
+}
+.mg-data-window-button::after {
+  position: absolute;
+  right: 0.65rem;
+  bottom: 0.42rem;
+  left: 0.65rem;
+  height: 1.5px;
+  background: transparent;
+  content: "";
+}
+.mg-data-window-button.is-active {
+  color: var(--ink-strong);
+  background: color-mix(in oklab, var(--brand-green) 8%, transparent);
+}
+.mg-data-window-button.is-active::after {
+  background: var(--brand-green);
+}
+.mg-data-canvas {
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+}
+.mg-data-module {
+  padding: clamp(1.5rem, 4vw, 2.75rem) clamp(1rem, 4vw, 3rem);
+  border-top: 1px solid var(--border);
+}
+.mg-data-module-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--mg-space-lg);
+}
+.mg-data-module-title {
+  max-width: 54rem;
+  margin: 0;
+  color: var(--ink-muted);
+  font-family: var(--font-display);
+  font-size: clamp(0.94rem, 2vw, 1.15rem);
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.55;
+}
+.mg-data-module-title strong {
+  color: var(--ink-strong);
+  font-weight: 600;
+}
+.mg-data-module-title span {
+  margin-left: 0.35em;
+}
+.mg-data-module-action {
+  flex: 0 0 auto;
+}
+.mg-data-module-chart,
+.mg-data-module-body {
+  margin-top: clamp(1.25rem, 3vw, 2rem);
+}
+.mg-data-module-footer {
+  margin-top: var(--mg-space-lg);
+  padding-top: var(--mg-space-sm);
+  border-top: 1px solid var(--border);
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-data-module--stake-flow .mg-data-module-chart {
+  margin-top: clamp(1.5rem, 4vw, 2.5rem);
+}
+.mg-data-plot-grid {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--ink-strong) 11%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 5px 5px;
+}
+.mg-data-measure-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.mg-data-measure-grid--4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.mg-data-measure {
+  min-width: 0;
+  padding: var(--mg-space-md);
+}
+.mg-data-measure + .mg-data-measure {
+  border-left: 1px solid var(--border);
+}
+.mg-data-measure > :first-child {
+  color: var(--ink-muted);
+  font-size: var(--mg-type-micro);
+  font-weight: 600;
+  letter-spacing: var(--mg-tracking-label);
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+.mg-data-measure > :last-child {
+  margin-top: 0.45rem;
+  overflow: hidden;
+  color: var(--ink-strong);
+  font-family: var(--font-display);
+  font-size: clamp(1rem, 2.4vw, 1.45rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-data-measure dd small {
+  display: block;
+  margin-top: 0.28rem;
+  overflow: hidden;
+  color: var(--ink-muted);
+  font-family: var(--font-sans);
+  font-size: var(--mg-type-micro);
+  font-weight: 400;
+  letter-spacing: normal;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-live-block-rail {
+  padding: var(--mg-space-md) 0;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--ink-strong) 8%, transparent);
+}
+.mg-data-rank-list {
+  margin: var(--mg-space-xl) 0 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+  list-style: none;
+}
+.mg-data-rank-list > li + li {
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-data-rank-row {
+  display: grid;
+  grid-template-columns:
+    2.3rem minmax(4.5rem, 0.75fr) minmax(8rem, 2fr)
+    max-content;
+  align-items: center;
+  gap: var(--mg-space-sm);
+  min-width: 0;
+  padding: 0.78rem 0;
+  color: inherit;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+.mg-data-rank-index {
+  color: var(--ink-subtle);
+  font-size: var(--mg-type-micro);
+}
+.mg-data-rank-label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink-strong);
+  font-size: var(--mg-type-caption);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mg-data-rank-track {
+  height: 0.28rem;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--ink-strong) 8%, transparent);
+}
+.mg-data-rank-fill {
+  display: block;
+  height: 100%;
+}
+.mg-data-rank-value {
+  display: grid;
+  justify-items: end;
+  color: var(--ink-strong);
+  font-size: var(--mg-type-caption);
+  line-height: 1.15;
+  text-align: right;
+  white-space: nowrap;
+}
+.mg-data-rank-value small {
+  margin-top: 0.2rem;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-micro);
+}
+.mg-data-module-note {
+  max-width: 56rem;
+  margin: var(--mg-space-md) 0 0;
+  color: var(--ink-muted);
+  font-size: var(--mg-type-caption);
+  line-height: 1.55;
+}
+.mg-data-module-note + .mg-data-module-note {
+  margin-top: var(--mg-space-xs);
+}
+.mg-data-wide-chart {
+  margin-bottom: var(--mg-space-xl);
+  padding: var(--mg-space-md) 0;
+  border-top: 1px solid color-mix(in oklab, var(--ink-strong) 7%, transparent);
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--ink-strong) 7%, transparent);
+}
+.mg-data-loading {
+  padding: clamp(1rem, 4vw, 3rem);
+  border-top: 1px solid var(--border);
+}
+
+@media (hover: hover) {
+  .mg-data-window-button:hover {
+    color: var(--ink-strong);
+    background: color-mix(in oklab, var(--ink-strong) 4%, transparent);
+  }
+  .mg-data-rank-row:hover {
+    background: color-mix(in oklab, var(--brand-green) 5%, transparent);
+  }
+}
+@media (max-width: 640px) {
+  .mg-data-stage {
+    width: 100%;
+  }
+  .mg-data-hero {
+    min-height: 0;
+    padding: var(--mg-space-2xl) 0 var(--mg-space-xl);
+  }
+  .mg-data-hero-field {
+    top: 1.75rem;
+    width: 100%;
+    height: 11rem;
+    opacity: 0.65;
+  }
+  .mg-data-hero-content {
+    display: block;
+    min-height: 0;
+  }
+  .mg-data-hero h1 {
+    margin-top: var(--mg-space-sm);
+    font-size: clamp(3.3rem, 16vw, 4.75rem);
+  }
+  .mg-data-hero-detail {
+    gap: var(--mg-space-md);
+    margin-top: var(--mg-space-2xl);
+  }
+  .mg-data-canvas {
+    margin-inline: calc(-1 * var(--mg-gutter-x));
+    border-right: 0;
+    border-left: 0;
+  }
+  .mg-data-module {
+    padding: var(--mg-space-xl) var(--mg-gutter-x);
+  }
+  .mg-data-module-heading {
+    display: block;
+  }
+  .mg-data-module-action {
+    margin-top: var(--mg-space-sm);
+  }
+  .mg-data-module-title span {
+    display: inline;
+  }
+  .mg-data-measure-grid,
+  .mg-data-measure-grid--4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .mg-data-measure-grid--3 > :last-child {
+    grid-column: span 2;
+  }
+  .mg-data-measure + .mg-data-measure {
+    border-left: 0;
+  }
+  .mg-data-measure:nth-child(even) {
+    border-left: 1px solid var(--border);
+  }
+  .mg-data-measure-grid--3 > :last-child {
+    border-top: 1px solid var(--border);
+  }
+  .mg-data-measure-grid--4 > :nth-child(n + 3) {
+    border-top: 1px solid var(--border);
+  }
+  .mg-data-rank-row {
+    grid-template-columns:
+      1.7rem minmax(3.8rem, 0.68fr) minmax(3rem, 1fr)
+      max-content;
+    gap: var(--mg-space-xs);
+  }
+  .mg-data-rank-value {
+    font-size: var(--mg-type-data-sm);
+  }
+  .mg-data-wide-chart {
+    margin-bottom: var(--mg-space-lg);
+  }
+  /* On the compact, vertical Sankey the node labels would either collide or
+     extend beyond a narrow column. The chart keeps its accessible summary and
+     selectable nodes; removing the redundant in-plot labels makes the mobile
+     reading surface calm instead of forcing truncated microcopy. */
+  .mg-data-module--stake-flow svg text {
+    display: none;
+  }
+  .mg-data-loading {
+    padding: var(--mg-space-xl) var(--mg-gutter-x);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mg-data-kicker-dot {
+    animation: none;
+  }
+  .mg-data-window-button,
+  .mg-data-rank-row {
     transition: none;
   }
 }

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -99,7 +99,8 @@
  *
  * The application is a public evidence terminal, not a trading dashboard:
  * carbon and graphite carry the data plane, ash carries the reading plane,
- * blue means "you can act here", and health/trust keep their own semantics.
+ * and Metagraphed's own mint mark (#30FFC0) means "you can act here".
+ * Health/trust keep their own semantics.
  * Light is a practical reading inverse of the dark terminal, not a second
  * visual language. Surfaces stay flat, bounded by one-pixel rules.
  */
@@ -198,7 +199,12 @@
      for legacy components during the route-by-route migration. */
   --radius: 0.25rem;
 
-  --paper: #f7f7f4;
+  /* `--brand-green` is the exact fill from the shipped Metagraphed M mark
+     (wordmark.tsx / favicon.svg). Keep it literal: it is the visual anchor
+     for filled actions, active states, focus, and key data highlights. */
+  --brand-green: #30ffc0;
+
+  --paper: #f8f8f5;
   --surface: #ffffff;
   --surface-2: #eeeeeb;
   --ink: #383838;
@@ -215,18 +221,18 @@
   --popover: var(--surface);
   --popover-foreground: var(--ink-strong);
 
-  --primary: #1f6feb;
-  --primary-foreground: #ffffff;
+  --primary: var(--brand-green);
+  --primary-foreground: #08110e;
   --primary-soft: color-mix(in oklab, var(--primary) 10%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface-2);
   --muted-foreground: var(--ink-muted);
-  --accent: #1f6feb;
+  /* A deep counterpart is required only when brand-green is rendered as small
+     text on a light surface. Filled primary controls still use #30FFC0. */
+  --accent: #087b5d;
   --accent-foreground: #ffffff;
-  /* Text-only action token. The filled accent stays blue; this one clears AA
-     on paper for compact links, labels, and table controls. */
-  --accent-text: #1857b7;
+  --accent-text: #087b5d;
 
   --destructive: #c93f3c;
   --destructive-foreground: #ffffff;
@@ -243,15 +249,15 @@
   --health-unknown: #737373;
 
   --curation-native: var(--ink-strong);
-  --curation-verified: #1f6feb;
-  --curation-pilot: #4f77c8;
+  --curation-verified: #087b5d;
+  --curation-pilot: #2d806c;
   --curation-candidate: var(--ink-muted);
   --curation-seeded: #b46b00;
   --curation-machine: #7562c6;
   --curation-adapter: #b24f8c;
 
   /* Arbitrary chart series, intentionally distinct from health and trust. */
-  --chart-1: #3679e8;
+  --chart-1: #119b76;
   --chart-2: #8562d7;
   --chart-3: #d56b25;
   --chart-4: #bd4e92;
@@ -259,7 +265,7 @@
   --chart-6: #6f7b87;
 
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
-  --mg-cadence-color: color-mix(in oklab, var(--accent) 20%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 13%, transparent);
 
   /* Third-party brand mark (ClaudeIcon) -- fixed regardless of theme, unlike
      the semantic tokens above. Converted from Claude's official simple-icons
@@ -545,16 +551,16 @@
   --popover: var(--surface-2);
   --popover-foreground: var(--ink-strong);
 
-  --primary: #72a6ff;
-  --primary-foreground: #0d0d0d;
+  --primary: var(--brand-green);
+  --primary-foreground: #08110e;
   --primary-soft: color-mix(in oklab, var(--primary) 12%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface);
   --muted-foreground: var(--ink-muted);
-  --accent: #72a6ff;
+  --accent: var(--brand-green);
   --accent-foreground: #0d0d0d;
-  --accent-text: #9bbdff;
+  --accent-text: var(--brand-green);
 
   --destructive: #fb7974;
   --destructive-foreground: #161616;
@@ -571,14 +577,14 @@
   --health-unknown: #8b8b8b;
 
   --curation-native: var(--ink-strong);
-  --curation-verified: #72a6ff;
-  --curation-pilot: #91b4ef;
+  --curation-verified: var(--brand-green);
+  --curation-pilot: #78d7bb;
   --curation-candidate: var(--ink-muted);
   --curation-seeded: #e8bb63;
   --curation-machine: #b49aff;
   --curation-adapter: #e79ac9;
 
-  --chart-1: #75a9ff;
+  --chart-1: var(--brand-green);
   --chart-2: #b69bff;
   --chart-3: #ffad72;
   --chart-4: #ec9bcf;
@@ -586,7 +592,7 @@
   --chart-6: #a6adb7;
 
   --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
-  --mg-cadence-color: color-mix(in oklab, var(--accent) 28%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--ink-strong) 15%, transparent);
 }
 
 @layer base {
@@ -604,19 +610,18 @@
     -moz-osx-font-smoothing: grayscale;
     overflow-x: clip;
   }
-  /* A quiet terminal lattice gives long explorer pages orientation without
-     competing with evidence, tables, or data visualisations. */
+  /* Pages stay quiet. The one dotted reference field lives in the hero where
+     it explains the landing-page hierarchy instead of competing with tables. */
   body {
-    background-image:
-      linear-gradient(to right, var(--mg-grid-color) 1px, transparent 1px),
-      linear-gradient(to bottom, var(--mg-grid-color) 1px, transparent 1px);
-    background-size:
-      32px 32px,
-      32px 32px;
-    background-position:
-      0 0,
-      0 0;
-    background-attachment: fixed;
+    background-image: none;
+  }
+  /* A few compact controls intentionally don't carry an explicit focus utility.
+     Their fallback must still be the Metagraphed mint ring, never the browser's
+     platform-colored outline. More specific component focus treatments remain
+     free to replace this baseline. */
+  :where(a, button, input, select, textarea, summary):focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
   }
   html.theme-transition,
   html.theme-transition * {
@@ -838,21 +843,53 @@ html[data-density="compact"] .bg-card > table td {
   animation-delay: 240ms;
 }
 
-/* Hero — a calm evidence field. The cadence lattice is the visual signature:
-   it evokes block intervals without pretending to be a data chart. */
+/* Hero — a single, quiet reference field. The dot matrix borrows the useful
+   spatial rhythm of a data display without impersonating a chart or becoming
+   a background treatment for every route. */
 .mg-hero-slab {
   position: relative;
-  background-color: color-mix(in oklab, var(--surface) 52%, transparent);
-  background-image:
-    linear-gradient(to right, var(--mg-cadence-color) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--mg-cadence-color) 1px, transparent 1px);
-  background-size: 16px 16px;
+  background: transparent;
   border-bottom: 1px solid var(--border);
   border-radius: 0;
-  border-top: 1px solid color-mix(in oklab, var(--accent) 68%, transparent);
 }
 .mg-hero-slab::before {
   content: none;
+}
+.mg-hero-dot-field {
+  position: absolute;
+  z-index: 0;
+  top: clamp(7.5rem, 11vw, 10.5rem);
+  right: 0;
+  left: clamp(1rem, 13vw, 10rem);
+  height: clamp(5rem, 10vw, 8rem);
+  pointer-events: none;
+  background-image: radial-gradient(
+    var(--mg-cadence-color) 0.7px,
+    transparent 0.85px
+  );
+  background-size: 7px 7px;
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 8%,
+    #000 92%,
+    transparent
+  );
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 8%,
+    #000 92%,
+    transparent
+  );
+}
+@media (max-width: 767px) {
+  .mg-hero-dot-field {
+    top: 8.5rem;
+    right: 0;
+    left: 0;
+    height: 4rem;
+  }
 }
 
 /* Restrained action band — a structural inverse surface, not a marketing
@@ -861,16 +898,16 @@ html[data-density="compact"] .bg-card > table td {
   background: var(--surface-2);
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
-  box-shadow: inset 2px 0 0 var(--accent);
+  box-shadow: inset 0 2px 0 var(--primary);
 }
 
-/* Cadence pattern — used inside the one deliberate action band. */
+/* Cadence pattern — reserved for the one deliberate action band. */
 .mg-dot-grid {
   background-image: radial-gradient(
-    color-mix(in oklab, var(--accent) 36%, transparent) 1px,
+    var(--mg-cadence-color) 1px,
     transparent 1px
   );
-  background-size: 14px 14px;
+  background-size: 8px 8px;
 }
 
 /* Hairline KPI strip used in heroes (Blockmachine signature). */

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -17,11 +17,17 @@
  */
 
 /*
- * Brand fonts, self-hosted. Weights are the exact set the app uses — verified
- * by grepping every font-weight utility class in src/ (font-normal/-medium/
- * -semibold only; font-bold never appears). Without these, --font-display/
- * --font-sans/--font-mono below fall back to system fonts.
+ * Metagraph Terminal typography. IBM Plex Mono carries the data interface
+ * (and deliberately has only the Latin subset we serve); DM Sans remains
+ * available as the proportional reading face for long-form content. The older
+ * local Space Grotesk / JetBrains files stay as offline fallbacks while route
+ * families migrate, rather than making the foundation change a font-loading
+ * risk for an existing surface.
  */
+@import "@fontsource/ibm-plex-mono/latin-400.css";
+@import "@fontsource/ibm-plex-mono/latin-500.css";
+@import "@fontsource/ibm-plex-mono/latin-600.css";
+
 @font-face {
   font-family: "Space Grotesk";
   font-style: normal;
@@ -89,11 +95,13 @@
 @custom-variant dark (&:is(.dark *));
 
 /*
- * Metagraphed design system — "Bone & Ink" (Blockmachine-inspired).
- * Light (default): warm bone canvas, deep ink text, mint used sparingly.
- * Dark:            quiet ink canvas, dialed-down mint.
- * Surfaces are flat — hairline borders, no shadows or gradients.
- * A very faint dot pattern lives on the body for premium texture.
+ * Metagraph Terminal design system.
+ *
+ * The application is a public evidence terminal, not a trading dashboard:
+ * carbon and graphite carry the data plane, ash carries the reading plane,
+ * blue means "you can act here", and health/trust keep their own semantics.
+ * Light is a practical reading inverse of the dark terminal, not a second
+ * visual language. Surfaces stay flat, bounded by one-pixel rules.
  */
 
 @theme inline {
@@ -166,9 +174,10 @@
   --color-chart-5: var(--chart-5);
   --color-chart-6: var(--chart-6);
 
-  --font-display: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
-  --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-display: "IBM Plex Mono", "Space Grotesk", ui-monospace, monospace;
+  --font-sans: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace;
+  --font-mono: "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace;
+  --font-prose: "DM Sans", ui-sans-serif, system-ui, sans-serif;
 
   /* Preserved metagraphed-ui design-system tokens (not in the Lovable source):
      section rhythm + the accent surface used by SectionHeading,
@@ -177,25 +186,26 @@
   --color-accent-surface: color-mix(in oklab, var(--accent) 6%, transparent);
 
   /* Layout geometry tokens — single source of truth for structural offsets. */
-  --spacing-nav: 3.5rem; /* app header height (h-nav in app-shell) */
+  --spacing-nav: 3.25rem; /* app header height (h-nav in app-shell) */
   --spacing-section-gap: 4rem; /* between top-level page sections */
   --spacing-shell-max: 1400px; /* page shell max width (max-w-shell-max) */
 }
 
-/* ============ LIGHT (default) — Bone + Ink ============ */
+/* ============ LIGHT — paper inverse of the terminal ============ */
 :root {
-  --radius: 0.75rem;
+  /* Keep Tailwind's derived radius ladder non-negative: rounded-sm resolves
+     to a square terminal edge, while rounded/md/lg remain subtle fallbacks
+     for legacy components during the route-by-route migration. */
+  --radius: 0.25rem;
 
-  --paper: oklch(0.975 0.006 95); /* warm bone */
-  --surface: oklch(1 0 0); /* cards = pure white, lifted by hairline */
-  --surface-2: oklch(0.945 0.008 95); /* table headers / inset rows */
-  --ink: oklch(0.32 0.012 200);
-  --ink-strong: oklch(0.2 0.012 200); /* deep ink */
-  --ink-muted: oklch(0.52 0.012 200);
-  --ink-subtle: oklch(0.74 0.008 200);
-  /* AA text variant of --ink-subtle (same hue/chroma, darker L). 4.69:1 on
-     paper, 5.04:1 on card. Used only where --ink-subtle styles small text. */
-  --ink-subtle-text: oklch(0.54 0.008 200);
+  --paper: #f7f7f4;
+  --surface: #ffffff;
+  --surface-2: #eeeeeb;
+  --ink: #383838;
+  --ink-strong: #161616;
+  --ink-muted: #686868;
+  --ink-subtle: #a3a3a3;
+  --ink-subtle-text: #686868;
 
   --background: var(--paper);
   --foreground: var(--ink-strong);
@@ -205,64 +215,51 @@
   --popover: var(--surface);
   --popover-foreground: var(--ink-strong);
 
-  --primary: oklch(0.74 0.15 168); /* trimmed mint */
-  --primary-foreground: oklch(0.2 0.012 200);
-  --primary-soft: color-mix(in oklab, oklch(0.74 0.15 168) 12%, var(--paper));
+  --primary: #1f6feb;
+  --primary-foreground: #ffffff;
+  --primary-soft: color-mix(in oklab, var(--primary) 10%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface-2);
   --muted-foreground: var(--ink-muted);
-  --accent: oklch(0.74 0.15 168);
-  --accent-foreground: oklch(0.2 0.012 200);
-  /* AA text variant of --accent (same hue/chroma, darker L). 4.58:1 on paper,
-     4.92:1 on card. Used only where --accent styles small text. */
-  --accent-text: oklch(0.515 0.15 168);
+  --accent: #1f6feb;
+  --accent-foreground: #ffffff;
+  /* Text-only action token. The filled accent stays blue; this one clears AA
+     on paper for compact links, labels, and table controls. */
+  --accent-text: #1857b7;
 
-  --destructive: oklch(0.58 0.22 28);
-  --destructive-foreground: oklch(1 0 0);
+  --destructive: #c93f3c;
+  --destructive-foreground: #ffffff;
 
   --border: color-mix(in oklab, var(--ink-strong) 8%, transparent);
   --input: color-mix(in oklab, var(--ink-strong) 12%, transparent);
   --ring: color-mix(in oklab, var(--accent) 45%, transparent);
 
-  --health-ok: oklch(
-    0.68 0.16 160
-  ); /* brand mint — same hue family as --accent */
-  --health-warn: oklch(0.72 0.16 75); /* softened amber, not neon */
-  /* AA text variant of --health-warn (same hue/chroma, darker L). 4.58:1 on
-     paper, 4.92:1 on card. Used only where --health-warn styles small text. */
-  --health-warn-text: oklch(0.55 0.12 80);
-  --health-bad: oklch(
-    0.66 0.18 50
-  ); /* orange — between warn (75) and down (28) */
-  --health-down: oklch(0.58 0.22 28);
-  --health-unknown: oklch(0.66 0.01 200);
+  --health-ok: #16824a;
+  --health-warn: #a56100;
+  --health-warn-text: #8a5000;
+  --health-bad: #c86400;
+  --health-down: #c93f3c;
+  --health-unknown: #737373;
 
   --curation-native: var(--ink-strong);
-  --curation-verified: oklch(
-    0.68 0.16 160
-  ); /* kept in lockstep with --health-ok */
-  --curation-pilot: oklch(0.6 0.15 150);
+  --curation-verified: #1f6feb;
+  --curation-pilot: #4f77c8;
   --curation-candidate: var(--ink-muted);
-  --curation-seeded: oklch(
-    0.64 0.15 80
-  ); /* same warm hue family as --chart-3 */
-  --curation-machine: oklch(0.54 0.14 250);
-  --curation-adapter: oklch(0.62 0.15 305);
+  --curation-seeded: #b46b00;
+  --curation-machine: #7562c6;
+  --curation-adapter: #b24f8c;
 
-  /* Categorical chart ramp — muted, on-brand; first color is blue to avoid
-     reading as the mint "healthy" semantic. */
-  --chart-1: oklch(0.64 0.13 250);
-  --chart-2: oklch(0.72 0.13 168);
-  --chart-3: oklch(0.76 0.12 80);
-  --chart-4: oklch(0.62 0.15 305);
-  --chart-5: oklch(0.66 0.14 350);
-  --chart-6: oklch(0.66 0.02 220);
+  /* Arbitrary chart series, intentionally distinct from health and trust. */
+  --chart-1: #3679e8;
+  --chart-2: #8562d7;
+  --chart-3: #d56b25;
+  --chart-4: #bd4e92;
+  --chart-5: #9c7b11;
+  --chart-6: #6f7b87;
 
-  /* Dot pattern tuning */
-  --mg-dot-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
-  --mg-dot-size: 24px;
-  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 3.5%, transparent);
+  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 6%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--accent) 20%, transparent);
 
   /* Third-party brand mark (ClaudeIcon) -- fixed regardless of theme, unlike
      the semantic tokens above. Converted from Claude's official simple-icons
@@ -271,7 +268,7 @@
 }
 
 /* ============================================================
- * Bone & Ink rhythm + type tokens. Relocated (2026-07-23) from
+ * Metagraph Terminal rhythm + type tokens. Relocated (2026-07-23) from
  * apps/ui/src/styles.css alongside <Panel>/<SectionLabel> and the other
  * dependency-free primitives that moved into this package so ui-kit's own
  * components can use them too; briefly duplicated in both files to keep
@@ -529,18 +526,16 @@
   background: color-mix(in oklab, var(--card) 95%, transparent);
 }
 
-/* ============ DARK — Ink + dialed mint ============ */
+/* ============ DARK — carbon terminal ============ */
 .dark {
-  --paper: oklch(0.14 0.003 250);
-  --surface: oklch(0.175 0.003 250);
-  --surface-2: oklch(0.215 0.004 250);
-  --ink: oklch(0.86 0.005 250);
-  --ink-strong: oklch(0.96 0.006 250);
-  --ink-muted: oklch(0.64 0.005 250);
-  --ink-subtle: oklch(0.42 0.004 250);
-  /* AA text variant of --ink-subtle (same hue/chroma, lighter L for the dark
-     canvas). 4.98:1 on paper, 4.63:1 on card. */
-  --ink-subtle-text: oklch(0.61 0.01 200);
+  --paper: #161616;
+  --surface: #1e1e1e;
+  --surface-2: #303030;
+  --ink: #d4d4d4;
+  --ink-strong: #ffffff;
+  --ink-muted: #a3a3a3;
+  --ink-subtle: #707070;
+  --ink-subtle-text: #b3b3b3;
 
   --background: var(--paper);
   --foreground: var(--ink-strong);
@@ -550,58 +545,48 @@
   --popover: var(--surface-2);
   --popover-foreground: var(--ink-strong);
 
-  --primary: oklch(0.85 0.14 168);
-  --primary-foreground: oklch(0.14 0.003 250);
-  --primary-soft: color-mix(in oklab, oklch(0.85 0.14 168) 10%, var(--paper));
+  --primary: #72a6ff;
+  --primary-foreground: #0d0d0d;
+  --primary-soft: color-mix(in oklab, var(--primary) 12%, var(--paper));
   --secondary: var(--surface-2);
   --secondary-foreground: var(--ink-strong);
   --muted: var(--surface);
   --muted-foreground: var(--ink-muted);
-  --accent: oklch(0.85 0.14 168);
-  --accent-foreground: oklch(0.14 0.003 250);
-  /* Dark --accent already clears AA as text (≈11.7:1), so the text variant is
-     the brand mint itself — no visual change in dark mode. */
-  --accent-text: var(--accent);
+  --accent: #72a6ff;
+  --accent-foreground: #0d0d0d;
+  --accent-text: #9bbdff;
 
-  --destructive: oklch(0.7 0.22 28);
-  --destructive-foreground: oklch(0.14 0.003 250);
+  --destructive: #fb7974;
+  --destructive-foreground: #161616;
 
   --border: color-mix(in oklab, var(--ink-strong) 11%, transparent);
   --input: color-mix(in oklab, var(--ink-strong) 16%, transparent);
   --ring: color-mix(in oklab, var(--accent) 50%, transparent);
 
-  --health-ok: oklch(0.85 0.14 168); /* brand mint — already matches --accent */
-  --health-warn: oklch(0.82 0.15 75); /* softened amber, not neon */
-  /* Dark --health-warn already clears AA as text (≈10.6:1), so the text variant
-     is the shared token itself — no visual change in dark mode. */
-  --health-warn-text: var(--health-warn);
-  --health-bad: oklch(
-    0.75 0.18 52
-  ); /* orange — between warn (75) and down (28) */
-  --health-down: oklch(0.72 0.2 28);
-  --health-unknown: oklch(0.52 0.005 250);
+  --health-ok: #54d98a;
+  --health-warn: #f4b65f;
+  --health-warn-text: #f4b65f;
+  --health-bad: #fb9a4c;
+  --health-down: #fb7974;
+  --health-unknown: #8b8b8b;
 
   --curation-native: var(--ink-strong);
-  --curation-verified: oklch(0.85 0.14 168);
-  --curation-pilot: oklch(0.8 0.14 150);
+  --curation-verified: #72a6ff;
+  --curation-pilot: #91b4ef;
   --curation-candidate: var(--ink-muted);
-  --curation-seeded: oklch(
-    0.78 0.14 80
-  ); /* same warm hue family as --chart-3 */
-  --curation-machine: oklch(0.76 0.12 250);
-  --curation-adapter: oklch(0.78 0.13 305);
+  --curation-seeded: #e8bb63;
+  --curation-machine: #b49aff;
+  --curation-adapter: #e79ac9;
 
-  /* Categorical chart ramp — lifted for the dark surface */
-  --chart-1: oklch(0.76 0.12 250);
-  --chart-2: oklch(0.85 0.13 168);
-  --chart-3: oklch(0.84 0.12 80);
-  --chart-4: oklch(0.76 0.14 305);
-  --chart-5: oklch(0.8 0.13 350);
-  --chart-6: oklch(0.62 0.02 220);
+  --chart-1: #75a9ff;
+  --chart-2: #b69bff;
+  --chart-3: #ffad72;
+  --chart-4: #ec9bcf;
+  --chart-5: #e9ca68;
+  --chart-6: #a6adb7;
 
-  --mg-dot-color: color-mix(in oklab, var(--ink-strong) 10%, transparent);
-  --mg-dot-size: 26px;
-  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 5%, transparent);
+  --mg-grid-color: color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  --mg-cadence-color: color-mix(in oklab, var(--accent) 28%, transparent);
 }
 
 @layer base {
@@ -613,32 +598,22 @@
     background-color: var(--color-paper);
     color: var(--color-ink-strong);
     font-family: var(--font-sans);
-    font-feature-settings: "ss01", "cv11";
+    font-feature-settings: "zero", "ss01";
     font-variant-numeric: tabular-nums;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     overflow-x: clip;
   }
-  /* Premium Blockmachine background: hairline grid + dot field + soft top
-     vignette. Layered top to bottom so the grid lives behind the dots. */
+  /* A quiet terminal lattice gives long explorer pages orientation without
+     competing with evidence, tables, or data visualisations. */
   body {
     background-image:
-      radial-gradient(var(--mg-dot-color) 1px, transparent 1px),
       linear-gradient(to right, var(--mg-grid-color) 1px, transparent 1px),
-      linear-gradient(to bottom, var(--mg-grid-color) 1px, transparent 1px),
-      radial-gradient(
-        ellipse 110% 60% at 50% 0%,
-        color-mix(in oklab, var(--accent) 5%, transparent) 0%,
-        transparent 70%
-      );
+      linear-gradient(to bottom, var(--mg-grid-color) 1px, transparent 1px);
     background-size:
-      var(--mg-dot-size) var(--mg-dot-size),
-      96px 96px,
-      96px 96px,
-      100% 100%;
+      32px 32px,
+      32px 32px;
     background-position:
-      0 0,
-      0 0,
       0 0,
       0 0;
     background-attachment: fixed;
@@ -863,30 +838,36 @@ html[data-density="compact"] .bg-card > table td {
   animation-delay: 240ms;
 }
 
-/* Hero — calm, no slab fill. Just a mint hairline at the top so the
-   hero sits flush with the page while still feeling anchored. */
+/* Hero — a calm evidence field. The cadence lattice is the visual signature:
+   it evokes block intervals without pretending to be a data chart. */
 .mg-hero-slab {
   position: relative;
-  background: transparent;
-  border: 0;
+  background-color: color-mix(in oklab, var(--surface) 52%, transparent);
+  background-image:
+    linear-gradient(to right, var(--mg-cadence-color) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--mg-cadence-color) 1px, transparent 1px);
+  background-size: 16px 16px;
+  border-bottom: 1px solid var(--border);
   border-radius: 0;
-  border-top: 1px solid color-mix(in oklab, var(--accent) 55%, transparent);
+  border-top: 1px solid color-mix(in oklab, var(--accent) 68%, transparent);
 }
 .mg-hero-slab::before {
   content: none;
 }
 
-/* Mint accent band — quiet bone band with hairline mint top. */
+/* Restrained action band — a structural inverse surface, not a marketing
+   gradient. The left rule is the only accent signal. */
 .mg-accent-band {
-  background: color-mix(in oklab, var(--accent) 6%, var(--paper));
-  border-top: 1px solid color-mix(in oklab, var(--accent) 35%, transparent);
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
-/* Mint dot pattern — used inside accent bands. */
+/* Cadence pattern — used inside the one deliberate action band. */
 .mg-dot-grid {
   background-image: radial-gradient(
-    color-mix(in oklab, var(--accent) 30%, transparent) 1px,
+    color-mix(in oklab, var(--accent) 36%, transparent) 1px,
     transparent 1px
   );
   background-size: 14px 14px;
@@ -921,21 +902,21 @@ html[data-density="compact"] .bg-card > table td {
   }
 }
 
-/* Live dot — small pulsing mint pip. */
+/* Live data is a health state, not an interactive action. */
 .mg-live-dot {
   position: relative;
   display: inline-block;
   width: 0.45rem;
   height: 0.45rem;
   border-radius: 9999px;
-  background: var(--accent);
+  background: var(--health-ok);
 }
 .mg-live-dot::after {
   content: "";
   position: absolute;
   inset: -3px;
   border-radius: 9999px;
-  background: var(--accent);
+  background: var(--health-ok);
   opacity: 0.3;
   animation: mg-pulse 1.8s ease-in-out infinite;
 }
@@ -1071,10 +1052,7 @@ html[data-density="compact"] .bg-card > table td {
 .mg-mega-surface {
   background: var(--paper);
   border: 1px solid var(--border);
-  box-shadow:
-    0 1px 0 var(--border) inset,
-    0 24px 60px -20px color-mix(in oklab, var(--ink-strong) 22%, transparent),
-    0 2px 8px -2px color-mix(in oklab, var(--ink-strong) 8%, transparent);
+  box-shadow: 0 1px 0 var(--border) inset;
 }
 .mg-mega-scrim {
   position: fixed;
@@ -1217,14 +1195,12 @@ html[data-density="compact"] .bg-card > table td {
    .mg-metric-tile, so the glow adapts across themes instead of a fixed
    slate-900 rgba that vanishes on a dark background (#6398). */
 .mg-card-glow {
-  box-shadow: 0 24px 80px -58px
-    color-mix(in oklab, var(--ink-strong) 45%, transparent);
+  box-shadow: 0 1px 0 var(--border);
 }
 
 /* Accent-tinted variant for the primary/summary card on the same pages. */
 .mg-card-glow-accent {
-  box-shadow: 0 24px 80px -52px
-    color-mix(in oklab, var(--accent) 45%, transparent);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .mg-skel-crossfade > * {
@@ -1425,8 +1401,8 @@ html[data-density="compact"] .bg-card > table td {
 }
 
 .mg-header[data-scrolled="true"] {
-  background-color: color-mix(in oklab, var(--paper) 88%, transparent);
-  border-bottom-color: color-mix(in oklab, var(--ink-strong) 14%, transparent);
+  background-color: var(--paper);
+  border-bottom-color: var(--border);
 }
 
 .mg-glyph-rule {


### PR DESCRIPTION
## Summary

- Establish a reusable Metagraph Terminal page grammar in the UI kit: editorial hero fields, continuous ruled canvases, calm local controls, progressive disclosures, and accessibility-aware motion.
- Recompose the homepage, subnet and validator directories, chain blocks and analytics, revenue, account dossiers, health, contribution, APIs, and supporting hubs around that system.
- Use Metagraphed mint for product action, focus, and live state; reserve the analytical rainbow palette for categorical data.
- Replace squeezed desktop layouts with deliberate tablet and mobile directory cards, filter sheets, and compact controls.
- Stabilize the visual-capture utility used for this review.

Part of #11517 — the epic remains open until its route-family children complete.

Closes #11531

## Validation

- `npm run typecheck --workspace=packages/ui-kit`
- `npm run test --workspace=packages/ui-kit` (125 tests)
- `npm run build --workspace=packages/ui-kit`
- `npm run typecheck --workspace=apps/ui`
- `npm run format:check --workspace=apps/ui`
- `npm run lint --workspace=apps/ui` (existing Fast Refresh warnings only)
- `npm run test --workspace=apps/ui` (2,330 tests)
- `npm run build:worker:e2e --workspace=apps/ui`
- responsive Playwright suite

## Visual evidence

Captured before/after in light and dark themes at desktop, tablet, and mobile. The table links the dark review pair; the full matrix is on the `screenshots` branch.

| Route | Desktop | Tablet | Mobile |
| --- | --- | --- | --- |
| Home | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-home-before-desktop-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-home-after-desktop-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-home-before-tablet-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-home-after-tablet-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-home-before-mobile-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-home-after-mobile-dark.png) |
| Subnets | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-subnets-before-desktop-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-subnets-after-desktop-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-subnets-before-tablet-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-subnets-after-tablet-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-subnets-before-mobile-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-subnets-after-mobile-dark.png) |
| Validators | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-validators-before-desktop-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-validators-after-desktop-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-validators-before-tablet-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-validators-after-tablet-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-validators-before-mobile-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-validators-after-mobile-dark.png) |
| Blocks | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-blocks-before-desktop-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-blocks-after-desktop-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-blocks-before-tablet-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-blocks-after-tablet-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-blocks-before-mobile-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-blocks-after-mobile-dark.png) |
| Network data | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-analytics-before-desktop-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-analytics-after-desktop-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-analytics-before-tablet-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-analytics-after-tablet-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-analytics-before-mobile-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-analytics-after-mobile-dark.png) |
| Revenue | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-revenue-before-desktop-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-revenue-after-desktop-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-revenue-before-tablet-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-revenue-after-tablet-dark.png) | [before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-revenue-before-mobile-dark.png) · [after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11517-revenue-after-mobile-dark.png) |