### PR TITLE
fix(mcp): challenge unauthenticated protected calls with a 401, and stop auth.md contradicting the server

### DIFF
--- a/public/.well-known/auth.md
+++ b/public/.well-known/auth.md
@@ -4,8 +4,11 @@ The metagraphed API at `api.metagraph.sh` is **public by default and
 read-only**. No authentication is _required_ for any endpoint — every tool and
 route is callable anonymously.
 
-Authentication is **optional and additive**: it raises rate limits. It does not
-currently unlock additional endpoints, tools, or data.
+Authentication is **optional and additive**. It raises rate limits, and it
+unlocks depth. History windows longer than 90 days need a
+paid tier, and a small number of tools need an identity at all (see below). Every
+tool stays listed and callable at every tier — what a tier buys is how far back
+you may read, not what you may see.
 
 - Auth scheme: none required; `Authorization: Bearer` accepted
 - Registration: not required, but self-serve keys are available
@@ -27,8 +30,27 @@ authorization with no manual configuration:
   https://api.metagraph.sh/.well-known/oauth-authorization-server
 
 A Bearer token that cannot be validated gets `401` with a
-`WWW-Authenticate` challenge pointing at the metadata above. **An anonymous
-request is not challenged** — it is served.
+`WWW-Authenticate` challenge pointing at the metadata above.
+
+An anonymous request is **served, not challenged** — with one exception. Calling
+a tool that needs an identity returns `401` with the same challenge, so a
+spec-compliant client can offer to sign in and retry. Those tools are:
+
+- `delete_surface_credential`
+- `list_surface_credentials`
+- `store_surface_credential`
+
+They bind a stored secret to an account, which an anonymous request has none of.
+
+## What a tier buys
+
+- **Depth.** Windows up to 90 days are open to every caller.
+  Longer windows answer `payment_required`, naming the tier that clears them and
+  where to get one.
+- **Rate.** See below.
+- **Identity.** The credential store above.
+
+Nothing is hidden from an anonymous caller: a refused call says what it needs.
 
 ## Rate limits
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -4,8 +4,11 @@ The metagraphed API at `api.metagraph.sh` is **public by default and
 read-only**. No authentication is _required_ for any endpoint — every tool and
 route is callable anonymously.
 
-Authentication is **optional and additive**: it raises rate limits. It does not
-currently unlock additional endpoints, tools, or data.
+Authentication is **optional and additive**. It raises rate limits, and it
+unlocks depth. History windows longer than 90 days need a
+paid tier, and a small number of tools need an identity at all (see below). Every
+tool stays listed and callable at every tier — what a tier buys is how far back
+you may read, not what you may see.
 
 - Auth scheme: none required; `Authorization: Bearer` accepted
 - Registration: not required, but self-serve keys are available
@@ -27,8 +30,27 @@ authorization with no manual configuration:
   https://api.metagraph.sh/.well-known/oauth-authorization-server
 
 A Bearer token that cannot be validated gets `401` with a
-`WWW-Authenticate` challenge pointing at the metadata above. **An anonymous
-request is not challenged** — it is served.
+`WWW-Authenticate` challenge pointing at the metadata above.
+
+An anonymous request is **served, not challenged** — with one exception. Calling
+a tool that needs an identity returns `401` with the same challenge, so a
+spec-compliant client can offer to sign in and retry. Those tools are:
+
+- `delete_surface_credential`
+- `list_surface_credentials`
+- `store_surface_credential`
+
+They bind a stored secret to an account, which an anonymous request has none of.
+
+## What a tier buys
+
+- **Depth.** Windows up to 90 days are open to every caller.
+  Longer windows answer `payment_required`, naming the tier that clears them and
+  where to get one.
+- **Rate.** See below.
+- **Identity.** The credential store above.
+
+Nothing is hidden from an anonymous caller: a refused call says what it needs.
 
 ## Rate limits
 

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -1,3 +1,5 @@
+import { AUTH_REQUIRED_TOOL_NAMES } from "../src/mcp-server.ts";
+import { FREE_HISTORY_WINDOW_DAYS } from "../src/mcp-tier-gate.ts";
 import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
@@ -2597,14 +2599,27 @@ await fs.writeFile(
 // vague: an integrator reading this would conclude there is no way to raise
 // their rate limit, and an OAuth-aware MCP client author would conclude there
 // is nothing to discover. Both are the opposite of the truth.
+// #11566: the two facts below are DERIVED, not restated. auth.md is the document
+// an agent reads to decide whether authenticating is worth it, and it spent a
+// release telling them it unlocked nothing -- written before the depth gate
+// (#11179 phase 3) and never revisited. A number or a tool name copied into
+// prose here drifts silently the next time the code moves.
+const AUTH_REQUIRED_TOOL_LIST = [...AUTH_REQUIRED_TOOL_NAMES]
+  .sort()
+  .map((name) => `- \`${name}\``)
+  .join("\n");
+
 const authMarkdown = `# Authentication
 
 The metagraphed API at \`${PRIMARY_DOMAIN}\` is **public by default and
 read-only**. No authentication is _required_ for any endpoint — every tool and
 route is callable anonymously.
 
-Authentication is **optional and additive**: it raises rate limits. It does not
-currently unlock additional endpoints, tools, or data.
+Authentication is **optional and additive**. It raises rate limits, and it
+unlocks depth. History windows longer than ${FREE_HISTORY_WINDOW_DAYS} days need a
+paid tier, and a small number of tools need an identity at all (see below). Every
+tool stays listed and callable at every tier — what a tier buys is how far back
+you may read, not what you may see.
 
 - Auth scheme: none required; \`Authorization: Bearer\` accepted
 - Registration: not required, but self-serve keys are available
@@ -2626,8 +2641,25 @@ authorization with no manual configuration:
   ${llmsApiBase}/.well-known/oauth-authorization-server
 
 A Bearer token that cannot be validated gets \`401\` with a
-\`WWW-Authenticate\` challenge pointing at the metadata above. **An anonymous
-request is not challenged** — it is served.
+\`WWW-Authenticate\` challenge pointing at the metadata above.
+
+An anonymous request is **served, not challenged** — with one exception. Calling
+a tool that needs an identity returns \`401\` with the same challenge, so a
+spec-compliant client can offer to sign in and retry. Those tools are:
+
+${AUTH_REQUIRED_TOOL_LIST}
+
+They bind a stored secret to an account, which an anonymous request has none of.
+
+## What a tier buys
+
+- **Depth.** Windows up to ${FREE_HISTORY_WINDOW_DAYS} days are open to every caller.
+  Longer windows answer \`payment_required\`, naming the tier that clears them and
+  where to get one.
+- **Rate.** See below.
+- **Identity.** The credential store above.
+
+Nothing is hidden from an anonymous caller: a refused call says what it needs.
 
 ## Rate limits
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18616,6 +18616,87 @@ export async function handleMcpRequest(
   return response;
 }
 
+/**
+ * The tools named in this body that require an identity, if any (#11563).
+ *
+ * Reads the PARSED body rather than re-deriving from the SDK, because the
+ * refusal has to happen before the SDK sees the message at all -- see
+ * mcpAuthChallenge for why.
+ *
+ * Handles the legacy array batch for the same reason the batch ceiling does:
+ * one HTTP request can carry many calls, and a protected one hidden among
+ * public ones must still challenge.
+ */
+export function authRequiredToolsIn(body: unknown): string[] {
+  const messages = Array.isArray(body) ? body : [body];
+  const names: string[] = [];
+  for (const message of messages) {
+    const row = rowOf(message);
+    if (row?.method !== "tools/call") continue;
+    const name = rowOf(row.params)?.name;
+    if (typeof name === "string" && AUTH_REQUIRED_TOOL_NAMES.has(name)) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+/**
+ * The 401 that makes an MCP client offer to sign in (#11563).
+ *
+ * ## WHY A TRANSPORT-LEVEL 401 AND NOT A TOOL ERROR
+ *
+ * This used to be `toolError("auth_required", ...)`, which rides
+ * `structuredContent.error` inside an HTTP 200. The MCP authorization spec and
+ * Claude's own lazy-authentication guidance both say what that does: a 200
+ * carrying `isError: true` is an APPLICATION failure, so the client hands the
+ * text to the model and moves on. No sign-in is ever offered. Only a
+ * transport-level 401 makes a client pause the call, run the authorization
+ * flow, and retry the same request with a token.
+ *
+ * Measured consequence of the old shape: five accounts completed the GitHub
+ * flow unprompted and every other caller stayed anonymous, because nothing in
+ * the surface ever asked (#11562). The tier ladder was reachable only by
+ * someone who already knew it existed.
+ *
+ * ## WHY THE METADATA URL IS DERIVED FROM THE REQUEST
+ *
+ * RFC 9728 says the `resource` in the metadata document must match the server
+ * URL the caller actually used, and this server is mounted at more than one
+ * path (`/mcp` and the `/mcp/core` listing profile). Hard-coding `/mcp` would
+ * hand a `/mcp/core` caller a document describing a different resource, which
+ * a spec-compliant client is right to reject. The OAuth provider already
+ * serves a per-path document -- verified in production for both -- so deriving
+ * the pointer the same way keeps the two halves agreeing.
+ *
+ * `scope` is stated so the consent prompt asks for what the protected tools
+ * actually need, rather than everything the resource advertises.
+ */
+export function mcpAuthChallenge(request: Request, tools: string[]): Response {
+  const url = new URL(request.url);
+  const metadata = `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`;
+  return new Response(
+    JSON.stringify({
+      error: "invalid_token",
+      error_description:
+        `Authentication required for: ${tools.join(", ")}. ` +
+        "Sign in, or send an Authorization: Bearer header with an mg_ API key.",
+    }),
+    {
+      status: 401,
+      headers: {
+        ...MCP_HEADERS,
+        "www-authenticate":
+          `Bearer error="invalid_token", ` +
+          `error_description="Authentication required for this tool", ` +
+          `resource_metadata="${metadata}", ` +
+          `scope="profile"`,
+        [MCP_REFUSAL_HEADER]: "auth_required",
+      },
+    },
+  );
+}
+
 async function dispatchMcpRequest(
   request: Request,
   env: Env,
@@ -18653,6 +18734,31 @@ async function dispatchMcpRequest(
 
   const { value: body, error: bodyError } = await readLimitedMcpBody(request);
   if (bodyError) return bodyError;
+
+  // #11563: challenge BEFORE the SDK, and before the quota.
+  //
+  // Before the SDK, because once a tool handler is running its return value is
+  // already destined to be wrapped in a 200 -- the refusal has to be the HTTP
+  // status itself or no client will offer to sign in.
+  //
+  // Before the quota, for the reason the blocklist states one control up:
+  // debiting a caller for a request we are about to refuse would bill them for
+  // work never served, and would mask the challenge as a 429.
+  //
+  // `resolveSurfaceCredentialIdentity` is the SAME test the protected tools
+  // themselves apply, and it accepts either identity system -- a verified `mg_`
+  // key or an OAuth account on the execution context -- so the gate and the
+  // handlers can never disagree about who is authenticated.
+  const protectedTools = authRequiredToolsIn(body);
+  if (
+    protectedTools.length > 0 &&
+    resolveSurfaceCredentialIdentity({
+      accountId,
+      executionCtx: deps.executionCtx,
+    }) === null
+  ) {
+    return mcpAuthChallenge(request, protectedTools);
+  }
 
   // The cost-weighted quota is spent HERE, not in the gate above: only now do we
   // know which tools were asked for. This is what stops `tools/call {"ask"}`

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -1858,6 +1858,44 @@ describe("surface credential store (#9009)", () => {
     }
   }
 
+  /** The raw HTTP response, for the one assertion that is about the TRANSPORT
+   * rather than the tool result -- see the anonymous-refusal test below. */
+  async function statusAs(
+    accountId: number | null,
+    name: string,
+    args: Row,
+    env: Row,
+  ) {
+    const of = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      return await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: { name, arguments: args },
+          }),
+        }),
+        env as unknown as Env,
+        {
+          ...deps,
+          executionCtx:
+            accountId === null ? undefined : { props: { accountId } },
+        },
+      );
+    } finally {
+      globalThis.fetch = of;
+    }
+  }
+
   const errorCode = (result: Row) =>
     ((result.structuredContent as Row).error as Row).code;
 
@@ -2007,17 +2045,36 @@ describe("surface credential store (#9009)", () => {
     assert.match(called.content[0].text, /store_surface_credential/);
   });
 
-  test("the store tools refuse an anonymous caller", async () => {
+  test("the store tools refuse an anonymous caller, with a challenge a client can follow", async () => {
+    // #11563: the refusal is now the HTTP status, not a tool error inside a
+    // 200. That is the whole point -- a 200 carrying `isError` produces no
+    // sign-in prompt in any MCP client, so the old shape refused the call and
+    // left the caller with no way to fix it.
     const env = credentialEnv();
     for (const [name, args] of [
       ["store_surface_credential", { surface_id: "x:api:6", credential: "x" }],
       ["list_surface_credentials", {}],
       ["delete_surface_credential", { surface_id: "x:api:6" }],
     ] as [string, Row][]) {
-      const result = await callAs(null, name, args, env);
-      assert.equal(result.isError, true, `${name} must refuse`);
-      assert.equal(errorCode(result), "auth_required");
+      const response = await statusAs(null, name, args, env);
+      assert.equal(response.status, 401, `${name} must refuse`);
+      const challenge = response.headers.get("www-authenticate");
+      assert.ok(challenge, `${name} must carry a challenge`);
+      assert.match(challenge!, /resource_metadata=/);
+      assert.match(
+        String(((await response.json()) as Row).error_description),
+        new RegExp(name),
+      );
     }
+  });
+
+  test("an authenticated caller is not challenged", async () => {
+    // The positive control: without it the assertions above would also pass if
+    // the gate refused EVERY caller.
+    const env = credentialEnv();
+    const response = await statusAs(7, "list_surface_credentials", {}, env);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("www-authenticate"), null);
   });
 
   test("the store tools refuse an unprovisioned deployment", async () => {

--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -2,6 +2,8 @@
 // the Agent Skills discovery index (digest must match the shipped SKILL.md)
 // and the honest auth.md. The MCP server card (SEP-1649) is now worker-computed
 // and tested via mcpServerCardResponse rather than read from a committed file.
+import { AUTH_REQUIRED_TOOL_NAMES } from "../src/mcp-server.ts";
+import { FREE_HISTORY_WINDOW_DAYS } from "../src/mcp-tier-gate.ts";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
@@ -143,6 +145,36 @@ describe("Discovery artifacts", () => {
     assert.match(authMd, /optional and additive/i);
     assert.match(authMd, /oauth-protected-resource/i);
     assert.match(authMd, /Bearer mg_/);
+    // #11566: the two facts that were WRONG, now derived rather than restated.
+    //
+    // auth.md is what an agent reads to decide whether authenticating is worth
+    // it, and it spent a release saying it unlocked nothing -- written before
+    // the depth gate (#11179 phase 3) and never revisited. It also said an
+    // anonymous request "is not challenged", which the 401 gate (#11563) made
+    // false for the credential tools.
+    assert.doesNotMatch(
+      authMd,
+      /does not\s+currently unlock additional endpoints, tools, or data/i,
+      "the claim the depth gate falsified must not come back",
+    );
+    assert.doesNotMatch(
+      authMd,
+      /An anonymous\s+request is not challenged/i,
+      "the claim the 401 gate falsified must not come back",
+    );
+    // The free window is the CONSTANT the code enforces, not a number retyped
+    // into prose -- so the document cannot drift from the gate.
+    assert.match(
+      authMd,
+      new RegExp(`${FREE_HISTORY_WINDOW_DAYS} days`),
+      "auth.md must state the free depth the tier gate actually enforces",
+    );
+    // ...and every tool that really does need an identity is named, so an
+    // agent can tell which calls will challenge before it makes them.
+    for (const name of AUTH_REQUIRED_TOOL_NAMES) {
+      assert.match(authMd, new RegExp(`\`${name}\``), name);
+    }
+    assert.match(authMd, /401/, "the challenge is stated, not implied");
     // The old text's specific falsehoods must not come back.
     assert.doesNotMatch(authMd, /Auth scheme: none$/im);
     assert.doesNotMatch(authMd, /Protected resources: none/i);

--- a/tests/mcp-auth-challenge.test.ts
+++ b/tests/mcp-auth-challenge.test.ts
@@ -1,0 +1,180 @@
+// #11563: a protected tool called without an identity must fail the HTTP
+// REQUEST with 401, not return a tool error inside a 200.
+//
+// The MCP authorization spec and Claude's lazy-authentication guidance agree on
+// what the old shape did: a 200 carrying `isError: true` is an application
+// failure, so the client hands the text to the model and moves on -- no sign-in
+// is ever offered. Only a transport-level 401 makes a client pause, run the
+// authorization flow, and retry.
+//
+// The measured consequence of the old shape is why this exists: five accounts
+// completed the GitHub flow unprompted and everyone else stayed anonymous,
+// because nothing in the surface ever asked (#11562).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  AUTH_REQUIRED_TOOL_NAMES,
+  authRequiredToolsIn,
+  handleMcpRequest,
+  mcpAuthChallenge,
+} from "../src/mcp-server.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+
+const PROTECTED = "list_surface_credentials";
+const PUBLIC = "get_coverage";
+
+function env() {
+  return mockEnv({
+    MCP_RATE_LIMITER: { limit: async () => ({ success: true }) },
+    MCP_RATE_LIMITER_KEYED: { limit: async () => ({ success: true }) },
+  } as Row);
+}
+
+function rpc(name: string, id = 1) {
+  return { jsonrpc: "2.0", id, method: "tools/call", params: { name } };
+}
+
+function post(body: unknown, path = "/mcp") {
+  return new Request(`https://api.metagraph.sh${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** An OAuth-authenticated caller, the way the provider presents one. */
+const authed = { executionCtx: { waitUntil() {}, props: { accountId: 7 } } };
+
+describe("authRequiredToolsIn", () => {
+  test("names the protected tools in a single call", () => {
+    assert.deepEqual(authRequiredToolsIn(rpc(PROTECTED)), [PROTECTED]);
+  });
+
+  test("finds one hidden among public calls in a legacy batch", () => {
+    // A batch is one HTTP request, so a protected call buried in it must still
+    // challenge -- otherwise the gate is bypassed by adding a public sibling.
+    const batch = [rpc(PUBLIC, 1), rpc(PROTECTED, 2), rpc(PUBLIC, 3)];
+    assert.deepEqual(authRequiredToolsIn(batch), [PROTECTED]);
+  });
+
+  test("ignores everything that is not a protected tools/call", () => {
+    for (const body of [
+      rpc(PUBLIC),
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: {} },
+      { jsonrpc: "2.0", id: 1, method: "tools/call" },
+      {},
+      null,
+      [],
+      "not an object",
+    ]) {
+      assert.deepEqual(authRequiredToolsIn(body), [], JSON.stringify(body));
+    }
+  });
+
+  test("covers every declared protected tool, so the set cannot drift", () => {
+    for (const name of AUTH_REQUIRED_TOOL_NAMES) {
+      assert.deepEqual(authRequiredToolsIn(rpc(name)), [name], name);
+    }
+  });
+});
+
+describe("mcpAuthChallenge", () => {
+  test("is a 401 whose WWW-Authenticate points at this path's metadata", () => {
+    const res = mcpAuthChallenge(post(rpc(PROTECTED)), [PROTECTED]);
+    assert.equal(res.status, 401);
+    const header = res.headers.get("www-authenticate")!;
+    assert.match(header, /^Bearer /);
+    assert.match(header, /error="invalid_token"/);
+    assert.match(header, /scope="profile"/);
+    assert.match(
+      header,
+      /resource_metadata="https:\/\/api\.metagraph\.sh\/\.well-known\/oauth-protected-resource\/mcp"/,
+    );
+  });
+
+  test("the metadata pointer follows the mount path, not a hard-coded /mcp", () => {
+    // RFC 9728 requires the document's `resource` to match the URL the caller
+    // used, and this server is mounted at both /mcp and the /mcp/core listing
+    // profile. A hard-coded pointer would hand a core caller a document
+    // describing a different resource, which a client is right to reject.
+    const res = mcpAuthChallenge(post(rpc(PROTECTED), "/mcp/core"), [
+      PROTECTED,
+    ]);
+    assert.match(
+      res.headers.get("www-authenticate")!,
+      /oauth-protected-resource\/mcp\/core"/,
+    );
+  });
+
+  test("names the tools that need the identity", async () => {
+    const res = mcpAuthChallenge(post(rpc(PROTECTED)), [PROTECTED]);
+    const body = (await res.json()) as Row;
+    assert.equal(body.error, "invalid_token");
+    assert.match(String(body.error_description), new RegExp(PROTECTED));
+  });
+});
+
+describe("handleMcpRequest — the gate end to end", () => {
+  test("an anonymous protected call is a 401, NOT a 200 tool error", async () => {
+    const res = await handleMcpRequest(post(rpc(PROTECTED)), env(), {});
+    assert.equal(res.status, 401);
+    assert.ok(res.headers.get("www-authenticate"), "carries the challenge");
+    // The regression this pins: a 200 here produces no sign-in prompt at all.
+    assert.notEqual(res.status, 200);
+  });
+
+  test("an anonymous PUBLIC call is still served", async () => {
+    // The server stays "an OAuth 2.1 protected resource that permits anonymous
+    // access" (ADR 0027). This narrows the challenge to protected calls; it
+    // does not gate the surface.
+    const res = await handleMcpRequest(post(rpc(PUBLIC)), env(), {});
+    assert.equal(res.status, 200);
+  });
+
+  test("initialize and tools/list are never challenged", async () => {
+    for (const method of ["initialize", "tools/list"]) {
+      const res = await handleMcpRequest(
+        post({ jsonrpc: "2.0", id: 1, method, params: {} }),
+        env(),
+        {},
+      );
+      assert.equal(res.status, 200, method);
+    }
+  });
+
+  test("an authenticated caller reaches the tool", async () => {
+    const res = await handleMcpRequest(post(rpc(PROTECTED)), env(), authed);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("www-authenticate"), null);
+  });
+
+  test("a batch hiding a protected call is challenged as a whole", async () => {
+    // Stated behaviour, not incidental: the challenge is a property of the HTTP
+    // request, and a batch is one request. Serving the public siblings and
+    // failing only the protected one would put the refusal back inside a 200 --
+    // exactly the shape this issue removes.
+    const res = await handleMcpRequest(
+      post([rpc(PUBLIC, 1), rpc(PROTECTED, 2)]),
+      env(),
+      {},
+    );
+    assert.equal(res.status, 401);
+  });
+
+  test("the handler's own check survives as defence in depth", async () => {
+    // The gate is transport-level; the tool itself is still the authority. A
+    // future caller that reaches the handler another way must not be served,
+    // so the in-handler refusal is deliberately NOT removed.
+    const res = await handleMcpRequest(post(rpc(PROTECTED)), env(), {});
+    assert.equal(res.status, 401);
+    for (const name of AUTH_REQUIRED_TOOL_NAMES) {
+      const one = await handleMcpRequest(post(rpc(name)), env(), {});
+      assert.equal(one.status, 401, name);
+    }
+  });
+});

--- a/tests/mcp-schema-enforcement.test.ts
+++ b/tests/mcp-schema-enforcement.test.ts
@@ -35,7 +35,11 @@
 // `listToolDefinitions()`, so a tool registered tomorrow is covered tonight.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import {
+  AUTH_REQUIRED_TOOL_NAMES,
+  handleMcpRequest,
+  listToolDefinitions,
+} from "../src/mcp-server.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
@@ -60,7 +64,18 @@ async function errorCode(
       }),
     }),
     env,
-    {},
+    // #11563: a tool that needs an identity now gets a transport-level 401
+    // BEFORE argument validation runs. Probing those anonymously would report
+    // "silently accepted" for arguments that are in fact enforced -- a false
+    // negative that would quietly stop this gate checking three tools.
+    //
+    // So the probe carries an identity when, and only when, the tool declares
+    // it needs one. That reaches the argument guards rather than weakening the
+    // gate to treat 401 as a pass, which would have been the easy fix and the
+    // wrong one.
+    AUTH_REQUIRED_TOOL_NAMES.has(name)
+      ? { executionCtx: { waitUntil() {}, props: { accountId: 7 } } }
+      : {},
   );
   const body = (await response.json()) as Row;
   return ((body?.result?.structuredContent as Row)?.error as Row)?.code ?? null;

--- a/tests/mcp-tool-auth-declaration.test.ts
+++ b/tests/mcp-tool-auth-declaration.test.ts
@@ -75,6 +75,20 @@ async function anonymousErrorCode(
     // => no mg_ key. This is exactly an anonymous caller.
     {},
   );
+  // #11563 moved the refusal from a tool error inside a 200 to a transport
+  // -level 401, because a 200 produces no sign-in prompt in any MCP client.
+  // This probe normalises BOTH shapes rather than switching to the new one, so
+  // the gate keeps proving what it was written to prove -- "this tool refuses
+  // an anonymous caller" -- and additionally proves the challenge is the kind a
+  // client can act on. A tool that regressed to a 200 tool error would still be
+  // "refusing", and would still be a defect; this way the test says which.
+  if (response.status === 401) {
+    assert.ok(
+      response.headers.get("www-authenticate"),
+      "a 401 without WWW-Authenticate is not a challenge a client can follow",
+    );
+    return "auth_required";
+  }
   const body = (await response.json()) as Row;
   return ((body?.result?.structuredContent as Row)?.error as Row)?.code ?? null;
 }


### PR DESCRIPTION
An unauthenticated `tools/call` for a credential-store tool returned **HTTP 200** with `{"isError": true}`. The MCP authorization spec and Claude's lazy-authentication guidance both say what that does:

> A `200` with `isError: true` is an application-level tool failure. Claude passes the error text to the model as the tool result and moves on — there is no auth prompt. Only a transport-level `401` causes Claude to pause the call, run the OAuth flow, and retry.

That is why nothing ever asked. Five accounts completed the GitHub flow unprompted (#11562) and everyone else stayed anonymous, because the surface had no code path that could produce a challenge a client would act on. The OAuth provider has been live and spec-correct the whole time — nothing triggered it.

## The gate

`dispatchMcpRequest` inspects the parsed body and, when it names a tool in `AUTH_REQUIRED_TOOL_NAMES` with no identity present, fails the **HTTP request** with `401` and `WWW-Authenticate: Bearer … resource_metadata=… scope="profile"`.

**Before the SDK**, because once a tool handler is executing its return value is already destined for a 200. **Before the quota**, for the reason the blocklist states one control up — debiting a caller for a request we are about to refuse bills them for work never served, and masks the challenge as a 429.

The identity test is `resolveSurfaceCredentialIdentity`, the same function the protected tools themselves apply. It accepts either a verified `mg_` key or an OAuth account, so the gate and the handlers cannot disagree about who is authenticated. The in-handler refusal is **kept** — the gate is transport-level, the tool is still the authority.

The metadata pointer is derived from the request path, not hard-coded. This server is mounted at both `/mcp` and the `/mcp/core` profile, and RFC 9728 requires the document's `resource` to match the URL the caller used. Verified in production — the provider already serves a correct per-path document for both, including `/mcp/core`.

A batch is one HTTP request, so a protected call hidden among public ones challenges the whole request. Pinned in a test rather than left incidental.

## auth.md was wrong twice (#11566)

It claimed authentication *"does not currently unlock additional endpoints, tools, or data"* — false since the depth gate — and that *"an anonymous request is not challenged"*, which this change falsifies.

Both facts are now **derived** in the generator: the free window from `FREE_HISTORY_WINDOW_DAYS`, the tool list from `AUTH_REQUIRED_TOOL_NAMES`. Copying a number into prose is how it got wrong the first time. Tests assert the derivation and that neither retired claim can come back.

Both `/auth.md` and `/.well-known/auth.md` regenerate byte-identical, as #11173 established.

## Three existing gates updated — none weakened

| gate | what changed |
|---|---|
| #9070 auth-declaration probe | Normalises **both** refusal shapes rather than switching to the new one, so it still proves "this tool refuses an anonymous caller" *and* now proves the challenge is one a client can follow |
| #8942 required-argument probe | Carries an identity when — and only when — the tool declares it needs one. Probing anonymously would report "silently accepted" for arguments that *are* enforced: a false negative that would have quietly stopped the gate checking three tools. Treating 401 as a pass was the easy fix and the wrong one |
| credential-store refusal test | Asserts the transport shape, with an authenticated **positive control** so it cannot pass by refusing everyone |

## Verification

- **Patch coverage 100%** — 15/15 lines, 12/12 branches, by diff intersection
- Full suite green (22,221 tests); the 3 suites that pinned the old shape were updated, not relaxed
- All 70 `validate:*` scripts, `tsc` clean, prettier clean, eslint clean

Part of #11561.

Closes #11563
Closes #11566
