### PR TITLE
fix(telemetry): let first-party sweeps declare themselves, with a token so nobody else can

### DIFF
--- a/.github/workflows/check-mcp-conformance.yml
+++ b/.github/workflows/check-mcp-conformance.yml
@@ -68,6 +68,13 @@ jobs:
       # to mean anything.
       - name: Validate live MCP responses against their published outputSchemas
         shell: bash
+        # #11565: proves this sweep is FIRST-PARTY, so its 4,990 monthly tool
+        # calls are excluded from product metrics instead of dominating the
+        # per-tool caller counts pricing is chosen from. Absent or wrong, the
+        # sweep still runs and simply counts as ordinary traffic -- the marker
+        # never gates the request, only its analytics label.
+        env:
+          MCP_PROBE_TOKEN: ${{ secrets.MCP_PROBE_TOKEN }}
         run: |
           node scripts/check-mcp-conformance.ts | tee mcp-conformance.log
           {

--- a/scripts/check-mcp-conformance.ts
+++ b/scripts/check-mcp-conformance.ts
@@ -55,6 +55,11 @@ const ENDPOINT =
 // read exactly like real defects (scripts/mcp-smoke-sweep.ts records the same
 // finding). ~1.6s is the measured floor.
 const CALL_SPACING_MS = Number(process.env.MCP_CONFORMANCE_SPACING_MS ?? 1600);
+
+// #11565: the shared secret that makes this sweep's probe marker believable.
+// Optional on purpose -- a local run without the secret still works and simply
+// is not excluded from metrics, which is the right way round.
+const PROBE_TOKEN = process.env.MCP_PROBE_TOKEN?.trim() || "";
 const RATE_LIMIT_RETRIES = 4;
 const RATE_LIMIT_BACKOFF_MS = 2000;
 const REQUEST_TIMEOUT_MS = 30000;
@@ -88,6 +93,22 @@ async function rpc(method: string, params: Row): Promise<Row> {
           // makes, including the deliberate error-path ones, showed up as an
           // anonymous agent failing rather than as our own nightly check.
           "user-agent": "metagraphed-conformance/1",
+          // #11565: and mark it FIRST-PARTY, so product metrics can exclude it.
+          // The UA above identifies the runner; this says the traffic is ours.
+          // The distinction matters -- a third party's `flowstacks-mcp-
+          // conformance` is also a conformance checker, and its calls are real
+          // usage that must stay in the numbers.
+          //
+          // This sweep touches all 242 tools every night, which is 4,990 tool
+          // calls a month against a surface whose real interactive traffic is
+          // ~1,600 -- so leaving it unlabelled does not merely add noise, it
+          // dominates the per-tool caller counts pricing is chosen from.
+          "x-metagraph-probe": "mcp-conformance",
+          // Proof the marker above is ours. Without it the server ignores the
+          // marker entirely and the sweep counts as ordinary traffic -- which
+          // is the safe failure, and lets the secret and the deploy land in
+          // either order.
+          ...(PROBE_TOKEN ? { "x-metagraph-probe-token": PROBE_TOKEN } : {}),
         },
         body: JSON.stringify({
           jsonrpc: "2.0",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1252,6 +1252,7 @@ import {
   FREE_HISTORY_WINDOW_DAYS,
   requireTierForDepth,
 } from "./mcp-tier-gate.ts";
+import { timingSafeEqual } from "./webhooks.ts";
 import {
   oauthAccountIdFrom,
   resolveOAuthAccountTier,
@@ -2043,6 +2044,14 @@ interface McpCtx {
   // the only client signal a tools/call request carries. Always tagged as
   // `user_agent`-sourced when emitted, never presented as MCP clientInfo.
   clientName?: string;
+  /**
+   * A FIRST-PARTY probe that declared itself via the probe header (#11565).
+   *
+   * Undefined for every real caller, which is the point: product queries filter
+   * on its absence, so our own monitoring stops inflating the numbers it exists
+   * to watch.
+   */
+  probe?: string;
   clientVersion?: string;
   recordUsageEvent?: AnyFn;
   /** Keyed by {@link chainSignersCacheKey}; holds the in-flight promise so a
@@ -16548,6 +16557,61 @@ async function callTool(params: Row | null, ctx: McpCtx) {
   return result;
 }
 
+/**
+ * The header a FIRST-PARTY probe uses to name itself (#11565).
+ *
+ * Declared rather than inferred. Our nightly sweeps already set a distinctive
+ * User-Agent, but filtering on that string would also catch
+ * `flowstacks-mcp-conformance` -- observed in production, a third party's
+ * conformance checker whose calls are real usage. A marker we set is the only
+ * one that means "ours".
+ */
+export const MCP_PROBE_HEADER = "x-metagraph-probe";
+
+/** The shared secret proving a probe marker is ours. */
+export const MCP_PROBE_TOKEN_HEADER = "x-metagraph-probe-token";
+
+/** Bound on the declared probe name. Long enough for `mcp-conformance`, short
+ * enough that the header cannot become a payload. */
+export const MCP_PROBE_NAME_MAX_LENGTH = 64;
+
+/**
+ * The probe name this request declares, or undefined.
+ *
+ * ## VERIFIED, NOT SELF-DECLARED
+ *
+ * The marker excludes traffic from product metrics, so an unauthenticated one
+ * would let any caller opt out of being counted -- and a crawler that can hide
+ * from the numbers is worse than one that shows up in them. The name is
+ * honoured only when the paired token matches `MCP_PROBE_TOKEN`, compared in
+ * constant time.
+ *
+ * ## FAILS TO "NOT A PROBE", DELIBERATELY
+ *
+ * No secret configured, no token sent, or a token that does not match, all
+ * yield undefined -- the traffic counts as ordinary usage. That is the safe
+ * direction: the failure mode is our own sweep briefly appearing in the
+ * numbers, never a real caller silently vanishing from them. It also means the
+ * secret and the deploy can land in either order without a window where real
+ * traffic is dropped.
+ *
+ * Nothing else keys on this: rate limits, quota, the blocklist and every tier
+ * are untouched. It labels an analytics event and only that.
+ */
+export function mcpProbeName(
+  request: Request,
+  env: Env | undefined,
+): string | undefined {
+  const configured = env?.MCP_PROBE_TOKEN;
+  if (typeof configured !== "string" || configured === "") return undefined;
+  if (!timingSafeEqual(request.headers.get(MCP_PROBE_TOKEN_HEADER), configured))
+    return undefined;
+  const raw = request.headers.get(MCP_PROBE_HEADER);
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim().slice(0, MCP_PROBE_NAME_MAX_LENGTH);
+  return trimmed === "" ? undefined : trimmed;
+}
+
 // #8963: the client/server attribution every $mcp_* event carries. Server
 // identity comes from the same constants that feed serverInfo and
 // server.json, so an event can always be pinned to the deploy that emitted
@@ -16571,6 +16635,10 @@ function mcpAttributionFor(ctx: McpCtx) {
           clientNameSource: "user_agent" as const,
         }
       : {}),
+    // #11565: rides the SAME shared attribution every $mcp_* event calls, so a
+    // breakdown that excludes first-party probes behaves identically whichever
+    // event it starts from -- the reason this helper exists at all.
+    ...(ctx?.probe ? { probe: ctx.probe } : {}),
   };
 }
 
@@ -17663,6 +17731,9 @@ async function buildContext(
   const { clientName, clientVersion } = parseUserAgentClient(
     request.headers.get("user-agent"),
   );
+  // #11565: a first-party probe naming itself. Sanitised like every other
+  // caller-supplied label, so a hostile value is bounded rather than trusted.
+  const probe = mcpProbeName(request, env);
   return {
     env,
     domain,
@@ -17674,6 +17745,7 @@ async function buildContext(
     clientIp: mcpClientKey(request),
     clientName,
     clientVersion,
+    probe,
     // #8967: "anonymous" or the resolved key tier, from the gate that already
     // verified the bearer token. Carried on the context so the $mcp_* emission
     // chokepoint can label the event without a second key verification.

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -1079,6 +1079,25 @@ function assignMcpAttribution(
   } & McpServerIdentity,
 ): void {
   properties["$mcp_source"] = MCP_ANALYTICS_SOURCE;
+  // #11565: a FIRST-PARTY probe declaring itself, so our own monitoring stops
+  // being counted as product usage. The nightly MCP conformance sweep alone was
+  // 4,990 tool calls over 30 days -- ~14% of the surface's traffic, touching
+  // all 242 tools every run, which distorts exactly the per-tool caller counts
+  // #11179 requires pricing to be chosen from.
+  //
+  // TAGGED, NOT SUPPRESSED, and the choice is deliberate. Suppression would
+  // make the sweep's own traffic unobservable at the moment we most want to
+  // know it ran, and a self-declared "do not count me" that DELETES data is
+  // strictly worse than one that labels it: a caller who mislabels itself is
+  // then invisible rather than merely excluded. Every product-facing query
+  // filters on this property; the rows stay for anyone auditing who claimed it.
+  //
+  // A DECLARED HEADER, NOT A USER-AGENT MATCH. Our sweep sets its own UA, but
+  // matching on the string would also catch `flowstacks-mcp-conformance` --
+  // observed in production, a THIRD party's conformance checker whose traffic
+  // is real usage and must not be filtered out of our numbers.
+  const probe = sanitizeLabel(event.probe);
+  if (probe !== undefined) properties["$mcp_probe"] = probe;
   // #8967: "anonymous", or the tier of the verified mg_ key. This is the one
   // dimension that makes the MCP access model measurable -- authentication
   // currently buys throughput only, and without this there is no way to ask
@@ -1188,6 +1207,15 @@ function boundedMcpPayload(value: unknown): unknown {
 export interface McpServerIdentity {
   serverName?: string;
   serverVersion?: string;
+  /**
+   * A FIRST-PARTY probe that proved itself with the probe token (#11565).
+   *
+   * Declared on the base every `$mcp_*` event extends, because it rides the
+   * shared attribution: a breakdown that excludes our own sweeps has to behave
+   * identically whichever event it starts from, which is the reason
+   * assignMcpAttribution exists at all. Undefined for every real caller.
+   */
+  probe?: string;
 }
 
 /** Where a client name came from (#8963). `client_info` is the MCP handshake's

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -538,3 +538,68 @@ describe("the default recorders, with nothing injected", () => {
     );
   });
 });
+
+// #11565: a verified first-party probe rides the shared attribution onto the
+// event, so product metrics can exclude our own sweeps. Driven through the
+// REAL request path rather than the recorder directly, because the thing under
+// test is that the header survives buildContext -> mcpAttributionFor -> event.
+describe("$mcp_probe", () => {
+  const PROBE_TOKEN = "test-probe-token-aaaaaaaaaaaaaaaaaaaa";
+
+  async function callWithHeaders(headers: Record<string, string>, env: Row) {
+    const mcp: Row[] = [];
+    await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...headers },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "get_contracts", arguments: {} },
+        }),
+      }),
+      env as unknown as Env,
+      makeDeps({
+        recordMcpToolCallEvent: (_e: unknown, event: Row) => {
+          mcp.push(event);
+          return true;
+        },
+      }),
+    );
+    return mcp;
+  }
+
+  test("a verified probe reaches the event", async () => {
+    const mcp = await callWithHeaders(
+      {
+        "x-metagraph-probe": "mcp-conformance",
+        "x-metagraph-probe-token": PROBE_TOKEN,
+      },
+      { ...CONFIGURED_ENV, MCP_PROBE_TOKEN: PROBE_TOKEN },
+    );
+    assert.equal(mcp[0].probe, "mcp-conformance");
+  });
+
+  test("an unverified marker does NOT reach the event", async () => {
+    // A caller who could self-declare would be opting out of being counted,
+    // and a crawler that can hide from the numbers is worse than one that
+    // shows up in them.
+    const mcp = await callWithHeaders(
+      {
+        "x-metagraph-probe": "mcp-conformance",
+        "x-metagraph-probe-token": "wrong-token",
+      },
+      { ...CONFIGURED_ENV, MCP_PROBE_TOKEN: PROBE_TOKEN },
+    );
+    assert.equal(mcp[0].probe, undefined);
+  });
+
+  test("ordinary traffic carries no probe at all", async () => {
+    const mcp = await callWithHeaders(
+      {},
+      { ...CONFIGURED_ENV, MCP_PROBE_TOKEN: PROBE_TOKEN },
+    );
+    assert.equal(mcp[0].probe, undefined);
+  });
+});

--- a/tests/mcp-probe-marker.test.ts
+++ b/tests/mcp-probe-marker.test.ts
@@ -1,0 +1,130 @@
+// #11565: our own scheduled sweeps must not be counted as product usage.
+//
+// The nightly MCP conformance run touches all 242 tools and was 4,990 tool
+// calls over 30 days -- against ~1,600 calls of real interactive traffic. It
+// does not merely add noise: because it touches EVERY tool every night, it
+// dominates the per-tool distinct-caller counts that #11179 requires the paid
+// boundary to be chosen from.
+//
+// The marker is VERIFIED rather than self-declared. An unauthenticated
+// "do not count me" would let any crawler opt out of the numbers, and a crawler
+// that can hide is worse than one that shows up.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  MCP_PROBE_HEADER,
+  MCP_PROBE_NAME_MAX_LENGTH,
+  MCP_PROBE_TOKEN_HEADER,
+  mcpProbeName,
+} from "../src/mcp-server.ts";
+
+const TOKEN = "test-probe-token-aaaaaaaaaaaaaaaaaaaa";
+
+function req(headers: Record<string, string> = {}) {
+  return new Request("https://api.metagraph.sh/mcp", {
+    method: "POST",
+    headers,
+  });
+}
+
+const env = (token?: string) => ({ MCP_PROBE_TOKEN: token }) as unknown as Env;
+
+describe("mcpProbeName", () => {
+  test("honours a named probe when the token matches", () => {
+    assert.equal(
+      mcpProbeName(
+        req({
+          [MCP_PROBE_HEADER]: "mcp-conformance",
+          [MCP_PROBE_TOKEN_HEADER]: TOKEN,
+        }),
+        env(TOKEN),
+      ),
+      "mcp-conformance",
+    );
+  });
+
+  test("a wrong or missing token yields NO probe, so the traffic is counted", () => {
+    // The safe direction: the failure mode is our own sweep briefly appearing
+    // in the numbers, never a real caller silently vanishing from them.
+    const cases: Record<string, string>[] = [
+      { [MCP_PROBE_HEADER]: "mcp-conformance" },
+      { [MCP_PROBE_HEADER]: "mcp-conformance", [MCP_PROBE_TOKEN_HEADER]: "" },
+      {
+        [MCP_PROBE_HEADER]: "mcp-conformance",
+        [MCP_PROBE_TOKEN_HEADER]: "wrong-token",
+      },
+      {
+        [MCP_PROBE_HEADER]: "mcp-conformance",
+        [MCP_PROBE_TOKEN_HEADER]: TOKEN.slice(0, -1),
+      },
+    ];
+    for (const headers of cases) {
+      assert.equal(mcpProbeName(req(headers), env(TOKEN)), undefined);
+    }
+  });
+
+  test("an unprovisioned deployment honours no marker at all", () => {
+    // Secret and deploy can land in either order without a window where real
+    // traffic is wrongly excluded.
+    for (const token of [undefined, ""]) {
+      assert.equal(
+        mcpProbeName(
+          req({
+            [MCP_PROBE_HEADER]: "mcp-conformance",
+            [MCP_PROBE_TOKEN_HEADER]: TOKEN,
+          }),
+          env(token),
+        ),
+        undefined,
+        String(token),
+      );
+    }
+    assert.equal(
+      mcpProbeName(
+        req({
+          [MCP_PROBE_HEADER]: "mcp-conformance",
+          [MCP_PROBE_TOKEN_HEADER]: TOKEN,
+        }),
+        undefined,
+      ),
+      undefined,
+    );
+  });
+
+  test("a valid token with no name is not a probe", () => {
+    const cases: Record<string, string>[] = [
+      { [MCP_PROBE_TOKEN_HEADER]: TOKEN },
+      { [MCP_PROBE_HEADER]: "   ", [MCP_PROBE_TOKEN_HEADER]: TOKEN },
+    ];
+    for (const headers of cases) {
+      assert.equal(mcpProbeName(req(headers), env(TOKEN)), undefined);
+    }
+  });
+
+  test("the name is bounded, so the header cannot become a payload", () => {
+    const long = "x".repeat(MCP_PROBE_NAME_MAX_LENGTH * 4);
+    const name = mcpProbeName(
+      req({ [MCP_PROBE_HEADER]: long, [MCP_PROBE_TOKEN_HEADER]: TOKEN }),
+      env(TOKEN),
+    );
+    assert.equal(name?.length, MCP_PROBE_NAME_MAX_LENGTH);
+  });
+
+  test("a third party's conformance checker is NOT treated as ours", () => {
+    // `flowstacks-mcp-conformance` is real, observed in production, and is
+    // someone else's checker -- its calls are genuine usage. This is why the
+    // marker is a token we issue and not a user-agent pattern: matching on the
+    // string "conformance" would have filtered their traffic out of our
+    // numbers alongside our own.
+    assert.equal(
+      mcpProbeName(
+        req({
+          "user-agent": "flowstacks-mcp-conformance/1",
+          [MCP_PROBE_HEADER]: "mcp-conformance",
+        }),
+        env(TOKEN),
+      ),
+      undefined,
+    );
+  });
+});

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -3931,3 +3931,59 @@ describe("recordUsageEvent — the two person namespaces agree", () => {
     assert.equal(await personFor("ip:account:acct_1"), false);
   });
 });
+
+// #11565: a first-party probe rides the SHARED attribution, so a breakdown
+// that excludes our own sweeps behaves identically whichever $mcp_* event it
+// starts from. The nightly conformance run was 4,990 tool calls in 30 days
+// against ~1,600 of real interactive traffic, and it touches every tool every
+// night -- so unlabelled it dominates exactly the per-tool caller counts the
+// paid boundary is meant to be chosen from.
+describe("$mcp_probe", () => {
+  const CONFIGURED_PROBE = {
+    [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
+  } as unknown as Env;
+
+  test("is stamped on a tool call when the request declared one", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED_PROBE,
+      {
+        toolName: "get_subnet",
+        isError: false,
+        durationMs: 5,
+        probe: "mcp-conformance",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(
+      (calls[0].body.properties as Row).$mcp_probe,
+      "mcp-conformance",
+    );
+  });
+
+  test("is absent for ordinary traffic, which is what makes the filter mean anything", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      CONFIGURED_PROBE,
+      { toolName: "get_subnet", isError: false, durationMs: 5 },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.ok(
+      !("$mcp_probe" in (calls[0].body.properties as Row)),
+      "a real caller must carry no probe label at all",
+    );
+  });
+
+  test("rides the shared attribution, so initialize carries it too", async () => {
+    const calls: Row[] = [];
+    await recordMcpInitializeEvent(
+      CONFIGURED_PROBE,
+      { probe: "mcp-conformance" } as Row,
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(
+      (calls[0].body.properties as Row).$mcp_probe,
+      "mcp-conformance",
+    );
+  });
+});

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -46,6 +46,10 @@ interface RuntimeSecretEnv {
   ALERT_TRIGGER_CREATE_TOKEN?: string;
   ALERT_TRIGGERS_INTERNAL_TOKEN?: string;
   API_KEY_LOOKUP_INTERNAL_TOKEN?: string;
+  /** #11565: proves a `x-metagraph-probe` marker came from one of our own
+   * scheduled sweeps. Absent on a deployment that has not provisioned it, in
+   * which case no probe marker is ever honoured -- see mcpProbeName. */
+  MCP_PROBE_TOKEN?: string;
   /** #9208: gates POST /api/v1/internal/chain-detail-sync and its head GET --
    * the live-follow decode lane's write path into the chain-detail hot tier.
    * Set via `wrangler secret put` on BOTH Workers (api.ts proxies, data-api.ts


### PR DESCRIPTION
Our own nightly MCP conformance run was **4,990 tool calls over 30 days**, against roughly **1,600** calls of real interactive traffic. It does not merely add noise — it touches all 242 tools every night, so it dominates exactly the per-tool distinct-caller counts #11179 requires the paid boundary to be chosen from.

## A token, not a user-agent match

The sweep already sets a distinctive User-Agent, and filtering on that string was the obvious fix. It is the wrong one: production also carries **`flowstacks-mcp-conformance`** — a *third party's* conformance checker whose calls are real usage. A pattern broad enough to catch ours catches theirs, and quietly removes a real caller from our numbers.

So the marker is one we issue:

| header | meaning |
|---|---|
| `x-metagraph-probe` | names the sweep |
| `x-metagraph-probe-token` | proves it is ours, compared in constant time against `MCP_PROBE_TOKEN` |

**Unauthenticated would not do.** The marker excludes traffic from product metrics, so a self-declared one lets any caller opt out of being counted — and a crawler that can hide from the numbers is worse than one that shows up in them.

Secrets are set: `MCP_PROBE_TOKEN` as a GitHub Actions secret and as a Worker secret on `metagraphed`.

## Fails to "not a probe"

No secret configured, no token sent, or a token that does not match all yield no marker, and the traffic counts as ordinary usage. The failure mode is our own sweep briefly appearing in the numbers — **never a real caller silently vanishing from them**. It also means the secret and the deploy can land in either order without a window where anything is wrongly excluded.

Nothing else keys on it: rate limits, quota, the blocklist and every tier are untouched.

## Tagged, not suppressed

Deliberate. Suppression would make "the sweep did not run" indistinguishable from "the sweep ran clean" — the observability gap this repo has been bitten by before. The rows stay, carrying `$mcp_probe`, and product queries filter on it.

The property rides `assignMcpAttribution`, the shared helper every `$mcp_*` recorder already calls, so a breakdown that excludes first-party sweeps behaves identically whichever event it starts from.

## Two premises did not survive measurement

The change is smaller than the issue for it:

- **Local dev is not polluting.** Zero events carry `environment: development` — the property already exists and nothing needed doing.
- **The conformance sweep is tagged `production`**, which is *why* it was indistinguishable from real traffic rather than merely unlabelled.

## Verification

- **Patch coverage 100%** — 14/14 lines, 14/14 branches, by diff intersection
- Full suite green: 966 files, 22,223 tests
- All 70 `validate:*` scripts, `tsc` clean, prettier clean

Part of #11561.

Closes #11565
