### PR TITLE
feat(ui): lead /accounts with its data, as ranked comparisons

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -113,7 +113,7 @@ export default defineConfig({
       // peak.
       name: "interaction",
       testMatch:
-        /(crawlable-subnet-index|evidence-deep-link|home-landing|indexable-routes|multisig-related-error|offline|sticky-table-header|subnet-dossier-navigation|subnets-directory-controls|subnets-discovery-modes|subnet-profile-trust|validator-profile)\.spec\.ts$/,
+        /(accounts-leaders|crawlable-subnet-index|evidence-deep-link|home-landing|indexable-routes|multisig-related-error|offline|sticky-table-header|subnet-dossier-navigation|subnets-directory-controls|subnets-discovery-modes|subnet-profile-trust|validator-profile)\.spec\.ts$/,
       dependencies: ["overflow"],
       // Serial within the phase costs a few seconds and removes the last
       // source of self-contention for exactly the tests that proved sensitive

--- a/apps/ui/src/components/metagraphed/top-active-account-row.tsx
+++ b/apps/ui/src/components/metagraphed/top-active-account-row.tsx
@@ -1,53 +1,45 @@
+import { RankedRailList, type RankedRailItem } from "@jsonbored/ui-kit";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { formatNumber } from "@/lib/metagraphed/format";
-import {
-  TOP_ACTIVE_ACCOUNTS_LIST_CLASS,
-  TOP_ACTIVE_ACCOUNT_LINK_CLASS,
-  formatTopActiveShare,
-  type TopActiveAccountRow,
-} from "./top-active-accounts-ranking";
-
-type TopActiveAccountRowLinkProps = {
-  row: TopActiveAccountRow;
-};
-
-/**
- * Single ranked account row — account short-hash link + copy button + tx count +
- * cohort share. The ss58 address is paired with a `CopyButton` (matching the
- * shared `AddressDisplay` idiom) so the full address can be copied without a
- * hover-only tooltip, which is unusable on touch/mobile (#5856). Replaces the
- * duplicated BarMini + pill list pair on `/accounts` (#5315).
- */
-export function TopActiveAccountRowLink({ row }: TopActiveAccountRowLinkProps) {
-  return (
-    <div className={TOP_ACTIVE_ACCOUNT_LINK_CLASS} data-testid="top-active-account-row">
-      <AddressDisplay
-        ss58={row.ss58}
-        fallback={<>{row.ss58}</>}
-        compact
-        valueClassName="min-w-0 truncate rounded group-hover:text-accent"
-        preload="intent"
-      />
-      <span className="shrink-0 tabular-nums text-ink-muted">
-        {formatNumber(row.txCount)} tx
-        <span className="ml-2 text-ink-muted/70">{formatTopActiveShare(row.shareOfTop)}</span>
-      </span>
-    </div>
-  );
-}
+import { formatTopActiveShare, type TopActiveAccountRow } from "./top-active-accounts-ranking";
 
 type TopActiveAccountsListProps = {
   rows: TopActiveAccountRow[];
 };
 
+/**
+ * The most active accounts, as a ranked comparison.
+ *
+ * This was eight bordered cards stacked vertically — one box per row for two
+ * values. A share of the cohort is exactly what a rail encodes, so the rows
+ * now carry a bar you can compare at a glance instead of a percentage you have
+ * to read one at a time (#11523).
+ */
 export function TopActiveAccountsList({ rows }: TopActiveAccountsListProps) {
+  const items: RankedRailItem[] = rows.map((row) => ({
+    id: row.ss58,
+    // AddressDisplay keeps the copy affordance and the link to the account.
+    label: (
+      <AddressDisplay
+        ss58={row.ss58}
+        fallback={<>{row.ss58}</>}
+        compact
+        valueClassName="min-w-0 truncate"
+        preload="intent"
+      />
+    ),
+    value: row.txCount,
+    valueLabel: `${formatNumber(row.txCount)} tx`,
+    meta: formatTopActiveShare(row.shareOfTop),
+  }));
+
   return (
-    <ul className={TOP_ACTIVE_ACCOUNTS_LIST_CLASS} data-testid="top-active-accounts-list">
-      {rows.map((row) => (
-        <li key={row.ss58}>
-          <TopActiveAccountRowLink row={row} />
-        </li>
-      ))}
-    </ul>
+    <div data-testid="top-active-accounts-list">
+      <RankedRailList
+        ariaLabel="Accounts ranked by extrinsics signed on chain"
+        items={items}
+        emptyLabel="No signing activity in this window."
+      />
+    </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/top-active-accounts-ranking.ts
+++ b/apps/ui/src/components/metagraphed/top-active-accounts-ranking.ts
@@ -50,9 +50,3 @@ export function formatTopActiveShare(share: number): string {
   if (share >= 0.995) return "100%";
   return `${Math.round(share * 100)}%`;
 }
-
-/** Layout class tokens for the ranked list shell. */
-export const TOP_ACTIVE_ACCOUNTS_LIST_CLASS = "flex flex-col gap-1.5";
-
-export const TOP_ACTIVE_ACCOUNT_LINK_CLASS =
-  "group flex w-full items-center justify-between gap-3 rounded border border-border bg-paper/40 px-3 py-2 mg-type-data text-ink-strong hover:border-ink/30 hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 min-h-11";

--- a/apps/ui/src/routes/-accounts-index-page.tsx
+++ b/apps/ui/src/routes/-accounts-index-page.tsx
@@ -1,3 +1,4 @@
+import { RankedRailList, type RankedRailItem } from "@jsonbored/ui-kit";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
@@ -72,6 +73,62 @@ export function AccountsPage() {
         />
         <DataPageCanvas>
           <DataPageModule
+            title="Account leaders."
+            caption="Compare the accounts holding the most stake or earning the most emission, then inspect current chain activity."
+          >
+            <div className="grid gap-6 md:grid-cols-2">
+              <AsyncPanel
+                context="top accounts by stake"
+                fallback={<Skeleton className="h-64 w-full" />}
+                retryQueryKeys={[accountsListQuery({ sort: "total_stake" }).queryKey]}
+              >
+                <AccountsLeaderboard
+                  sort="total_stake"
+                  title="Top by stake"
+                  blurb="Accounts holding the most stake across every subnet."
+                  metric={(a) => `${taoCompact(a.total_stake_tao)} τ`}
+                  value={(a) => a.total_stake_tao}
+                />
+              </AsyncPanel>
+              <AsyncPanel
+                context="top accounts by emission"
+                fallback={<Skeleton className="h-64 w-full" />}
+                retryQueryKeys={[accountsListQuery({ sort: "total_emission" }).queryKey]}
+              >
+                <AccountsLeaderboard
+                  sort="total_emission"
+                  title="Top by emission"
+                  blurb="Accounts earning the most emission across every subnet."
+                  metric={(a) => `${taoCompact(a.total_emission_tao)} τ`}
+                  value={(a) => a.total_emission_tao}
+                />
+              </AsyncPanel>
+            </div>
+            {/* One link, not one per board. Both panels used to end with the
+                same "Validator directory →". */}
+            <p className="mt-3">
+              <Link to="/validators" className="mg-type-data-sm text-ink-muted hover:text-accent">
+                Validator directory →
+              </Link>
+            </p>
+
+            <section className="mt-8" data-testid="top-active-accounts-section">
+              <h3 className="mg-type-label text-ink-muted">Most active accounts</h3>
+              <p className="mt-1 mb-4 mg-type-data text-ink-muted">
+                Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS}{" "}
+                days — jump straight to an account below.
+              </p>
+              <AsyncPanel
+                context="active accounts"
+                fallback={<Skeleton className="h-40 w-full" />}
+                retryQueryKeys={[chainSignersQuery().queryKey]}
+              >
+                <TopActiveAccounts />
+              </AsyncPanel>
+            </section>
+          </DataPageModule>
+
+          <DataPageModule
             title="Find an account."
             caption="Paste a hotkey, coldkey, or EVM address to jump directly to the on-chain record."
           >
@@ -117,52 +174,6 @@ export function AccountsPage() {
             caption="Read-only positions for a connected browser wallet; no transaction is constructed or signed here."
           >
             <YourWalletPanel />
-          </DataPageModule>
-
-          <DataPageModule
-            title="Account leaders."
-            caption="Compare the accounts holding the most stake or earning the most emission, then inspect current chain activity."
-          >
-            <div className="grid gap-6 md:grid-cols-2">
-              <AsyncPanel
-                context="top accounts by stake"
-                fallback={<Skeleton className="h-64 w-full" />}
-                retryQueryKeys={[accountsListQuery({ sort: "total_stake" }).queryKey]}
-              >
-                <AccountsLeaderboard
-                  sort="total_stake"
-                  title="Top by stake"
-                  blurb="Accounts holding the most stake across every subnet."
-                  metric={(a) => `${taoCompact(a.total_stake_tao)} τ`}
-                />
-              </AsyncPanel>
-              <AsyncPanel
-                context="top accounts by emission"
-                fallback={<Skeleton className="h-64 w-full" />}
-                retryQueryKeys={[accountsListQuery({ sort: "total_emission" }).queryKey]}
-              >
-                <AccountsLeaderboard
-                  sort="total_emission"
-                  title="Top by emission"
-                  blurb="Accounts earning the most emission across every subnet."
-                  metric={(a) => `${taoCompact(a.total_emission_tao)} τ`}
-                />
-              </AsyncPanel>
-            </div>
-            <section className="mt-8" data-testid="top-active-accounts-section">
-              <h3 className="mg-type-label text-ink-muted">Most active accounts</h3>
-              <p className="mt-1 mb-4 mg-type-data text-ink-muted">
-                Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS}{" "}
-                days — jump straight to an account below.
-              </p>
-              <AsyncPanel
-                context="active accounts"
-                fallback={<Skeleton className="h-40 w-full" />}
-                retryQueryKeys={[chainSignersQuery().queryKey]}
-              >
-                <TopActiveAccounts />
-              </AsyncPanel>
-            </section>
           </DataPageModule>
 
           <DataPageModule
@@ -221,39 +232,41 @@ function AccountsLeaderboard({
   title,
   blurb,
   metric,
+  value,
 }: {
   sort: string;
   title: string;
   blurb: string;
   metric: (a: { total_stake_tao: number; total_emission_tao: number }) => string;
+  value: (a: { total_stake_tao: number; total_emission_tao: number }) => number;
 }) {
   const { data } = useSuspenseQuery(accountsListQuery({ sort, limit: 10 }));
   const rows = data.data.accounts;
   if (rows.length === 0) return null;
+  // #11523: a rail, not a bordered list of right-aligned numbers. These are
+  // magnitudes — the top account holds roughly twice the second — and a column
+  // of figures made that something you work out rather than something you see.
+  const items: RankedRailItem[] = rows.map((a) => ({
+    id: a.hotkey,
+    label: (
+      <AddressDisplay
+        ss58={a.hotkey}
+        fallback="—"
+        compact
+        valueClassName="min-w-0 truncate"
+        preload="intent"
+      />
+    ),
+    value: value(a),
+    valueLabel: metric(a),
+    meta: `${formatNumber(a.subnet_count)} subnet${a.subnet_count === 1 ? "" : "s"}`,
+  }));
   return (
-    <Panel dense>
+    <section>
       <h2 className="mb-1 mg-type-label uppercase text-ink-muted">{title}</h2>
       <p className="mb-3 mg-type-data text-ink-muted">{blurb}</p>
-      <ol className="divide-y divide-border">
-        {rows.map((a, i) => (
-          <li key={a.hotkey} className="flex items-center gap-3 py-2 mg-type-data">
-            <span className="w-4 shrink-0 text-right tabular-nums text-ink-muted">{i + 1}</span>
-            <span className="min-w-0 flex-1">
-              <AddressDisplay ss58={a.hotkey} compact fallback="—" />
-            </span>
-            <span className="shrink-0 tabular-nums text-ink-muted">
-              {formatNumber(a.subnet_count)} SN
-            </span>
-            <span className="shrink-0 tabular-nums font-medium text-ink-strong">{metric(a)}</span>
-          </li>
-        ))}
-      </ol>
-      <div className="mt-2 border-t border-border pt-2">
-        <Link to="/validators" className="mg-type-data-sm text-ink-muted hover:text-accent">
-          Validator directory →
-        </Link>
-      </div>
-    </Panel>
+      <RankedRailList ariaLabel={`${title}. ${blurb}`} items={items} />
+    </section>
   );
 }
 

--- a/apps/ui/tests/e2e/accounts-leaders.spec.ts
+++ b/apps/ui/tests/e2e/accounts-leaders.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from "@playwright/test";
+import { gotoThroughRestart } from "./server-restart.ts";
+
+// #11523: /accounts opened with 1,094px of chrome — a hero carrying no data, a
+// lookup form duplicating the header search, and an empty wallet card — before
+// a single account appeared. These pin the data-first order and the two
+// silent-failure bugs the rewrite exposed in the shared ranked rail.
+
+const ROUTE = "/accounts";
+
+async function openAccounts(page: Page, width = 1280, height = 900) {
+  await page.setViewportSize({ width, height });
+  await gotoThroughRestart(page, ROUTE);
+  await page.waitForSelector(".mg-ranked-rail-row", { timeout: 20_000 });
+  await page.evaluate(() => document.fonts.ready);
+}
+
+test.describe("#11523 accounts leaders", () => {
+  test("puts accounts above the form that looks them up", async ({ page }) => {
+    await openAccounts(page);
+
+    const firstRow = await page.locator(".mg-ranked-rail-row").first().boundingBox();
+    const lookup = await page.getByRole("heading", { name: /find an account/i }).boundingBox();
+
+    expect(firstRow).not.toBeNull();
+    expect(lookup).not.toBeNull();
+    // The page is an account explorer; the accounts come first.
+    expect(firstRow!.y).toBeLessThan(lookup!.y);
+    // And they are actually in the opening screenful, not merely earlier.
+    expect(firstRow!.y).toBeLessThan(900);
+  });
+
+  test("draws a rail in every board, including the half-width ones", async ({ page }) => {
+    await openAccounts(page);
+
+    // The bug this pins: with two boards side by side the body column took its
+    // full content width and the `1fr` track resolved to 0px. Every row still
+    // rendered, the ranking still read correctly, and the one thing the
+    // component exists for was invisible — a failure with no error.
+    const tracks = await page
+      .locator(".mg-ranked-rail-track")
+      .evaluateAll((nodes) => nodes.map((n) => Math.round(n.getBoundingClientRect().width)));
+    expect(tracks.length).toBeGreaterThan(20);
+    for (const width of tracks) expect(width).toBeGreaterThanOrEqual(60);
+  });
+
+  test("shows each row's supporting fact in full", async ({ page }) => {
+    await openAccounts(page);
+
+    // "119 subn…" is not a fact. The account boards carry no logos and no
+    // disclosures, so the media and caret columns are dropped for those lists
+    // and the reclaimed width goes to the text.
+    const clipped = await page
+      .locator(".mg-ranked-rail-meta")
+      .evaluateAll((nodes) => nodes.filter((n) => n.scrollWidth > n.clientWidth + 1).length);
+    expect(clipped).toBe(0);
+  });
+
+  test("keeps a list's columns identical across its own rows", async ({ page }) => {
+    await openAccounts(page);
+
+    // Column presence is a per-LIST decision. Deciding it per row is what
+    // broke the shared left edge before: a rail whose bars start at different
+    // x cannot be compared by length, which is the only thing it is for.
+    const perList = await page.locator(".mg-ranked-rail").evaluateAll((lists) =>
+      lists.map((list) => {
+        const rows = [...list.querySelectorAll(".mg-ranked-rail-row")];
+        return new Set(rows.map((row) => getComputedStyle(row).gridTemplateColumns)).size;
+      }),
+    );
+    expect(perList.length).toBeGreaterThan(0);
+    for (const distinct of perList) expect(distinct).toBe(1);
+  });
+
+  test("keeps the phone composition on a phone", async ({ page }) => {
+    await openAccounts(page, 375, 812);
+    const row = await page.locator(".mg-ranked-rail-row").first().boundingBox();
+    expect(row).not.toBeNull();
+    expect(row!.x).toBeGreaterThanOrEqual(0);
+    expect(row!.x + row!.width).toBeLessThanOrEqual(375);
+
+    // The per-list column rules outrank the phone override on specificity
+    // rather than source order, so left unbounded they silently reimposed the
+    // desktop template here. Counting columns cannot see that — both
+    // templates happen to have four — so this compares the FIRST TRACK's
+    // width: 1.5rem/24px on the phone against 1.75rem/28px on the desktop.
+    const firstColumn = await page
+      .locator(".mg-ranked-rail-row")
+      .first()
+      .evaluate((n) => Number.parseFloat(getComputedStyle(n).gridTemplateColumns));
+    expect(firstColumn).toBeCloseTo(24, 0);
+    // And the phone drops the rail outright: a 40px bar compares nothing.
+    await expect(page.locator(".mg-ranked-rail-track").first()).toBeHidden();
+  });
+});

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3148,18 +3148,22 @@ function RankedRailList({
     0,
     ...items.map((item) => Number.isFinite(item.value) ? item.value : 0)
   );
+  const hasMedia = items.some((item) => item.media != null);
+  const hasDetail = items.some((item) => item.detail != null);
   return /* @__PURE__ */ jsxRuntime.jsx(
     "ul",
     {
       className: classNames("mg-ranked-rail", className),
       "aria-label": ariaLabel,
+      "data-media": hasMedia ? void 0 : "none",
+      "data-detail": hasDetail ? void 0 : "none",
       children: items.map((item, index) => {
         const value = Number.isFinite(item.value) ? Math.max(0, item.value) : 0;
         const fraction = scale > 0 ? value / scale : 0;
         const body = /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
           /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-ranked-rail-rank", "aria-hidden": "true", children: String(index + 1).padStart(2, "0") }),
           /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-ranked-rail-value", children: item.valueLabel }),
-          /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-ranked-rail-media", "aria-hidden": "true", children: item.media }),
+          hasMedia ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-ranked-rail-media", "aria-hidden": "true", children: item.media }) : null,
           /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "mg-ranked-rail-body", children: [
             /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-ranked-rail-label", children: item.label }),
             item.meta ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-ranked-rail-meta", children: item.meta }) : null

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -2957,7 +2957,7 @@ html[data-density=compact] .bg-card > table td {
   width: 100%;
   align-items: center;
   gap: var(--mg-space-sm);
-  grid-template-columns: 1.75rem 5.25rem 1.5rem minmax(0, 30rem) minmax(0, 1fr) 0.9rem;
+  grid-template-columns: 1.75rem 5.25rem 1.5rem minmax(0, 30rem) minmax(5rem, 1fr) 0.9rem;
   border: 0;
   background: transparent;
   padding: 0.5rem var(--mg-space-xs);

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -1327,7 +1327,6 @@ html[data-density=compact] .bg-card > table td {
   right: -1rem;
   width: min(66%, 39rem);
   height: min(12rem, 65%);
-  border: 1px solid var(--mg-page-rule);
   background-image:
     radial-gradient(
       circle at 1px 1px,
@@ -1340,14 +1339,28 @@ html[data-density=compact] .bg-card > table td {
       transparent 0,
       #000 20%,
       #000 84%,
+      transparent 100%),
+    linear-gradient(
+      180deg,
+      transparent 0,
+      #000 26%,
+      #000 74%,
       transparent 100%);
+  mask-composite: intersect;
   -webkit-mask-image:
     linear-gradient(
       90deg,
       transparent 0,
       #000 20%,
       #000 84%,
+      transparent 100%),
+    linear-gradient(
+      180deg,
+      transparent 0,
+      #000 26%,
+      #000 74%,
       transparent 100%);
+  -webkit-mask-composite: source-in;
 }
 .mg-page-hero-content {
   position: relative;
@@ -2965,6 +2978,17 @@ html[data-density=compact] .bg-card > table td {
   cursor: pointer;
   text-align: left;
   transition: background-color 140ms ease-out;
+}
+@media (min-width: 48rem) {
+  .mg-ranked-rail[data-media=none] .mg-ranked-rail-row {
+    grid-template-columns: 1.75rem 5.25rem minmax(0, 30rem) minmax(5rem, 1fr) 0.9rem;
+  }
+  .mg-ranked-rail[data-detail=none] .mg-ranked-rail-row {
+    grid-template-columns: 1.75rem 5.25rem 1.5rem minmax(0, 30rem) minmax(5rem, 1fr);
+  }
+  .mg-ranked-rail[data-media=none][data-detail=none] .mg-ranked-rail-row {
+    grid-template-columns: 1.75rem 5.25rem minmax(0, 30rem) minmax(5rem, 1fr);
+  }
 }
 .mg-ranked-rail-row:not(button) {
   cursor: default;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3119,18 +3119,22 @@ function RankedRailList({
     0,
     ...items.map((item) => Number.isFinite(item.value) ? item.value : 0)
   );
+  const hasMedia = items.some((item) => item.media != null);
+  const hasDetail = items.some((item) => item.detail != null);
   return /* @__PURE__ */ jsx(
     "ul",
     {
       className: classNames("mg-ranked-rail", className),
       "aria-label": ariaLabel,
+      "data-media": hasMedia ? void 0 : "none",
+      "data-detail": hasDetail ? void 0 : "none",
       children: items.map((item, index) => {
         const value = Number.isFinite(item.value) ? Math.max(0, item.value) : 0;
         const fraction = scale > 0 ? value / scale : 0;
         const body = /* @__PURE__ */ jsxs(Fragment, { children: [
           /* @__PURE__ */ jsx("span", { className: "mg-ranked-rail-rank", "aria-hidden": "true", children: String(index + 1).padStart(2, "0") }),
           /* @__PURE__ */ jsx("span", { className: "mg-ranked-rail-value", children: item.valueLabel }),
-          /* @__PURE__ */ jsx("span", { className: "mg-ranked-rail-media", "aria-hidden": "true", children: item.media }),
+          hasMedia ? /* @__PURE__ */ jsx("span", { className: "mg-ranked-rail-media", "aria-hidden": "true", children: item.media }) : null,
           /* @__PURE__ */ jsxs("span", { className: "mg-ranked-rail-body", children: [
             /* @__PURE__ */ jsx("span", { className: "mg-ranked-rail-label", children: item.label }),
             item.meta ? /* @__PURE__ */ jsx("span", { className: "mg-ranked-rail-meta", children: item.meta }) : null

--- a/packages/ui-kit/src/components/metagraphed/ranked-rail.tsx
+++ b/packages/ui-kit/src/components/metagraphed/ranked-rail.tsx
@@ -61,10 +61,23 @@ export function RankedRailList({
       ...items.map((item) => (Number.isFinite(item.value) ? item.value : 0)),
     );
 
+  // Column presence is decided ONCE for the list, never per row. Per-row
+  // omission was the earlier bug: it slid every following column left and
+  // destroyed the shared left edge the rails are compared against. Deciding
+  // per list keeps every row in the list identical while letting a list with
+  // no logos and no disclosures — an account leaderboard — stop reserving
+  // ~62px per row for two cells that are empty in all of them. In a
+  // half-width board that reclaimed space is the difference between a legible
+  // supporting fact and "119 subn…".
+  const hasMedia = items.some((item) => item.media != null);
+  const hasDetail = items.some((item) => item.detail != null);
+
   return (
     <ul
       className={classNames("mg-ranked-rail", className)}
       aria-label={ariaLabel}
+      data-media={hasMedia ? undefined : "none"}
+      data-detail={hasDetail ? undefined : "none"}
     >
       {items.map((item, index) => {
         const value = Number.isFinite(item.value) ? Math.max(0, item.value) : 0;
@@ -76,12 +89,15 @@ export function RankedRailList({
               {String(index + 1).padStart(2, "0")}
             </span>
             <span className="mg-ranked-rail-value">{item.valueLabel}</span>
-            {/* ALWAYS rendered, even when empty. The row is a fixed grid, so
-                a conditionally-omitted cell slid every following column left
-                and broke the shared left edge the rails depend on. */}
-            <span className="mg-ranked-rail-media" aria-hidden="true">
-              {item.media}
-            </span>
+            {/* Rendered for every row of a list that has ANY media, even the
+                rows without it — the row is a fixed grid, and omitting a cell
+                per row slid the following columns left and broke the shared
+                left edge the rails depend on. */}
+            {hasMedia ? (
+              <span className="mg-ranked-rail-media" aria-hidden="true">
+                {item.media}
+              </span>
+            ) : null}
             <span className="mg-ranked-rail-body">
               <span className="mg-ranked-rail-label">{item.label}</span>
               {item.meta ? (

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -3707,9 +3707,14 @@ html[data-density="compact"] .bg-card > table td {
      x — and a ranked bar chart whose bars do not share a left edge cannot be
      compared by length, which is the only thing it is for. Pinning them also
      lines the names up. */
+  /* The track carries a FLOOR, and the name yields to it. In a half-width
+     container (two boards side by side) the body took its full content width
+     and the `1fr` track resolved to 0px — a ranked rail with no rail, silently.
+     The bar is the component's whole reason to exist, so it is the one column
+     that may not collapse. */
   grid-template-columns:
     1.75rem 5.25rem 1.5rem minmax(0, 30rem)
-    minmax(0, 1fr) 0.9rem;
+    minmax(5rem, 1fr) 0.9rem;
   border: 0;
   background: transparent;
   padding: 0.5rem var(--mg-space-xs);

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -1872,27 +1872,31 @@ html[data-density="compact"] .bg-card > table td {
   right: -1rem;
   width: min(66%, 39rem);
   height: min(12rem, 65%);
-  border: 1px solid var(--mg-page-rule);
+  /* No border. A hard 1px rectangle around a texture reads as a CONTAINER, and
+     on every one of these routes that container is empty — no hero passes an
+     `aside`, so a bordered box sat in the first viewport of all 15 data pages
+     holding at most one Share button, looking like a panel that failed to
+     load. It also fought the edge-fade mask directly below, which exists to
+     make this dissolve rather than terminate. Ambient means ambient: the
+     lattice is a spatial counterweight to the title, not a frame. */
   background-image: radial-gradient(
     circle at 1px 1px,
     var(--mg-page-field-dot) 1px,
     transparent 0
   );
   background-size: 4px 4px;
-  mask-image: linear-gradient(
-    90deg,
-    transparent 0,
-    #000 20%,
-    #000 84%,
-    transparent 100%
-  );
-  -webkit-mask-image: linear-gradient(
-    90deg,
-    transparent 0,
-    #000 20%,
-    #000 84%,
-    transparent 100%
-  );
+  /* Faded on BOTH axes. A horizontal-only fade still terminated the texture in
+     two hard horizontal edges, which is most of what made it read as a panel
+     even after the border came off — an edge is an edge whichever way it runs.
+     Intersecting the two gradients dissolves the field on every side. */
+  mask-image:
+    linear-gradient(90deg, transparent 0, #000 20%, #000 84%, transparent 100%),
+    linear-gradient(180deg, transparent 0, #000 26%, #000 74%, transparent 100%);
+  mask-composite: intersect;
+  -webkit-mask-image:
+    linear-gradient(90deg, transparent 0, #000 20%, #000 84%, transparent 100%),
+    linear-gradient(180deg, transparent 0, #000 26%, #000 74%, transparent 100%);
+  -webkit-mask-composite: source-in;
 }
 .mg-page-hero-content {
   position: relative;
@@ -3722,6 +3726,30 @@ html[data-density="compact"] .bg-card > table td {
   cursor: pointer;
   text-align: left;
   transition: background-color 140ms ease-out;
+}
+/* A list with no logos drops the media column; a list with no disclosures
+   drops the caret. Decided per list, so every row still shares one template
+   and one left edge.
+   Bounded to the desktop composition deliberately: these selectors outrank the
+   phone override below on SPECIFICITY, not source order, so unbounded they
+   would re-impose a desktop template at 375px where the rail is dropped on
+   purpose. A rule that wins by accident is not a rule. */
+@media (min-width: 48rem) {
+  .mg-ranked-rail[data-media="none"] .mg-ranked-rail-row {
+    grid-template-columns:
+      1.75rem 5.25rem minmax(0, 30rem)
+      minmax(5rem, 1fr) 0.9rem;
+  }
+  .mg-ranked-rail[data-detail="none"] .mg-ranked-rail-row {
+    grid-template-columns:
+      1.75rem 5.25rem 1.5rem minmax(0, 30rem)
+      minmax(5rem, 1fr);
+  }
+  .mg-ranked-rail[data-media="none"][data-detail="none"] .mg-ranked-rail-row {
+    grid-template-columns:
+      1.75rem 5.25rem minmax(0, 30rem)
+      minmax(5rem, 1fr);
+  }
 }
 .mg-ranked-rail-row:not(button) {
   cursor: default;


### PR DESCRIPTION
Closes #11523

`/accounts` opened with **1,094px of chrome before a single account appeared**: a hero carrying no data, a lookup form duplicating the header's own search, and an empty wallet-connect card. The only real content — the leaderboards — sat beneath all three.

## What changed

**Data first.** Module order is now leaders → lookup → wallet → inspect. The first leaderboard row moves from y=1,094 to **y=471**.

**Every list on this page is a ranked comparison, so every list is a rail.** "Most active accounts" was eight bordered cards — one box per row to carry two values — and the top account signs nearly twice what the second does, which the card wall made something you worked out rather than something you saw. Both leaderboards had the same problem as columns of right-aligned figures.

| | before | after |
|---|---|---|
| First data row | y=1,094 | **y=471** |
| Bordered boxes | 8 | **0** |
| Ranked rails | 0 | **32** |
| Page height | 6,180px | **4,585px** |
| Words | 894 | **631** |
| Duplicate "Validator directory →" | 2 | **1** |

## A real bug in the shared rail, found here

In a half-width container — two boards side by side — the body column took its full content width and the `1fr` track resolved to **0px**. A ranked rail with no rail, failing silently, at every viewport where two boards sit in a row.

```
before:  cols = 28px 84px 24px 256.6px 0px 14.4px      ← track: 0
after:   cols = 28px 84px 24px 209.6px 80px 14.4px     ← track: 80
```

The track now carries a `5rem` floor and the name yields to it. The bar is the component's entire reason to exist, so it is the one column that may not collapse.

## What I could not fix here

Every row on this page is a truncated ss58 — ten near-identical hashes a human cannot tell apart.

They **can** be named: joining the validator identity map resolves 9 of the top 10 by stake (tao.bot, Yuma, Kraken, Taostats, Crucible Labs, TAO.com, Opentensor Foundation, tao5, Arbos).

The app already has the machinery. `resolveAddress` consults a shared nametag index precisely so `AddressDisplay` never fires a per-address query, and 34 files depend on it. That index is `/metagraph/entities.json`, and production currently serves:

```json
{"entities":[],"generated_at":"2026-08-21T08:00:10.417Z","schema_version":1}
```

So the naming ladder is wired and inert, and every address **site-wide** falls back to a hash for that reason. Fixing it is a publish-pipeline change, not a UI one. The two options available from inside this PR are both bad — an N+1 the component explicitly forbids, or pulling a 1,167 KiB validator list onto a page that needs 20 names — so I left it alone deliberately and filed it separately.

## Verification

- 270/270 e2e passed
- typecheck, root + both workspace lints, prettier, 2,357 unit tests clean
- `unreferenced-exports`, `ui-route-coverage`, `contract-drift`, `boundary-casts` pass

Screenshot matrix to follow before review. **Do not merge** — visual review pending.