### PR TITLE
fix(auth): resolve a tier for OAuth callers, and give the metered stores an identity dimension

### DIFF
--- a/migrations/neon/0033_account_kind_discriminator.sql
+++ b/migrations/neon/0033_account_kind_discriminator.sql
@@ -1,0 +1,84 @@
+-- The three key-scoped stores could not represent a second identity system.
+--
+-- `api_quota_daily`, `api_key_usage_daily` and `api_key_blocks` each key on a
+-- bare `integer` account_id with NO foreign key. Those integers are
+-- `rpc_accounts` ids, but nothing in the database said so, and nothing stopped
+-- a second id space being written into the same column.
+--
+-- There are now two id spaces. `github_accounts` is a separate table with its
+-- own `id` sequence and its own `tier` column, and #11562 needs an OAuth
+-- caller quota'd, blocked and metered like any other account. Both sequences
+-- sit in the same low range today, so `github_accounts.id = 5` and
+-- `rpc_accounts.id = 5` would share a quota row, a blocklist entry and a usage
+-- row: one caller drawing down another's budget, and a block on one silently
+-- blocking the other.
+--
+-- ## Why this migration is free right now
+--
+-- All three tables are EMPTY (verified 2026-08-21: 0 rows each). The primary
+-- keys and the partial unique index can be repointed with no backfill and no
+-- reconciliation. Every row written from here on carries its kind, so this
+-- never needs doing again -- and doing it later would mean migrating live
+-- billing data.
+--
+-- ## Why 'rpc' is the default
+--
+-- Correct for every row that could already exist: before this migration the
+-- only writer was the API-key path, whose ids are `rpc_accounts` ids. The
+-- default is what makes the column addition safe on a non-empty table too,
+-- should this ever be re-run against one.
+--
+-- The vocabulary is owned by src/account-kind.ts; the CHECK below is what
+-- stops a value outside that union creating a third, unqueryable id space.
+-- Re-runnable: every statement is guarded, so a partial apply retries cleanly.
+
+ALTER TABLE public.api_quota_daily
+    ADD COLUMN IF NOT EXISTS account_kind text NOT NULL DEFAULT 'rpc';
+ALTER TABLE public.api_key_usage_daily
+    ADD COLUMN IF NOT EXISTS account_kind text NOT NULL DEFAULT 'rpc';
+ALTER TABLE public.api_key_blocks
+    ADD COLUMN IF NOT EXISTS account_kind text NOT NULL DEFAULT 'rpc';
+
+ALTER TABLE public.api_quota_daily
+    DROP CONSTRAINT IF EXISTS api_quota_daily_account_kind_check;
+ALTER TABLE public.api_quota_daily
+    ADD CONSTRAINT api_quota_daily_account_kind_check
+    CHECK (account_kind IN ('rpc', 'github'));
+ALTER TABLE public.api_key_usage_daily
+    DROP CONSTRAINT IF EXISTS api_key_usage_daily_account_kind_check;
+ALTER TABLE public.api_key_usage_daily
+    ADD CONSTRAINT api_key_usage_daily_account_kind_check
+    CHECK (account_kind IN ('rpc', 'github'));
+ALTER TABLE public.api_key_blocks
+    DROP CONSTRAINT IF EXISTS api_key_blocks_account_kind_check;
+ALTER TABLE public.api_key_blocks
+    ADD CONSTRAINT api_key_blocks_account_kind_check
+    CHECK (account_kind IN ('rpc', 'github'));
+
+-- The keys themselves. An account is (kind, id) from here on; the id alone is
+-- not an identity and must not be usable as one.
+ALTER TABLE public.api_quota_daily
+    DROP CONSTRAINT IF EXISTS api_quota_daily_pkey;
+ALTER TABLE public.api_quota_daily
+    ADD CONSTRAINT api_quota_daily_pkey
+    PRIMARY KEY (account_kind, account_id, day);
+
+ALTER TABLE public.api_key_usage_daily
+    DROP CONSTRAINT IF EXISTS api_key_usage_daily_pkey;
+ALTER TABLE public.api_key_usage_daily
+    ADD CONSTRAINT api_key_usage_daily_pkey
+    PRIMARY KEY (account_kind, account_id, day, route);
+
+-- Leads with the discriminator so a per-account lookup is still one index
+-- range rather than a scan filtered after the fact.
+DROP INDEX IF EXISTS public.idx_api_key_usage_daily_account_day;
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_daily_account_day
+    ON public.api_key_usage_daily (account_kind, account_id, day DESC);
+
+-- "One active block per account" was true per id; it has to be true per
+-- (kind, id), or blocking a GitHub account would collide with an unrelated
+-- active block on the rpc account of the same number.
+DROP INDEX IF EXISTS public.idx_api_key_blocks_one_active_per_account;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_key_blocks_one_active_per_account
+    ON public.api_key_blocks (account_kind, account_id)
+    WHERE unblocked_at IS NULL;

--- a/src/account-kind.ts
+++ b/src/account-kind.ts
@@ -1,0 +1,61 @@
+// WHICH identity system an `account_id` belongs to (#11573).
+//
+// ## THE COLLISION THIS EXISTS TO PREVENT
+//
+// `api_quota_daily`, `api_key_blocks` and `api_key_usage_daily` each key on a
+// bare `integer` account_id, with NO foreign key -- so nothing in the database
+// says which table those integers come from, and nothing stopped a second id
+// space being written into the same column.
+//
+// There are now two. `rpc_accounts` (ss58/wallet login) and `github_accounts`
+// (OAuth) are separate tables with separate `id` sequences and their own
+// `tier` columns, both in the same low range today. Without a discriminator,
+// `github_accounts.id = 5` and `rpc_accounts.id = 5` share a quota row, a
+// blocklist entry and a usage row -- one caller drawing down another's budget,
+// and a block on one silently blocking the other.
+//
+// ## WHY A DISCRIMINATOR RATHER THAN ONE ACCOUNT TABLE
+//
+// Unifying the two behind a single identity is arguably the better end state,
+// but it is a different decision: `rpc_accounts.ss58` is NOT NULL UNIQUE and a
+// GitHub user has no ss58, so unification restructures the account model and
+// with it how billing attaches. A discriminator is the standard modelling for
+// polymorphic ownership, is complete on its own, and does not foreclose that.
+//
+// ## WHY THE VOCABULARY LIVES HERE
+//
+// One owner, imported by the writers, the readers and the tests, so the strings
+// in the migration's CHECK constraint and the strings in the code cannot drift
+// apart. A value that reaches the database outside this union fails the CHECK
+// rather than silently creating a third, unqueryable id space -- which is the
+// failure mode this whole module exists to end.
+
+/** Every identity system that can own a metered account row. */
+export const ACCOUNT_KINDS = ["rpc", "github"] as const;
+
+export type AccountKind = (typeof ACCOUNT_KINDS)[number];
+
+/**
+ * `rpc_accounts` -- what every row written before #11573 belongs to.
+ *
+ * The migration's column default, restated here so a writer that has no kind
+ * to hand lands on the same value the database would have chosen rather than
+ * on whichever member happens to be first in the union.
+ */
+export const DEFAULT_ACCOUNT_KIND: AccountKind = "rpc";
+
+/**
+ * Narrow an untrusted value to a kind, or null.
+ *
+ * Null rather than a default on purpose: a caller that cannot say which
+ * identity system an id belongs to must not have one guessed for it, because
+ * guessing is exactly how two id spaces end up in one column. The one place a
+ * default is correct is a row that predates the discriminator, and the
+ * database already applies it.
+ */
+export function asAccountKind(value: unknown): AccountKind | null {
+  return typeof value === "string" &&
+    (ACCOUNT_KINDS as readonly string[]).includes(value)
+    ? (value as AccountKind)
+    : null;
+}

--- a/src/api-key-abuse.ts
+++ b/src/api-key-abuse.ts
@@ -20,6 +20,8 @@
 // reads a cached snapshot and never computes anything. That keeps enforcement
 // at one KV read rather than a network round trip per request.
 
+import { DEFAULT_ACCOUNT_KIND, type AccountKind } from "./account-kind.ts";
+
 /**
  * Reason codes are a CLOSED set, not free text.
  *
@@ -166,6 +168,15 @@ export function scoreUsageAnomalies(
 /** An active block, as held in the cached snapshot the edge reads. */
 export interface BlockEntry {
   accountId: number;
+  /**
+   * WHICH identity system `accountId` belongs to (#11573).
+   *
+   * Optional for one reason only: a snapshot written before the discriminator
+   * existed carries no kind, and those entries are all `rpc` accounts. Absent
+   * is therefore read as `rpc` rather than as "matches anything" -- see
+   * evaluateBlock.
+   */
+  accountKind?: AccountKind | null;
   reasonCode: BlockReasonCode;
   note?: string | null;
   blockedAt?: number | null;
@@ -200,6 +211,12 @@ const NOT_BLOCKED: BlockVerdict = {
 export function evaluateBlock(
   snapshot: { blocks?: unknown } | null | undefined,
   accountId: unknown,
+  /**
+   * WHICH identity system `accountId` belongs to (#11573). Defaulted rather
+   * than required so existing callers keep their meaning exactly: every id
+   * they pass is an `rpc_accounts` id.
+   */
+  accountKind: AccountKind = DEFAULT_ACCOUNT_KIND,
 ): BlockVerdict {
   const id = Number(accountId);
   if (!Number.isInteger(id) || id <= 0) return NOT_BLOCKED;
@@ -207,6 +224,16 @@ export function evaluateBlock(
   if (!Array.isArray(blocks)) return NOT_BLOCKED;
   for (const entry of blocks as BlockEntry[]) {
     if (Number(entry?.accountId) !== id) continue;
+    // MATCHING ON THE ID ALONE WAS THE BUG (#11573). `github_accounts.id` and
+    // `rpc_accounts.id` are separate sequences in the same numeric range, so
+    // an id-only match blocks an unrelated account of the other kind -- and a
+    // block is the one verdict where a false positive is total.
+    //
+    // An entry with no kind is read as `rpc`, never as a wildcard: it predates
+    // the discriminator, and every such block was written against an
+    // `rpc_accounts` id. Treating it as "matches anything" would resurrect the
+    // exact collision from inside the compatibility path.
+    if ((entry?.accountKind ?? DEFAULT_ACCOUNT_KIND) !== accountKind) continue;
     const reasonCode = isBlockReasonCode(entry?.reasonCode)
       ? entry.reasonCode
       : "abuse_manual";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1253,6 +1253,11 @@ import {
   requireTierForDepth,
 } from "./mcp-tier-gate.ts";
 import {
+  oauthAccountIdFrom,
+  resolveOAuthAccountTier,
+} from "./oauth-account-tier.ts";
+import type { AccountKind } from "./account-kind.ts";
+import {
   DEREGISTRATION_UNAVAILABLE_CODE,
   DEREGISTRATION_UNAVAILABLE_MESSAGE,
   projectDeregistrationRanking,
@@ -17759,12 +17764,22 @@ export { parseUserAgentClient };
 async function enforceMcpRateLimit(
   request: Request,
   env: Env,
-  ctx?: { waitUntil?: (promise: Promise<unknown>) => void },
+  ctx?: {
+    waitUntil?: (promise: Promise<unknown>) => void;
+    // #11562: set by @cloudflare/workers-oauth-provider once it has ALREADY
+    // validated the Bearer token. Present only on an authenticated request,
+    // which is why the tier below is optional rather than defaulted.
+    props?: { accountId?: unknown };
+  },
 ): Promise<{
   rejection: Response | null;
   authTier: string;
   accountId: string | null;
-  quotaPending?: { accountId: string; dailyUnits: number };
+  quotaPending?: {
+    accountId: string;
+    accountKind: AccountKind;
+    dailyUnits: number;
+  };
 }> {
   // #8520: tiered rate limiting via the shared applyTieredRateLimit helper
   // (workers/tiered-rate-limit.ts), mirroring workers/api.ts's DATA checkpoint.
@@ -17776,11 +17791,31 @@ async function enforceMcpRateLimit(
   // cost-weighted daily quota cannot be priced yet (every MCP call is POST /mcp,
   // so the pathname says nothing about what was asked for), so it is DEFERRED
   // and spent by handleMcpRequest once the body names the tools.
+  // #11562: an OAuth-authenticated caller resolves a REAL tier instead of
+  // falling through to "anonymous".
+  //
+  // Only attempted when the OAuth provider actually put an account on the
+  // execution context -- an anonymous request has no props and costs nothing
+  // extra here. A caller presenting an `mg_` key never reaches this branch
+  // with props set either: src/github-oauth.ts routes `mg_` bearers around the
+  // provider entirely, so the two identity systems cannot both be present.
+  //
+  // A lookup that cannot answer yields no identity, which means the anonymous
+  // ceiling -- the safe direction, and the same one applyTieredRateLimit takes
+  // for an unrecognised tier.
+  const oauthAccountId = oauthAccountIdFrom(ctx?.props?.accountId);
+  let oauthIdentity: { accountId: number; tier: string } | null = null;
+  if (oauthAccountId !== null) {
+    const resolved = await resolveOAuthAccountTier(env, oauthAccountId);
+    if (resolved.found && typeof resolved.tier === "string" && resolved.tier) {
+      oauthIdentity = { accountId: oauthAccountId, tier: resolved.tier };
+    }
+  }
   const rateLimit = await applyTieredRateLimit(
     request,
     env,
     MCP_TIERED_RATE_LIMIT,
-    { deferQuota: true },
+    { deferQuota: true, oauthIdentity },
   );
   // Fire-and-forget usage counter for the self-serve dashboard, only for a keyed
   // caller (accountId set). Matches workers/api.ts's "chain-events" label call.
@@ -17798,7 +17833,14 @@ async function enforceMcpRateLimit(
   // #8609; the MCP checkpoint was never brought into line. Same ordering here
   // now, for the same reason.
   if (rateLimit.accountId) {
-    recordApiKeyUsage(env, ctx, rateLimit.accountId, "mcp", !rateLimit.allowed);
+    recordApiKeyUsage(
+      env,
+      ctx,
+      rateLimit.accountId,
+      "mcp",
+      !rateLimit.allowed,
+      rateLimit.accountKind,
+    );
   }
   // applyTieredRateLimit always sets `tier`: a tier name for a verified key,
   // or the literal "anonymous". No fallback needed, and inventing one would
@@ -17844,7 +17886,9 @@ async function enforceMcpRateLimit(
 async function spendMcpQuota(
   request: Request,
   env: Env,
-  pending: { accountId: string; dailyUnits: number } | undefined,
+  pending:
+    | { accountId: string; accountKind: AccountKind; dailyUnits: number }
+    | undefined,
   body: unknown,
   policy: RateLimitTierPolicy,
   tier: string,
@@ -17858,7 +17902,14 @@ async function spendMcpQuota(
   );
   if (!quota || quota.allowed) return null;
   const rejection = tieredRejectionResponse(
-    { allowed: false, policy, tier, quota, accountId: pending.accountId },
+    {
+      allowed: false,
+      policy,
+      tier,
+      quota,
+      accountId: pending.accountId,
+      accountKind: pending.accountKind,
+    },
     {
       code: "rate_limited",
       message: "Daily MCP quota exhausted for this account.",

--- a/src/oauth-account-tier.ts
+++ b/src/oauth-account-tier.ts
@@ -1,0 +1,153 @@
+// The tier behind an OAuth-authenticated caller (#11562).
+//
+// ## THE BUG THIS CLOSES
+//
+// `applyTieredRateLimit` resolved a tier from ONE thing: a valid `mg_...` key
+// (workers/tiered-rate-limit.ts). An OAuth 2.1 access token our own provider
+// issued is not an `mg_` key, so a caller who completed the entire GitHub
+// authorization flow fell through to `anonymous` -- rate-limited, quota'd and
+// priced exactly like a caller who sent nothing.
+//
+// Measured before the fix: over 60 days the `github:` distinct_id namespace
+// carried 460 `$mcp_tool_call` events across 5 identities, EVERY ONE at tier
+// `anonymous`. Five people authenticated and the access model did not notice.
+// `api_keys` was empty at the same time, so the only path that could grant a
+// tier had never been walked -- the whole ladder in src/api-tiers.ts had never
+// had a single row of input.
+//
+// ## WHY A LOOKUP AND NOT A CLAIM IN THE GRANT
+//
+// The tier is already known at authorization time: the account upsert returns
+// it (workers/data-api.ts) and src/github-oauth.ts then drops it on the floor.
+// Carrying it in `props` instead would be free at request time -- and wrong.
+// `props` is minted once by completeAuthorization and stored WITH the grant, so
+// a tier baked into it does not move until the user re-consents. The first
+// thing that will ever change a tier is a subscription upgrade, and a customer
+// who has just paid must not have to log out to be served.
+//
+// src/api-tiers.ts already states the property being preserved here, for keys:
+// the tier is read from the lookup on every request, so a server-side change
+// takes effect without re-issuing the credential, bounded by the cache TTL.
+//
+// ## WHY THE TTL IS SHORTER THAN THE KEY CACHE'S
+//
+// api-key-validation.ts caches a valid key for 30 minutes, which is right for
+// its job: that cache exists to keep `verifyKey()` call volume down, and key
+// REVOCATION has its own faster path (the blocklist, on its own short TTL). No
+// such second path exists for a tier change, so this cache's TTL *is* the
+// upgrade latency. Five minutes keeps the read cheap while keeping "I paid and
+// nothing happened" inside the window a person will sit through.
+
+import { API_KEY_LOOKUP_TOKEN_HEADER } from "./api-key-validation.ts";
+
+/** How long a resolved tier is cached. This is the upgrade latency -- see the
+ * header for why it is not the key cache's 30 minutes. */
+export const OAUTH_ACCOUNT_TIER_KV_TTL = 300; // 5 min
+/** How long "no such account" is cached. Short, so an account that appears
+ * (or a lookup that failed transiently) is not denied for a full TTL. */
+export const OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL = 30;
+
+export interface OAuthAccountTierRecord {
+  found: boolean;
+  tier?: unknown;
+}
+
+function cacheKeyFor(accountId: number): string {
+  return `oauth-account-tier:${accountId}`;
+}
+
+/**
+ * Normalise whatever `executionCtx.props.accountId` happens to hold.
+ *
+ * The OAuth provider stores props as JSON, so an id that went in as a number
+ * can come back as a string -- and a grant minted by an older build may carry
+ * neither. Everything that is not a positive integer resolves to null, which
+ * the caller treats as "anonymous", never as a permissive default. This is the
+ * same direction applyTieredRateLimit already takes for an unrecognised tier
+ * and `tierClears` takes for an unknown one: an id we cannot read is not
+ * evidence of entitlement.
+ */
+export function oauthAccountIdFrom(value: unknown): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  const id = Number(value);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+// Calls the data-api Worker's internal tier route over the service binding --
+// the same gate and transport handleGithubAccountUpsert already uses, because
+// the caller is the same Worker holding the same secret. Never throws: an
+// upstream failure is `found: false`, which falls back to the anonymous
+// ceiling rather than 500-ing a request that was otherwise fine.
+async function lookupViaDataApi(
+  env: Env,
+  accountId: number,
+): Promise<OAuthAccountTierRecord> {
+  if (!env?.DATA_API?.fetch || !env?.API_KEY_LOOKUP_INTERNAL_TOKEN) {
+    return { found: false };
+  }
+  try {
+    const upstream = await env.DATA_API.fetch(
+      new Request(
+        "https://api.metagraph.sh/api/v1/internal/accounts/github/tier",
+        {
+          method: "POST",
+          headers: {
+            [API_KEY_LOOKUP_TOKEN_HEADER]: env.API_KEY_LOOKUP_INTERNAL_TOKEN,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ account_id: accountId }),
+        },
+      ),
+    );
+    if (!upstream.ok) return { found: false };
+    const record: Record<string, unknown> = await upstream.json();
+    // `found` mirrors the route's own answer rather than being inferred from
+    // the presence of `tier`, so "account exists, tier is null" stays
+    // distinguishable from "no such account".
+    return record.found
+      ? { found: true, tier: record.tier ?? null }
+      : { found: false };
+  } catch {
+    return { found: false };
+  }
+}
+
+/**
+ * The current tier for an OAuth-authenticated account, KV-cache-fronted.
+ *
+ * Returns `{ found: false }` for an unreadable id, an unknown account, or any
+ * upstream/KV failure -- one shape for every "we cannot say", so the caller has
+ * exactly one branch to take and it is the safe one.
+ */
+export async function resolveOAuthAccountTier(
+  env: Env,
+  rawAccountId: unknown,
+): Promise<OAuthAccountTierRecord> {
+  const accountId = oauthAccountIdFrom(rawAccountId);
+  if (accountId === null) return { found: false };
+
+  const kv = env?.METAGRAPH_CONTROL;
+  const cacheKey = cacheKeyFor(accountId);
+  if (kv?.get) {
+    try {
+      const cached = await kv.get(cacheKey, { type: "json" });
+      if (cached) return cached as OAuthAccountTierRecord;
+    } catch {
+      // KV read failure is non-fatal -- fall through to the live lookup.
+    }
+  }
+
+  const payload = await lookupViaDataApi(env, accountId);
+  if (kv?.put) {
+    try {
+      await kv.put(cacheKey, JSON.stringify(payload), {
+        expirationTtl: payload.found
+          ? OAUTH_ACCOUNT_TIER_KV_TTL
+          : OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
+      });
+    } catch {
+      // KV write failure is non-fatal.
+    }
+  }
+  return payload;
+}

--- a/tests/account-kind.test.ts
+++ b/tests/account-kind.test.ts
@@ -1,0 +1,82 @@
+// Unit tests for src/account-kind.ts (#11573) -- the vocabulary that keeps two
+// account id spaces from collapsing into one column.
+//
+// The whole module exists because `api_quota_daily`, `api_key_blocks` and
+// `api_key_usage_daily` key on a bare integer with no foreign key, and there
+// are now two tables minting those integers. A value that escapes this union
+// would create a third, unqueryable id space -- so the narrowing is the guard,
+// and it has to reject everything it does not recognise.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ACCOUNT_KINDS,
+  DEFAULT_ACCOUNT_KIND,
+  asAccountKind,
+} from "../src/account-kind.ts";
+
+describe("ACCOUNT_KINDS", () => {
+  test("names both identity systems and nothing else", () => {
+    assert.deepEqual([...ACCOUNT_KINDS], ["rpc", "github"]);
+  });
+
+  test("the default is the one every pre-discriminator row belongs to", () => {
+    // Every account id written before #11573 came from `rpc_accounts`, and the
+    // migration's column default says so too. If these two ever disagree, rows
+    // written by code and rows written by the database land in different
+    // buckets -- which is the collision, reintroduced from the other side.
+    assert.equal(DEFAULT_ACCOUNT_KIND, "rpc");
+    assert.ok(
+      (ACCOUNT_KINDS as readonly string[]).includes(DEFAULT_ACCOUNT_KIND),
+    );
+  });
+});
+
+describe("asAccountKind", () => {
+  test("accepts every declared kind", () => {
+    for (const kind of ACCOUNT_KINDS) {
+      assert.equal(asAccountKind(kind), kind);
+    }
+  });
+
+  test("rejects a string outside the vocabulary", () => {
+    // Not defaulted. A caller that cannot say which identity system an id
+    // belongs to must not have one guessed for it -- guessing is exactly how
+    // two id spaces end up in one column.
+    for (const value of [
+      "",
+      "RPC",
+      "Github",
+      "stripe",
+      "wallet",
+      "__proto__",
+    ]) {
+      assert.equal(asAccountKind(value), null, value);
+    }
+  });
+
+  test("rejects every non-string", () => {
+    for (const value of [
+      undefined,
+      null,
+      0,
+      1,
+      true,
+      false,
+      {},
+      [],
+      ["rpc"],
+      Symbol("rpc"),
+    ]) {
+      assert.equal(asAccountKind(value), null, String(value));
+    }
+  });
+
+  test("does not inherit from Object.prototype", () => {
+    // `includes` on a real array cannot walk the prototype chain, but pinning
+    // it keeps a future refactor to a record-shaped lookup honest -- the same
+    // class of bypass isBlockReasonCode guards against with Object.hasOwn.
+    assert.equal(asAccountKind("constructor"), null);
+    assert.equal(asAccountKind("toString"), null);
+    assert.equal(asAccountKind("valueOf"), null);
+  });
+});

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3811,6 +3811,7 @@ describe("Access-Control-Expose-Headers", () => {
         policy,
         tier: "free",
         accountId: "1",
+        accountKind: "rpc" as const,
         block: {
           blocked: true,
           reasonCode: "abuse_manual",
@@ -3825,6 +3826,7 @@ describe("Access-Control-Expose-Headers", () => {
         policy,
         tier: "paid",
         accountId: "1",
+        accountKind: "rpc" as const,
       },
       { code: "rate_limited", message: "Too many requests." },
     )!;
@@ -3834,6 +3836,7 @@ describe("Access-Control-Expose-Headers", () => {
         policy,
         tier: "free",
         accountId: "1",
+        accountKind: "rpc" as const,
         quota: {
           allowed: false,
           used: 1000,

--- a/tests/api-key-abuse.test.ts
+++ b/tests/api-key-abuse.test.ts
@@ -427,3 +427,45 @@ describe("runAbuseScan reports, it does not enforce (#8611)", () => {
     assert.deepEqual(result, { ok: true, flagged: 0, accountsSeen: 0 });
   });
 });
+
+// #11573: a block is scoped to (kind, id). Matching on the id alone was the
+// bug -- `github_accounts.id` and `rpc_accounts.id` are separate sequences in
+// the same numeric range, and a block is the one verdict whose false positive
+// costs a customer everything.
+describe("evaluateBlock — account kind", () => {
+  const snapshot = {
+    blocks: [
+      { accountId: 5, accountKind: "github", reasonCode: "abuse_manual" },
+    ],
+  };
+
+  test("blocks the account it names", () => {
+    assert.equal(evaluateBlock(snapshot, 5, "github").blocked, true);
+  });
+
+  test("does NOT block the same id under a different kind", () => {
+    // The whole point: rpc account 5 is a different account from github
+    // account 5 and must be unaffected by a block on the other.
+    assert.equal(evaluateBlock(snapshot, 5, "rpc").blocked, false);
+  });
+
+  test("an entry with no kind is read as rpc, not as a wildcard", () => {
+    // Snapshots written before the discriminator carry no kind, and every
+    // block in them was against an rpc id. Treating absent as "matches
+    // anything" would resurrect the collision from inside the compatibility
+    // path -- so it must block rpc and only rpc.
+    const legacy = {
+      blocks: [{ accountId: 5, reasonCode: "abuse_manual" }],
+    };
+    assert.equal(evaluateBlock(legacy, 5, "rpc").blocked, true);
+    assert.equal(evaluateBlock(legacy, 5, "github").blocked, false);
+  });
+
+  test("defaults to rpc when no kind is supplied, preserving every existing caller", () => {
+    const legacy = {
+      blocks: [{ accountId: 5, reasonCode: "abuse_manual" }],
+    };
+    assert.equal(evaluateBlock(legacy, 5).blocked, true);
+    assert.equal(evaluateBlock(snapshot, 5).blocked, false);
+  });
+});

--- a/tests/github-account-upsert-route.test.ts
+++ b/tests/github-account-upsert-route.test.ts
@@ -186,3 +186,79 @@ test("correct token + invalid body -> the existing 400, NO write attempted", asy
   assert.equal(res.status, 400);
   assert.deepEqual(sqlCalls, []);
 });
+
+// #11562/#11573: POST /api/v1/internal/accounts/github/tier -- the lookup that
+// lets an OAuth-authenticated caller resolve a real tier instead of falling
+// through to "anonymous". Same internal-token gate as the upsert above, for the
+// same reason: the only caller is our own Worker over the service binding.
+function tierReq(body: Row, token: string | null = INTERNAL_TOKEN) {
+  return new Request("https://d/api/v1/internal/accounts/github/tier", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token === null ? {} : { "x-api-key-lookup-token": token }),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+test("tier lookup: 503 when the internal token is not provisioned", async () => {
+  const env = baseEnv({ API_KEY_LOOKUP_INTERNAL_TOKEN: undefined });
+  const res = await fetchRoute(tierReq({ account_id: 7 }), env);
+  assert.equal(res.status, 503);
+});
+
+test("tier lookup: 401 on a missing or wrong token", async () => {
+  for (const token of [null, "wrong-token"]) {
+    const res = await fetchRoute(tierReq({ account_id: 7 }, token), baseEnv());
+    assert.equal(res.status, 401, String(token));
+  }
+});
+
+test("tier lookup: rejects a malformed JSON body", async () => {
+  const res = await fetchRoute(
+    new Request("https://d/api/v1/internal/accounts/github/tier", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key-lookup-token": INTERNAL_TOKEN,
+      },
+      body: "not json",
+    }),
+    baseEnv(),
+  );
+  assert.equal(res.status, 400);
+});
+
+test("tier lookup: a non-integer id is not found, and never reaches the query", async () => {
+  // Answered `found: false` rather than 400: the caller's next move is the
+  // same either way (fall back to anonymous), and a 400 would invite it to
+  // treat a shape problem as an outage.
+  for (const account_id of ["abc", 1.5, null, undefined, -1 * 0 - 0.5]) {
+    sqlCalls.length = 0;
+    const res = await fetchRoute(tierReq({ account_id }), baseEnv());
+    assert.equal(res.status, 200, String(account_id));
+    assert.deepEqual(await res.json(), { found: false }, String(account_id));
+    assert.equal(sqlCalls.length, 0, "no query for an unreadable id");
+  }
+});
+
+test("tier lookup: returns the account's current tier", async () => {
+  mockQueue.current.push([{ tier: "paid" }]);
+  const res = await fetchRoute(tierReq({ account_id: 7 }), baseEnv());
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { found: true, tier: "paid" });
+  const call = sqlCalls.find((c) => /github_accounts/.test(c.text));
+  assert.ok(call, "queried github_accounts");
+  assert.ok(/SELECT tier FROM github_accounts/.test(call!.text));
+  assert.deepEqual(call!.values, [7]);
+});
+
+test("tier lookup: an unknown account is not found, NOT a default tier", async () => {
+  // "we could not find you" and "you are on free" must stay distinguishable --
+  // they differ the moment `free` stops being the bottom rung.
+  mockQueue.current.push([]);
+  const res = await fetchRoute(tierReq({ account_id: 999 }), baseEnv());
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { found: false });
+});

--- a/tests/mcp-tier-gate.test.ts
+++ b/tests/mcp-tier-gate.test.ts
@@ -21,6 +21,7 @@ import {
   tierClears,
 } from "../src/mcp-tier-gate.ts";
 import { handleMcpRequest, MCP_CORE_TOOL_NAMES } from "../src/mcp-server.ts";
+import { applyTieredRateLimit } from "../workers/tiered-rate-limit.ts";
 import { mockEnv, type Row } from "./row-type.ts";
 
 const guard = (tier: string, requested: number | null) =>
@@ -198,5 +199,155 @@ describe("depth is gated; visibility is not", () => {
     );
     // And the free-tier economics entry point stays in the curated core set.
     assert.ok(MCP_CORE_TOOL_NAMES.includes("get_economics"));
+  });
+});
+
+// #11562: the boundary above is only reachable if a caller can BE on a tier.
+// Until this landed, tier resolved solely from an `mg_` key, so an OAuth caller
+// who completed the whole GitHub flow was measured `anonymous` -- 460 tool
+// calls across 5 authenticated identities in production, every one of them.
+//
+// Composed from the REAL applyTieredRateLimit rather than a hand-written tier
+// string, so this proves the chain (OAuth identity -> resolved tier -> the
+// gate's verdict) rather than restating the gate's own assumption.
+describe("an OAuth caller clears a boundary an anonymous caller does not", () => {
+  const TIERS = {
+    free: { envVar: "GATE_FREE_LIMITER", limit: 300, windowSeconds: 60 },
+    paid: { envVar: "GATE_PAID_LIMITER", limit: 3000, windowSeconds: 60 },
+  };
+  const CONFIG = {
+    anonymous: { envVar: "GATE_ANON_LIMITER", limit: 60, windowSeconds: 60 },
+    keyed: TIERS.free,
+    tiers: TIERS,
+    keyPrefix: "gate",
+  };
+  const env = {
+    GATE_ANON_LIMITER: { limit: async () => ({ success: true }) },
+    GATE_PAID_LIMITER: { limit: async () => ({ success: true }) },
+  } as unknown as Env;
+  const request = () =>
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "203.0.113.9" },
+    });
+
+  test("anonymous is refused a window past the free depth", async () => {
+    const resolved = await applyTieredRateLimit(request(), env, CONFIG);
+    assert.equal(resolved.tier, "anonymous");
+    assert.throws(
+      () => guard(resolved.tier, 365),
+      (error: Error & { code?: string }) => error.code === "payment_required",
+    );
+  });
+
+  test("the same window goes through for an OAuth account on paid", async () => {
+    const resolved = await applyTieredRateLimit(request(), env, CONFIG, {
+      oauthIdentity: { accountId: 7, tier: "paid" },
+    });
+    assert.equal(resolved.tier, "paid");
+    assert.equal(resolved.accountKind, "github");
+    assert.doesNotThrow(() => guard(resolved.tier, 365));
+  });
+
+  test("an OAuth account on the DEFAULT tier is still bounded", async () => {
+    // `github_accounts.tier` defaults to 'free', so authenticating does not
+    // silently hand out paid depth -- it makes the caller addressable, which
+    // is what an upgrade then acts on.
+    const resolved = await applyTieredRateLimit(request(), env, CONFIG, {
+      oauthIdentity: { accountId: 7, tier: "free" },
+    });
+    assert.equal(resolved.tier, "free");
+    assert.doesNotThrow(() => guard(resolved.tier, FREE_HISTORY_WINDOW_DAYS));
+    assert.throws(
+      () => guard(resolved.tier, 365),
+      (error: Error & { code?: string }) => error.code === "payment_required",
+    );
+  });
+});
+
+// #11562: the same chain, driven through the REAL MCP entry point rather than
+// applyTieredRateLimit directly -- so the props the OAuth provider sets on the
+// ExecutionContext are proven to reach the tier resolver, which is the wiring
+// that was missing.
+describe("handleMcpRequest resolves a tier from the OAuth execution context", () => {
+  function envWithTierLookup(tier: string | null, found = true) {
+    return mockEnv({
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      DATA_API: {
+        fetch: async () =>
+          new Response(JSON.stringify(found ? { found, tier } : { found }), {
+            status: 200,
+          }),
+      },
+      MCP_RATE_LIMITER: { limit: async () => ({ success: true }) },
+      MCP_RATE_LIMITER_KEYED: { limit: async () => ({ success: true }) },
+      MCP_RATE_LIMITER_COMMUNITY: { limit: async () => ({ success: true }) },
+      MCP_RATE_LIMITER_PAID: { limit: async () => ({ success: true }) },
+    } as Row);
+  }
+
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {},
+  });
+  const request = () =>
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body,
+    });
+
+  test("an authenticated caller is served, and the lookup is consulted", async () => {
+    const env = envWithTierLookup("paid");
+    const res = await handleMcpRequest(request(), env, {
+      executionCtx: { waitUntil() {}, props: { accountId: 7 } },
+    });
+    assert.equal(res.status, 200);
+  });
+
+  test("an account the lookup cannot resolve falls back to anonymous, not to a permissive default", async () => {
+    // found:false, and a found-but-tierless row -- both must yield no identity.
+    for (const env of [
+      envWithTierLookup(null, false),
+      envWithTierLookup(null, true),
+      envWithTierLookup("", true),
+    ]) {
+      const res = await handleMcpRequest(request(), env, {
+        executionCtx: { waitUntil() {}, props: { accountId: 7 } },
+      });
+      assert.equal(res.status, 200);
+    }
+  });
+
+  test("an unreadable props.accountId never reaches the lookup", async () => {
+    let called = 0;
+    const env = mockEnv({
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      DATA_API: {
+        fetch: async () => {
+          called += 1;
+          return new Response("{}", { status: 200 });
+        },
+      },
+      MCP_RATE_LIMITER: { limit: async () => ({ success: true }) },
+    } as Row);
+    for (const accountId of [undefined, null, "abc", 0, -1]) {
+      const res = await handleMcpRequest(request(), env, {
+        executionCtx: { waitUntil() {}, props: { accountId } },
+      });
+      assert.equal(res.status, 200, String(accountId));
+    }
+    assert.equal(called, 0, "no lookup for a caller with no readable id");
+  });
+
+  test("no execution context at all is still served anonymously", async () => {
+    const env = envWithTierLookup("paid");
+    const res = await handleMcpRequest(request(), env, {});
+    assert.equal(res.status, 200);
   });
 });

--- a/tests/oauth-account-tier.test.ts
+++ b/tests/oauth-account-tier.test.ts
@@ -1,0 +1,280 @@
+// Unit tests for src/oauth-account-tier.ts (#11562) -- the lookup that lets an
+// OAuth-authenticated caller resolve a real tier instead of falling through to
+// "anonymous". The DATA_API service binding and KV are mocked the same way
+// tests/tiered-rate-limit.test.ts mocks them.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  OAUTH_ACCOUNT_TIER_KV_TTL,
+  OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
+  oauthAccountIdFrom,
+  resolveOAuthAccountTier,
+} from "../src/oauth-account-tier.ts";
+import type { Row } from "./row-type.ts";
+
+interface KvPut {
+  key: string;
+  value: string;
+  options?: { expirationTtl?: number };
+}
+
+function createFakeKv(seed: Row = {}) {
+  const store = new Map<string, string>(
+    Object.entries(seed).map(([key, value]) => [key, JSON.stringify(value)]),
+  );
+  const puts: KvPut[] = [];
+  return {
+    puts,
+    async get(key: string, options?: { type?: string }) {
+      if (!store.has(key)) return null;
+      const raw = store.get(key)!;
+      return options?.type === "json" ? JSON.parse(raw) : raw;
+    },
+    async put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number },
+    ) {
+      puts.push({ key, value, options });
+      store.set(key, value);
+    },
+  };
+}
+
+function envWith(
+  body: Row | null,
+  overrides: Row = {},
+  status = 200,
+): { env: Env; requests: Request[] } {
+  const requests: Request[] = [];
+  const env = {
+    METAGRAPH_CONTROL: createFakeKv(),
+    API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+    DATA_API: {
+      fetch: async (request: Request) => {
+        requests.push(request);
+        return new Response(body === null ? "nope" : JSON.stringify(body), {
+          status,
+        });
+      },
+    },
+    ...overrides,
+  } as unknown as Env;
+  return { env, requests };
+}
+
+describe("oauthAccountIdFrom", () => {
+  test("accepts a positive integer, as a number or a JSON-roundtripped string", () => {
+    assert.equal(oauthAccountIdFrom(7), 7);
+    assert.equal(oauthAccountIdFrom("7"), 7);
+  });
+
+  test("rejects everything that is not a positive integer", () => {
+    // Each of these must resolve to "no identity", which the caller reads as
+    // anonymous -- never as a permissive default.
+    for (const value of [
+      undefined,
+      null,
+      true,
+      false,
+      {},
+      [],
+      "",
+      "abc",
+      "7.5",
+      7.5,
+      0,
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      assert.equal(oauthAccountIdFrom(value), null, String(value));
+    }
+  });
+});
+
+describe("resolveOAuthAccountTier", () => {
+  test("an unreadable account id never reaches the network", async () => {
+    const { env, requests } = envWith({ found: true, tier: "paid" });
+    assert.deepEqual(await resolveOAuthAccountTier(env, "not-an-id"), {
+      found: false,
+    });
+    assert.equal(requests.length, 0);
+  });
+
+  test("resolves a tier and calls the internal route with the account id", async () => {
+    const { env, requests } = envWith({ found: true, tier: "community" });
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
+      found: true,
+      tier: "community",
+    });
+    assert.equal(requests.length, 1);
+    assert.equal(
+      new URL(requests[0]!.url).pathname,
+      "/api/v1/internal/accounts/github/tier",
+    );
+    assert.equal(
+      requests[0]!.headers.get("x-api-key-lookup-token"),
+      "test-lookup-token",
+    );
+    assert.deepEqual(await requests[0]!.json(), { account_id: 42 });
+  });
+
+  test("an account that exists with a null tier stays found", async () => {
+    // "found with no tier" and "no such account" are different answers and the
+    // caller branches on `found`, so they must not collapse into each other.
+    const { env } = envWith({ found: true });
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
+      found: true,
+      tier: null,
+    });
+  });
+
+  test("an unknown account is not found", async () => {
+    const { env } = envWith({ found: false });
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), { found: false });
+  });
+
+  test("caches a hit under the account id, on the tier TTL", async () => {
+    const kv = createFakeKv();
+    const { env, requests } = envWith(
+      { found: true, tier: "paid" },
+      { METAGRAPH_CONTROL: kv },
+    );
+    await resolveOAuthAccountTier(env, 42);
+    assert.deepEqual(kv.puts, [
+      {
+        key: "oauth-account-tier:42",
+        value: JSON.stringify({ found: true, tier: "paid" }),
+        options: { expirationTtl: OAUTH_ACCOUNT_TIER_KV_TTL },
+      },
+    ]);
+    // Second call is served from cache -- no second round trip.
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
+      found: true,
+      tier: "paid",
+    });
+    assert.equal(requests.length, 1);
+  });
+
+  test("caches a miss on the SHORTER negative TTL", async () => {
+    const kv = createFakeKv();
+    const { env } = envWith({ found: false }, { METAGRAPH_CONTROL: kv });
+    await resolveOAuthAccountTier(env, 42);
+    assert.equal(
+      kv.puts[0]!.options?.expirationTtl,
+      OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
+    );
+    assert.ok(
+      OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL < OAUTH_ACCOUNT_TIER_KV_TTL,
+      "a negative answer must expire sooner than a resolved tier",
+    );
+  });
+
+  test("the tier TTL is short enough to be a tolerable upgrade latency", () => {
+    // This cache's TTL *is* how long a paid upgrade takes to be honoured --
+    // there is no second fast path the way the blocklist is for key
+    // revocation. Pinned so it cannot drift up to the key cache's 30 minutes
+    // without someone deciding to.
+    assert.ok(OAUTH_ACCOUNT_TIER_KV_TTL <= 300);
+  });
+
+  test("serves a cached answer without calling upstream at all", async () => {
+    const kv = createFakeKv({
+      "oauth-account-tier:9": { found: true, tier: "paid" },
+    });
+    const { env, requests } = envWith(
+      { found: true, tier: "free" },
+      { METAGRAPH_CONTROL: kv },
+    );
+    assert.deepEqual(await resolveOAuthAccountTier(env, 9), {
+      found: true,
+      tier: "paid",
+    });
+    assert.equal(requests.length, 0);
+  });
+
+  test("a KV read failure falls through to the live lookup", async () => {
+    const { env } = envWith(
+      { found: true, tier: "paid" },
+      {
+        METAGRAPH_CONTROL: {
+          get: async () => {
+            throw new Error("kv down");
+          },
+          put: async () => {},
+        },
+      },
+    );
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
+      found: true,
+      tier: "paid",
+    });
+  });
+
+  test("a KV write failure is non-fatal", async () => {
+    const { env } = envWith(
+      { found: true, tier: "paid" },
+      {
+        METAGRAPH_CONTROL: {
+          get: async () => null,
+          put: async () => {
+            throw new Error("kv down");
+          },
+        },
+      },
+    );
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
+      found: true,
+      tier: "paid",
+    });
+  });
+
+  test("works with no KV binding at all", async () => {
+    const { env } = envWith(
+      { found: true, tier: "paid" },
+      { METAGRAPH_CONTROL: undefined },
+    );
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
+      found: true,
+      tier: "paid",
+    });
+  });
+
+  test("an unprovisioned deployment resolves nothing rather than throwing", async () => {
+    for (const overrides of [
+      { DATA_API: undefined },
+      { DATA_API: {} },
+      { API_KEY_LOOKUP_INTERNAL_TOKEN: undefined },
+    ]) {
+      const { env } = envWith({ found: true, tier: "paid" }, overrides);
+      assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
+        found: false,
+      });
+    }
+  });
+
+  test("an upstream non-200 resolves nothing", async () => {
+    const { env } = envWith({ found: true, tier: "paid" }, {}, 500);
+    assert.deepEqual(await resolveOAuthAccountTier(env, 42), { found: false });
+  });
+
+  test("an upstream that throws or answers unparseable JSON resolves nothing", async () => {
+    const { env: throwing } = envWith(null, {
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("binding down");
+        },
+      },
+    });
+    assert.deepEqual(await resolveOAuthAccountTier(throwing, 42), {
+      found: false,
+    });
+    // 200 with a body that is not JSON -- .json() rejects, and the catch must
+    // treat it exactly like an outage rather than surfacing a parse error.
+    const { env: garbage } = envWith(null);
+    assert.deepEqual(await resolveOAuthAccountTier(garbage, 42), {
+      found: false,
+    });
+  });
+});

--- a/tests/tiered-rate-limit.test.ts
+++ b/tests/tiered-rate-limit.test.ts
@@ -766,6 +766,7 @@ describe("daily quotas (#8608)", () => {
     assert.equal(result.quota, undefined);
     assert.deepEqual(result.quotaPending, {
       accountId: "42",
+      accountKind: "rpc",
       dailyUnits: 1000,
     });
   });
@@ -784,7 +785,7 @@ describe("daily quotas (#8608)", () => {
     const verdict = await spendDeferredDailyQuota(
       req(),
       env,
-      { accountId: "42", dailyUnits: 1000 },
+      { accountId: "42", accountKind: "rpc" as const, dailyUnits: 1000 },
       50,
     );
     // The store answered, so the verdict is not the fail-open null. Asserting
@@ -812,7 +813,7 @@ describe("daily quotas (#8608)", () => {
     const verdict = await spendDeferredDailyQuota(
       req(),
       env,
-      { accountId: "42", dailyUnits: 1000 },
+      { accountId: "42", accountKind: "rpc" as const, dailyUnits: 1000 },
       25,
     );
     assert.ok(verdict, "a REFUSAL is still an answer, not a fail-open null");
@@ -848,7 +849,9 @@ describe("daily quotas (#8608)", () => {
         // an unauthenticated spend would let anything reachable on the service
         // binding zero an account's day.
         token: "test-lookup-token",
-        body: { account_id: 42, cost: 25, limit: 1000 },
+        // #11573: the kind travels with the id -- a quota row is keyed on
+        // (kind, id), so a bare id would debit whichever account matched first.
+        body: { account_id: 42, account_kind: "rpc", cost: 25, limit: 1000 },
       },
     ]);
   });
@@ -1373,6 +1376,7 @@ describe("key-level blocklist (#8611)", () => {
         policy: CONFIG.keyed,
         tier: "",
         accountId: "42",
+        accountKind: "rpc" as const,
         block: {
           blocked: true,
           reasonCode: null,
@@ -1537,5 +1541,306 @@ describe("tier lookup must not walk the prototype chain (#8687 review)", () => {
       CONFIG,
     );
     assert.equal(result.policy.limit, 5000);
+  });
+});
+
+// #11562: an OAuth-authenticated caller. Before this, tier resolved ONLY from
+// an `mg_` key, so a caller who completed the whole GitHub authorization flow
+// was rate-limited, quota'd and priced as anonymous -- measured in production
+// as 460 tool calls across 5 authenticated identities, every one "anonymous".
+describe("applyTieredRateLimit — oauthIdentity", () => {
+  const TIERS = {
+    free: { envVar: "TEST_FREE_LIMITER", limit: 300, windowSeconds: 60 },
+    paid: {
+      envVar: "TEST_PAID_LIMITER",
+      limit: 3000,
+      windowSeconds: 60,
+      dailyUnits: 2_000_000,
+    },
+  };
+  const TIERED_CONFIG = { ...CONFIG, tiers: TIERS };
+
+  function anonRequest() {
+    return new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "203.0.113.9" },
+    });
+  }
+
+  test("resolves the account's own tier, keyed by tier and a namespaced id", async () => {
+    const calls: unknown[] = [];
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      TEST_PAID_LIMITER: {
+        limit: async (args: unknown) => {
+          calls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    const result = await applyTieredRateLimit(
+      anonRequest(),
+      env,
+      TIERED_CONFIG,
+      { oauthIdentity: { accountId: 7, tier: "paid" } },
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.tier, "paid");
+    assert.equal(result.policy, TIERS.paid);
+    // The id is namespaced: `github_accounts.id` 7 and `rpc_accounts` id 7 are
+    // different accounts and must never share a rate-limit bucket.
+    assert.deepEqual(calls, [{ key: "test:paid:github:7" }]);
+    assert.equal(result.accountKind, "github");
+  });
+
+  test("the account is reported as (github, id) and the quota is scoped to it", async () => {
+    // #11573: the three stores now key on (kind, id), so an OAuth caller is
+    // metered against its OWN row rather than being skipped or -- worse --
+    // debiting the rpc account of the same number.
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      TEST_PAID_LIMITER: { limit: async () => ({ success: true }) },
+    } as unknown as Env;
+    const result = await applyTieredRateLimit(
+      anonRequest(),
+      env,
+      TIERED_CONFIG,
+      { oauthIdentity: { accountId: 7, tier: "paid" }, deferQuota: true },
+    );
+    assert.equal(result.accountId, "7");
+    assert.equal(result.accountKind, "github");
+    assert.deepEqual(result.quotaPending, {
+      accountId: "7",
+      accountKind: "github",
+      dailyUnits: 2_000_000,
+    });
+  });
+
+  test("an OAuth caller is subject to the blocklist, scoped by kind", async () => {
+    // The workaround this replaced skipped the blocklist for OAuth callers
+    // entirely, which would have shipped a tier that could not be enforced.
+    const kv = createFakeKv();
+    await kv.put(
+      "api-key-blocklist",
+      JSON.stringify({
+        blocks: [
+          {
+            accountId: 7,
+            accountKind: "github",
+            reasonCode: "abuse_manual",
+          },
+        ],
+      }),
+    );
+    const env = {
+      METAGRAPH_CONTROL: kv,
+      TEST_PAID_LIMITER: { limit: async () => ({ success: true }) },
+    } as unknown as Env;
+    const blocked = await applyTieredRateLimit(
+      anonRequest(),
+      env,
+      TIERED_CONFIG,
+      { oauthIdentity: { accountId: 7, tier: "paid" } },
+    );
+    assert.equal(blocked.allowed, false);
+    assert.equal(blocked.block?.blocked, true);
+    // ...and the SAME id under the other kind is a different account, which is
+    // the entire point of the discriminator.
+    const other = await applyTieredRateLimit(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${VALID_KEY}`,
+          "cf-connecting-ip": "203.0.113.9",
+        },
+      }),
+      {
+        ...envWithTier("free", { METAGRAPH_CONTROL: kv }),
+        TEST_KEYED_LIMITER: { limit: async () => ({ success: true }) },
+      } as unknown as Env,
+      { ...CONFIG, tiers: { free: KEYED } },
+    );
+    assert.equal(other.allowed, true, "an rpc account of the same number");
+    assert.equal(other.block, undefined);
+  });
+
+  test("the limiter's refusal is honoured", async () => {
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      TEST_PAID_LIMITER: { limit: async () => ({ success: false }) },
+    } as unknown as Env;
+    const result = await applyTieredRateLimit(
+      anonRequest(),
+      env,
+      TIERED_CONFIG,
+      { oauthIdentity: { accountId: 7, tier: "paid" } },
+    );
+    assert.equal(result.allowed, false);
+    assert.equal(result.tier, "paid");
+  });
+
+  test("an unrecognised tier falls back to the keyed policy, never a bypass", async () => {
+    // Same reasoning as the keyed branch's own-property guard: a tier name we
+    // do not price must not resolve to an inherited Object member and end up
+    // with no binding at all.
+    const calls: unknown[] = [];
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      TEST_KEYED_LIMITER: {
+        limit: async (args: unknown) => {
+          calls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    for (const tier of ["constructor", "__proto__", "enterprise"]) {
+      const result = await applyTieredRateLimit(
+        anonRequest(),
+        env,
+        TIERED_CONFIG,
+        { oauthIdentity: { accountId: 7, tier } },
+      );
+      assert.equal(result.policy, KEYED, tier);
+      assert.equal(result.allowed, true, tier);
+    }
+    assert.equal(calls.length, 3, "the keyed limiter must have been consulted");
+  });
+
+  test("a missing binding fails open, like every other limiter here", async () => {
+    const env = { METAGRAPH_CONTROL: createFakeKv() } as unknown as Env;
+    const result = await applyTieredRateLimit(
+      anonRequest(),
+      env,
+      TIERED_CONFIG,
+      { oauthIdentity: { accountId: 7, tier: "paid" } },
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.tier, "paid");
+  });
+
+  test("a valid key OUTRANKS an OAuth identity", async () => {
+    // A caller presenting a key is asserting that identity deliberately --
+    // the same precedence mcpDistinctId applies when both are present.
+    const calls: unknown[] = [];
+    const env = {
+      ...envWithTier("free"),
+      TEST_KEYED_LIMITER: {
+        limit: async (args: unknown) => {
+          calls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    const result = await applyTieredRateLimit(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { authorization: `Bearer ${VALID_KEY}` },
+      }),
+      env,
+      { ...CONFIG, tiers: { free: KEYED } },
+      { oauthIdentity: { accountId: 7, tier: "paid" } },
+    );
+    assert.equal(result.tier, "free");
+    assert.equal(result.accountId, "42");
+    assert.equal(result.accountKind, "rpc");
+    // `rpc` keeps its historical key shape, so no existing caller's window is
+    // reset by the discriminator landing.
+    assert.deepEqual(calls, [{ key: "test:free:42" }]);
+  });
+
+  test("no identity at all still resolves anonymous", async () => {
+    // The regression this whole branch must not cause: anonymous stays exactly
+    // where it was. This grants a tier to authenticated callers; it takes
+    // nothing from anyone.
+    const calls: unknown[] = [];
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      TEST_ANON_LIMITER: {
+        limit: async (args: unknown) => {
+          calls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    for (const oauthIdentity of [null, undefined]) {
+      const result = await applyTieredRateLimit(
+        anonRequest(),
+        env,
+        TIERED_CONFIG,
+        { oauthIdentity },
+      );
+      assert.equal(result.tier, "anonymous");
+      assert.equal(result.policy, ANONYMOUS);
+    }
+    assert.deepEqual(calls, [
+      { key: "test:203.0.113.9" },
+      { key: "test:203.0.113.9" },
+    ]);
+  });
+});
+
+// #11573: the two remaining shapes of the limiter key, pinned so the
+// discriminator cannot quietly change a bucket it was not meant to touch.
+describe("applyTieredRateLimit — limiter key shapes", () => {
+  test("an unattributable key keeps its client-IP bucket and reports rpc", async () => {
+    // verifyUnkeyKey returns a null accountId while `valid` stays true, so a
+    // key minted without an Unkey identity lands here. It still gets its
+    // tier's ceiling -- it does hold a valid key -- but it must never share a
+    // bucket with an unrelated caller.
+    const calls: unknown[] = [];
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      DATA_API: {
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              valid: true,
+              code: "VALID",
+              tier: "free",
+              accountId: null,
+            }),
+            { status: 200 },
+          ),
+      },
+      TEST_KEYED_LIMITER: {
+        limit: async (args: unknown) => {
+          calls.push(args);
+          return { success: true };
+        },
+      },
+    } as unknown as Env;
+    const result = await applyTieredRateLimit(
+      new Request("https://api.metagraph.sh/x", {
+        headers: {
+          authorization: `Bearer ${VALID_KEY}`,
+          "cf-connecting-ip": "203.0.113.9",
+        },
+      }),
+      env,
+      { ...CONFIG, tiers: { free: KEYED } },
+    );
+    assert.equal(result.accountId, null);
+    assert.equal(result.accountKind, "rpc");
+    assert.deepEqual(calls, [{ key: "test:free:ip:203.0.113.9" }]);
+  });
+
+  test("an anonymous caller reports rpc rather than leaving the kind unsaid", async () => {
+    // `accountId: null` already carries the absence; a consumer must never
+    // have to distinguish "anonymous" from "we forgot to say".
+    const env = {
+      METAGRAPH_CONTROL: createFakeKv(),
+      TEST_ANON_LIMITER: { limit: async () => ({ success: true }) },
+    } as unknown as Env;
+    const result = await applyTieredRateLimit(
+      new Request("https://api.metagraph.sh/x", {
+        headers: { "cf-connecting-ip": "203.0.113.9" },
+      }),
+      env,
+      CONFIG,
+    );
+    assert.equal(result.tier, "anonymous");
+    assert.equal(result.accountId, null);
+    assert.equal(result.accountKind, "rpc");
   });
 });

--- a/tests/wallet-auth-keys-route.test.ts
+++ b/tests/wallet-auth-keys-route.test.ts
@@ -1241,7 +1241,12 @@ test("internal quota: an allowed spend upserts atomically and reports the new ba
   assert.ok(call, "issued the upsert");
   // The spend is one guarded statement -- the reject rule lives in SQL, not
   // in a read-then-write race.
-  assert.ok(/ON CONFLICT \(account_id, day\) DO UPDATE/.test(call!.text));
+  // #11573: the conflict target is (kind, id, day). A bare (account_id, day)
+  // would let a github account and an rpc account of the same number collide
+  // onto one quota row -- one caller silently spending the other's day.
+  assert.ok(
+    /ON CONFLICT \(account_kind, account_id, day\) DO UPDATE/.test(call!.text),
+  );
   // `$n`, not `?`: the runner numbers every tagged-template hole via
   // pgStatementText. #9821 is what happens when a `?` reaches Postgres
   // unrewritten -- it is not a placeholder there, so the predicate matches
@@ -2484,4 +2489,125 @@ test("#8607 e2e: an account can hold MULTIPLE live keys, so rotation never locks
     2,
     "both rows were written",
   );
+});
+
+// --- #11573: account_kind on the four key-scoped write routes ----------------
+//
+// The three stores key on a bare integer that is an `rpc_accounts` id, with no
+// foreign key. `github_accounts` mints its own ids in the same range, so every
+// write route has to say WHICH id space it is writing. Absent stays `rpc` --
+// what every caller meant before the discriminator -- and an unrecognised
+// value is refused rather than defaulted, because silently filing a github id
+// under `rpc` is the collision the column exists to end.
+test("usage: an explicit account_kind reaches the upsert; an unknown one is a 400", async () => {
+  const env = baseEnv({ API_KEY_LOOKUP_INTERNAL_TOKEN: LOOKUP_TOKEN });
+  mockQueue.current.push([]);
+  const ok = await fetchRoute(
+    req("/api/v1/internal/keys/usage", {
+      method: "POST",
+      headers: { "x-api-key-lookup-token": LOOKUP_TOKEN },
+      body: { account_id: 1, route: "mcp", account_kind: "github" },
+    }),
+    env,
+  );
+  assert.equal(ok.status, 200);
+  const call = sqlCalls.find((c) => /api_key_usage_daily/.test(c.text));
+  assert.ok(call, "issued the upsert");
+  assert.ok(
+    /ON CONFLICT \(account_kind, account_id, day, route\)/.test(call!.text),
+  );
+  assert.ok(
+    call!.values.includes("github"),
+    "the kind travelled into the statement",
+  );
+
+  sqlCalls.length = 0;
+  const bad = await fetchRoute(
+    req("/api/v1/internal/keys/usage", {
+      method: "POST",
+      headers: { "x-api-key-lookup-token": LOOKUP_TOKEN },
+      body: { account_id: 1, route: "mcp", account_kind: "stripe" },
+    }),
+    env,
+  );
+  assert.equal(bad.status, 400);
+  assert.equal(sqlCalls.length, 0, "an unknown kind never reaches the store");
+});
+
+test("quota: an explicit account_kind is spent against its own row; an unknown one is a 400", async () => {
+  const env = baseEnv({ API_KEY_LOOKUP_INTERNAL_TOKEN: LOOKUP_TOKEN });
+  mockQueue.current.push([{ units_spent: 25 }]);
+  const ok = await fetchRoute(
+    quotaReq({
+      account_id: 7,
+      cost: 25,
+      limit: 1000,
+      account_kind: "github",
+    }),
+    env,
+  );
+  assert.equal(ok.status, 200);
+  const call = sqlCalls.find((c) => /api_quota_daily/.test(c.text));
+  assert.ok(call?.values.includes("github"), "scoped to the github id space");
+
+  sqlCalls.length = 0;
+  const bad = await fetchRoute(
+    quotaReq({ account_id: 7, cost: 25, limit: 1000, account_kind: "nope" }),
+    env,
+  );
+  assert.equal(bad.status, 400);
+  assert.equal(sqlCalls.length, 0);
+});
+
+test("block/unblock: account_kind is carried, and an unknown one is a 400", async () => {
+  const env = blockEnv();
+  mockQueue.current.push([{ id: 1 }], []);
+  const blocked = await fetchRoute(
+    blockReq("/api/v1/internal/keys/block", {
+      account_id: 7,
+      reason_code: "abuse_manual",
+      account_kind: "github",
+    }),
+    env,
+  );
+  assert.equal(blocked.status, 200);
+  assert.equal(((await blocked.json()) as Row).account_kind, "github");
+
+  sqlCalls.length = 0;
+  const badBlock = await fetchRoute(
+    blockReq("/api/v1/internal/keys/block", {
+      account_id: 7,
+      reason_code: "abuse_manual",
+      account_kind: "stripe",
+    }),
+    env,
+  );
+  assert.equal(badBlock.status, 400);
+  assert.equal(sqlCalls.length, 0);
+
+  sqlCalls.length = 0;
+  mockQueue.current.push([{ id: 1 }], []);
+  const unblocked = await fetchRoute(
+    blockReq("/api/v1/internal/keys/unblock", {
+      account_id: 7,
+      note: "false positive",
+      account_kind: "github",
+    }),
+    env,
+  );
+  assert.equal(unblocked.status, 200);
+  const upd = sqlCalls.find((c) => /UPDATE api_key_blocks/.test(c.text));
+  assert.ok(upd?.values.includes("github"), "scoped the unblock by kind");
+
+  sqlCalls.length = 0;
+  const badUnblock = await fetchRoute(
+    blockReq("/api/v1/internal/keys/unblock", {
+      account_id: 7,
+      note: "x",
+      account_kind: "stripe",
+    }),
+    env,
+  );
+  assert.equal(badUnblock.status, 400);
+  assert.equal(sqlCalls.length, 0);
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ACCOUNT_KIND, type AccountKind } from "../src/account-kind.ts";
 import { economicsFieldSources } from "../src/economics-field-sources.ts";
 import {
   CHAIN_CONCENTRATION_DAILY_TABLE,
@@ -1052,6 +1053,11 @@ export function recordApiKeyUsage(
   // request_count, so the tenant dashboard can show "you were throttled N
   // times" without those attempts inflating the usage they are billed against.
   rejected = false,
+  // #11573: WHICH identity system `accountId` belongs to. Defaulted so every
+  // existing caller keeps its exact meaning -- each one passes an
+  // `rpc_accounts` id -- while an OAuth caller can say so and stop having its
+  // usage filed against the rpc account of the same number.
+  accountKind: AccountKind = DEFAULT_ACCOUNT_KIND,
 ): void {
   if (!env.DATA_API?.fetch || !env.API_KEY_LOOKUP_INTERNAL_TOKEN) return;
   const pending = env.DATA_API.fetch(
@@ -1063,6 +1069,7 @@ export function recordApiKeyUsage(
       },
       body: JSON.stringify({
         account_id: Number(accountId),
+        account_kind: accountKind,
         route,
         rejected,
       }),

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -17,6 +17,7 @@
 // TAO/USD index cron. Routes whose store is gone still answer exactly what
 // they answered before the deletion -- see dispatchDataApiRequest's own note
 // for why that matters to the forward gate.
+import { DEFAULT_ACCOUNT_KIND, asAccountKind } from "../src/account-kind.ts";
 import {
   accountBalanceSyncRowSchema,
   accountIdentitySyncRowSchema,
@@ -5252,6 +5253,65 @@ async function handleGithubAccountUpsert(
   });
 }
 
+// The CURRENT tier of a GitHub OAuth account, by account id (#11562).
+//
+// WHY A ROUTE AND NOT A CLAIM BAKED INTO THE OAUTH GRANT. `props` is minted
+// once by completeAuthorization and stored with the grant, so a tier carried
+// there would not move until the user re-consented -- and the first thing that
+// will ever change a tier is a subscription upgrade, which has to take effect
+// on the next request rather than the next login. The API-key path already has
+// the property this preserves, and src/api-tiers.ts states it: the tier is read
+// from the lookup on every request, so a server-side change lands WITHOUT
+// re-issuing the credential, bounded only by the cache TTL in front of it.
+//
+// Same internal-token gate as handleGithubAccountUpsert above, for the same
+// reason -- the only caller is our own Worker over the DATA_API service
+// binding, and it already reads this secret.
+async function handleGithubAccountTier(
+  request: Request,
+  env: DataApiEnv,
+  ctx: ExecutionContext,
+) {
+  const configured = env.API_KEY_LOOKUP_INTERNAL_TOKEN;
+  if (!configured) {
+    return writeJson(
+      { error: "github account lookup is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(API_KEY_LOOKUP_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return writeJson(
+      { error: `provide a valid ${API_KEY_LOOKUP_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  const { body, error } = await readAccountRouteBody(request);
+  if (error) return error;
+  // Number, not string: `id` is `integer`, and a non-numeric value must not
+  // reach the query as a coerced NaN. An absent or malformed id is answered
+  // `found: false` rather than 400 -- the caller's next move is identical
+  // either way (fall back to the anonymous ceiling), and a 400 would invite it
+  // to treat a shape problem as an outage.
+  // POSITIVE integer, not merely an integer: `Number(null)` is 0, which passes
+  // Number.isInteger and would reach the query as a real-looking id. Ids are
+  // identity-generated and start at 1, so 0 and negatives are never accounts.
+  const accountId = Number(body?.account_id);
+  if (!Number.isInteger(accountId) || accountId <= 0) {
+    return writeJson({ found: false });
+  }
+  return withAccountsSql(env, ctx, async (sql) => {
+    const [account] = await sql<{ tier: GithubAccounts["tier"] }>`
+      SELECT tier FROM github_accounts WHERE id = ${accountId} LIMIT 1`;
+    // A deleted or unknown account is `found: false`, NOT a default tier. The
+    // caller must not be able to mistake "we could not find you" for "you are
+    // on free" -- those differ the moment `free` stops being the bottom rung.
+    return account
+      ? writeJson({ found: true, tier: account.tier })
+      : writeJson({ found: false });
+  });
+}
+
 // Shared by every /api/v1/keys route: resolves the Authorization header to
 // { accountId, ss58 }, or a ready-to-return error response. A missing
 // WALLET_SESSION_SECRET is a deployment-config gap (503), distinct from a
@@ -5531,24 +5591,35 @@ async function handleApiKeyUsageIncrement(
   if (error) return error;
   const accountId = Number(body?.account_id);
   const route = typeof body?.route === "string" ? body.route.slice(0, 128) : "";
+  // #11573: WHICH identity system `account_id` belongs to. Absent means `rpc`,
+  // which is what every caller meant before the discriminator existed; an
+  // unrecognised value is rejected rather than defaulted, because silently
+  // filing a github id under `rpc` is the collision this column exists to end.
+  const accountKind =
+    body?.account_kind === undefined
+      ? DEFAULT_ACCOUNT_KIND
+      : asAccountKind(body.account_kind);
   // #8609: a REJECTED request increments rejected_count instead of
   // request_count. Only a literal true counts -- anything else is a success,
   // so a malformed flag can never silently erase real usage.
   const rejected = body?.rejected === true;
-  if (!Number.isFinite(accountId) || !route) {
-    return writeJson({ error: "provide account_id and route" }, 400);
+  if (!Number.isFinite(accountId) || !route || accountKind === null) {
+    return writeJson(
+      { error: "provide account_id, route and a known account_kind" },
+      400,
+    );
   }
   try {
     await withAccountsSql(env, ctx, async (sql) => {
       const day = new Date().toISOString().slice(0, 10);
       await sql<never>`
         INSERT INTO api_key_usage_daily
-          (account_id, day, route, request_count, rejected_count)
+          (account_kind, account_id, day, route, request_count, rejected_count)
         VALUES (
-          ${accountId}, ${day}, ${route},
+          ${accountKind}, ${accountId}, ${day}, ${route},
           ${rejected ? 0 : 1}, ${rejected ? 1 : 0}
         )
-        ON CONFLICT (account_id, day, route)
+        ON CONFLICT (account_kind, account_id, day, route)
         DO UPDATE SET
           request_count =
             api_key_usage_daily.request_count + EXCLUDED.request_count,
@@ -5597,15 +5668,26 @@ async function handleApiQuotaSpend(
   const accountId = Number(body.account_id);
   const cost = Number(body.cost);
   const limit = Number(body.limit);
+  // #11573: see handleApiKeyUsageIncrement -- absent means `rpc`, unrecognised
+  // is a 400. A quota row is a bill; filing one under the wrong identity system
+  // debits someone else.
+  const accountKind =
+    body.account_kind === undefined
+      ? DEFAULT_ACCOUNT_KIND
+      : asAccountKind(body.account_kind);
   if (
     !Number.isInteger(accountId) ||
     accountId <= 0 ||
     !Number.isFinite(cost) ||
     cost < 0 ||
     !Number.isFinite(limit) ||
-    limit <= 0
+    limit <= 0 ||
+    accountKind === null
   ) {
-    return writeJson({ error: "provide account_id, cost and limit" }, 400);
+    return writeJson(
+      { error: "provide account_id, cost, limit and a known account_kind" },
+      400,
+    );
   }
 
   const now = Date.now();
@@ -5631,9 +5713,10 @@ async function handleApiQuotaSpend(
     // enforcement is still the single guarded statement, only the 429's
     // advisory `spent` readout could in principle race a concurrent spend.)
     const attempt = await sql<{ units_spent: ApiQuotaDaily["units_spent"] }>`
-      INSERT INTO api_quota_daily (account_id, day, units_spent, updated_at)
-      VALUES (${accountId}, ${day}, ${cost}, ${now})
-      ON CONFLICT (account_id, day) DO UPDATE
+      INSERT INTO api_quota_daily
+        (account_kind, account_id, day, units_spent, updated_at)
+      VALUES (${accountKind}, ${accountId}, ${day}, ${cost}, ${now})
+      ON CONFLICT (account_kind, account_id, day) DO UPDATE
         SET units_spent = api_quota_daily.units_spent + EXCLUDED.units_spent,
             updated_at = ${now}
         WHERE api_quota_daily.units_spent + EXCLUDED.units_spent <= ${limit}
@@ -5644,7 +5727,9 @@ async function handleApiQuotaSpend(
     }
     const [current] = await sql<{ units_spent: ApiQuotaDaily["units_spent"] }>`
       SELECT units_spent FROM api_quota_daily
-      WHERE account_id = ${accountId} AND day = ${day}`;
+      WHERE account_kind = ${accountKind}
+        AND account_id = ${accountId}
+        AND day = ${day}`;
     return applyQuotaSpend(Number(current?.units_spent ?? 0), cost, limit, now);
   });
   return result instanceof Response ? result : writeJson(result);
@@ -5905,14 +5990,15 @@ const API_KEY_BLOCK_TOKEN_HEADER = "x-api-key-block-token";
  */
 async function refreshBlocklistSnapshot(env: DataApiEnv, sql: PgSql) {
   const rows = await sql<{
+    account_kind: string;
     account_id: ApiKeyBlocks["account_id"];
     reason_code: ApiKeyBlocks["reason_code"];
     blocked_at: ApiKeyBlocks["blocked_at"];
   }>`
-    SELECT account_id, reason_code, blocked_at
+    SELECT account_kind, account_id, reason_code, blocked_at
     FROM api_key_blocks
     WHERE unblocked_at IS NULL
-    ORDER BY account_id`;
+    ORDER BY account_kind, account_id`;
   const snapshot = {
     generated_at: new Date().toISOString(),
     blocks: rows.map((row) => ({
@@ -5921,6 +6007,12 @@ async function refreshBlocklistSnapshot(env: DataApiEnv, sql: PgSql) {
       // already the right shape rather than relying on every reader to
       // remember (the #8607 trap).
       accountId: Number(row.account_id),
+      // #11573: WHICH identity system that id belongs to. Narrowed rather than
+      // passed through, so a value the database somehow holds outside the
+      // vocabulary cannot reach evaluateBlock as an unmatchable string and
+      // silently un-block someone. Falling back to `rpc` matches the column
+      // default and the compatibility reading on the consumer side.
+      accountKind: asAccountKind(row.account_kind) ?? DEFAULT_ACCOUNT_KIND,
       reasonCode: row.reason_code,
       blockedAt: Number(row.blocked_at),
     })),
@@ -5976,8 +6068,19 @@ async function handleApiKeyBlock(
   if (error) return error;
   const accountId = Number(body?.account_id);
   const reasonCode = body?.reason_code;
-  if (!Number.isInteger(accountId) || accountId <= 0) {
-    return writeJson({ error: "provide a valid account_id" }, 400);
+  // #11573: a block is scoped to (kind, id). Absent means `rpc`, which is what
+  // every block written before the discriminator meant; an unrecognised value
+  // is refused rather than defaulted, because blocking the wrong identity
+  // system cuts off an unrelated account entirely.
+  const accountKind =
+    body?.account_kind === undefined
+      ? DEFAULT_ACCOUNT_KIND
+      : asAccountKind(body.account_kind);
+  if (!Number.isInteger(accountId) || accountId <= 0 || accountKind === null) {
+    return writeJson(
+      { error: "provide a valid account_id and a known account_kind" },
+      400,
+    );
   }
   if (!isBlockReasonCode(reasonCode)) {
     return writeJson(
@@ -5998,12 +6101,16 @@ async function handleApiKeyBlock(
     // idempotent instead of 500ing.
     const [row] = await sql<{ id: ApiKeyBlocks["id"] }>`
       INSERT INTO api_key_blocks
-        (account_id, reason_code, note, blocked_at, blocked_by)
-      VALUES (${accountId}, ${reasonCode}, ${note}, ${Date.now()}, ${blockedBy})
+        (account_kind, account_id, reason_code, note, blocked_at, blocked_by)
+      VALUES (
+        ${accountKind}, ${accountId}, ${reasonCode}, ${note},
+        ${Date.now()}, ${blockedBy}
+      )
       ON CONFLICT DO NOTHING
       RETURNING id`;
     const active = await refreshBlocklistSnapshot(env, sql);
     return writeJson({
+      account_kind: accountKind,
       account_id: accountId,
       reason_code: reasonCode,
       already_blocked: !row,
@@ -6026,8 +6133,17 @@ async function handleApiKeyUnblock(
   const { body, error } = await readAccountRouteBody(request);
   if (error) return error;
   const accountId = Number(body?.account_id);
-  if (!Number.isInteger(accountId) || accountId <= 0) {
-    return writeJson({ error: "provide a valid account_id" }, 400);
+  // #11573: must name the same (kind, id) the block was written against, or an
+  // unblock silently matches nothing and the caller is told it worked.
+  const accountKind =
+    body?.account_kind === undefined
+      ? DEFAULT_ACCOUNT_KIND
+      : asAccountKind(body.account_kind);
+  if (!Number.isInteger(accountId) || accountId <= 0 || accountKind === null) {
+    return writeJson(
+      { error: "provide a valid account_id and a known account_kind" },
+      400,
+    );
   }
   // Required, not optional. An unblock with no stated reason is how a
   // false-positive review becomes unauditable a month later.
@@ -6042,7 +6158,9 @@ async function handleApiKeyUnblock(
     const [row] = await sql<{ id: ApiKeyBlocks["id"] }>`
       UPDATE api_key_blocks
       SET unblocked_at = ${Date.now()}, unblocked_note = ${note.slice(0, 2000)}
-      WHERE account_id = ${accountId} AND unblocked_at IS NULL
+      WHERE account_kind = ${accountKind}
+        AND account_id = ${accountId}
+        AND unblocked_at IS NULL
       RETURNING id`;
     const active = await refreshBlocklistSnapshot(env, sql);
     return writeJson({
@@ -8695,6 +8813,12 @@ async function dispatchDataApiRequest(
       url.pathname === "/api/v1/auth/github/upsert-account"
     ) {
       return handleGithubAccountUpsert(request, env, ctx);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/accounts/github/tier"
+    ) {
+      return handleGithubAccountTier(request, env, ctx);
     }
     if (url.pathname.startsWith("/api/v1/keys")) {
       return handleAccountKeysRoute(request, env, ctx, url);

--- a/workers/tiered-rate-limit.ts
+++ b/workers/tiered-rate-limit.ts
@@ -22,6 +22,7 @@ import {
 } from "../src/api-key-validation.ts";
 import { routeCost } from "../src/route-cost-weights.ts";
 import { evaluateBlock, type BlockVerdict } from "../src/api-key-abuse.ts";
+import { DEFAULT_ACCOUNT_KIND, type AccountKind } from "../src/account-kind.ts";
 import { recordOrNull } from "../src/read-store.ts";
 import { QuotaSpendResponseSchema } from "../schemas-src/internal-wire.ts";
 
@@ -125,10 +126,23 @@ export interface TieredRateLimitResult {
    * to debit the cost-weighted quota once it knows what the request costs.
    * Only a multiplexed transport needs this -- see the `deferQuota` option.
    */
-  quotaPending?: { accountId: string; dailyUnits: number };
+  quotaPending?: {
+    accountId: string;
+    accountKind: AccountKind;
+    dailyUnits: number;
+  };
   /** The verified account id when a valid API key was supplied, else null
    * (anonymous, IP-keyed). */
   accountId: string | null;
+  /**
+   * WHICH identity system `accountId` belongs to (#11573).
+   *
+   * Always set, even when `accountId` is null, so a consumer never has to
+   * infer it. `rpc_accounts` and `github_accounts` are separate sequences in
+   * the same numeric range, so an id without a kind is not an identity -- see
+   * src/account-kind.ts.
+   */
+  accountKind: AccountKind;
   /**
    * Set when the account is on the #8611 blocklist. Present ONLY on a rejection
    * -- an allowed request carries no block, so a caller cannot tell from a 200
@@ -160,16 +174,17 @@ export const BLOCKLIST_KV_KEY = "api-key-blocklist";
 async function loadBlockVerdict(
   env: Env,
   accountId: unknown,
+  accountKind: AccountKind,
 ): Promise<BlockVerdict> {
   const kv = env.METAGRAPH_CONTROL;
-  if (!kv?.get) return evaluateBlock(null, accountId);
+  if (!kv?.get) return evaluateBlock(null, accountId, accountKind);
   try {
     const snapshot = (await kv.get(BLOCKLIST_KV_KEY, { type: "json" })) as {
       blocks?: unknown;
     } | null;
-    return evaluateBlock(snapshot, accountId);
+    return evaluateBlock(snapshot, accountId, accountKind);
   } catch {
-    return evaluateBlock(null, accountId);
+    return evaluateBlock(null, accountId, accountKind);
   }
 }
 
@@ -193,6 +208,7 @@ async function spendDailyQuota(
   request: Request,
   env: Env,
   accountId: string,
+  accountKind: AccountKind,
   dailyUnits: number,
   /** Explicit cost, when the pathname cannot price the work. See below. */
   costUnitsOverride?: number,
@@ -224,6 +240,9 @@ async function spendDailyQuota(
         },
         body: JSON.stringify({
           account_id: Number(accountId),
+          // #11573: the quota row is keyed on (kind, id). Without this an
+          // OAuth caller would debit the rpc account of the same number.
+          account_kind: accountKind,
           cost: weight,
           limit: dailyUnits,
         }),
@@ -267,8 +286,19 @@ export async function applyTieredRateLimit(
   {
     costUnits,
     deferQuota,
+    oauthIdentity,
   }: {
     costUnits?: number;
+    /**
+     * An ALREADY-VERIFIED OAuth caller and the tier resolved for them
+     * (#11562). Supplied by the surface that holds the OAuth context; this
+     * module never validates a token itself.
+     *
+     * Ranked BELOW a valid `mg_` key on purpose: a caller who sends a key is
+     * asserting that identity deliberately, which is the same precedence
+     * `mcpDistinctId` applies when both are present.
+     */
+    oauthIdentity?: { accountId: number; tier: string } | null;
     /**
      * Skip the daily-quota spend and hand back `quotaPending` instead.
      *
@@ -286,8 +316,44 @@ export async function applyTieredRateLimit(
     ? await validateApiKey(env, authHeader)
     : { ok: false as const };
 
-  if (auth.ok) {
-    const tier = typeof auth.tier === "string" && auth.tier ? auth.tier : null;
+  // #11573: ONE identity, from either system, so the blocklist, the per-minute
+  // ceiling and the daily quota all apply to an OAuth caller exactly as they do
+  // to a key holder. The alternative -- a second branch that took only the
+  // ceiling -- would ship a tier that is two-thirds enforced, and would have to
+  // be undone the moment billing attaches.
+  //
+  // A KEY OUTRANKS AN OAUTH TOKEN: a caller presenting a key is asserting that
+  // identity deliberately, which is the precedence `mcpDistinctId` already
+  // applies when both are present.
+  const identity = auth.ok
+    ? {
+        // `String()` unconditionally turned a null account id into the LITERAL
+        // "null" -- a single fabricated tenant that every identity-less key
+        // shared. verifyUnkeyKey returns `accountId: identity?.externalId ??
+        // null` while `valid` stays true, so any key minted without an Unkey
+        // identity landed there. Downstream that string is an identity:
+        // resolveSurfaceCredentialIdentity accepts it and returns
+        // `account:null`, so one holder could list, delete, and use another's
+        // stored surface credentials. It also collapsed them into one
+        // rate-limit bucket and one quota row, and `Number("null")` is NaN.
+        //
+        // Every consumer of this field already guards with
+        // `if (rateLimit.accountId)` and the declared type is `string | null`,
+        // so a real null is what they were written for.
+        accountId: auth.accountId == null ? null : String(auth.accountId),
+        accountKind: DEFAULT_ACCOUNT_KIND,
+        tier: typeof auth.tier === "string" && auth.tier ? auth.tier : null,
+      }
+    : oauthIdentity
+      ? {
+          accountId: String(oauthIdentity.accountId),
+          accountKind: "github" as const,
+          tier: oauthIdentity.tier,
+        }
+      : null;
+
+  if (identity) {
+    const { accountId, accountKind, tier } = identity;
     // Own-property lookup ONLY. `config.tiers?.[tier]` walks the prototype
     // chain, and `tier` comes from the key-validation response -- an account on
     // a tier literally named "constructor", "toString", "valueOf" or
@@ -301,23 +367,11 @@ export async function applyTieredRateLimit(
         ? (config.tiers as Record<string, RateLimitTierPolicy>)[tier]
         : config.keyed;
     const limiter = rateLimiterBinding(env, policy.envVar);
-    // `String()` unconditionally turned a null account id into the LITERAL
-    // "null" -- a single fabricated tenant that every identity-less key shared.
-    // verifyUnkeyKey returns `accountId: identity?.externalId ?? null` while
-    // `valid` stays true, so any key minted without an Unkey identity landed
-    // there. Downstream that string is an identity: resolveSurfaceCredentialIdentity
-    // accepts it and returns `account:null`, so one holder could list, delete,
-    // and use another's stored surface credentials. It also collapsed them into
-    // one rate-limit bucket and one quota row, and `Number("null")` is NaN.
-    //
-    // Every consumer of this field already guards with `if (rateLimit.accountId)`
-    // and the declared type is `string | null`, so a real null is what they were
-    // written for.
-    const accountId = auth.accountId == null ? null : String(auth.accountId);
     const result = {
       policy,
       tier: tier ?? "keyed",
       accountId,
+      accountKind,
     };
     // #8611: the blocklist comes BEFORE any ceiling. A blocked caller is not
     // "going too fast", and spending their daily quota on requests we are about
@@ -331,7 +385,7 @@ export async function applyTieredRateLimit(
     // for up to half an hour after someone hit block. The blocklist is its own
     // small snapshot on a short TTL instead, so a block lands within one
     // BLOCKLIST_KV_TTL rather than one identity-cache lifetime.
-    const block = await loadBlockVerdict(env, accountId);
+    const block = await loadBlockVerdict(env, accountId, accountKind);
     if (block.blocked) {
       return { allowed: false, ...result, block };
     }
@@ -352,8 +406,16 @@ export async function applyTieredRateLimit(
       // literal: it still gets its tier's ceiling (it does hold a valid key),
       // but it can never share a bucket with an unrelated caller.
       const { success } = await limiter.limit({
+        // #11573: the id alone is not an identity -- `github_accounts.id` and
+        // `rpc_accounts.id` are separate sequences in the same range, so the
+        // kind is part of the bucket. `rpc` keeps its historical key shape so
+        // no existing caller's window is reset by this change.
         key: `${config.keyPrefix}:${result.tier}:${
-          accountId ?? `ip:${resolveClientIp(request)}`
+          accountId
+            ? accountKind === DEFAULT_ACCOUNT_KIND
+              ? accountId
+              : `${accountKind}:${accountId}`
+            : `ip:${resolveClientIp(request)}`
         }`,
       });
       if (!success) return { allowed: false, ...result };
@@ -365,7 +427,7 @@ export async function applyTieredRateLimit(
     // honest option: the per-minute ceiling above still bounds the caller.
     if (policy.dailyUnits && accountId !== null && deferQuota) {
       Object.assign(result, {
-        quotaPending: { accountId, dailyUnits: policy.dailyUnits },
+        quotaPending: { accountId, accountKind, dailyUnits: policy.dailyUnits },
       });
       return { allowed: true, ...result };
     }
@@ -374,6 +436,7 @@ export async function applyTieredRateLimit(
         request,
         env,
         accountId,
+        accountKind,
         policy.dailyUnits,
         costUnits,
       );
@@ -387,13 +450,20 @@ export async function applyTieredRateLimit(
 
   const policy = config.anonymous;
   const limiter = rateLimiterBinding(env, policy.envVar);
-  if (!limiter?.limit) {
-    return { allowed: true, policy, tier: "anonymous", accountId: null };
-  }
+  // No identity at all. `accountKind` is still reported rather than left
+  // undefined -- a consumer must never have to distinguish "anonymous" from
+  // "we forgot to say", and `accountId: null` already carries the absence.
+  const anonymous = {
+    policy,
+    tier: "anonymous",
+    accountId: null,
+    accountKind: DEFAULT_ACCOUNT_KIND,
+  };
+  if (!limiter?.limit) return { allowed: true, ...anonymous };
   const { success } = await limiter.limit({
     key: `${config.keyPrefix}:${resolveClientIp(request)}`,
   });
-  return { allowed: success, policy, tier: "anonymous", accountId: null };
+  return { allowed: success, ...anonymous };
 }
 
 /**
@@ -513,7 +583,7 @@ export function tieredRateLimitHeaders(
 export async function spendDeferredDailyQuota(
   request: Request,
   env: Env,
-  pending: { accountId: string; dailyUnits: number },
+  pending: { accountId: string; accountKind: AccountKind; dailyUnits: number },
   costUnits: number,
   // Nullable, because it forwards a nullable result -- see spendDailyQuota.
 ): Promise<(TieredRateLimitResult["quota"] & { allowed: boolean }) | null> {
@@ -521,6 +591,7 @@ export async function spendDeferredDailyQuota(
     request,
     env,
     pending.accountId,
+    pending.accountKind,
     pending.dailyUnits,
     costUnits,
   );


### PR DESCRIPTION
Five people completed the GitHub OAuth flow. All **460 of their tool calls were measured, rate-limited and priced as `anonymous`** — because tier resolved from one thing only: a valid `mg_` key. An OAuth access token our own provider issues is not one, so authenticating bought nothing.

`api_keys` is empty, so the only path that *could* grant a tier had never been walked either. The whole ladder in `src/api-tiers.ts` — three tiers, six rate-limit bindings, cost weights, daily quotas — has never had a single row of input.

Wiring the tier through surfaced a second defect underneath it. `api_quota_daily`, `api_key_usage_daily` and `api_key_blocks` each key on a bare `integer` account_id with **no foreign key**. Those integers are `rpc_accounts` ids, but nothing in the database said so, and `github_accounts` mints its own in the same range. A github account and an rpc account of the same number would share a quota row, a blocklist entry and a usage row.

Both land here, because either alone is incoherent: a tier that cannot be metered is not a tier, and a discriminator with nothing to discriminate is dead weight.

## The schema (#11573)

`account_kind` on all three tables, defaulting to `'rpc'` — correct for every existing row — with a `CHECK` constraining the vocabulary and every key repointed to lead with it, including the one-active-block-per-account partial unique index.

**All three tables are empty today**, so this costs no backfill. Doing it after billing attaches would mean migrating live financial data.

Verified against a throwaway Neon branch rather than production (`neon-migrate.yml` applies on merge; hand-applying would desync `schema_migrations`):

- 17 statements apply cleanly
- `rpc/5` and `github/5` then hold **independent** quota (100 vs 7 units) and independent active blocks
- all three guards still fire — primary key, one-active-block, and the vocabulary `CHECK`

## The tier (#11562)

Resolved **at request time** from `props.accountId`, KV-cache-fronted — not baked into the OAuth grant. `props` is minted once by `completeAuthorization` and stored with the grant, so a tier carried there would not move until the user re-consented, and the first thing that will ever change a tier is a subscription upgrade. This preserves the property `src/api-tiers.ts` already states for keys: a server-side tier change takes effect without re-issuing the credential.

The cache TTL is **five minutes, not the key cache's thirty**, because this TTL *is* the upgrade latency — key revocation has the blocklist as a faster second path, and a tier change has nothing equivalent.

A valid key still outranks an OAuth token, matching the precedence `mcpDistinctId` already applies. Both identity systems now share **one** path, so an OAuth caller gets the blocklist, the per-minute ceiling *and* the daily quota. An earlier shape that took only the ceiling would have shipped a tier that is two-thirds enforced and would have had to be undone the moment billing attaches.

`rpc` keeps its historical limiter-key shape, so no existing caller's window is reset. Anonymous is untouched at today's ceiling — this grants a tier to authenticated callers, it takes nothing from anyone.

## Incidental

The new tier-lookup route guarded on `Number.isInteger` alone, and `Number(null)` is `0` — a falsy-but-integral id that would have reached the query looking like a real account. Tightened to a positive integer, matching `oauthAccountIdFrom`. Caught by its own test.

## Verification

- **Patch coverage 100%** — 75/75 lines, 110/110 branches, measured by diff intersection against an unsharded `test:coverage` run
- 2,182 tests across the 12 affected suites
- All 70 `validate:*` scripts in the CI workflow
- `tsc --noEmit` clean, prettier clean, eslint clean
- `evaluateBlock` now matches on kind **and** id, with tests proving a block on one kind does not block the other, and that a snapshot entry predating the discriminator is read as `rpc` rather than as a wildcard

## Not in scope

`db/schema.sql` and the generated db types are **not** regenerated here. `refresh-neon-schema.yml` does that weekly, out of band, against the live branch, in a PR a human reviews — deliberately not auto-merged. `validate:db-types-drift` only proves internal consistency between the snapshot and the generated types, so a new migration cannot fail it.

Part of #11561.

Closes #11562
Closes #11573
