### PR TITLE
feat(oauth): add a consent screen, and prefer CIMD over dynamic client registration

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -45,6 +45,7 @@
 // The package's real TYPES (as opposed to its runtime) have no
 // cloudflare:workers dependency, so `import type` below is safe at module
 // scope -- type-only imports are fully erased and carry no runtime cost.
+import { renderConsentPage } from "./oauth-consent.ts";
 import { asJsonObject } from "../schemas-src/json-request.ts";
 
 import type {
@@ -134,6 +135,19 @@ export function buildOAuthProviderOptions(
     },
     defaultHandler,
     authorizeEndpoint: "/authorize",
+    // #11569: prefer Client ID Metadata Documents over Dynamic Client
+    // Registration. Anthropic's guidance for anything expecting directory
+    // traffic is explicit -- DCR registers a NEW client on every fresh
+    // connection -- and this server has already accumulated 27 registered
+    // clients without being listed anywhere.
+    //
+    // The library gates this on the `global_fetch_strictly_public`
+    // compatibility flag, and correctly: honouring a CIMD means fetching a
+    // URL the caller chose, which without that flag is an SSRF primitive
+    // pointed at our own internal surfaces. The flag is set in wrangler.jsonc;
+    // without it the library declines to advertise support rather than
+    // fetching anyway.
+    clientIdMetadataDocumentEnabled: true,
     tokenEndpoint: "/oauth/token",
     clientRegistrationEndpoint: "/oauth/register",
     // S256 ONLY (#9637). OAuth 2.1 removes `plain`, and the MCP authorization
@@ -330,6 +344,89 @@ export async function handleAuthorizeRequest(
     JSON.stringify(authRequest),
     { expirationTtl: OAUTH_PENDING_TTL_SECONDS },
   );
+  // #11569: ASK, rather than redirect straight to GitHub.
+  //
+  // The user's actual decision is "do I let this client act as me", and until
+  // now the flow never showed them which client had asked -- GitHub's own page
+  // names US, not the caller. Under CIMD the client_id is a self-hosted URL and
+  // its metadata is self-asserted, so the MCP spec requires the consent screen
+  // to display that URL's HOST as the relying party. There has to be a screen
+  // for it to be displayed on.
+  //
+  // The pending request is already stashed under `nonce`, so the nonce doubles
+  // as the CSRF token: POST /authorize proceeds only for a nonce that names a
+  // request we ourselves parsed and stored moments ago.
+  return new Response(
+    renderConsentPage({
+      clientId: authRequest.clientId,
+      clientName: stringOrNull(client.clientName),
+      redirectUri: authRequest.redirectUri,
+      registeredRedirectUris: Array.isArray(client.redirectUris)
+        ? client.redirectUris.filter(
+            (uri): uri is string => typeof uri === "string",
+          )
+        : [],
+      scopes:
+        authRequest.scope.length > 0
+          ? authRequest.scope
+          : DEFAULT_CONSENT_SCOPES,
+      nonce,
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        // A consent screen must never be cached: it is bound to one pending
+        // request, and a cached copy would show a stale client to the next
+        // person through.
+        "cache-control": "no-store",
+        "x-content-type-options": "nosniff",
+        "referrer-policy": "no-referrer",
+      },
+    },
+  );
+}
+
+/** Scopes named when the request asks for none, so the screen never reads as
+ * "this client will be able to: (nothing)" for a grant that still happens. */
+const DEFAULT_CONSENT_SCOPES = ["profile"] as const;
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+/**
+ * POST /authorize -- the user approved. Hand off to GitHub (#11569).
+ *
+ * Split from the GET so that ARRIVING at the page cannot itself authorize
+ * anything: a link, a prefetch, or an image tag pointed at /authorize now
+ * renders a page instead of starting a grant.
+ */
+export async function handleAuthorizeConsent(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (!env.OAUTH_KV || !env.GITHUB_OAUTH_CLIENT_ID) {
+    return new Response("oauth is not provisioned on this deployment", {
+      status: 503,
+    });
+  }
+  const form = await request.formData().catch(() => null);
+  const nonce = form?.get("consent_nonce");
+  if (typeof nonce !== "string" || !nonce) {
+    return new Response("missing consent token", { status: 400 });
+  }
+  // The nonce must name a request WE stashed. That is what stops a forged POST
+  // from starting a grant for a client the user never saw.
+  const pending = await env.OAUTH_KV.get(`${OAUTH_PENDING_KV_PREFIX}${nonce}`, {
+    type: "json",
+  });
+  if (!pending) {
+    return new Response(
+      "this authorization request has expired; start again from your client",
+      { status: 400 },
+    );
+  }
   const redirectUri = new URL("/oauth/callback/github", request.url).toString();
   const githubUrl = new URL(GITHUB_AUTHORIZE_URL);
   githubUrl.searchParams.set("client_id", env.GITHUB_OAUTH_CLIENT_ID);

--- a/src/oauth-consent.ts
+++ b/src/oauth-consent.ts
@@ -1,0 +1,214 @@
+// The authorization consent screen (#11569).
+//
+// ## WHY THIS EXISTS AT ALL
+//
+// `/authorize` used to redirect straight to GitHub. The user saw GitHub's own
+// "Authorize metagraphed" page and was never told WHICH MCP client had asked --
+// so the one decision they were actually making, "do I let this client act as
+// me", was the one thing the flow never showed them.
+//
+// That was tolerable while every client arrived through Dynamic Client
+// Registration, where the client at least presented itself to us first. It is
+// not tolerable under Client ID Metadata Documents, where the `client_id` IS a
+// self-hosted URL and the metadata behind it is self-asserted. The MCP
+// authorization specification is explicit about the consequence:
+//
+//   Because the document is self-asserted, the consent screen must display the
+//   HOST of the client_id URL (not the client_name field) as the relying party.
+//
+// So the identity shown here is derived from the URL, never from anything the
+// document claims about itself. A client may call itself whatever it likes; it
+// cannot choose which host serves its metadata.
+//
+// ## WHAT IS TRUSTED, AND WHAT IS MERELY DISPLAYED
+//
+// TRUSTED: the client_id URL's host, and the redirect_uri's host. Both are
+// structural -- the flow cannot complete anywhere else.
+//
+// DISPLAYED, LABELLED AS CLAIMED: a registered client's name. Shown because a
+// bare host is not always recognisable, and withheld from any position where a
+// reader could mistake it for verified.
+//
+// Every caller-supplied value is escaped on the way in. These strings arrive in
+// a query parameter from an unauthenticated request and land in HTML.
+
+/** The one place caller-supplied text becomes markup. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * The relying party, as the consent screen may state it.
+ *
+ * A CIMD `client_id` is an HTTPS URL and its host is the identity. Anything
+ * else (a DCR-issued opaque id) has no host to show, so the caller falls back
+ * to the registered name -- clearly labelled as self-reported, because it is.
+ */
+export function relyingPartyHost(clientId: string): string | null {
+  if (!/^https:\/\//i.test(clientId)) return null;
+  try {
+    // NO `|| null` FALLBACK on the host. The WHATWG parser requires a
+    // non-empty host for a special scheme, so every `https://` string that
+    // parses at all has one -- verified against `https://`, `https://#f`,
+    // `https://?q`, `https://:80`, `https://@` and `https://%20`, all of which
+    // throw rather than yielding an empty host. An arm no input can reach
+    // hides a future shape change instead of surfacing it.
+    return new URL(clientId).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is every redirect target a loopback address?
+ *
+ * The MCP authorization spec calls this out: a Client ID Metadata Document is
+ * self-asserted, so any local process can bind a port and claim to be the
+ * legitimate client. It recommends warning when the ONLY registered redirect
+ * URIs are loopback, which is exactly the case a user cannot distinguish by
+ * looking at the name.
+ */
+export function isLoopbackOnly(redirectUris: readonly string[]): boolean {
+  if (redirectUris.length === 0) return false;
+  return redirectUris.every((uri) => {
+    try {
+      const { hostname } = new URL(uri);
+      return (
+        hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "::1"
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+export interface ConsentView {
+  /** The `client_id` exactly as presented. */
+  clientId: string;
+  /** The client's self-reported name, when it registered one. */
+  clientName?: string | null;
+  /** Where the authorization code will be sent. */
+  redirectUri: string;
+  /** Every redirect URI this client registered, for the loopback check. */
+  registeredRedirectUris?: readonly string[];
+  /** Scopes being requested. */
+  scopes: readonly string[];
+  /** CSRF token; echoed back by the form. */
+  nonce: string;
+}
+
+/** What a scope actually lets the client do, in words a person can act on. */
+const SCOPE_DESCRIPTIONS: Record<string, string> = {
+  profile: "Read your GitHub username, to identify your account here.",
+  offline_access: "Stay signed in without asking you again each time.",
+};
+
+function scopeRow(scope: string): string {
+  const described = SCOPE_DESCRIPTIONS[scope];
+  return `<li><code>${escapeHtml(scope)}</code>${
+    described ? ` — ${escapeHtml(described)}` : ""
+  }</li>`;
+}
+
+/**
+ * Render the consent screen.
+ *
+ * The style block is the one apps/ui/src/lib/error-page.ts and
+ * rate-limited-response.ts already share, verbatim where it applies -- same
+ * type stack, ground, greys, radii and .primary/.secondary buttons. A consent
+ * screen inventing its own palette would look like a different product at the
+ * exact moment a user is deciding whether to trust this one. The additions
+ * (the definition list, the warning box) follow the same scale.
+ *
+ * Self-contained: no external stylesheet, no script, no font host. This page is
+ * where a user hands over an identity, and a third-party request in it is both
+ * a privacy leak and one more thing that can fail at the worst moment.
+ */
+export function renderConsentPage(view: ConsentView): string {
+  const host = relyingPartyHost(view.clientId);
+  // The identity line. A CIMD host is structural and stated plainly; anything
+  // else is a claim and is marked as one.
+  const identity = host
+    ? `<strong class="host">${escapeHtml(host)}</strong>`
+    : `<strong class="host">${escapeHtml(
+        view.clientName?.trim() || view.clientId,
+      )}</strong> <span class="claimed">(name self-reported)</span>`;
+  const redirectHost = (() => {
+    try {
+      return new URL(view.redirectUri).host;
+    } catch {
+      return view.redirectUri;
+    }
+  })();
+  const loopbackWarning = isLoopbackOnly(view.registeredRedirectUris ?? [])
+    ? `<p class="warn"><strong>This client runs on your own machine.</strong>
+       Its identity cannot be verified beyond the address above — any program on
+       this computer could present it. Continue only if you started it
+       yourself.</p>`
+    : "";
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Authorize access</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <style>
+      body { font: 15px/1.5 system-ui, -apple-system, sans-serif; background: #fafafa; color: #111; display: grid; place-items: center; min-height: 100vh; margin: 0; padding: 1.5rem; }
+      .card { max-width: 28rem; width: 100%; padding: 2rem; }
+      h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
+      p { color: #4b5563; margin: 0 0 1.5rem; }
+      .host { color: #111; font-weight: 600; word-break: break-all; }
+      .claimed { color: #6b7280; font-weight: 400; }
+      dl { margin: 0 0 1.5rem; padding: 1rem; background: #fff; border: 1px solid #d1d5db; border-radius: 0.375rem; }
+      dt { font-size: 0.75rem; letter-spacing: 0.05em; text-transform: uppercase; color: #6b7280; margin-bottom: 0.15rem; }
+      dd { margin: 0 0 0.85rem; color: #111; word-break: break-all; }
+      dd:last-child { margin-bottom: 0; }
+      ul { margin: 0.25rem 0 0; padding-left: 1.1rem; color: #4b5563; }
+      li { margin-bottom: 0.25rem; }
+      code { font: 0.9em ui-monospace, SFMono-Regular, Menlo, monospace; background: #f3f4f6; padding: 0.1rem 0.3rem; border-radius: 0.25rem; color: #111; }
+      .warn { background: #fffbeb; border: 1px solid #fde68a; color: #92400e; border-radius: 0.375rem; padding: 0.75rem 1rem; margin: 0 0 1.5rem; }
+      .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+      a, button { padding: 0.5rem 1rem; border-radius: 0.375rem; font: inherit; cursor: pointer; text-decoration: none; border: 1px solid transparent; }
+      .primary { background: #111; color: #fff; }
+      .secondary { background: #fff; color: #111; border-color: #d1d5db; }
+      footer { margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid #e5e7eb; color: #6b7280; font-size: 0.85rem; }
+      footer a { padding: 0; border: 0; color: #111; text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Authorize access</h1>
+      <p>${identity} is asking to connect to your metagraphed account.</p>
+      ${loopbackWarning}
+      <dl>
+        <dt>Signing in with</dt>
+        <dd>Your GitHub account</dd>
+        <dt>Returns you to</dt>
+        <dd><code>${escapeHtml(redirectHost)}</code></dd>
+        <dt>It will be able to</dt>
+        <dd><ul>${view.scopes.map(scopeRow).join("")}</ul></dd>
+      </dl>
+      <form method="POST" action="/authorize">
+        <input type="hidden" name="consent_nonce" value="${escapeHtml(view.nonce)}" />
+        <div class="actions">
+          <button class="primary" type="submit" name="approve" value="yes">Continue to GitHub</button>
+          <a class="secondary" href="/">Cancel</a>
+        </div>
+      </form>
+      <footer>
+        metagraphed never sees your GitHub password, and this grant can be
+        revoked at any time. See <a href="/auth.md">auth.md</a> for what
+        authenticating changes.
+      </footer>
+    </div>
+  </body>
+</html>`;
+}

--- a/tests/github-oauth.test.ts
+++ b/tests/github-oauth.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
   buildOAuthProviderOptions,
+  handleAuthorizeConsent,
   handleAuthorizeRequest,
   handleGithubOAuthCallback,
   isAnonymousMcpRequest,
@@ -254,11 +255,17 @@ describe("handleAuthorizeRequest", () => {
       new Request("https://api.metagraph.sh/authorize"),
       env,
     );
-    assert.equal(res.status, 302);
+    // #11569: GET now RENDERS the consent screen rather than redirecting. The
+    // hand-off to GitHub moved to POST, so that arriving at this URL -- via a
+    // link, a prefetch, an <img> -- can no longer start a grant.
+    assert.equal(res.status, 200);
     assert.equal(getOAuthApiMock.mock.calls.length, 1);
   });
 
-  test("stashes the parsed AuthRequest in OAUTH_KV and redirects to GitHub", async () => {
+  test("stashes the parsed AuthRequest and renders consent; POST hands off to GitHub", async () => {
+    // The two halves of #11569's split, asserted together because neither is
+    // meaningful alone: the GET must stash the request AND show it, and the
+    // POST must only proceed for a nonce that names something we stashed.
     const env = baseEnv();
     const deps = { getHelpers: async () => fakeHelpers() };
     const res = await handleAuthorizeRequest(
@@ -266,25 +273,133 @@ describe("handleAuthorizeRequest", () => {
       env,
       deps,
     );
-    assert.equal(res.status, 302);
-    const location = new URL(res.headers.get("location")!);
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") ?? "", /text\/html/);
+    // A consent screen bound to one pending request must never be cached; a
+    // cached copy would show a stale client to the next person through.
+    assert.equal(res.headers.get("cache-control"), "no-store");
+    const html = await res.text();
+    const nonce = /name="consent_nonce" value="([^"]+)"/.exec(html)?.[1];
+    assert.ok(nonce, "the form must carry the CSRF nonce");
+
+    const approved = await handleAuthorizeConsent(
+      new Request("https://api.metagraph.sh/authorize", {
+        method: "POST",
+        body: new URLSearchParams({ consent_nonce: nonce! }),
+      }),
+      env,
+    );
+    assert.equal(approved.status, 302);
+    const location = new URL(approved.headers.get("location")!);
     assert.equal(location.origin, "https://github.com");
     assert.equal(location.pathname, "/login/oauth/authorize");
     assert.equal(location.searchParams.get("client_id"), "client-id");
-    assert.equal(
-      location.searchParams.get("redirect_uri"),
-      "https://api.metagraph.sh/oauth/callback/github",
-    );
-    assert.equal(location.searchParams.get("scope"), "read:user");
-    const nonce = location.searchParams.get("state");
-    assert.ok(nonce && nonce.length > 0);
+    assert.equal(location.searchParams.get("state"), nonce);
+  });
 
-    const stored = (env.OAUTH_KV as unknown as Row)._store.get(
-      `oauth-pending:${nonce}`,
+  test("consent renders for a client that registered nothing but an id", async () => {
+    // A DCR client may carry no name and no redirectUris array at all. The
+    // page still has to render -- a missing field is not a reason to fail an
+    // authorization, and an unrendered consent screen is a dead flow.
+    const env = baseEnv();
+    const deps = {
+      getHelpers: async () =>
+        fakeHelpers({
+          lookupClient: async () => ({ clientId: "bare-client" }),
+          parseAuthRequest: async () => ({
+            ...FAKE_AUTH_REQUEST,
+            scope: [],
+          }),
+        }),
+    };
+    const res = await handleAuthorizeRequest(
+      new Request("https://api.metagraph.sh/authorize"),
+      env,
+      deps,
     );
-    assert.ok(stored);
-    assert.deepEqual(JSON.parse(stored.value), FAKE_AUTH_REQUEST);
-    assert.equal(stored.opts.expirationTtl, OAUTH_PENDING_TTL_SECONDS);
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    // No host to show and no name to fall back to, so the id itself stands in
+    // -- labelled as self-reported, never as verified.
+    assert.match(html, /name self-reported/);
+    // An empty scope list must not render as "will be able to: (nothing)" for
+    // a grant that still happens.
+    assert.match(html, /profile/);
+  });
+
+  test("a registered name and redirect list reach the page", async () => {
+    const env = baseEnv();
+    const deps = {
+      getHelpers: async () =>
+        fakeHelpers({
+          lookupClient: async () => ({
+            clientId: "local-client",
+            clientName: "My Local Agent",
+            redirectUris: ["http://localhost:3118/callback", 42],
+          }),
+        }),
+    };
+    const res = await handleAuthorizeRequest(
+      new Request("https://api.metagraph.sh/authorize"),
+      env,
+      deps,
+    );
+    const html = await res.text();
+    assert.match(html, /My Local Agent/);
+    // Loopback-only, so the warning fires -- and the non-string entry in the
+    // list is filtered rather than reaching the URL parser.
+    assert.match(html, /runs on your own machine/);
+  });
+
+  test("POST without a nonce, or with one we never issued, starts nothing", async () => {
+    // The nonce is what stops a forged POST beginning a grant for a client the
+    // user never saw. Both arms matter: absent, and present-but-unknown.
+    const env = baseEnv();
+    const missing = await handleAuthorizeConsent(
+      new Request("https://api.metagraph.sh/authorize", {
+        method: "POST",
+        body: new URLSearchParams({}),
+      }),
+      env,
+    );
+    assert.equal(missing.status, 400);
+    const forged = await handleAuthorizeConsent(
+      new Request("https://api.metagraph.sh/authorize", {
+        method: "POST",
+        body: new URLSearchParams({ consent_nonce: "never-issued" }),
+      }),
+      env,
+    );
+    assert.equal(forged.status, 400);
+    assert.match(await forged.text(), /expired/);
+  });
+
+  test("POST is 503 on a deployment with no oauth provisioned", async () => {
+    for (const env of [
+      baseEnv({ OAUTH_KV: undefined }),
+      baseEnv({ GITHUB_OAUTH_CLIENT_ID: undefined }),
+    ]) {
+      const res = await handleAuthorizeConsent(
+        new Request("https://api.metagraph.sh/authorize", {
+          method: "POST",
+          body: new URLSearchParams({ consent_nonce: "x" }),
+        }),
+        env,
+      );
+      assert.equal(res.status, 503);
+    }
+  });
+
+  test("a malformed POST body is refused rather than throwing", async () => {
+    const res = await handleAuthorizeConsent(
+      new Request("https://api.metagraph.sh/authorize", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{not-form-data",
+      }),
+      baseEnv(),
+    );
+    assert.equal(res.status, 400);
   });
 });
 

--- a/tests/oauth-consent.test.ts
+++ b/tests/oauth-consent.test.ts
@@ -1,0 +1,194 @@
+// #11569: the consent screen, and the one rule that makes it worth having.
+//
+// Under Client ID Metadata Documents the `client_id` IS a self-hosted URL and
+// everything the document says about itself is self-asserted. The MCP
+// authorization spec is explicit: the consent screen must display the HOST of
+// the client_id URL -- not `client_name` -- as the relying party. A client can
+// call itself anything; it cannot choose which host serves its metadata.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  escapeHtml,
+  isLoopbackOnly,
+  relyingPartyHost,
+  renderConsentPage,
+} from "../src/oauth-consent.ts";
+
+const base = {
+  clientId: "https://claude.ai/oauth/claude-code-client-metadata",
+  redirectUri: "https://claude.ai/api/mcp/auth_callback",
+  scopes: ["profile"],
+  nonce: "nonce-123",
+};
+
+describe("relyingPartyHost", () => {
+  test("is the host of an https client_id", () => {
+    assert.equal(relyingPartyHost(base.clientId), "claude.ai");
+    assert.equal(
+      relyingPartyHost("https://evil.example/pretending-to-be/claude.ai"),
+      "evil.example",
+      "the host is the identity -- a path cannot borrow another party's name",
+    );
+  });
+
+  test("is null for an https string the URL parser rejects", () => {
+    // The scheme test passes but construction throws. Without the catch this
+    // would be an unhandled exception ON THE CONSENT PAGE -- the one request
+    // where failing closed matters most, since the alternative is rendering an
+    // authorization prompt with no relying party on it.
+    for (const id of ["https://", "https://[", "https://a b"]) {
+      assert.equal(relyingPartyHost(id), null, id);
+    }
+  });
+
+  test("is null for anything that is not an https URL", () => {
+    // A DCR-issued opaque id has no host to show, so the caller falls back to
+    // the registered name and must label it as claimed.
+    for (const id of [
+      "mcp-client",
+      "client:abc123",
+      "http://claude.ai/meta",
+      "not a url",
+      "",
+    ]) {
+      assert.equal(relyingPartyHost(id), null, id);
+    }
+  });
+});
+
+describe("isLoopbackOnly", () => {
+  test("is true only when every registered redirect is local", () => {
+    assert.equal(isLoopbackOnly(["http://localhost:3118/callback"]), true);
+    assert.equal(isLoopbackOnly(["http://127.0.0.1/callback"]), true);
+    assert.equal(
+      isLoopbackOnly(["http://localhost/cb", "https://claude.ai/cb"]),
+      false,
+      "one remote redirect means the client is not purely local",
+    );
+  });
+
+  test("is false for an empty list, which is an absence and not a finding", () => {
+    assert.equal(isLoopbackOnly([]), false);
+  });
+
+  test("a malformed uri does not make the set look local", () => {
+    assert.equal(isLoopbackOnly(["::::"]), false);
+  });
+});
+
+describe("escapeHtml", () => {
+  test("neutralises every character that could break out of markup", () => {
+    assert.equal(
+      escapeHtml(`<script>alert("x")&'`),
+      "&lt;script&gt;alert(&quot;x&quot;)&amp;&#39;",
+    );
+  });
+});
+
+describe("renderConsentPage", () => {
+  test("names the client_id HOST as the relying party", () => {
+    const html = renderConsentPage(base);
+    assert.match(html, /claude\.ai/);
+    assert.match(html, /asking to connect/);
+  });
+
+  test("a self-reported name NEVER stands in for a verified host", () => {
+    // The attack this blocks: a client registers `clientName: "claude.ai"` and
+    // a user reads it as the real thing. When there is no host to show, the
+    // name is shown WITH the qualifier, never bare.
+    const html = renderConsentPage({
+      ...base,
+      clientId: "opaque-dcr-id",
+      clientName: "claude.ai",
+    });
+    assert.match(html, /name self-reported/);
+  });
+
+  test("a host, when present, wins over whatever the client calls itself", () => {
+    const html = renderConsentPage({
+      ...base,
+      clientName: "Totally Legitimate Software",
+    });
+    assert.match(html, /claude\.ai/);
+    assert.doesNotMatch(
+      html,
+      /Totally Legitimate Software/,
+      "a self-asserted name must not appear as the identity when a host exists",
+    );
+  });
+
+  test("escapes every caller-supplied value", () => {
+    // client_id and redirect_uri arrive in a query string from an
+    // unauthenticated request and land in HTML.
+    const html = renderConsentPage({
+      ...base,
+      clientId: "<img src=x onerror=alert(1)>",
+      clientName: '"><script>alert(1)</script>',
+      redirectUri: "<svg/onload=alert(1)>",
+      scopes: ["<b>profile</b>"],
+      nonce: '"><script>',
+    });
+    assert.doesNotMatch(html, /<script>alert/);
+    assert.doesNotMatch(html, /onerror=/);
+    assert.doesNotMatch(html, /<svg\/onload/);
+    assert.match(html, /&lt;/);
+  });
+
+  test("warns when the client is loopback-only", () => {
+    const html = renderConsentPage({
+      ...base,
+      registeredRedirectUris: ["http://localhost:3118/callback"],
+    });
+    assert.match(html, /runs on your own machine/);
+  });
+
+  test("does not warn for a remote client", () => {
+    const html = renderConsentPage({
+      ...base,
+      registeredRedirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+    });
+    assert.doesNotMatch(html, /runs on your own machine/);
+  });
+
+  test("states what each scope actually permits, not just its name", () => {
+    // A scope name is jargon. The decision the page asks for is only
+    // meaningful if the reader is told what it grants.
+    const html = renderConsentPage({
+      ...base,
+      scopes: ["profile", "offline_access"],
+    });
+    assert.match(html, /Read your GitHub username/);
+    assert.match(html, /Stay signed in/);
+  });
+
+  test("an unrecognised scope is still shown, not silently dropped", () => {
+    // Omitting it would understate the grant, which is the one direction a
+    // consent screen must never err in.
+    const html = renderConsentPage({ ...base, scopes: ["future:scope"] });
+    assert.match(html, /future:scope/);
+  });
+
+  test("shows where the code will be sent, by host", () => {
+    assert.match(renderConsentPage(base), /claude\.ai/);
+  });
+
+  test("carries the nonce so the approval can be bound to this request", () => {
+    assert.match(
+      renderConsentPage(base),
+      /name="consent_nonce" value="nonce-123"/,
+    );
+  });
+
+  test("is self-contained: no external stylesheet, script, or font host", () => {
+    // This page is where a user hands over an identity. A third-party request
+    // in it is both a privacy leak and one more thing that can fail here.
+    const html = renderConsentPage(base);
+    assert.doesNotMatch(html, /<script/i);
+    assert.doesNotMatch(html, /https:\/\/fonts\./);
+    assert.doesNotMatch(html, /<link[^>]+stylesheet/i);
+  });
+
+  test("asks search engines not to index it", () => {
+    assert.match(renderConsentPage(base), /noindex/);
+  });
+});

--- a/tests/worker-runtime.test.ts
+++ b/tests/worker-runtime.test.ts
@@ -2741,9 +2741,28 @@ describe("GitHub OAuth route dispatch", () => {
     assert.match(await response.text(), /oauth is not provisioned/);
   });
 
-  test("POST /authorize is not routed (GET-only)", async () => {
+  test("POST /authorize reaches handleAuthorizeConsent", async () => {
+    // #11569 made /authorize a two-step: GET renders the consent screen, POST
+    // is the approval. This test previously asserted POST was NOT routed --
+    // true then, and deliberately false now. The split is what stops merely
+    // ARRIVING at the URL from starting a grant: a link, a prefetch or an
+    // <img> pointed here renders a page instead.
     const response = await handleRequest(
       new Request("https://api.metagraph.sh/authorize", { method: "POST" }),
+      env as unknown as Env,
+      {},
+    );
+    // Same unprovisioned-deployment answer as the GET above, which is how we
+    // know it reached the OAuth handler rather than falling through to a 404.
+    assert.equal(response.status, 503);
+    assert.match(await response.text(), /oauth is not provisioned/);
+  });
+
+  test("another verb on /authorize is still not routed", async () => {
+    // The pair above widened the surface by exactly one verb. This holds the
+    // rest of it shut, so a future handler cannot quietly claim DELETE.
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/authorize", { method: "DELETE" }),
       env as unknown as Env,
       {},
     );

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -650,6 +650,7 @@ import {
 } from "../src/response-validation-tripwire.ts";
 import { urlProjects } from "../src/projection-signal.ts";
 import {
+  handleAuthorizeConsent,
   handleAuthorizeRequest,
   handleGithubOAuthCallback,
   isMcpCorePath,
@@ -6355,13 +6356,19 @@ async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {
     return handleAccountKeysProxy(request, env);
   }
 
-  // GitHub OAuth (metagraphed#7151): the two routes @cloudflare/workers-
+  // GitHub OAuth (metagraphed#7151): the routes @cloudflare/workers-
   // oauth-provider's own authorizeEndpoint deliberately leaves to
-  // application code (see src/github-oauth.ts's header). GET-only --
-  // both are browser-redirect targets, never called by a client library
-  // directly.
+  // application code (see src/github-oauth.ts's header). Browser-redirect
+  // targets, never called by a client library directly.
+  //
+  // #11569 made /authorize a two-step: GET renders the consent screen, POST is
+  // the approval. The split is what stops ARRIVING at the URL from starting a
+  // grant -- a link, a prefetch or an <img> pointed here now renders a page.
   if (request.method === "GET" && url.pathname === "/authorize") {
     return handleAuthorizeRequest(request, env);
+  }
+  if (request.method === "POST" && url.pathname === "/authorize") {
+    return handleAuthorizeConsent(request, env);
   }
   if (request.method === "GET" && url.pathname === "/oauth/callback/github") {
     return handleGithubOAuthCallback(request, env);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,7 +7,15 @@
   // workers/api.ts directly and are unaffected by this).
   "main": "workers/api.entry.ts",
   "compatibility_date": "2026-06-06",
-  "compatibility_flags": ["nodejs_compat"],
+  // `global_fetch_strictly_public` (#11569): required before the OAuth provider
+  // will advertise Client ID Metadata Document support, and required for a
+  // good reason -- honouring a CIMD means fetching a URL the CALLER chose, and
+  // without this flag that is an SSRF primitive aimed at our own internal
+  // surfaces. Safe here because every global fetch this Worker makes already
+  // targets a public host (subnet surfaces, RPC endpoints, GitHub); every
+  // internal call goes over the DATA_API service binding, which the flag does
+  // not touch.
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "minify": true,
   // Cloudflare's own per-deploy version UUID (metagraphed#7766: no longer
   // read for Sentry release tagging -- Sentry fully removed -- but still


### PR DESCRIPTION
Two changes that only make sense together.

## CIMD (#11569)

Anthropic's guidance for anything expecting Connectors Directory traffic is explicit:

> For servers expecting high traffic from the directory, prefer **CIMD or `oauth_anthropic_creds` over DCR**. DCR causes Claude to register a new client on every fresh connection, which can result in very large numbers of registered clients on your authorization server.

**That is already happening.** `OAUTH_KV` holds **27 registered clients**, and we are not listed anywhere yet.

`@cloudflare/workers-oauth-provider` supports it behind `clientIdMetadataDocumentEnabled`, gated on the `global_fetch_strictly_public` compatibility flag — and correctly so. Honouring a CIMD means fetching a URL the *caller* chose; without that flag it is an SSRF primitive pointed at our own internal surfaces. The library declines to advertise support rather than fetching anyway, so the flag is not optional.

**Verified safe before setting it:** every global `fetch()` this Worker makes already targets a public host (subnet surfaces, RPC endpoints, GitHub), and every internal call goes over the `DATA_API` service binding, which the flag does not touch.

## The consent screen

`/authorize` redirected **straight to GitHub**. The user saw GitHub's own "Authorize metagraphed" page and was never told *which client* had asked — so the one decision they were actually making was the one thing the flow never showed them.

Survivable under DCR, where a client at least presented itself to us first. Not survivable under CIMD, where the `client_id` **is** a self-hosted URL and its metadata is self-asserted. The MCP authorization spec requires the consent screen to display the **host of that URL**, not `client_name`, as the relying party — so there has to be a screen for it to be displayed on.

What the page trusts and what it merely repeats are kept apart:

| | shown as |
|---|---|
| **client_id URL host** | the identity — a client can call itself anything, but cannot choose which host serves its metadata |
| **registered `clientName`** | only when there is no host, and never bare — always with "name self-reported" |

It also warns when every registered redirect URI is loopback — the spec's own recommendation, since any local process can bind a port and claim to be the legitimate client, and a user cannot tell by reading the name.

**GET renders, POST approves.** The split stops merely *arriving* at `/authorize` from starting a grant: a link, a prefetch or an `<img>` now renders a page. The pending-request nonce doubles as the CSRF token, so a POST proceeds only for a request we parsed and stored ourselves.

## Style

The page reuses the block `apps/ui/src/lib/error-page.ts` and `rate-limited-response.ts` already share — same type stack, ground, greys, radii and `.primary`/`.secondary` buttons. I first wrote it with its own palette; that was wrong. A consent screen that looks like a different product is worst exactly where it matters — at the moment someone decides whether to trust this one.

## Incidental

Removed a `|| null` fallback on the parsed host. No `https://` string that parses can yield an empty host — checked against `https://`, `https://#f`, `https://?q`, `https://:80`, `https://@`, `https://%20`, all of which throw — so it was an arm nothing could reach.

## Verification

- **Patch coverage 100%** — 37/37 lines, 39/39 branches, by diff intersection
- Full suite green: 968 files, 22,265 tests
- All 70 `validate:*` scripts, `tsc` clean, prettier clean
- Two existing tests updated to the new contract, not relaxed: `POST /authorize is not routed` became `POST /authorize reaches handleAuthorizeConsent`, plus a new test holding every *other* verb shut so a future handler cannot quietly claim `DELETE`

Part of #11561.

Closes #11569
