### PR TITLE
refactor(mcp): split call_subnet_surface into a read tool and a write tool

### DIFF
--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -198,75 +198,167 @@ export const CALL_SURFACE_METHODS = [
 ] as const;
 export const CALL_SURFACE_BODY_METHODS = ["POST", "PUT", "PATCH"] as const;
 
+/**
+ * The verb split behind the two surface-call tools (#11568).
+ *
+ * The Connectors Directory rejects a single tool whose `method` spans safe and
+ * unsafe verbs -- "do not ship a catch-all `api_request` tool with a `method`
+ * parameter" -- and says outright that documenting the split inside one
+ * description does not satisfy it. Two tools, two enums, two annotations.
+ *
+ * Derived from CALL_SURFACE_METHODS rather than restated, so a verb added
+ * there lands in exactly one of these and cannot silently appear in neither.
+ * `read` is the SAFE set in the HTTP sense (RFC 9110): no observable effect on
+ * the origin, which is what makes `readOnlyHint` truthful and lets a client run
+ * it without a per-call confirmation.
+ */
+export const CALL_SURFACE_READ_METHODS = ["GET", "HEAD"] as const;
+export const CALL_SURFACE_WRITE_METHODS = CALL_SURFACE_METHODS.filter(
+  (
+    method,
+  ): method is Exclude<
+    (typeof CALL_SURFACE_METHODS)[number],
+    (typeof CALL_SURFACE_READ_METHODS)[number]
+  > => !(CALL_SURFACE_READ_METHODS as readonly string[]).includes(method),
+);
+
+/**
+ * The fields BOTH surface-call tools share (#11568).
+ *
+ * One shape, composed twice, so the two tools cannot drift apart in what they
+ * accept for the parts that are genuinely identical -- the surface, where to
+ * send the request, and the caller's own credential.
+ */
+const surfaceCallSharedShape = {
+  surface_id: surfaceIdSchema(),
+  query: z
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+    .optional()
+    .describe(
+      "Query-string parameters to append, as a flat object of " +
+        "string/number/boolean values. Nested objects and arrays are not " +
+        "supported — encode them into `path` or `body` instead.",
+    )
+    .meta({ examples: ["inference"] }),
+  path: z
+    .string()
+    .optional()
+    .describe(
+      "Path appended to the surface's base URL, e.g. `/v1/status`. Leading slash optional.",
+    )
+    // uri-reference, not uri: this is a RELATIVE path resolved against the
+    // surface's own base URL, so `uri` (which wants a scheme) would be the
+    // wrong assertion (#9659).
+    .meta({ format: "uri-reference", examples: ["/v1/status"] }),
+  method: z
+    // PATCH and DELETE joined the four originals in #11146: across the
+    // fleet's captured specs, 184 DELETE and 53 PATCH operations were
+    // declared by subnets and unreachable through this tool purely because
+    // the verb was not in this enum. The gate is unchanged and does the real
+    // work -- the exact path+method must be declared in the surface's own
+    // captured schema, and an authenticated surface still needs the caller's
+    // own credential -- so widening the verb set grants no authority the
+    // caller did not already have calling the API directly.
+    .enum(CALL_SURFACE_READ_METHODS)
+    .optional()
+    .describe(
+      "HTTP method for the read. Only the safe verbs are available here; to " +
+        "POST/PUT/PATCH/DELETE a declared operation, use write_subnet_surface.",
+    )
+    .meta({ examples: ["GET"] }),
+  // Branch order (string, then object) mirrors the hand-written original's
+  // `type: ["string", "object"]` -- the reverse of `body` above.
+  credential: z
+    .union([z.string(), OpenObjectSchema])
+    .optional()
+    .describe(
+      "Secret for an authenticated surface: a bearer token string, or an object of header/query values. Sent to the surface and never stored unless you use store_surface_credential.",
+    )
+    .meta({ examples: ["Bearer <token>"] }),
+} as const;
+
+/** The body fields, which only the write tool has any use for. */
+const surfaceWriteBodyShape = {
+  body: z
+    .union([OpenObjectSchema, z.string()])
+    .optional()
+    .describe(
+      "Request body: an object (sent as JSON) or a pre-serialized string. " +
+        "Validated against the matched operation's declared request body.",
+    )
+    .meta({ examples: [{ prompt: "hello" }] }),
+  content_type: z
+    .string()
+    .optional()
+    .describe(
+      "Overrides the Content-Type header. Defaults to `application/json` when the body is an object.",
+    )
+    .meta({ examples: ["application/json"] }),
+} as const;
+
+/**
+ * The READ tool's arguments: safe verbs only, and no request body.
+ *
+ * Publishing no `body` is part of the point. A read tool that advertises one
+ * invites an agent to try a write through it and be refused, which is the
+ * confusion the split exists to remove.
+ */
 export const CallSubnetSurfaceInputSchema = z
-  .object({
-    surface_id: surfaceIdSchema(),
-    query: z
-      .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
-      .optional()
-      .describe(
-        "Query-string parameters to append, as a flat object of " +
-          "string/number/boolean values. Nested objects and arrays are not " +
-          "supported — encode them into `path` or `body` instead.",
-      )
-      .meta({ examples: ["inference"] }),
-    path: z
-      .string()
-      .optional()
-      .describe(
-        "Path appended to the surface's base URL, e.g. `/v1/status`. Leading slash optional.",
-      )
-      // uri-reference, not uri: this is a RELATIVE path resolved against the
-      // surface's own base URL, so `uri` (which wants a scheme) would be the
-      // wrong assertion (#9659).
-      .meta({ format: "uri-reference", examples: ["/v1/status"] }),
-    method: z
-      // PATCH and DELETE joined the four originals in #11146: across the
-      // fleet's captured specs, 184 DELETE and 53 PATCH operations were
-      // declared by subnets and unreachable through this tool purely because
-      // the verb was not in this enum. The gate is unchanged and does the real
-      // work -- the exact path+method must be declared in the surface's own
-      // captured schema, and an authenticated surface still needs the caller's
-      // own credential -- so widening the verb set grants no authority the
-      // caller did not already have calling the API directly.
-      .enum(CALL_SURFACE_METHODS)
-      .optional()
-      .describe(
-        "HTTP method to use for the call. A destructive verb (PATCH/DELETE) is " +
-          "accepted only when the surface's captured schema declares that exact " +
-          "path+method, and is sent with the caller's own credential.",
-      )
-      .meta({ examples: ["GET"] }),
-    // Branch order (object, then string) mirrors the hand-written original's
-    // `type: ["object", "string"]`.
-    body: z
-      .union([OpenObjectSchema, z.string()])
-      .optional()
-      .describe(
-        "Request body: an object (sent as JSON) or a pre-serialized string.",
-      )
-      .meta({ examples: [{ prompt: "hello" }] }),
-    content_type: z
-      .string()
-      .optional()
-      .describe(
-        "Overrides the Content-Type header. Defaults to `application/json` when the body is an object.",
-      )
-      .meta({ examples: ["application/json"] }),
-    // Branch order (string, then object) mirrors the hand-written original's
-    // `type: ["string", "object"]` -- the reverse of `body` above.
-    credential: z
-      .union([z.string(), OpenObjectSchema])
-      .optional()
-      .describe(
-        "Secret for an authenticated surface: a bearer token string, or an object of header/query values. Sent to the surface and never stored unless you use store_surface_credential.",
-      )
-      .meta({ examples: ["Bearer <token>"] }),
-  })
+  .object(surfaceCallSharedShape)
   .strict();
 export type CallSubnetSurfaceInput = z.infer<
   typeof CallSubnetSurfaceInputSchema
 >;
+
+/**
+ * The WRITE tool's arguments: unsafe verbs, and a body to send with them.
+ *
+ * `path` and `method` are REQUIRED here, unlike the read tool where omitting
+ * both means "fetch the surface's own curated url". There is no curated write:
+ * a write always names a declared operation, and making that structural stops
+ * an agent discovering it by being refused.
+ */
+export const WriteSubnetSurfaceInputSchema = z
+  .object({
+    ...surfaceCallSharedShape,
+    ...surfaceWriteBodyShape,
+    path: z
+      .string()
+      .describe(
+        "Path of the operation to call, e.g. `/v1/items/abc`. Must be declared " +
+          "in the surface's captured schema for this method.",
+      )
+      .meta({ format: "uri-reference", examples: ["/v1/items/abc"] }),
+    method: z
+      .enum(CALL_SURFACE_WRITE_METHODS)
+      .describe(
+        "HTTP method for the write. Accepted only when the surface's captured " +
+          "schema declares that exact path+method, and sent with the caller's " +
+          "own credential -- so this grants no authority the caller lacks " +
+          "calling the API directly.",
+      )
+      .meta({ examples: ["POST"] }),
+  })
+  .strict();
+export type WriteSubnetSurfaceInput = z.infer<
+  typeof WriteSubnetSurfaceInputSchema
+>;
+
+/**
+ * The superset the SHARED handler operates on (#11568).
+ *
+ * Neither published schema is a superset of the other -- the read tool has no
+ * `body`, and the write tool makes `path`/`method` required -- so the one
+ * implementation behind both needs a type that admits either call. Declared
+ * rather than inferred, because widening with `Partial` of one schema would
+ * quietly re-allow the write verbs on the read tool's type and lose the very
+ * distinction this split exists to make.
+ */
+export type SubnetSurfaceCallArgs = Omit<CallSubnetSurfaceInput, "method"> & {
+  method?: (typeof CALL_SURFACE_METHODS)[number];
+  body?: WriteSubnetSurfaceInput["body"];
+  content_type?: WriteSubnetSurfaceInput["content_type"];
+};
 
 export const CallSubnetSurfaceOutputSchema = z
   .object({

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -1938,6 +1938,20 @@ const RESPONSE_UNVALIDATED_REASONS = new Map<string, string>([
     "read-only RPC proxying is intentionally disabled until endpoint scoring and abuse controls land (rpc_proxy_disabled)",
   ],
   [
+    "write_subnet_surface",
+    // #11568. Its READ sibling call_subnet_surface is swept here and validated
+    // against this exact same outputSchema, so the envelope is proven -- the
+    // two tools are one implementation and differ only in which verbs they
+    // will issue.
+    //
+    // The write half cannot be swept, and deliberately so. Succeeding would
+    // mean this gate issuing a real POST/PUT/PATCH/DELETE against a third
+    // party's host on every CI run, which is not a thing a validation sweep
+    // should do at any frequency. The hermetic fixture declares no write
+    // operation either, so the call is refused before a response exists.
+    "issuing real writes to third-party subnet hosts is not something a sweep may do; the identical response envelope is validated via its read sibling call_subnet_surface",
+  ],
+  [
     "get_deregistration_ranking",
     // NOT a gap in the tool -- this is the decline working. The committed
     // economics artifact the harness falls back to is a captured snapshot that

--- a/scripts/validate-unreferenced-exports.ts
+++ b/scripts/validate-unreferenced-exports.ts
@@ -75,7 +75,7 @@ import { repoRoot } from "./lib.ts";
  * nothing lost, because the thing deleted was a copy.
  *
  */
-export const MAX_UNREFERENCED_EXPORTS: number = 731;
+export const MAX_UNREFERENCED_EXPORTS: number = 730;
 
 /** knip's JSON shape, as much of it as this gate reads. */
 interface KnipIssue {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1127,6 +1127,10 @@ import {
   VerifyIntegrationInputSchema,
   VerifyIntegrationOutputSchema,
   CallSubnetSurfaceInputSchema,
+  CALL_SURFACE_READ_METHODS,
+  CALL_SURFACE_WRITE_METHODS,
+  WriteSubnetSurfaceInputSchema,
+  type SubnetSurfaceCallArgs,
   CALL_SURFACE_METHODS,
   CALL_SURFACE_BODY_METHODS,
   CallSubnetSurfaceOutputSchema,
@@ -2407,7 +2411,12 @@ const TOOL_ANNOTATIONS_BY_NAME: Record<
 > = {
   // Caller-supplied method + body + credential forwarded to a third-party
   // subnet host (src/call-subnet-surface.ts). The reason #8964 exists.
-  call_subnet_surface: PROXY_WRITE_TOOL_ANNOTATIONS,
+  // #11568: SPLIT. `call_subnet_surface` now issues only GET/HEAD, which is
+  // read-only in the HTTP sense and therefore truthfully annotated as such --
+  // so a client can run a catalogue read without a per-call confirmation.
+  // Everything that can change a third-party system moved to the sibling.
+  call_subnet_surface: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  write_subnet_surface: PROXY_WRITE_TOOL_ANNOTATIONS,
 
   // Live POST to the public Finney RPC entrypoint on a KV-cache miss.
   get_account_balance: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
@@ -5650,6 +5659,501 @@ function mcpEconomicsRowReader(ctx: McpCtx, netuid: number) {
       row: subnetEconomicsRow(blob, netuid),
       generatedAt: blob?.generated_at ?? blob?.captured_at ?? null,
     };
+  };
+}
+
+/**
+ * The one implementation behind BOTH surface-call tools (#11568).
+ *
+ * ## WHY TWO TOOLS OVER ONE
+ *
+ * This was a single tool whose `method` argument spanned GET/HEAD and
+ * POST/PUT/PATCH/DELETE. The Connectors Directory review criteria name that
+ * exact shape as an automatic rejection -- "do not ship a catch-all
+ * `api_request` tool with a `method` parameter" -- and are explicit that
+ * documenting the split inside one description does not satisfy it.
+ *
+ * It is the better surface regardless of the listing: a read-only tool can run
+ * without a per-call confirmation in an MCP client, while one that MIGHT write
+ * always prompts. Merged, every catalogue read paid the write tool's
+ * interruption.
+ *
+ * ## THE VERB SPLIT IS ENFORCED HERE; THE ARGUMENT SPLIT IS NOT
+ *
+ * Dispatch rejects unknown argument NAMES against the published schema, so
+ * dropping `body`/`content_type` from the read tool genuinely stops a body
+ * reaching this function through it. It does NOT check enum VALUES or
+ * required-ness -- a caller may send `method: "DELETE"` to the read tool and
+ * reach the handler. `allowedMethods` is what holds that boundary.
+ *
+ * The refusal NAMES THE SIBLING, because an agent that guessed the wrong tool
+ * has a correct intent and a wrong address; telling it only "no" turns a
+ * one-step correction into an abandoned task.
+ */
+async function subnetSurfaceCall(
+  args: SubnetSurfaceCallArgs,
+  ctx: McpCtx,
+  allowedMethods: readonly string[],
+  siblingTool: string,
+) {
+  // Checked before anything else reads the arguments: a caller that reached the
+  // wrong tool has not earned the schema fetch below. An unrecognised verb is
+  // left alone here so the existing enum check still owns that message.
+  if (typeof args?.method === "string" && args.method.length > 0) {
+    const upper = args.method.toUpperCase();
+    if (
+      (CALL_SURFACE_METHODS as readonly string[]).includes(upper) &&
+      !allowedMethods.includes(upper)
+    ) {
+      throw toolError(
+        "invalid_params",
+        `${upper} is not available on this tool; use ${siblingTool} instead. ` +
+          `This tool accepts ${allowedMethods.join(", ")}.`,
+      );
+    }
+  }
+
+  if (typeof args?.surface_id !== "string" || !args.surface_id) {
+    throw toolError("invalid_params", "surface_id is required.");
+  }
+  if (!SURFACE_ID_PATTERN.test(args.surface_id)) {
+    throw toolError("invalid_params", "Invalid surface_id format.");
+  }
+  const hasPath = typeof args?.path === "string" && args.path.length > 0;
+  const hasMethod = typeof args?.method === "string" && args.method.length > 0;
+  if (hasPath !== hasMethod) {
+    throw toolError(
+      "invalid_params",
+      "`path` and `method` must be supplied together, or both omitted.",
+    );
+  }
+  const hasBodyArg = args?.body !== undefined && args?.body !== null;
+  const hasContentTypeArg =
+    typeof args?.content_type === "string" && args.content_type.length > 0;
+  if (
+    hasBodyArg &&
+    !(
+      typeof args.body === "string" ||
+      (typeof args.body === "object" && !Array.isArray(args.body))
+    )
+  ) {
+    throw toolError("invalid_params", "`body` must be a string or object.");
+  }
+  if (hasContentTypeArg && !hasBodyArg) {
+    throw toolError(
+      "invalid_params",
+      "`content_type` requires `body` to also be set.",
+    );
+  }
+  if (hasBodyArg && !hasPath) {
+    throw toolError(
+      "invalid_params",
+      "`body` requires `path` and `method` to also be set.",
+    );
+  }
+  let normalizedMethod: string | undefined;
+  if (hasMethod) {
+    // hasMethod already proved args.method is a non-empty string.
+    normalizedMethod = (args.method as string).toUpperCase();
+    if (
+      !(CALL_SURFACE_METHODS as readonly string[]).includes(normalizedMethod)
+    ) {
+      throw toolError(
+        "invalid_params",
+        `\`method\` must be ${CALL_SURFACE_METHODS.join(", ")}.`,
+      );
+    }
+    // DELETE joins GET/HEAD here rather than with the body-carrying verbs:
+    // a request body on DELETE is permitted by HTTP and ignored by most
+    // servers, and accepting one would mean validating it against a
+    // requestBody the operation almost never declares.
+    if (
+      hasBodyArg &&
+      !(CALL_SURFACE_BODY_METHODS as readonly string[]).includes(
+        normalizedMethod,
+      )
+    ) {
+      throw toolError(
+        "invalid_params",
+        `\`body\` is only valid with method ${CALL_SURFACE_BODY_METHODS.join(", ")}.`,
+      );
+    }
+  }
+  const surface = await findCataloguedSurface(ctx, args.surface_id);
+  if (!surface) {
+    throw await uncallableSurfaceError(ctx, args.surface_id);
+  }
+  // The catalog row's OWN id -- the credential-store key and the id echoed
+  // back in the result. A row can be matched by `surface_key` or by a
+  // deprecated alias, so it is not necessarily the id the caller asked
+  // with; falling back to that one keeps the key a string rather than
+  // storing a credential under `undefined` (#10782).
+  const surfaceId = stringOf(surface.surface_id) ?? args.surface_id;
+  const hasInBandStringCredential =
+    typeof args?.credential === "string" && args.credential.length > 0;
+  const hasInBandObjectCredential =
+    args?.credential !== null &&
+    typeof args?.credential === "object" &&
+    !Array.isArray(args?.credential);
+  const hasInBandCredential =
+    hasInBandStringCredential || hasInBandObjectCredential;
+  if (hasInBandCredential && !surface.auth_required) {
+    throw toolError(
+      "invalid_params",
+      "`credential` was supplied but this surface does not require one.",
+    );
+  }
+  // #9009: an authenticated caller can register a credential once
+  // (store_surface_credential) instead of passing it as a tool argument
+  // on every call -- a tool argument travels through client logs, the
+  // conversation transcript, and the analytics parameter capture. The
+  // in-band argument still WINS when both exist (an explicit argument
+  // must never be silently overridden by stale stored state) and stays
+  // fully supported for anonymous callers, per ADR 0027's Model B: this
+  // cleanup must not remove anonymous reach as a side effect.
+  const storeIdentity = resolveSurfaceCredentialIdentity(ctx);
+  let resolvedCredential: StoredSurfaceCredential | undefined =
+    hasInBandCredential
+      ? (args.credential as StoredSurfaceCredential)
+      : undefined;
+  let credentialSource: "argument" | "stored" | undefined = hasInBandCredential
+    ? "argument"
+    : undefined;
+  if (surface.auth_required && !hasInBandCredential && storeIdentity) {
+    const stored = await loadSurfaceCredential(
+      asCredentialStoreEnv(ctx.env),
+      storeIdentity,
+      surfaceId,
+    );
+    if (stored) {
+      resolvedCredential = stored;
+      credentialSource = "stored";
+    }
+  }
+  const hasStringCredentialArg =
+    typeof resolvedCredential === "string" && resolvedCredential.length > 0;
+  const hasObjectCredentialArg =
+    resolvedCredential !== null &&
+    typeof resolvedCredential === "object" &&
+    !Array.isArray(resolvedCredential);
+  const hasCredentialArg = hasStringCredentialArg || hasObjectCredentialArg;
+  let credentialPlacement: CallSubnetSurfaceCredential | undefined;
+  if (surface.auth_required) {
+    if (!hasCredentialArg) {
+      throw toolError(
+        "auth_required",
+        "This surface requires a credential. Supply `credential` (see this tool's description for the required format), register one first with store_surface_credential if you are authenticated, or use list_subnet_apis / how_do_i_call to see how to call it directly.",
+      );
+    }
+    // The curated auth block, read ONCE. `surface.auth?.scheme` on a bag
+    // is an `any` five times over, and one of those five (`names`) is
+    // then `Array.isArray`-checked and re-read from the bag rather than
+    // from what the check proved (#10782).
+    const auth = rowOf(surface.auth);
+    const scheme = auth?.scheme;
+    // `location` reaches `CallSubnetSurfaceCredential.location`, a union
+    // of four literals. The `!==` chains below VALIDATE it and narrow
+    // nothing -- excluding literals from `unknown` leaves `unknown` -- so
+    // it crossed into the published placement as an `any` (#10782).
+    const location = authLocationOf(auth?.location);
+    if (scheme === "bearer" || scheme === "api-key" || scheme === "basic") {
+      const name = stringOf(auth?.name);
+      if (!name || location === null || location === "body") {
+        throw toolError(
+          "credential_not_supported",
+          "This surface's auth mechanism (location/name) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+        );
+      }
+      if (!hasStringCredentialArg) {
+        throw toolError(
+          "invalid_params",
+          `This surface's auth.scheme ("${scheme}") requires \`credential\` to be a single string, not an object.`,
+        );
+      }
+      // hasStringCredentialArg already proved this at runtime.
+      credentialPlacement = {
+        location,
+        name,
+        value: resolvedCredential as string,
+      };
+    } else if (scheme === "signature") {
+      const names = Array.isArray(auth?.names) ? auth.names : null;
+      if (!names || names.length === 0 || location === null) {
+        throw toolError(
+          "credential_not_supported",
+          "This surface's auth mechanism (location/names) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
+        );
+      }
+      if (!hasObjectCredentialArg) {
+        throw toolError(
+          "invalid_params",
+          `This surface's auth.scheme ("signature") requires \`credential\` to be an object mapping each of ${JSON.stringify(names)} to a value you have already computed -- this tool does not sign requests itself.`,
+        );
+      }
+      // hasObjectCredentialArg already proved this at runtime.
+      const credentialObj = resolvedCredential as Record<string, unknown>;
+      const suppliedNames = Object.keys(credentialObj);
+      const missing = names.filter(
+        (n: unknown) => !suppliedNames.includes(n as string),
+      );
+      const unexpected = suppliedNames.filter((n) => !names.includes(n));
+      if (missing.length > 0 || unexpected.length > 0) {
+        throw toolError(
+          "invalid_params",
+          `\`credential\` must have exactly these keys: ${JSON.stringify(names)}.` +
+            (missing.length > 0
+              ? ` Missing: ${JSON.stringify(missing)}.`
+              : "") +
+            (unexpected.length > 0
+              ? ` Unexpected: ${JSON.stringify(unexpected)}.`
+              : ""),
+        );
+      }
+      for (const [key, value] of Object.entries(credentialObj)) {
+        if (typeof value !== "string" || value.length === 0) {
+          throw toolError(
+            "invalid_params",
+            `\`credential.${key}\` must be a non-empty string.`,
+          );
+        }
+      }
+      // The loop above has just verified every value is a non-empty
+      // string, so this is Record<string, string> despite the wider
+      // Record<string, unknown> inferred from the input schema.
+      const credentialValues = credentialObj as Record<string, string>;
+      if (
+        location === "body" &&
+        !(
+          hasPath &&
+          (normalizedMethod === "POST" || normalizedMethod === "PUT")
+        )
+      ) {
+        throw toolError(
+          "invalid_params",
+          "This surface's credential is sent in the request body, which requires `path` and `method` (POST or PUT) to also be set.",
+        );
+      }
+      // metagraphed#7716: some APIs wrap the credential in its own
+      // nested object alongside the semantic payload (e.g.
+      // {"payload": {...}, "sig": {...}}) rather than a flat top-level
+      // merge -- auth.body_envelope, curated registry data, describes
+      // that shape. Only meaningful for location:"body"; malformed or
+      // absent falls back to the existing flat-merge behavior.
+      const envelope = rowOf(auth?.body_envelope);
+      const bodyEnvelope =
+        location === "body" &&
+        envelope &&
+        typeof envelope.payload_key === "string" &&
+        envelope.payload_key.length > 0 &&
+        typeof envelope.credential_key === "string" &&
+        envelope.credential_key.length > 0
+          ? {
+              payloadKey: envelope.payload_key,
+              credentialKey: envelope.credential_key,
+            }
+          : undefined;
+      credentialPlacement = {
+        location,
+        values: credentialValues,
+        ...(bodyEnvelope ? { bodyEnvelope } : {}),
+      };
+    } else {
+      throw toolError(
+        "credential_not_supported",
+        `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key/basic/signature are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
+      );
+    }
+  }
+  if (rowOf(surface.probe)?.enabled === false) {
+    throw toolError(
+      "surface_unavailable",
+      "This surface is flagged as not safe to call automatically (probe.enabled:false).",
+    );
+  }
+  let requestBody;
+  let requestContentType;
+  if (hasPath) {
+    const schemaArtifactId =
+      rowOf(surface.schema_source)?.surface_id || surface.surface_id;
+    const schema = await loadOptionalArtifact(
+      ctx,
+      `/metagraph/schemas/${schemaArtifactId}.json`,
+    );
+    if (!schema) {
+      throw toolError(
+        "no_schema",
+        "This surface has no captured schema, so path/method execution is not available for it -- omit path/method to call its single declared url instead.",
+      );
+    }
+    // hasPath already proved args.path is a string; the `hasPath !==
+    // hasMethod` check above guarantees normalizedMethod is set
+    // whenever hasPath is true.
+    const match = matchSchemaOperation(
+      rowOf(schema)?.document,
+      args.path as string,
+      normalizedMethod as string,
+    );
+    if (!match) {
+      throw toolError(
+        "path_not_declared",
+        `"${normalizedMethod} ${args.path}" is not declared in this surface's captured schema. Fetch the schema with get_api_schema to see valid paths/methods.`,
+      );
+    }
+    if (
+      hasBodyArg &&
+      (normalizedMethod === "POST" || normalizedMethod === "PUT")
+    ) {
+      const declaredContent = rowOf(
+        rowOf(match.operation.requestBody)?.content,
+      );
+      const declaredMediaTypes = declaredContent
+        ? Object.keys(declaredContent)
+        : [];
+      if (declaredMediaTypes.length === 0) {
+        throw toolError(
+          "invalid_params",
+          `"${normalizedMethod} ${args.path}" does not declare a request body in its schema.`,
+        );
+      }
+      if (hasContentTypeArg) {
+        // hasContentTypeArg already proved this is a non-empty string.
+        const contentType = args.content_type as string;
+        if (!declaredMediaTypes.includes(contentType)) {
+          throw toolError(
+            "invalid_params",
+            `content_type "${contentType}" is not declared for this operation. Declared: ${declaredMediaTypes.join(", ")}.`,
+          );
+        }
+        requestContentType = contentType;
+      } else if (declaredMediaTypes.includes("application/json")) {
+        requestContentType = "application/json";
+      } else if (declaredMediaTypes.length === 1) {
+        requestContentType = declaredMediaTypes[0];
+      } else {
+        throw toolError(
+          "invalid_params",
+          `This operation declares multiple request body media types (${declaredMediaTypes.join(", ")}) and none is application/json -- supply content_type explicitly.`,
+        );
+      }
+      const isJsonContentType =
+        requestContentType === "application/json" ||
+        requestContentType.endsWith("+json");
+      if (isJsonContentType) {
+        requestBody =
+          typeof args.body === "string" ? args.body : JSON.stringify(args.body);
+      } else {
+        if (typeof args.body !== "string") {
+          throw toolError(
+            "invalid_params",
+            `body must be a string for content type "${requestContentType}".`,
+          );
+        }
+        requestBody = args.body;
+      }
+      // No separate size ceiling here: MAX_MCP_BODY_BYTES (64 KiB) already
+      // caps the ENTIRE inbound JSON-RPC request at the transport layer,
+      // before this handler ever runs -- requestBody, as one field within
+      // that request, can never exceed it. A second, larger bound (e.g.
+      // reusing MAX_RESPONSE_BYTES's 256 KiB) would be strictly weaker
+      // than the transport cap and could never fire.
+    }
+  }
+  // A body-location signature credential (#7701) is merged into the
+  // outgoing JSON body by callSubnetSurface regardless of whether the
+  // caller separately supplied `body` -- if they didn't (credential
+  // fields only), the block above never ran and requestContentType is
+  // still unset. This surface's own auth object already independently
+  // establishes that a JSON body carrying these fields is expected (the
+  // operation's OpenAPI schema frequently doesn't document it at all,
+  // which is exactly why it's scheme:signature and not something
+  // generic), so default to application/json here rather than reusing
+  // the schema-driven resolution above, which only ever runs when the
+  // caller supplied a body of their own.
+  if (credentialPlacement?.location === "body" && !requestContentType) {
+    requestContentType = "application/json";
+  }
+  // The url `callSubnetSurface` will hand to `new URL()` two frames down,
+  // checked HERE rather than assumed. The catalog is a baked artifact, so
+  // by the time a row reaches this line it is untrusted bytes; a row with
+  // no usable url declines the way every other uncallable surface does
+  // instead of throwing a TypeError inside the fetch path (#11339).
+  const surfaceUrl = stringOf(surface.url);
+  if (!surfaceUrl) {
+    throw await uncallableSurfaceError(ctx, args.surface_id);
+  }
+  const surfaceProbe = recordOrNull(surface.probe);
+  const result = await callSubnetSurface(
+    {
+      url: surfaceUrl,
+      ...(surfaceProbe
+        ? {
+            probe: {
+              ...(stringOf(surfaceProbe.method)
+                ? { method: stringOf(surfaceProbe.method) as string }
+                : {}),
+              ...(numberOrNull(surfaceProbe.timeout_ms) !== null
+                ? {
+                    timeout_ms: numberOrNull(surfaceProbe.timeout_ms) as number,
+                  }
+                : {}),
+            },
+          }
+        : {}),
+    },
+    {
+      query:
+        args.query && typeof args.query === "object" ? args.query : undefined,
+      path: hasPath ? args.path : undefined,
+      method: hasPath ? normalizedMethod : undefined,
+      body: requestBody,
+      contentType: requestContentType,
+      credential: credentialPlacement,
+      fetchImpl: globalThis.fetch,
+      isUnsafeUrl: workerResolvedUrlSafetyGuard({
+        fetchImpl: globalThis.fetch,
+      }),
+    },
+  );
+  if (!result.ok) {
+    if (
+      result.unsafe_url ||
+      result.private_redirect_blocked ||
+      result.path_origin_mismatch
+    ) {
+      throw toolError(
+        "forbidden",
+        "This surface's URL is not safe to call (private/loopback address, an unsafe redirect target, or a path that resolves outside the surface's own origin).",
+      );
+    }
+    if (result.error?.startsWith("unsupported content-type")) {
+      throw toolError("unsupported_content_type", result.error);
+    }
+    throw toolError(
+      "upstream_unavailable",
+      result.error || "The surface could not be reached.",
+    );
+  }
+  return {
+    surface_id: surfaceId,
+    url: result.url,
+    status_code: result.status_code,
+    content_type: result.content_type,
+    latency_ms: result.latency_ms,
+    body: result.body,
+    truncated: result.truncated,
+    ...(result.parse_error ? { parse_error: result.parse_error } : {}),
+    ...(credentialSource ? { credential_source: credentialSource } : {}),
+    // #9009: the deprecation window. An authenticated caller still passing
+    // the secret in-band gets told, per call, that the stored path exists
+    // -- the argument is not rejected for them yet. Anonymous callers see
+    // nothing: for them the argument is the supported mechanism, not a
+    // deprecated one, so warning them would be false.
+    ...(hasInBandCredential && storeIdentity
+      ? {
+          credential_deprecation:
+            "Passing `credential` as a tool argument is deprecated for authenticated callers: it travels through client logs and the conversation transcript. Register it once with store_surface_credential and omit the argument.",
+        }
+      : {}),
   };
 }
 
@@ -14579,462 +15083,37 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     name: "call_subnet_surface",
     title: "Call a subnet's live API and return its response",
     description:
-      "Actually call a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (GET/HEAD) -- MCP execute Phase 1 (#7014). Supplying both `path` and `method` (GET/HEAD/POST/PUT/PATCH/DELETE) calls a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed -- MCP execute Phase 2 (#7674, #7675). A concrete value substitutes into a templated path, so `/workers/abc` reaches a declared `/workers/{worker_id}`. PATCH and DELETE are reachable on the same terms as every other verb and grant no authority the caller lacks calling the API directly: the operation must be declared, and an authenticated surface still needs the caller's own credential. For POST/PUT/PATCH, `body` is validated against the matched operation's declared request body: rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) that can be placed in a header, query param, cookie, or merged into a POST/PUT/PATCH JSON body (MCP execute Phase 3-4, #7686-#7688, #7701). Never obtains a credential on your behalf. Authenticated callers should register the credential once with store_surface_credential and OMIT the `credential` argument -- it is then resolved from the caller's own store and never travels through tool arguments, client logs, or the conversation transcript; passing it in-band still works but is deprecated for authenticated callers (#9009). Anonymous callers have no store to bind to and keep passing `credential` in-band, which is never retained past the single call.",
+      "Read a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. GET and HEAD only; to POST/PUT/PATCH/DELETE a declared operation, use write_subnet_surface. Both are the same implementation behind the same gate, split so a read never carries a write's risk. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (#7014). Supplying both `path` and `method` reads a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed (#7674, #7675). A concrete value substitutes into a templated path, so `/workers/abc` reaches a declared `/workers/{worker_id}`. A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) that can be placed in a header, query param, or cookie (#7686-#7688, #7701). Never obtains a credential on your behalf. Authenticated callers should register the credential once with store_surface_credential and OMIT the `credential` argument -- it is then resolved from the caller's own store and never travels through tool arguments, client logs, or the conversation transcript; passing it in-band still works but is deprecated for authenticated callers (#9009). Anonymous callers have no store to bind to and keep passing `credential` in-band, which is never retained past the single call. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected.",
+
     inputSchema: inputJsonSchema(CallSubnetSurfaceInputSchema),
     async handler(
       args: z.infer<typeof CallSubnetSurfaceInputSchema>,
       ctx: McpCtx,
     ) {
-      if (typeof args?.surface_id !== "string" || !args.surface_id) {
-        throw toolError("invalid_params", "surface_id is required.");
-      }
-      if (!SURFACE_ID_PATTERN.test(args.surface_id)) {
-        throw toolError("invalid_params", "Invalid surface_id format.");
-      }
-      const hasPath = typeof args?.path === "string" && args.path.length > 0;
-      const hasMethod =
-        typeof args?.method === "string" && args.method.length > 0;
-      if (hasPath !== hasMethod) {
-        throw toolError(
-          "invalid_params",
-          "`path` and `method` must be supplied together, or both omitted.",
-        );
-      }
-      const hasBodyArg = args?.body !== undefined && args?.body !== null;
-      const hasContentTypeArg =
-        typeof args?.content_type === "string" && args.content_type.length > 0;
-      if (
-        hasBodyArg &&
-        !(
-          typeof args.body === "string" ||
-          (typeof args.body === "object" && !Array.isArray(args.body))
-        )
-      ) {
-        throw toolError("invalid_params", "`body` must be a string or object.");
-      }
-      if (hasContentTypeArg && !hasBodyArg) {
-        throw toolError(
-          "invalid_params",
-          "`content_type` requires `body` to also be set.",
-        );
-      }
-      if (hasBodyArg && !hasPath) {
-        throw toolError(
-          "invalid_params",
-          "`body` requires `path` and `method` to also be set.",
-        );
-      }
-      let normalizedMethod: string | undefined;
-      if (hasMethod) {
-        // hasMethod already proved args.method is a non-empty string.
-        normalizedMethod = (args.method as string).toUpperCase();
-        if (
-          !(CALL_SURFACE_METHODS as readonly string[]).includes(
-            normalizedMethod,
-          )
-        ) {
-          throw toolError(
-            "invalid_params",
-            `\`method\` must be ${CALL_SURFACE_METHODS.join(", ")}.`,
-          );
-        }
-        // DELETE joins GET/HEAD here rather than with the body-carrying verbs:
-        // a request body on DELETE is permitted by HTTP and ignored by most
-        // servers, and accepting one would mean validating it against a
-        // requestBody the operation almost never declares.
-        if (
-          hasBodyArg &&
-          !(CALL_SURFACE_BODY_METHODS as readonly string[]).includes(
-            normalizedMethod,
-          )
-        ) {
-          throw toolError(
-            "invalid_params",
-            `\`body\` is only valid with method ${CALL_SURFACE_BODY_METHODS.join(", ")}.`,
-          );
-        }
-      }
-      const surface = await findCataloguedSurface(ctx, args.surface_id);
-      if (!surface) {
-        throw await uncallableSurfaceError(ctx, args.surface_id);
-      }
-      // The catalog row's OWN id -- the credential-store key and the id echoed
-      // back in the result. A row can be matched by `surface_key` or by a
-      // deprecated alias, so it is not necessarily the id the caller asked
-      // with; falling back to that one keeps the key a string rather than
-      // storing a credential under `undefined` (#10782).
-      const surfaceId = stringOf(surface.surface_id) ?? args.surface_id;
-      const hasInBandStringCredential =
-        typeof args?.credential === "string" && args.credential.length > 0;
-      const hasInBandObjectCredential =
-        args?.credential !== null &&
-        typeof args?.credential === "object" &&
-        !Array.isArray(args?.credential);
-      const hasInBandCredential =
-        hasInBandStringCredential || hasInBandObjectCredential;
-      if (hasInBandCredential && !surface.auth_required) {
-        throw toolError(
-          "invalid_params",
-          "`credential` was supplied but this surface does not require one.",
-        );
-      }
-      // #9009: an authenticated caller can register a credential once
-      // (store_surface_credential) instead of passing it as a tool argument
-      // on every call -- a tool argument travels through client logs, the
-      // conversation transcript, and the analytics parameter capture. The
-      // in-band argument still WINS when both exist (an explicit argument
-      // must never be silently overridden by stale stored state) and stays
-      // fully supported for anonymous callers, per ADR 0027's Model B: this
-      // cleanup must not remove anonymous reach as a side effect.
-      const storeIdentity = resolveSurfaceCredentialIdentity(ctx);
-      let resolvedCredential: StoredSurfaceCredential | undefined =
-        hasInBandCredential
-          ? (args.credential as StoredSurfaceCredential)
-          : undefined;
-      let credentialSource: "argument" | "stored" | undefined =
-        hasInBandCredential ? "argument" : undefined;
-      if (surface.auth_required && !hasInBandCredential && storeIdentity) {
-        const stored = await loadSurfaceCredential(
-          asCredentialStoreEnv(ctx.env),
-          storeIdentity,
-          surfaceId,
-        );
-        if (stored) {
-          resolvedCredential = stored;
-          credentialSource = "stored";
-        }
-      }
-      const hasStringCredentialArg =
-        typeof resolvedCredential === "string" && resolvedCredential.length > 0;
-      const hasObjectCredentialArg =
-        resolvedCredential !== null &&
-        typeof resolvedCredential === "object" &&
-        !Array.isArray(resolvedCredential);
-      const hasCredentialArg = hasStringCredentialArg || hasObjectCredentialArg;
-      let credentialPlacement: CallSubnetSurfaceCredential | undefined;
-      if (surface.auth_required) {
-        if (!hasCredentialArg) {
-          throw toolError(
-            "auth_required",
-            "This surface requires a credential. Supply `credential` (see this tool's description for the required format), register one first with store_surface_credential if you are authenticated, or use list_subnet_apis / how_do_i_call to see how to call it directly.",
-          );
-        }
-        // The curated auth block, read ONCE. `surface.auth?.scheme` on a bag
-        // is an `any` five times over, and one of those five (`names`) is
-        // then `Array.isArray`-checked and re-read from the bag rather than
-        // from what the check proved (#10782).
-        const auth = rowOf(surface.auth);
-        const scheme = auth?.scheme;
-        // `location` reaches `CallSubnetSurfaceCredential.location`, a union
-        // of four literals. The `!==` chains below VALIDATE it and narrow
-        // nothing -- excluding literals from `unknown` leaves `unknown` -- so
-        // it crossed into the published placement as an `any` (#10782).
-        const location = authLocationOf(auth?.location);
-        if (scheme === "bearer" || scheme === "api-key" || scheme === "basic") {
-          const name = stringOf(auth?.name);
-          if (!name || location === null || location === "body") {
-            throw toolError(
-              "credential_not_supported",
-              "This surface's auth mechanism (location/name) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
-            );
-          }
-          if (!hasStringCredentialArg) {
-            throw toolError(
-              "invalid_params",
-              `This surface's auth.scheme ("${scheme}") requires \`credential\` to be a single string, not an object.`,
-            );
-          }
-          // hasStringCredentialArg already proved this at runtime.
-          credentialPlacement = {
-            location,
-            name,
-            value: resolvedCredential as string,
-          };
-        } else if (scheme === "signature") {
-          const names = Array.isArray(auth?.names) ? auth.names : null;
-          if (!names || names.length === 0 || location === null) {
-            throw toolError(
-              "credential_not_supported",
-              "This surface's auth mechanism (location/names) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
-            );
-          }
-          if (!hasObjectCredentialArg) {
-            throw toolError(
-              "invalid_params",
-              `This surface's auth.scheme ("signature") requires \`credential\` to be an object mapping each of ${JSON.stringify(names)} to a value you have already computed -- this tool does not sign requests itself.`,
-            );
-          }
-          // hasObjectCredentialArg already proved this at runtime.
-          const credentialObj = resolvedCredential as Record<string, unknown>;
-          const suppliedNames = Object.keys(credentialObj);
-          const missing = names.filter(
-            (n: unknown) => !suppliedNames.includes(n as string),
-          );
-          const unexpected = suppliedNames.filter((n) => !names.includes(n));
-          if (missing.length > 0 || unexpected.length > 0) {
-            throw toolError(
-              "invalid_params",
-              `\`credential\` must have exactly these keys: ${JSON.stringify(names)}.` +
-                (missing.length > 0
-                  ? ` Missing: ${JSON.stringify(missing)}.`
-                  : "") +
-                (unexpected.length > 0
-                  ? ` Unexpected: ${JSON.stringify(unexpected)}.`
-                  : ""),
-            );
-          }
-          for (const [key, value] of Object.entries(credentialObj)) {
-            if (typeof value !== "string" || value.length === 0) {
-              throw toolError(
-                "invalid_params",
-                `\`credential.${key}\` must be a non-empty string.`,
-              );
-            }
-          }
-          // The loop above has just verified every value is a non-empty
-          // string, so this is Record<string, string> despite the wider
-          // Record<string, unknown> inferred from the input schema.
-          const credentialValues = credentialObj as Record<string, string>;
-          if (
-            location === "body" &&
-            !(
-              hasPath &&
-              (normalizedMethod === "POST" || normalizedMethod === "PUT")
-            )
-          ) {
-            throw toolError(
-              "invalid_params",
-              "This surface's credential is sent in the request body, which requires `path` and `method` (POST or PUT) to also be set.",
-            );
-          }
-          // metagraphed#7716: some APIs wrap the credential in its own
-          // nested object alongside the semantic payload (e.g.
-          // {"payload": {...}, "sig": {...}}) rather than a flat top-level
-          // merge -- auth.body_envelope, curated registry data, describes
-          // that shape. Only meaningful for location:"body"; malformed or
-          // absent falls back to the existing flat-merge behavior.
-          const envelope = rowOf(auth?.body_envelope);
-          const bodyEnvelope =
-            location === "body" &&
-            envelope &&
-            typeof envelope.payload_key === "string" &&
-            envelope.payload_key.length > 0 &&
-            typeof envelope.credential_key === "string" &&
-            envelope.credential_key.length > 0
-              ? {
-                  payloadKey: envelope.payload_key,
-                  credentialKey: envelope.credential_key,
-                }
-              : undefined;
-          credentialPlacement = {
-            location,
-            values: credentialValues,
-            ...(bodyEnvelope ? { bodyEnvelope } : {}),
-          };
-        } else {
-          throw toolError(
-            "credential_not_supported",
-            `This surface's auth scheme ("${scheme || "undocumented"}") is not one this tool can attach a credential to (only bearer/api-key/basic/signature are supported). Use list_subnet_apis / how_do_i_call to see how to call it directly.`,
-          );
-        }
-      }
-      if (rowOf(surface.probe)?.enabled === false) {
-        throw toolError(
-          "surface_unavailable",
-          "This surface is flagged as not safe to call automatically (probe.enabled:false).",
-        );
-      }
-      let requestBody;
-      let requestContentType;
-      if (hasPath) {
-        const schemaArtifactId =
-          rowOf(surface.schema_source)?.surface_id || surface.surface_id;
-        const schema = await loadOptionalArtifact(
-          ctx,
-          `/metagraph/schemas/${schemaArtifactId}.json`,
-        );
-        if (!schema) {
-          throw toolError(
-            "no_schema",
-            "This surface has no captured schema, so path/method execution is not available for it -- omit path/method to call its single declared url instead.",
-          );
-        }
-        // hasPath already proved args.path is a string; the `hasPath !==
-        // hasMethod` check above guarantees normalizedMethod is set
-        // whenever hasPath is true.
-        const match = matchSchemaOperation(
-          rowOf(schema)?.document,
-          args.path as string,
-          normalizedMethod as string,
-        );
-        if (!match) {
-          throw toolError(
-            "path_not_declared",
-            `"${normalizedMethod} ${args.path}" is not declared in this surface's captured schema. Fetch the schema with get_api_schema to see valid paths/methods.`,
-          );
-        }
-        if (
-          hasBodyArg &&
-          (normalizedMethod === "POST" || normalizedMethod === "PUT")
-        ) {
-          const declaredContent = rowOf(
-            rowOf(match.operation.requestBody)?.content,
-          );
-          const declaredMediaTypes = declaredContent
-            ? Object.keys(declaredContent)
-            : [];
-          if (declaredMediaTypes.length === 0) {
-            throw toolError(
-              "invalid_params",
-              `"${normalizedMethod} ${args.path}" does not declare a request body in its schema.`,
-            );
-          }
-          if (hasContentTypeArg) {
-            // hasContentTypeArg already proved this is a non-empty string.
-            const contentType = args.content_type as string;
-            if (!declaredMediaTypes.includes(contentType)) {
-              throw toolError(
-                "invalid_params",
-                `content_type "${contentType}" is not declared for this operation. Declared: ${declaredMediaTypes.join(", ")}.`,
-              );
-            }
-            requestContentType = contentType;
-          } else if (declaredMediaTypes.includes("application/json")) {
-            requestContentType = "application/json";
-          } else if (declaredMediaTypes.length === 1) {
-            requestContentType = declaredMediaTypes[0];
-          } else {
-            throw toolError(
-              "invalid_params",
-              `This operation declares multiple request body media types (${declaredMediaTypes.join(", ")}) and none is application/json -- supply content_type explicitly.`,
-            );
-          }
-          const isJsonContentType =
-            requestContentType === "application/json" ||
-            requestContentType.endsWith("+json");
-          if (isJsonContentType) {
-            requestBody =
-              typeof args.body === "string"
-                ? args.body
-                : JSON.stringify(args.body);
-          } else {
-            if (typeof args.body !== "string") {
-              throw toolError(
-                "invalid_params",
-                `body must be a string for content type "${requestContentType}".`,
-              );
-            }
-            requestBody = args.body;
-          }
-          // No separate size ceiling here: MAX_MCP_BODY_BYTES (64 KiB) already
-          // caps the ENTIRE inbound JSON-RPC request at the transport layer,
-          // before this handler ever runs -- requestBody, as one field within
-          // that request, can never exceed it. A second, larger bound (e.g.
-          // reusing MAX_RESPONSE_BYTES's 256 KiB) would be strictly weaker
-          // than the transport cap and could never fire.
-        }
-      }
-      // A body-location signature credential (#7701) is merged into the
-      // outgoing JSON body by callSubnetSurface regardless of whether the
-      // caller separately supplied `body` -- if they didn't (credential
-      // fields only), the block above never ran and requestContentType is
-      // still unset. This surface's own auth object already independently
-      // establishes that a JSON body carrying these fields is expected (the
-      // operation's OpenAPI schema frequently doesn't document it at all,
-      // which is exactly why it's scheme:signature and not something
-      // generic), so default to application/json here rather than reusing
-      // the schema-driven resolution above, which only ever runs when the
-      // caller supplied a body of their own.
-      if (credentialPlacement?.location === "body" && !requestContentType) {
-        requestContentType = "application/json";
-      }
-      // The url `callSubnetSurface` will hand to `new URL()` two frames down,
-      // checked HERE rather than assumed. The catalog is a baked artifact, so
-      // by the time a row reaches this line it is untrusted bytes; a row with
-      // no usable url declines the way every other uncallable surface does
-      // instead of throwing a TypeError inside the fetch path (#11339).
-      const surfaceUrl = stringOf(surface.url);
-      if (!surfaceUrl) {
-        throw await uncallableSurfaceError(ctx, args.surface_id);
-      }
-      const surfaceProbe = recordOrNull(surface.probe);
-      const result = await callSubnetSurface(
-        {
-          url: surfaceUrl,
-          ...(surfaceProbe
-            ? {
-                probe: {
-                  ...(stringOf(surfaceProbe.method)
-                    ? { method: stringOf(surfaceProbe.method) as string }
-                    : {}),
-                  ...(numberOrNull(surfaceProbe.timeout_ms) !== null
-                    ? {
-                        timeout_ms: numberOrNull(
-                          surfaceProbe.timeout_ms,
-                        ) as number,
-                      }
-                    : {}),
-                },
-              }
-            : {}),
-        },
-        {
-          query:
-            args.query && typeof args.query === "object"
-              ? args.query
-              : undefined,
-          path: hasPath ? args.path : undefined,
-          method: hasPath ? normalizedMethod : undefined,
-          body: requestBody,
-          contentType: requestContentType,
-          credential: credentialPlacement,
-          fetchImpl: globalThis.fetch,
-          isUnsafeUrl: workerResolvedUrlSafetyGuard({
-            fetchImpl: globalThis.fetch,
-          }),
-        },
+      return subnetSurfaceCall(
+        args,
+        ctx,
+        CALL_SURFACE_READ_METHODS,
+        "write_subnet_surface",
       );
-      if (!result.ok) {
-        if (
-          result.unsafe_url ||
-          result.private_redirect_blocked ||
-          result.path_origin_mismatch
-        ) {
-          throw toolError(
-            "forbidden",
-            "This surface's URL is not safe to call (private/loopback address, an unsafe redirect target, or a path that resolves outside the surface's own origin).",
-          );
-        }
-        if (result.error?.startsWith("unsupported content-type")) {
-          throw toolError("unsupported_content_type", result.error);
-        }
-        throw toolError(
-          "upstream_unavailable",
-          result.error || "The surface could not be reached.",
-        );
-      }
-      return {
-        surface_id: surfaceId,
-        url: result.url,
-        status_code: result.status_code,
-        content_type: result.content_type,
-        latency_ms: result.latency_ms,
-        body: result.body,
-        truncated: result.truncated,
-        ...(result.parse_error ? { parse_error: result.parse_error } : {}),
-        ...(credentialSource ? { credential_source: credentialSource } : {}),
-        // #9009: the deprecation window. An authenticated caller still passing
-        // the secret in-band gets told, per call, that the stored path exists
-        // -- the argument is not rejected for them yet. Anonymous callers see
-        // nothing: for them the argument is the supported mechanism, not a
-        // deprecated one, so warning them would be false.
-        ...(hasInBandCredential && storeIdentity
-          ? {
-              credential_deprecation:
-                "Passing `credential` as a tool argument is deprecated for authenticated callers: it travels through client logs and the conversation transcript. Register it once with store_surface_credential and omit the argument.",
-            }
-          : {}),
-      };
+    },
+  },
+  {
+    name: "write_subnet_surface",
+    title: "Call a declared write operation on a subnet's live API",
+    description:
+      "Issue a POST, PUT, PATCH or DELETE against a catalogued surface, and return its real response body. The write sibling of call_subnet_surface, which handles GET/HEAD -- see the MCP tool registry for that one. Both are the same implementation and enforce the same gate; they are separate tools so a read never carries a write's risk. `path` and `method` are REQUIRED: there is no curated write, so the operation is always named explicitly. The exact path+method must be declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright and never guessed (#7674, #7675, #11146). A concrete value substitutes into a templated path, so `/workers/abc` reaches a declared `/workers/{worker_id}`. This grants no authority the caller lacks calling the API directly: the operation must be declared, and an authenticated surface still needs the caller's own credential. `body` is validated against the matched operation's declared request body -- rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) placed in a header, query param, cookie, or merged into the JSON body (#7686-#7688, #7701). Never obtains a credential on your behalf. Authenticated callers should register the credential once with store_surface_credential and OMIT the `credential` argument -- it is then resolved from the caller's own store and never travels through tool arguments, client logs, or the conversation transcript; passing it in-band still works but is deprecated for authenticated callers (#9009). Anonymous callers have no store to bind to and keep passing `credential` in-band, which is never retained past the single call. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected.",
+    inputSchema: inputJsonSchema(WriteSubnetSurfaceInputSchema),
+    async handler(
+      args: z.infer<typeof WriteSubnetSurfaceInputSchema>,
+      ctx: McpCtx,
+    ) {
+      return subnetSurfaceCall(
+        args,
+        ctx,
+        CALL_SURFACE_WRITE_METHODS,
+        "call_subnet_surface",
+      );
     },
   },
   // ─── Surface-credential store (#9009) ────────────────────────────────────
@@ -15568,6 +15647,9 @@ const TOOL_OUTPUT_SCHEMAS: Record<string, JsonSchemaLike> = {
   ask: outputJsonSchema(AskOutputSchema),
   verify_integration: outputJsonSchema(VerifyIntegrationOutputSchema),
   call_subnet_surface: outputJsonSchema(CallSubnetSurfaceOutputSchema),
+  // Same envelope: the split is about which verbs a tool will issue, not about
+  // what a surface answers with.
+  write_subnet_surface: outputJsonSchema(CallSubnetSurfaceOutputSchema),
   store_surface_credential: outputJsonSchema(
     StoreSurfaceCredentialOutputSchema,
   ),

--- a/src/mcp-tool-exposures.ts
+++ b/src/mcp-tool-exposures.ts
@@ -410,6 +410,11 @@ export const MCP_EXPOSURES: Readonly<Record<string, McpExposure>> = {
     reason:
       "Calls a catalogued third-party surface and returns ITS body; the shape is the subnet's, not ours.",
   },
+  write_subnet_surface: {
+    operation: null,
+    reason:
+      "The write half of call_subnet_surface (#11568): same third-party surface, same absence of a route of ours to mirror.",
+  },
   store_surface_credential: {
     operation: null,
     reason:

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -329,8 +329,65 @@ const SIGNATURE_NO_LOCATION_SURFACE = {
   probe: { method: "GET", enabled: true },
 };
 
+/** #11568: a catalogued surface with NO url. The catalogue is built from
+ * captured data, so a surface can be listed and still have nothing callable --
+ * the handler must say so rather than hand `undefined` to `new URL()`. */
+const NO_URL_SURFACE = {
+  surface_id: "x:api:nourl",
+  surface_key: "srf-xapinourl0000",
+  netuid: 5,
+  kind: "subnet-api",
+  provider: "p",
+  auth_required: false,
+  probe: { method: "GET", expect: "json", timeout_ms: 8000, enabled: true },
+};
+
+/** A probe block present but declaring NO method: the surface says how long to
+ * wait and nothing about the verb, so the method key must be omitted rather
+ * than spread in as `undefined`. */
+const PROBE_WITHOUT_METHOD_SURFACE = {
+  surface_id: "x:api:noprobemethod",
+  surface_key: "srf-xapinopm00000",
+  netuid: 5,
+  kind: "subnet-api",
+  url: "https://x.example/noprobemethod",
+  provider: "p",
+  auth_required: false,
+  probe: { expect: "json", timeout_ms: 8000, enabled: true },
+};
+
+/** A surface with no probe block at all: nothing declares which method the
+ * curated url answers, so the call falls back to the default rather than
+ * spreading `undefined` into the request. */
+const NO_PROBE_SURFACE = {
+  surface_id: "x:api:noprobe",
+  surface_key: "srf-xapinoprobe00",
+  netuid: 5,
+  kind: "subnet-api",
+  url: "https://x.example/noprobe",
+  provider: "p",
+  auth_required: false,
+};
+
+/** A surface whose own `surface_id` field is absent. Credential keys are built
+ * from it, so the caller-supplied id is the fallback that keeps the key a
+ * string rather than storing one under `undefined` (#10782). */
+const UNNAMED_SURFACE = {
+  surface_key: "srf-xapiunnamed00",
+  netuid: 5,
+  kind: "subnet-api",
+  url: "https://x.example/unnamed",
+  provider: "p",
+  auth_required: false,
+  probe: { method: "GET", expect: "json", timeout_ms: 8000, enabled: true },
+};
+
 const CATALOG = {
   surfaces: [
+    NO_URL_SURFACE,
+    PROBE_WITHOUT_METHOD_SURFACE,
+    NO_PROBE_SURFACE,
+    UNNAMED_SURFACE,
     NO_AUTH_SURFACE,
     AUTH_SURFACE,
     DISABLED_PROBE_SURFACE,
@@ -368,6 +425,22 @@ const deps = {
   },
 };
 
+/**
+ * Which of the two surface-call tools this call belongs to (#11568).
+ *
+ * The suite predates the split and asserts BEHAVIOUR -- schema gating, body
+ * validation, credential placement -- none of which changed. Routing by verb
+ * here keeps every one of those assertions pointed at the tool that now owns
+ * the verb, and makes the split itself load-bearing: a write sent to the read
+ * tool would be refused, so these tests fail if the routing regresses.
+ */
+function surfaceToolFor(args: Row): string {
+  const method = String(args?.method ?? "").toUpperCase();
+  return ["POST", "PUT", "PATCH", "DELETE"].includes(method)
+    ? "write_subnet_surface"
+    : "call_subnet_surface";
+}
+
 async function callTool(args: Row, fetchImpl?: typeof fetch) {
   const of = globalThis.fetch;
   globalThis.fetch =
@@ -386,7 +459,7 @@ async function callTool(args: Row, fetchImpl?: typeof fetch) {
           jsonrpc: "2.0",
           id: 1,
           method: "tools/call",
-          params: { name: "call_subnet_surface", arguments: args },
+          params: { name: surfaceToolFor(args), arguments: args },
         }),
       }),
       {} as unknown as Env,
@@ -1591,7 +1664,7 @@ describe("not_callable vs not_found (#8652)", () => {
           jsonrpc: "2.0",
           id: 1,
           method: "tools/call",
-          params: { name: "call_subnet_surface", arguments: args },
+          params: { name: surfaceToolFor(args), arguments: args },
         }),
       }),
       {} as unknown as Env,
@@ -2311,5 +2384,44 @@ describe("surface credential store (#9009)", () => {
     } finally {
       globalThis.fetch = of;
     }
+  });
+});
+
+// #11568: arms of the shared handler that no fixture previously reached. They
+// moved with the extraction, so they are in the patch either way -- and each
+// one is a real refusal path that had never fired.
+describe("catalogued surfaces that are not fully callable", () => {
+  test("a surface with no url is reported uncallable, not dereferenced", async () => {
+    // The catalogue is captured data: a surface can be listed with no url at
+    // all. Handing that to `new URL()` would be a TypeError inside the fetch
+    // path instead of an answer (#11339).
+    const result = await callTool({ surface_id: "x:api:nourl" });
+    assert.equal(result.isError, true);
+    assert.ok(
+      ((result.structuredContent as Row).error as Row).code,
+      "carries a structured error code rather than a thrown TypeError",
+    );
+  });
+
+  test("a probe block with no method omits the key rather than sending undefined", async () => {
+    const result = await callTool({ surface_id: "x:api:noprobemethod" });
+    assert.notEqual(result.isError, true);
+  });
+
+  test("a surface with no probe block still calls its curated url", async () => {
+    const result = await callTool({ surface_id: "x:api:noprobe" });
+    assert.notEqual(
+      result.isError,
+      true,
+      "a missing probe block is not a reason to refuse",
+    );
+  });
+
+  test("a surface with no surface_id of its own falls back to the caller's", async () => {
+    // Resolved by its stable surface_key, which is the only way to reach a
+    // surface that carries no surface_id field -- and therefore the only way
+    // the fallback that keeps credential keys a string is ever exercised.
+    const result = await callTool({ surface_id: "srf-xapiunnamed00" });
+    assert.notEqual(result.isError, true);
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -322,15 +322,19 @@ describe("MCP tool registry", () => {
       }
       assert.ok(def.name && def.title && def.description && def.inputSchema);
       // #8964: every tool except the known mutators is read-only with no side
-      // effects, so clients may auto-run it. call_subnet_surface proxies a
-      // caller-supplied method, body, and credential to a third-party host and
-      // is annotated accordingly — this assertion previously claimed otherwise
-      // for all 207 tools, which is the defect that issue fixed. #9009 added
-      // the two credential-store writers. Every mutator's full annotation block
-      // is pinned in tests/mcp-tool-annotations.test.ts.
+      // effects, so clients may auto-run it. This assertion previously claimed
+      // that for all 207 tools, which is the defect that issue fixed. #9009
+      // added the two credential-store writers.
+      //
+      // #11568 REMOVED call_subnet_surface from this list rather than adding
+      // to it: the catch-all was split, and the read half now issues only
+      // GET/HEAD, so it is genuinely auto-runnable. write_subnet_surface is
+      // the tool that proxies a caller-supplied method, body and credential to
+      // a third-party host. Every mutator's full annotation block is pinned in
+      // tests/mcp-tool-annotations.test.ts.
       if (
         ![
-          "call_subnet_surface",
+          "write_subnet_surface",
           "store_surface_credential",
           "delete_surface_credential",
         ].includes(def.name)

--- a/tests/mcp-tool-annotations.test.ts
+++ b/tests/mcp-tool-annotations.test.ts
@@ -5,7 +5,8 @@
 // make credentialed writes it would never have made knowingly.
 //
 // These tests pin the three claims that matter:
-//   1. `call_subnet_surface` — the only true mutator — is never read-only.
+//   1. `write_subnet_surface` — the only true mutator — is never read-only,
+//      and its read sibling never claims to be one.
 //   2. Every tool that leaves metagraphed infrastructure declares open-world,
 //      and every tool that does not, does not.
 //   3. The open-world list cannot silently rot: a tool whose handler reaches a
@@ -44,17 +45,35 @@ describe("MCP tool annotations", () => {
     }
   });
 
-  // The specific defect #8964 was filed for. call_subnet_surface issues
-  // caller-supplied POST/PUT with a caller-supplied credential to third-party
-  // subnet hosts; every one of these four claims was previously wrong.
-  test("call_subnet_surface is not advertised as a safe read", () => {
-    const annotations = byName.get("call_subnet_surface")
+  // The specific defect #8964 was filed for, now carried by the tool that
+  // actually issues the writes. #11568 split the verbs: write_subnet_surface
+  // sends caller-supplied POST/PUT/PATCH/DELETE with a caller-supplied
+  // credential to third-party subnet hosts, and every one of these four claims
+  // was once wrong on the merged tool.
+  test("write_subnet_surface is not advertised as a safe read", () => {
+    const annotations = byName.get("write_subnet_surface")
       ?.annotations as Record<string, unknown>;
-    assert.ok(annotations, "call_subnet_surface must be registered");
+    assert.ok(annotations, "write_subnet_surface must be registered");
     assert.equal(annotations.readOnlyHint, false);
     assert.equal(annotations.destructiveHint, true);
     // A caller-supplied POST/PUT is not idempotent by construction.
     assert.equal(annotations.idempotentHint, false);
+    assert.equal(annotations.openWorldHint, true);
+  });
+
+  // The other half of the split, and the reason it was worth doing beyond the
+  // directory rule: a read that cannot write may run without a per-call
+  // confirmation. That claim is only safe because the handler enforces the
+  // verb set -- see the write-verb refusal test in the split suite.
+  test("call_subnet_surface is a truthful read after the split", () => {
+    const annotations = byName.get("call_subnet_surface")
+      ?.annotations as Record<string, unknown>;
+    assert.ok(annotations, "call_subnet_surface must be registered");
+    assert.equal(annotations.readOnlyHint, true);
+    assert.equal(annotations.destructiveHint, false);
+    // GET/HEAD are idempotent by definition (RFC 9110).
+    assert.equal(annotations.idempotentHint, true);
+    // Still somebody else's host.
     assert.equal(annotations.openWorldHint, true);
   });
 
@@ -83,7 +102,13 @@ describe("MCP tool annotations", () => {
     // subnets -- a closed-world annotation that was only true because the read
     // was broken. Widening the set here is the annotation catching up with a
     // tool that now genuinely leaves our infrastructure.
-    assert.equal(OPEN_WORLD_TOOL_NAMES.length, 23);
+    //
+    // 24 since #11568 split call_subnet_surface into a read and a write tool.
+    // This is the one increment that adds NO new reach: both halves call the
+    // same catalogued third-party surfaces the merged tool already did, and
+    // both are open-world for that reason. The count moved because one tool
+    // became two, not because the set of things we touch grew.
+    assert.equal(OPEN_WORLD_TOOL_NAMES.length, 24);
     assert.ok(
       definitions.length > 200,
       `expected the full catalogue, saw ${definitions.length}`,
@@ -105,7 +130,7 @@ describe("MCP tool annotations", () => {
   //
   // #9009 added two: the credential store's writer and its deleter. Both write
   // only to our own KV, under the authenticated caller's own identity — hence
-  // closed-world, unlike call_subnet_surface, which forwards a caller-supplied
+  // closed-world, unlike write_subnet_surface, which forwards a caller-supplied
   // write to somebody else's host.
   test("the non-read-only tools are exactly the known mutators", () => {
     const mutating = definitions
@@ -115,7 +140,9 @@ describe("MCP tool annotations", () => {
       )
       .map((def) => def.name);
     assert.deepEqual(mutating, [
-      "call_subnet_surface",
+      // #11568: the write half of the surface-call split. Its read sibling is
+      // deliberately absent from this list now -- that is the split working.
+      "write_subnet_surface",
       "store_surface_credential",
       "delete_surface_credential",
     ]);

--- a/tests/subnet-surface-tool-split.test.ts
+++ b/tests/subnet-surface-tool-split.test.ts
@@ -1,0 +1,237 @@
+// #11568: the surface-call tool was a catch-all whose `method` argument spanned
+// GET/HEAD and POST/PUT/PATCH/DELETE. The Connectors Directory review criteria
+// name that exact shape as an automatic rejection -- "do not ship a catch-all
+// `api_request` tool with a `method` parameter" -- and say outright that
+// documenting the split inside one description does not satisfy it.
+//
+// The split is enforced in the HANDLER, not by the published schema: MCP
+// dispatch does not validate arguments against the Zod schema, so a narrowed
+// enum is advertisement. These tests exercise the enforcement.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import {
+  CALL_SURFACE_METHODS,
+  CALL_SURFACE_READ_METHODS,
+  CALL_SURFACE_WRITE_METHODS,
+} from "../schemas-src/mcp-tools/ai-integration.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+
+const READ = "call_subnet_surface";
+const WRITE = "write_subnet_surface";
+
+async function call(name: string, args: Row) {
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    mockEnv({}) as Env,
+    {},
+  );
+  return ((await response.json()) as Row).result as Row;
+}
+
+const errorOf = (result: Row) =>
+  ((result?.structuredContent as Row)?.error ?? {}) as Row;
+
+describe("the verb sets partition CALL_SURFACE_METHODS", () => {
+  test("every method belongs to exactly one tool", () => {
+    // Derived, not restated: a verb added to CALL_SURFACE_METHODS lands in one
+    // set or the other and cannot silently appear in neither.
+    const union = [
+      ...CALL_SURFACE_READ_METHODS,
+      ...CALL_SURFACE_WRITE_METHODS,
+    ].sort();
+    assert.deepEqual(union, [...CALL_SURFACE_METHODS].sort());
+    for (const method of CALL_SURFACE_READ_METHODS) {
+      assert.ok(
+        !(CALL_SURFACE_WRITE_METHODS as readonly string[]).includes(method),
+        method,
+      );
+    }
+  });
+
+  test("the read set is exactly the HTTP-safe verbs", () => {
+    // What makes `readOnlyHint: true` truthful, and therefore what lets a
+    // client run the read tool without a per-call confirmation.
+    assert.deepEqual([...CALL_SURFACE_READ_METHODS], ["GET", "HEAD"]);
+  });
+});
+
+describe("both tools are registered and published distinctly", () => {
+  const byName = new Map(
+    (listToolDefinitions() as Row[]).map((def) => [def.name as string, def]),
+  );
+
+  test("each exists", () => {
+    assert.ok(byName.get(READ), `${READ} must be registered`);
+    assert.ok(byName.get(WRITE), `${WRITE} must be registered`);
+  });
+
+  test("the read tool publishes no request body at all", () => {
+    // A read tool advertising a `body` invites an agent to attempt a write
+    // through it and be refused -- the confusion the split exists to remove.
+    const props = ((byName.get(READ)!.inputSchema as Row).properties ??
+      {}) as Row;
+    assert.ok(!("body" in props), "read tool must not advertise a body");
+    assert.ok(!("content_type" in props));
+    assert.deepEqual((props.method as Row).enum, [
+      ...CALL_SURFACE_READ_METHODS,
+    ]);
+  });
+
+  test("the write tool requires the operation to be named", () => {
+    // There is no curated write: a write always names a declared operation,
+    // and making that structural stops an agent discovering it by refusal.
+    const schema = byName.get(WRITE)!.inputSchema as Row;
+    const required = (schema.required ?? []) as string[];
+    assert.ok(required.includes("path"), "path must be required");
+    assert.ok(required.includes("method"), "method must be required");
+    assert.deepEqual(((schema.properties as Row).method as Row).enum, [
+      ...CALL_SURFACE_WRITE_METHODS,
+    ]);
+  });
+
+  test("both names are within the directory's 64-character limit", () => {
+    for (const name of [READ, WRITE]) assert.ok(name.length <= 64, name);
+  });
+});
+
+describe("the handler enforces the split", () => {
+  test("the read tool refuses every write verb and names the sibling", async () => {
+    for (const method of CALL_SURFACE_WRITE_METHODS) {
+      const error = errorOf(
+        await call(READ, { surface_id: "sn-1-example", path: "/x", method }),
+      );
+      assert.equal(error.code, "invalid_params", method);
+      assert.match(String(error.message), new RegExp(WRITE), method);
+      // An agent that guessed wrong has a correct intent and a wrong address;
+      // being told only "no" turns a one-step correction into a dead end.
+      assert.match(String(error.message), /GET, HEAD/, method);
+    }
+  });
+
+  test("the write tool refuses every read verb and names the sibling", async () => {
+    for (const method of CALL_SURFACE_READ_METHODS) {
+      const error = errorOf(
+        await call(WRITE, { surface_id: "sn-1-example", path: "/x", method }),
+      );
+      assert.equal(error.code, "invalid_params", method);
+      assert.match(String(error.message), new RegExp(READ), method);
+    }
+  });
+
+  test("a verb in neither set still gets the enum message, not the sibling one", async () => {
+    // The sibling hint is only correct when the verb exists somewhere. Telling
+    // a caller who sent TRACE to "use write_subnet_surface" would be a lie.
+    const error = errorOf(
+      await call(READ, {
+        surface_id: "sn-1-example",
+        path: "/x",
+        method: "TRACE",
+      }),
+    );
+    assert.equal(error.code, "invalid_params");
+    assert.doesNotMatch(String(error.message), new RegExp(WRITE));
+  });
+
+  test("the verb check runs before any schema fetch", async () => {
+    // A caller that reached the wrong tool has not earned the work. An
+    // unknown surface_id would otherwise be the first complaint, which would
+    // hide the actual mistake.
+    const error = errorOf(
+      await call(READ, {
+        surface_id: "sn-999-does-not-exist",
+        path: "/x",
+        method: "DELETE",
+      }),
+    );
+    assert.match(String(error.message), new RegExp(WRITE));
+  });
+
+  test("case is normalised, so a lowercase verb is routed the same way", async () => {
+    const error = errorOf(
+      await call(READ, {
+        surface_id: "sn-1-example",
+        path: "/x",
+        method: "post",
+      }),
+    );
+    assert.match(String(error.message), new RegExp(WRITE));
+  });
+});
+
+// Argument-shape refusals that run BEFORE any surface is resolved. They moved
+// with the extraction in #11568 and were never exercised; each one exists to
+// stop a malformed call reaching the outbound fetch path, so leaving them
+// unproven would mean trusting a guard nothing has ever fired.
+describe("body-argument guards", () => {
+  test("a body that is neither string nor object is refused", async () => {
+    for (const body of [42, true, ["a"], null]) {
+      const args: Row = {
+        surface_id: "sn-1-example",
+        path: "/x",
+        method: "POST",
+        body,
+      };
+      const error = errorOf(await call(WRITE, args));
+      // `null` reads as "no body supplied" rather than a malformed one, so it
+      // is the one value here that must NOT be refused for its shape.
+      if (body === null) {
+        assert.notEqual(
+          String(error.message ?? ""),
+          "`body` must be a string or object.",
+        );
+        continue;
+      }
+      assert.equal(error.code, "invalid_params", String(body));
+      assert.match(String(error.message), /`body` must be a string or object/);
+    }
+  });
+
+  test("content_type without a body is refused", async () => {
+    // A content type describes a body. Accepting one without it would send a
+    // header that describes nothing, which is the kind of quiet wrongness that
+    // surfaces later as an unexplained 415 from someone else's host.
+    const error = errorOf(
+      await call(WRITE, {
+        surface_id: "sn-1-example",
+        path: "/x",
+        method: "POST",
+        content_type: "application/json",
+      }),
+    );
+    assert.equal(error.code, "invalid_params");
+    assert.match(String(error.message), /`content_type` requires `body`/);
+  });
+
+  test("the READ tool rejects a body at dispatch, before the handler sees it", async () => {
+    // Dispatch DOES reject unknown argument names against the published
+    // schema, so dropping `body` from the read tool's schema is enforcement
+    // and not merely advertisement. (Enum VALUES are a different matter --
+    // see the verb tests above, which is why the handler still checks those.)
+    const error = errorOf(
+      await call(READ, { surface_id: "sn-1-example", body: { a: 1 } }),
+    );
+    assert.match(String(error.message), /Unknown argument for tool/);
+    assert.match(String(error.message), /`body`/);
+  });
+
+  test("a body with no operation is refused on the write tool", async () => {
+    // `path` is required by the write schema, but required-ness is not what
+    // dispatch enforces -- so the handler is what stops a body with nowhere
+    // to go.
+    const error = errorOf(
+      await call(WRITE, { surface_id: "sn-1-example", body: { a: 1 } }),
+    );
+    assert.equal(error.code, "invalid_params");
+    assert.match(String(error.message), /`body` requires `path` and `method`/);
+  });
+});


### PR DESCRIPTION
`call_subnet_surface` took a `method` argument spanning GET/HEAD **and** POST/PUT/PATCH/DELETE. The Connectors Directory review criteria name that exact shape as an automatic rejection:

> A single tool that accepts both safe HTTP methods (GET, HEAD, OPTIONS) and unsafe methods (POST, PUT, PATCH, DELETE) is rejected. Do not ship a catch-all `api_request` tool with a `method` parameter. […] Documenting safe versus unsafe operations within one tool's description does not satisfy this requirement.

It is the better surface regardless of the listing. A read-only tool can run **without a per-call confirmation**; one that might write always prompts. Merged, every catalogue read paid the write tool's interruption.

## The split

| | verbs | annotation |
|---|---|---|
| `call_subnet_surface` (keeps its name) | GET, HEAD | `readOnlyHint: true` — truthfully, for the first time |
| `write_subnet_surface` (new) | POST, PUT, PATCH, DELETE | `destructiveHint: true` |

One implementation behind both. The schema gate, credential handling and response bounding are untouched.

`path` and `method` are **required** on the write tool. There is no curated write: a write always names a declared operation, and making that structural stops an agent discovering it by being refused.

## Enforcement — and a correction to my own first reading

I assumed MCP dispatch does no argument validation, so a narrowed enum would be advertisement only. Half right, and the difference matters:

- dispatch **does** reject unknown argument *names* — so dropping `body`/`content_type` from the read tool's schema genuinely stops a body reaching the handler through it;
- it does **not** check enum values or required-ness — so a caller may still send `method: "DELETE"` to the read tool.

The handler therefore holds the verb boundary, and the refusal **names the sibling tool**: an agent that guessed wrong has a correct intent and a wrong address, and telling it only "no" turns a one-step correction into an abandoned task. A verb in *neither* set still gets the enum message, because "use write_subnet_surface" would be a lie for `TRACE`.

The verb sets are **derived** from `CALL_SURFACE_METHODS`, so a verb added there lands in exactly one tool and cannot appear in neither.

## Registration

Annotations, output schema, tool-exposure classification and the `validate:mcp` sweep exemption all follow the checklist.

The write half **cannot** be swept and should not be — succeeding would mean CI issuing real writes against third-party hosts on every run. Its response envelope is identical to the read tool's, which *is* swept, so the shape stays proven.

Open-world count moves 23 → 24. It is the one increment that adds **no new reach**: both halves call the same catalogued surfaces the merged tool already did. The count moved because one tool became two.

## Incidental

- Lowered `MAX_UNREFERENCED_EXPORTS` 731 → 730, which the gate asked for.
- Covered four refusal paths the extraction pulled into the diff that no fixture had ever reached: a catalogued surface with no url, a probe block with no method, a surface with no `surface_id` of its own, and a body with no operation to send it to.

## Verification

- **Patch coverage 100%** — 135/135 lines, 212/212 branches, by diff intersection
- Full suite green: 967 files, 22,243 tests
- All 70 `validate:*` scripts, `tsc` clean, prettier clean

Part of #11561.

Closes #11568
