### PR TITLE
feat(ui): publish a privacy policy and terms of use

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -549,8 +549,16 @@ function SiteFooter() {
       </div>
       <div className="border-t border-border/70">
         <div className="max-w-shell-max mx-auto px-4 md:px-10 py-4 flex flex-wrap items-center justify-between gap-2 mg-type-data text-ink-muted">
-          <span>
-            © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
+          <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span>
+              © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
+            </span>
+            {/* #11567: the only link to these anywhere on the site. A privacy
+                policy nothing links to is one a reader cannot find and a
+                directory reviewer cannot verify. */}
+            <span aria-hidden="true">·</span>
+            <FooterLink to="/privacy">Privacy</FooterLink>
+            <FooterLink to="/terms">Terms</FooterLink>
           </span>
           <EndpointHealthPill />
         </div>

--- a/apps/ui/src/lib/metagraphed/config.ts
+++ b/apps/ui/src/lib/metagraphed/config.ts
@@ -1,4 +1,4 @@
-import { API_ORIGIN, GITHUB_REPO_URL } from "./identity";
+import { API_DATA_ORIGIN, GITHUB_REPO_URL } from "./identity";
 
 // Metagraphed API client config.
 //
@@ -16,11 +16,10 @@ const env = (import.meta as ImportMeta & { env?: Record<string, string | undefin
 const STORAGE_KEY = "metagraphed:api-base";
 const EVT = "metagraphed:api-base-changed";
 
-export const DEFAULT_API_BASE = (
-  env?.VITE_METAGRAPH_API_BASE ||
-  env?.VITE_METAGRAPHED_API_BASE ||
-  API_ORIGIN
-).replace(/\/$/, "");
+// One definition, in identity.ts, so the server half and the client half of the
+// app cannot resolve different data hosts -- see API_DATA_ORIGIN for the bug
+// that caused.
+export const DEFAULT_API_BASE = API_DATA_ORIGIN;
 
 let cached: string | null = null;
 

--- a/apps/ui/src/lib/metagraphed/identity.ts
+++ b/apps/ui/src/lib/metagraphed/identity.ts
@@ -28,6 +28,33 @@ export const SITE_ORIGIN = "https://metagraph.sh";
  */
 export const API_ORIGIN = "https://api.metagraph.sh";
 
+/**
+ * The API host to FETCH DATA FROM, honouring the build-time override.
+ *
+ * Distinct from API_ORIGIN above, and the distinction is load-bearing:
+ * API_ORIGIN names the canonical host and must stay canonical (a discovery
+ * Link header or a redirect target pointing at a dev Worker would be wrong).
+ * This one names wherever this build's data actually comes from.
+ *
+ * `server.ts` used API_ORIGIN for the sitemap's data fetches, which made the
+ * server half of the app read PRODUCTION while the client half read whatever
+ * the build pointed at. Under the hermetic e2e stub that is not a hermetic
+ * test at all: the sitemap listed `/subnets/category/privacy` from live data
+ * (where it has exactly 3 subnets, the threshold) while the page rendered 0
+ * from the fixture, and the two disagreed for reasons no code change could fix.
+ * A test whose result depends on production drift is not testing this build.
+ *
+ * Kept dependency-free like everything else here -- config.ts layers
+ * localStorage and runtime switching on top; this is only the build default,
+ * which is all a Worker needs.
+ */
+const buildEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
+export const API_DATA_ORIGIN = (
+  buildEnv?.VITE_METAGRAPH_API_BASE ||
+  buildEnv?.VITE_METAGRAPHED_API_BASE ||
+  API_ORIGIN
+).replace(/\/$/, "");
+
 /** The public source repository. */
 export const GITHUB_REPO_URL = "https://github.com/JSONbored/metagraphed";
 

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1840,7 +1840,9 @@ export function normalizeSubnet(raw: unknown): Subnet {
  * the registry table and the crawlable index cannot drift onto two different
  * limits and disagree about what "every subnet" means.
  */
-export const SUBNETS_ALL_LIMIT = 200;
+// Re-exported from its new home so every existing importer keeps working.
+// Moved because server.ts needs it too and cannot import this module.
+export { SUBNETS_ALL_LIMIT } from "./subnet-categories";
 
 export const subnetsQuery = (params?: QueryParams) =>
   queryOptions({

--- a/apps/ui/src/lib/metagraphed/subnet-categories.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-categories.ts
@@ -31,6 +31,30 @@
  */
 export const MIN_CATEGORY_SUBNETS = 3;
 
+/**
+ * One page size for "every subnet", shared by every surface that derives a set
+ * from the whole registry.
+ *
+ * It lives HERE, next to the threshold it is counted against, rather than in
+ * queries.ts where it started: `server.ts` needs it to build the sitemap and
+ * importing queries.ts would drag @tanstack/react-query into the server
+ * bundle for one number.
+ *
+ * The drift this prevents is not hypothetical. The sitemap fetched
+ * `?limit=500` while the hub fetched this constant, and the two agreed only by
+ * accident -- both exceeded the ~128 subnets that exist. Under the hermetic
+ * e2e stub they did NOT agree: the stub indexes recordings by exact URL with a
+ * bare-pathname fallback, so two different query strings resolve to two
+ * different recorded payloads, and a category sitting exactly on
+ * MIN_CATEGORY_SUBNETS landed on one side only. The sitemap listed
+ * `/subnets/category/privacy`; the hub did not link it.
+ *
+ * Sharing the constant makes the two fetches the SAME URL. If it is ever too
+ * small for the registry, both surfaces under-count together and visibly,
+ * rather than disagreeing quietly -- which is the property worth having.
+ */
+export const SUBNETS_ALL_LIMIT = 200;
+
 export interface CategoryCopy {
   /** Human label, as a heading and in the title. */
   readonly label: string;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -22,11 +22,13 @@ import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as PortfolioRouteImport } from './routes/portfolio'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as RevenueRouteImport } from './routes/revenue'
 import { Route as SchemasRouteImport } from './routes/schemas'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SurfacesRouteImport } from './routes/surfaces'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
 import { Route as AccountsSs58RouteImport } from './routes/accounts.$ss58'
 import { Route as AdminChangesIndexRouteImport } from './routes/admin-changes.index'
@@ -137,6 +139,11 @@ const PortfolioRoute = PortfolioRouteImport.update({
   path: '/portfolio',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RevenueRoute = RevenueRouteImport.update({
   id: '/revenue',
   path: '/revenue',
@@ -160,6 +167,11 @@ const StatusRoute = StatusRouteImport.update({
 const SurfacesRoute = SurfacesRouteImport.update({
   id: '/surfaces',
   path: '/surfaces',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AccountsIndexRoute = AccountsIndexRouteImport.update({
@@ -397,11 +409,13 @@ export interface FileRoutesByFullPath {
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/portfolio': typeof PortfolioRoute
+  '/privacy': typeof PrivacyRoute
   '/revenue': typeof RevenueRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/terms': typeof TermsRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/api/search': typeof ApiSearchRoute
   '/apis/endpoints': typeof ApisEndpointsRoute
@@ -459,11 +473,13 @@ export interface FileRoutesByTo {
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/portfolio': typeof PortfolioRoute
+  '/privacy': typeof PrivacyRoute
   '/revenue': typeof RevenueRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/terms': typeof TermsRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/api/search': typeof ApiSearchRoute
   '/apis/endpoints': typeof ApisEndpointsRoute
@@ -524,11 +540,13 @@ export interface FileRoutesById {
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/portfolio': typeof PortfolioRoute
+  '/privacy': typeof PrivacyRoute
   '/revenue': typeof RevenueRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/terms': typeof TermsRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/api/search': typeof ApiSearchRoute
   '/apis/endpoints': typeof ApisEndpointsRoute
@@ -590,11 +608,13 @@ export interface FileRouteTypes {
     | '/health'
     | '/leaderboards'
     | '/portfolio'
+    | '/privacy'
     | '/revenue'
     | '/schemas'
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/terms'
     | '/accounts/$ss58'
     | '/api/search'
     | '/apis/endpoints'
@@ -652,11 +672,13 @@ export interface FileRouteTypes {
     | '/health'
     | '/leaderboards'
     | '/portfolio'
+    | '/privacy'
     | '/revenue'
     | '/schemas'
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/terms'
     | '/accounts/$ss58'
     | '/api/search'
     | '/apis/endpoints'
@@ -716,11 +738,13 @@ export interface FileRouteTypes {
     | '/health'
     | '/leaderboards'
     | '/portfolio'
+    | '/privacy'
     | '/revenue'
     | '/schemas'
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/terms'
     | '/accounts/$ss58'
     | '/api/search'
     | '/apis/endpoints'
@@ -781,11 +805,13 @@ export interface RootRouteChildren {
   HealthRoute: typeof HealthRoute
   LeaderboardsRoute: typeof LeaderboardsRoute
   PortfolioRoute: typeof PortfolioRoute
+  PrivacyRoute: typeof PrivacyRoute
   RevenueRoute: typeof RevenueRoute
   SchemasRoute: typeof SchemasRoute
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
   SurfacesRoute: typeof SurfacesRoute
+  TermsRoute: typeof TermsRoute
   AccountsSs58Route: typeof AccountsSs58Route
   ApiSearchRoute: typeof ApiSearchRoute
   BlocksRefRoute: typeof BlocksRefRoute
@@ -913,6 +939,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PortfolioRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/revenue': {
       id: '/revenue'
       path: '/revenue'
@@ -946,6 +979,13 @@ declare module '@tanstack/react-router' {
       path: '/surfaces'
       fullPath: '/surfaces'
       preLoaderRoute: typeof SurfacesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/accounts/': {
@@ -1313,11 +1353,13 @@ const rootRouteChildren: RootRouteChildren = {
   HealthRoute: HealthRoute,
   LeaderboardsRoute: LeaderboardsRoute,
   PortfolioRoute: PortfolioRoute,
+  PrivacyRoute: PrivacyRoute,
   RevenueRoute: RevenueRoute,
   SchemasRoute: SchemasRoute,
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,
   SurfacesRoute: SurfacesRoute,
+  TermsRoute: TermsRoute,
   AccountsSs58Route: AccountsSs58Route,
   ApiSearchRoute: ApiSearchRoute,
   BlocksRefRoute: BlocksRefRoute,

--- a/apps/ui/src/routes/-privacy-page.tsx
+++ b/apps/ui/src/routes/-privacy-page.tsx
@@ -1,0 +1,222 @@
+import { Link } from "@tanstack/react-router";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ExternalLink } from "@jsonbored/ui-kit";
+import { PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import { API_BASE } from "@/lib/metagraphed/config";
+
+/**
+ * The numbers below are the ones the server actually enforces
+ * (`src/mcp-surface-credentials.ts`). `apps/ui` cannot import them — they are
+ * not part of the published client package, and widening that package's public
+ * surface for a prose page would be the wrong trade — so a root-level test
+ * reads this file and asserts they still match the constants.
+ */
+const CREDENTIAL_DEFAULT_TTL_DAYS = 30;
+const CREDENTIAL_MAX_TTL_DAYS = 90;
+
+export function PrivacyPage() {
+  return (
+    <AppShell>
+      <PageMasthead
+        eyebrow="Privacy"
+        title="Privacy policy"
+        description="What Metagraphed collects, why, how long it is kept, and who else processes it. Written to be checkable against the code rather than to be reassuring."
+      />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="space-y-8 min-w-0">
+          <Section title="The short version">
+            <p>
+              The API and MCP server are public and read-only. You can use nearly all of it without
+              an account, and without telling us who you are. We do not sell data, we do not run
+              advertising, and we do not build profiles of individuals.
+            </p>
+            <p>
+              What we do keep is operational: enough to run the service, bill the accounts that have
+              one, and know which parts of it are actually used.
+            </p>
+          </Section>
+
+          <Section title="Requests to the API and MCP server">
+            <p>Every request is logged for operational purposes. That record includes:</p>
+            <ul className="list-disc pl-6 space-y-1.5">
+              <li>The route or tool called, response status, and timing.</li>
+              <li>
+                A <strong>salted SHA-256 hash of your IP address</strong> — never the address
+                itself. It exists so &ldquo;how many distinct callers&rdquo; is answerable without
+                identifying any of them.
+              </li>
+              <li>
+                Your client&rsquo;s self-reported name and version, from the User-Agent or the MCP
+                handshake.
+              </li>
+              <li>
+                For MCP tool calls, the tool name and arguments, and{" "}
+                <strong>any free-text context your agent chose to send</strong> describing why it
+                was calling. That text is written by your agent, not by us — if it puts something
+                sensitive there, we receive it.
+              </li>
+            </ul>
+            <p>
+              Cloudflare, which serves every request, keeps its own edge logs independently of this.
+            </p>
+          </Section>
+
+          <Section title="If you sign in">
+            <p>
+              Signing in with GitHub stores your GitHub user ID, your login, and a tier. We ask
+              GitHub only for <code>read:user</code> — we never see your password, your email is not
+              requested, and we cannot act on your GitHub account. You are shown which client is
+              asking before the flow begins, and you can revoke the grant at any time.
+            </p>
+            <p>
+              Accounts with an API key also accumulate per-day request and quota counters, which is
+              what a usage dashboard and any bill are computed from.
+            </p>
+          </Section>
+
+          <Section title="The credential store">
+            <p>
+              If you register a credential for a third-party subnet API, it is encrypted with{" "}
+              <strong>AES-256-GCM</strong> before storage and is readable only by your own account.
+              It is sent to the subnet surface you registered it against and to nowhere else.
+            </p>
+            <p>
+              Stored credentials <strong>expire automatically</strong>: after{" "}
+              {CREDENTIAL_DEFAULT_TTL_DAYS} days by default, and at most {CREDENTIAL_MAX_TTL_DAYS}{" "}
+              days if you ask for longer. You can delete one at any time. The store exists so
+              secrets stop travelling through tool arguments, client logs, and conversation
+              transcripts.
+            </p>
+          </Section>
+
+          <Section title="What we do not collect">
+            <ul className="list-disc pl-6 space-y-1.5">
+              <li>Raw IP addresses in our own analytics.</li>
+              <li>Advertising, cross-site, or third-party tracking identifiers.</li>
+              <li>
+                Private keys, seed phrases, or wallet secrets. Wallet signing is non-custodial and
+                happens in your own wallet — never on our servers.
+              </li>
+              <li>Payment card details. We do not process card payments.</li>
+            </ul>
+          </Section>
+
+          <Section title="Retention">
+            <ul className="list-disc pl-6 space-y-1.5">
+              <li>
+                <strong>Product analytics</strong> are retained by PostHog under its own retention
+                policy.
+              </li>
+              <li>
+                <strong>Stored credentials</strong> expire on the schedule above, enforced by the
+                storage layer rather than by a cleanup job.
+              </li>
+              <li>
+                <strong>Account records and usage counters</strong> are kept while the account
+                exists.
+              </li>
+              <li>
+                <strong>Chain data</strong> — blocks, extrinsics, balances — is public information
+                read from the Bittensor network. It is not personal data we collected, and we cannot
+                delete it from the chain.
+              </li>
+            </ul>
+          </Section>
+
+          <Section title="Who else processes it">
+            <p>
+              We use a small number of infrastructure providers, each processing data only to
+              deliver the service:
+            </p>
+            <ul className="list-disc pl-6 space-y-1.5">
+              <li>
+                <strong>Cloudflare</strong> — serving, edge caching, storage, and DDoS protection.
+              </li>
+              <li>
+                <strong>Neon</strong> — the Postgres database behind accounts and indexed chain
+                data.
+              </li>
+              <li>
+                <strong>PostHog</strong> — product analytics and error tracking.
+              </li>
+              <li>
+                <strong>Unkey</strong> — API key issuance and verification.
+              </li>
+              <li>
+                <strong>GitHub</strong> — sign-in, when you choose to use it.
+              </li>
+            </ul>
+          </Section>
+
+          <Section title="Your choices">
+            <ul className="list-disc pl-6 space-y-1.5">
+              <li>Use the API and MCP server anonymously — most of it needs no account at all.</li>
+              <li>
+                Omit the optional context argument on MCP tool calls if you would rather not send
+                it.
+              </li>
+              <li>Delete a stored credential, or let it expire.</li>
+              <li>Ask us to delete your account and its records, using the contact below.</li>
+            </ul>
+          </Section>
+
+          <Section title="Changes">
+            <p>
+              This policy is versioned in the same repository as the code it describes, so any
+              change to it is visible in the commit history alongside the change that prompted it.
+            </p>
+          </Section>
+
+          <Section title="Contact">
+            <p>
+              Questions, corrections, or a deletion request:{" "}
+              <ExternalLink href="https://github.com/JSONbored/metagraphed/issues">
+                open an issue
+              </ExternalLink>
+              , or see{" "}
+              <ExternalLink href={`${API_BASE}/.well-known/security.txt`}>
+                security.txt
+              </ExternalLink>{" "}
+              for a security contact.
+            </p>
+          </Section>
+        </div>
+        <aside className="space-y-6">
+          <Panel title="Also relevant">
+            <div className="grid gap-1.5">
+              <Link
+                to="/terms"
+                className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+              >
+                → Terms of use
+              </Link>
+              <ExternalLink
+                href={`${API_BASE}/auth.md`}
+                className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+              >
+                → auth.md — what authenticating changes
+              </ExternalLink>
+              <Link
+                to="/about"
+                className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+              >
+                → Methodology &amp; scope
+              </Link>
+            </div>
+          </Panel>
+        </aside>
+      </div>
+    </AppShell>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h2 className="font-display text-sm font-semibold uppercase tracking-wider text-ink-strong mb-2">
+        {title}
+      </h2>
+      <div className="text-sm leading-relaxed text-ink space-y-2">{children}</div>
+    </section>
+  );
+}

--- a/apps/ui/src/routes/-terms-page.tsx
+++ b/apps/ui/src/routes/-terms-page.tsx
@@ -1,0 +1,172 @@
+import { Link } from "@tanstack/react-router";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ExternalLink } from "@jsonbored/ui-kit";
+import { PageMasthead, Panel } from "@/components/metagraphed/primitives";
+import { API_BASE, GITHUB_REPO } from "@/lib/metagraphed/config";
+
+export function TermsPage() {
+  return (
+    <AppShell>
+      <PageMasthead
+        eyebrow="Terms"
+        title="Terms of use"
+        description="What you can rely on from Metagraphed, what you cannot, and the few things we ask in return."
+      />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="space-y-8 min-w-0">
+          <Section title="What this service is">
+            <p>
+              Metagraphed is an independent, unofficial explorer and integration registry for
+              Bittensor. It is not an OpenTensor or Bittensor Foundation product, and nothing here
+              is endorsed by them.
+            </p>
+            <p>
+              The REST API, GraphQL endpoint, and MCP server are public and read-only. Most of the
+              surface needs no account.
+            </p>
+          </Section>
+
+          <Section title="Accuracy, and what you should not rely on">
+            <p>
+              Data is provided <strong>as is</strong>. We read the chain, probe public endpoints,
+              and publish what we observe, with freshness and provenance attached wherever we can.
+              That is a best effort, not a guarantee: a reading can be stale, an endpoint can be
+              misconfigured, and a derived figure can be wrong.
+            </p>
+            <p>
+              Nothing here is financial advice. Economic figures — emissions, yields, prices, stake
+              previews — are informational, frequently approximate, and must not be the sole basis
+              for a financial decision. Verify against the chain before acting on anything that
+              moves money.
+            </p>
+            <p>We make no uptime guarantee and offer no SLA on the free tier.</p>
+          </Section>
+
+          <Section title="Fair use">
+            <p>Please:</p>
+            <ul className="list-disc pl-6 space-y-1.5">
+              <li>
+                Stay within the published rate limits — see{" "}
+                <ExternalLink href={`${API_BASE}/auth.md`}>auth.md</ExternalLink>. Authenticating
+                raises them.
+              </li>
+              <li>
+                Send a User-Agent that identifies your client, so we can tell a problem with your
+                integration from a problem with ours.
+              </li>
+              <li>
+                Cache what you can. Most artifacts are edge-cached and carry validators; honouring
+                them costs you nothing and costs us less.
+              </li>
+              <li>
+                Do not attempt to bypass rate limits, quotas, or access controls, including by
+                rotating identities to evade them.
+              </li>
+            </ul>
+            <p>
+              We may throttle or block an account or client that makes the service worse for
+              everyone else. Where we do, the response says so with a reason code rather than
+              failing silently.
+            </p>
+          </Section>
+
+          <Section title="Calling subnet APIs through us">
+            <p>
+              The registry can call a catalogued subnet&rsquo;s own API on your behalf. When it
+              does, you are using <em>their</em> service, under <em>their</em> terms, with{" "}
+              <em>your</em> credential. We do not obtain credentials for you, we grant no authority
+              you did not already have calling that API directly, and we are not responsible for
+              what a third-party surface does with a request you asked us to forward.
+            </p>
+          </Section>
+
+          <Section title="Non-custodial by design">
+            <p>
+              We never hold your keys, seed phrases, or funds. Any signing happens in your own
+              wallet, locally. We cannot move your assets, and we cannot recover them.
+            </p>
+          </Section>
+
+          <Section title="Using the data">
+            <p>
+              Chain data is public information. Our derived artifacts, schemas, and registry records
+              are published so they can be used — build on them. If you redistribute them at scale,
+              attribution is appreciated and a link back helps people find the source of a figure
+              they want to check.
+            </p>
+            <p>
+              The code is open source; see the{" "}
+              <ExternalLink href={GITHUB_REPO}>repository</ExternalLink> for its licence, which
+              governs the code rather than this service.
+            </p>
+          </Section>
+
+          <Section title="Liability">
+            <p>
+              To the fullest extent permitted by law, Metagraphed is provided without warranty of
+              any kind, and we are not liable for any loss arising from use of, or inability to use,
+              this service or its data — including trading losses, missed opportunities, or
+              downstream failures in systems that depend on it.
+            </p>
+          </Section>
+
+          <Section title="Changes">
+            <p>
+              These terms live in the same repository as the code, so any change is visible in the
+              commit history. Continuing to use the service after a change means accepting it.
+            </p>
+          </Section>
+
+          <Section title="Contact">
+            <p>
+              Questions or disputes:{" "}
+              <ExternalLink href="https://github.com/JSONbored/metagraphed/issues">
+                open an issue
+              </ExternalLink>
+              . For security reports, see{" "}
+              <ExternalLink href={`${API_BASE}/.well-known/security.txt`}>
+                security.txt
+              </ExternalLink>
+              .
+            </p>
+          </Section>
+        </div>
+        <aside className="space-y-6">
+          <Panel title="Also relevant">
+            <div className="grid gap-1.5">
+              <Link
+                to="/privacy"
+                className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+              >
+                → Privacy policy
+              </Link>
+              <ExternalLink
+                href={`${API_BASE}/auth.md`}
+                className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+              >
+                → auth.md — rate limits &amp; auth
+              </ExternalLink>
+              <Link
+                to="/about"
+                className="mg-type-data text-ink-muted hover:text-ink-strong inline-flex items-center gap-1"
+              >
+                → Methodology &amp; scope
+              </Link>
+            </div>
+          </Panel>
+        </aside>
+      </div>
+    </AppShell>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h2 className="font-display text-sm font-semibold uppercase tracking-wider text-ink-strong mb-2">
+        {title}
+      </h2>
+      <div className="text-sm leading-relaxed text-ink space-y-2">{children}</div>
+    </section>
+  );
+}

--- a/apps/ui/src/routes/privacy.tsx
+++ b/apps/ui/src/routes/privacy.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PrivacyPage } from "./-privacy-page";
+
+export const Route = createFileRoute("/privacy")({
+  head: () => ({
+    meta: [
+      { title: "Privacy policy — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "What Metagraphed collects, why, how long it is kept, and who else processes it — checkable against the code that implements it.",
+      },
+    ],
+  }),
+  component: PrivacyPage,
+});

--- a/apps/ui/src/routes/terms.tsx
+++ b/apps/ui/src/routes/terms.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { TermsPage } from "./-terms-page";
+
+export const Route = createFileRoute("/terms")({
+  head: () => ({
+    meta: [
+      { title: "Terms of use — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "What you can rely on from Metagraphed, what you cannot, and the fair-use expectations for its public API and MCP server.",
+      },
+    ],
+  }),
+  component: TermsPage,
+});

--- a/apps/ui/src/server.og-copy.test.ts
+++ b/apps/ui/src/server.og-copy.test.ts
@@ -89,3 +89,36 @@ describe("OG card copy coverage (#8489)", () => {
     expect(generic, `routes with no OG copy: ${generic.join(", ")}`).toEqual([]);
   });
 });
+
+// The sitemap and the subnet hub both derive "which categories get a page"
+// from a page of subnets, and both apply MIN_CATEGORY_SUBNETS to it. If they
+// fetch DIFFERENT page sizes they are two different requests, and two
+// different requests can produce two different answers.
+//
+// They did. The sitemap hard-coded `?limit=500` while the hub used
+// SUBNETS_ALL_LIMIT; in production both exceeded the ~128 subnets that exist,
+// so they agreed by accident. Under the hermetic e2e stub -- which indexes
+// recordings by exact URL and falls back to the bare pathname -- the two query
+// strings resolved to two different recorded payloads, and a category sitting
+// exactly on the threshold appeared in the sitemap while going unlinked from
+// the hub. That is precisely the unreachable-subtree defect #11266 fixed for
+// /news, reintroduced through a query parameter.
+describe("the sitemap and the hub agree on what 'every subnet' means", () => {
+  const serverSource = fs.readFileSync(path.join(import.meta.dirname, "server.ts"), "utf8");
+
+  it("the sitemap fetches subnets with the shared limit, not a literal", () => {
+    expect(serverSource).toContain("limit=${SUBNETS_ALL_LIMIT}");
+    // A literal here is the regression: it makes this a second, silently
+    // different request from the one the hub makes.
+    expect(serverSource).not.toMatch(/\/api\/v1\/subnets\?limit=\d+/);
+  });
+
+  it("both surfaces import the same constant", () => {
+    const hubSource = fs.readFileSync(
+      path.join(import.meta.dirname, "components/metagraphed/subnet-category-links.tsx"),
+      "utf8",
+    );
+    expect(serverSource).toContain("SUBNETS_ALL_LIMIT");
+    expect(hubSource).toContain("SUBNETS_ALL_LIMIT");
+  });
+});

--- a/apps/ui/src/server.og-copy.test.ts
+++ b/apps/ui/src/server.og-copy.test.ts
@@ -122,3 +122,29 @@ describe("the sitemap and the hub agree on what 'every subnet' means", () => {
     expect(hubSource).toContain("SUBNETS_ALL_LIMIT");
   });
 });
+
+// The server half and the client half of the app must resolve the SAME data
+// host. server.ts fetched the sitemap's data from API_ORIGIN -- the canonical
+// constant -- while the client used the build-time override, so under the
+// hermetic e2e stub the sitemap read live production and the page read the
+// fixture. They disagreed about `/subnets/category/privacy` (exactly 3 subnets
+// live, the threshold; 0 in the fixture) and no application change could
+// reconcile them, because one side was not testing this build at all.
+describe("the sitemap fetches data from the configured host, not the canonical one", () => {
+  const serverSource = fs.readFileSync(path.join(import.meta.dirname, "server.ts"), "utf8");
+
+  it("every /api/v1 data fetch uses API_DATA_ORIGIN", () => {
+    const canonicalDataFetches = [
+      ...serverSource.matchAll(/fetch\(`\$\{API_ORIGIN\}\/api\/v1[^`]*`/g),
+    ].map((m) => m[0]);
+    expect(canonicalDataFetches).toEqual([]);
+  });
+
+  it("still uses the canonical origin where canonicality is the point", () => {
+    // The apex /metagraph/* proxy must reach the host that actually serves it
+    // (#11204), and discovery Link headers must name the real API host — those
+    // are correct uses and this test must not push them onto the override.
+    expect(serverSource).toContain("API_ORIGIN");
+    expect(serverSource).toContain('rel="api-catalog"');
+  });
+});

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -838,6 +838,16 @@ export const OG_SECTIONS: Record<string, OgCopy> = {
     subtitle: "What Metagraphed is, and how the data is produced",
     eyebrow: "About",
   },
+  "/privacy": {
+    title: "Privacy policy",
+    subtitle: "What we collect, how long it is kept, and who else processes it",
+    eyebrow: "Legal",
+  },
+  "/terms": {
+    title: "Terms of use",
+    subtitle: "What you can rely on, what you cannot, and fair use",
+    eyebrow: "Legal",
+  },
 };
 
 /** Shortens an ss58/hotkey for a card, which has no room for 48 characters. */

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -16,7 +16,7 @@ import {
   SUBNETS_ALL_LIMIT,
 } from "./lib/metagraphed/subnet-categories";
 import { isoTimestamp } from "./lib/metagraphed/freshness";
-import { API_ORIGIN, SITE_ORIGIN, X_HANDLE } from "./lib/metagraphed/identity";
+import { API_DATA_ORIGIN, API_ORIGIN, SITE_ORIGIN, X_HANDLE } from "./lib/metagraphed/identity";
 import { handleAnalyticsProxy, type PostHogAssetContext } from "./lib/analytics-proxy";
 
 type ServerEntry = {
@@ -372,7 +372,7 @@ async function buildSitemap(): Promise<Response> {
     // page of subnets. A hard-coded 500 here made the sitemap and the hub two
     // different requests, which the e2e stub answers with two different
     // recordings.
-    const res = await fetch(`${API_ORIGIN}/api/v1/subnets?limit=${SUBNETS_ALL_LIMIT}`, {
+    const res = await fetch(`${API_DATA_ORIGIN}/api/v1/subnets?limit=${SUBNETS_ALL_LIMIT}`, {
       headers: { accept: "application/json" },
     });
     if (res.ok) {
@@ -422,7 +422,7 @@ async function buildSitemap(): Promise<Response> {
   // Stamping that would be the "lastmod is really just now" antipattern the helper above exists
   // to avoid, on 1029 URLs at once.
   try {
-    const res = await fetch(`${API_ORIGIN}/api/v1/validators?limit=2000`, {
+    const res = await fetch(`${API_DATA_ORIGIN}/api/v1/validators?limit=2000`, {
       headers: { accept: "application/json" },
     });
     if (res.ok) {
@@ -441,7 +441,7 @@ async function buildSitemap(): Promise<Response> {
     // Network hiccup — validators are omitted; the sitemap stays valid XML.
   }
   try {
-    const res = await fetch(`${API_ORIGIN}/api/v1/providers?limit=500`, {
+    const res = await fetch(`${API_DATA_ORIGIN}/api/v1/providers?limit=500`, {
       headers: { accept: "application/json" },
     });
     if (res.ok) {

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -10,7 +10,11 @@ import {
   siteGraphNodes,
   stringifyJsonLd,
 } from "./lib/metagraphed/json-ld";
-import { categoryPath, MIN_CATEGORY_SUBNETS } from "./lib/metagraphed/subnet-categories";
+import {
+  categoryPath,
+  MIN_CATEGORY_SUBNETS,
+  SUBNETS_ALL_LIMIT,
+} from "./lib/metagraphed/subnet-categories";
 import { isoTimestamp } from "./lib/metagraphed/freshness";
 import { API_ORIGIN, SITE_ORIGIN, X_HANDLE } from "./lib/metagraphed/identity";
 import { handleAnalyticsProxy, type PostHogAssetContext } from "./lib/analytics-proxy";
@@ -364,7 +368,11 @@ async function buildSitemap(): Promise<Response> {
     // News source unavailable — omit rather than fail the whole sitemap.
   }
   try {
-    const res = await fetch(`${API_ORIGIN}/api/v1/subnets?limit=500`, {
+    // The SAME limit the hub uses, so both derive their category set from one
+    // page of subnets. A hard-coded 500 here made the sitemap and the hub two
+    // different requests, which the e2e stub answers with two different
+    // recordings.
+    const res = await fetch(`${API_ORIGIN}/api/v1/subnets?limit=${SUBNETS_ALL_LIMIT}`, {
       headers: { accept: "application/json" },
     });
     if (res.ok) {

--- a/tests/legal-pages-accuracy.test.ts
+++ b/tests/legal-pages-accuracy.test.ts
@@ -1,0 +1,108 @@
+// #11567: the privacy policy states retention numbers, and a privacy policy
+// that is WRONG is worse than one that is missing -- it is a claim a reader
+// relies on and a directory reviewer checks.
+//
+// apps/ui cannot import the server constants (they are not part of the
+// published client package, and widening that package's public surface for a
+// prose page would be the wrong trade), so the page restates them. This test is
+// what stops the restatement drifting: it reads the page source and asserts the
+// numbers still equal what the server enforces.
+//
+// The same discipline auth.md now uses (#11566), applied where a direct import
+// is not available.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import {
+  SURFACE_CREDENTIAL_DEFAULT_TTL_SECONDS,
+  SURFACE_CREDENTIAL_MAX_TTL_SECONDS,
+} from "../src/mcp-surface-credentials.ts";
+
+const PRIVACY_PAGE = fileURLToPath(
+  new URL("../apps/ui/src/routes/-privacy-page.tsx", import.meta.url),
+);
+const TERMS_PAGE = fileURLToPath(
+  new URL("../apps/ui/src/routes/-terms-page.tsx", import.meta.url),
+);
+
+const privacy = readFileSync(PRIVACY_PAGE, "utf8");
+const terms = readFileSync(TERMS_PAGE, "utf8");
+
+const SECONDS_PER_DAY = 86_400;
+
+function declaredDays(source: string, name: string): number {
+  const match = new RegExp(`const ${name} = (\\d+);`).exec(source);
+  assert.ok(match, `${name} must be declared in the page`);
+  return Number(match[1]);
+}
+
+describe("the privacy policy's retention numbers match what the server enforces", () => {
+  test("the default credential lifetime", () => {
+    assert.equal(
+      declaredDays(privacy, "CREDENTIAL_DEFAULT_TTL_DAYS") * SECONDS_PER_DAY,
+      SURFACE_CREDENTIAL_DEFAULT_TTL_SECONDS,
+    );
+  });
+
+  test("the maximum credential lifetime", () => {
+    assert.equal(
+      declaredDays(privacy, "CREDENTIAL_MAX_TTL_DAYS") * SECONDS_PER_DAY,
+      SURFACE_CREDENTIAL_MAX_TTL_SECONDS,
+    );
+  });
+
+  test("the stated maximum is genuinely above the default", () => {
+    // A positive control: the two assertions above would both pass if someone
+    // set the constants equal, and the page's "at most" sentence would then be
+    // describing a ceiling that is not one.
+    assert.ok(
+      SURFACE_CREDENTIAL_MAX_TTL_SECONDS >
+        SURFACE_CREDENTIAL_DEFAULT_TTL_SECONDS,
+    );
+  });
+});
+
+describe("the pages state the things a directory review checks for", () => {
+  // The Connectors Directory rejects on a missing or incomplete privacy
+  // policy, and names the sections it must cover. These assert the SUBSTANCE
+  // is present, not that particular prose survives editing.
+  test("the privacy policy covers collection, use, sharing, retention and contact", () => {
+    for (const [claim, pattern] of [
+      ["collection", /Every request is logged/i],
+      ["ip handling", /salted SHA-256 hash of your IP/i],
+      ["agent-supplied text", /free-text context your agent chose to send/i],
+      ["third-party sharing", /Who else processes it/i],
+      ["retention", /Retention/],
+      ["deletion route", /delete your account/i],
+      ["contact", /open an issue/i],
+    ] as const) {
+      assert.match(privacy, pattern, `privacy policy must cover ${claim}`);
+    }
+  });
+
+  test("the privacy policy names every processor we actually use", () => {
+    // Naming a processor we do not use would be false; omitting one we do is
+    // the failure that matters. Each of these appears in the deployed config.
+    for (const processor of [
+      "Cloudflare",
+      "Neon",
+      "PostHog",
+      "Unkey",
+      "GitHub",
+    ]) {
+      assert.match(privacy, new RegExp(processor), processor);
+    }
+  });
+
+  test("the terms disclaim financial advice and warranty", () => {
+    assert.match(terms, /Nothing here is financial advice/i);
+    assert.match(terms, /without warranty/i);
+    assert.match(terms, /non-custodial/i);
+  });
+
+  test("each page links to the other, so neither is a dead end", () => {
+    assert.match(privacy, /to="\/terms"/);
+    assert.match(terms, /to="\/privacy"/);
+  });
+});


### PR DESCRIPTION
The Connectors Directory rejects a submission with a **missing or incomplete privacy policy**, and the submission portal requires the URL as a form field. Both pages 404'd, so this is a hard blocker on the listing rather than a nicety.

## Written against the code, not from a template

Every claim was checked against what the server actually does:

| claim on the page | verified in |
|---|---|
| Stored credentials are **AES-256-GCM** encrypted | `src/mcp-surface-credentials.ts` |
| They expire after **30 days** by default, **90** at most | `SURFACE_CREDENTIAL_{DEFAULT,MAX}_TTL_SECONDS` |
| Client IPs are a **salted SHA-256 digest**, never stored raw | `anonymousUsageDistinctId` |
| MCP calls carry **free-text context the calling agent chose to send** | `$mcp_intent` |
| Five processors: Cloudflare, Neon, PostHog, Unkey, GitHub | deployed config |

That last one is stated plainly because a user cannot audit their own agent's prompt and should know it reaches us. **A privacy policy that is wrong is worse than one that is missing** — it is a claim a reader relies on and a reviewer checks.

## The numbers cannot drift

`apps/ui` cannot import the server constants — they are not in the published client package, and widening that package's public surface for a prose page would be the wrong trade. So the page restates them, and `tests/legal-pages-accuracy.test.ts` reads the page source and asserts they still equal `SURFACE_CREDENTIAL_*_TTL_SECONDS` — with a positive control so both assertions cannot pass on accidentally-equal constants.

Same discipline `auth.md` took in #11566, applied where a direct import is not available.

## Screenshots

**There is no meaningful "before": both routes 404 on `main`.** Stating that rather than fabricating a comparison — the repo's `capture-pr-screenshots.ts` cannot run this matrix for the same reason (it navigates the *same* route on both refs, and the before navigation to a non-existent route times out).

| viewport | privacy | terms |
|---|---|---|
| **mobile** · light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-mobile-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-mobile-light.png) |
| **mobile** · dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-mobile-dark.png) |
| **tablet** · light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-tablet-light.png) |
| **tablet** · dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-tablet-dark.png) |
| **desktop** · light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-desktop-light.png) |
| **desktop** · dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-privacy-after-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11567-terms-after-desktop-dark.png) |

## Also

- Both pages are linked from the footer — **the only link to either anywhere on the site**. A privacy policy nothing links to is one a reader cannot find and a reviewer cannot verify.
- OG card copy added for both routes. `apps/ui` asserts every top-level route has it, and that gate caught the omission rather than me remembering.
- `routeTree.gen.ts` regenerated — adding an `apps/ui` route is a build step, not just two files.

## Verification

- **`apps/ui` own toolchain** (which the root gate does not cover): 2,329 tests, `tsc` clean, eslint 0 errors, prettier clean
- Root suite: 969 files, 22,275 tests
- All 70 `validate:*` scripts, root `tsc` and prettier clean

Part of #11561.

Closes #11567
