### PR TITLE
feat(mcp): recommend the core profile everywhere an install is published

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6088,9 +6088,19 @@ export interface components {
             };
             generated_at: string;
             mcp: {
+                /**
+                 * Format: uri
+                 * @description The core listing profile: 23 tools instead of 243. Filters tools/list only -- a core session can still call every tool.
+                 */
+                core_endpoint?: string;
                 /** Format: uri */
                 endpoint: string;
                 install: string;
+                /**
+                 * Format: uri
+                 * @description The endpoint a first-time caller should connect to, which `install` uses.
+                 */
+                recommended_endpoint?: string;
                 /** Format: uri */
                 server_card?: string;
                 tools: {
@@ -24657,8 +24667,10 @@ export interface operations {
                      *         },
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "mcp": {
+                     *           "core_endpoint": "https://api.metagraph.sh/example",
                      *           "endpoint": "https://api.metagraph.sh/example",
                      *           "install": "example",
+                     *           "recommended_endpoint": "https://api.metagraph.sh/example",
                      *           "server_card": "https://api.metagraph.sh/example",
                      *           "tools": [
                      *             {

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -3,7 +3,7 @@
   "skills": [
     {
       "description": "Use when a developer asks what a Bittensor subnet does, whether it's up right now, how to call/integrate its API, or what mining/validating one costs and earns — e.g. \"which subnet does image generation\", \"is subnet 7 healthy\", \"call the Beam API for me\", \"does mining subnet 3 need a GPU\", \"what does the median miner on subnet 13 make\". Can EXECUTE subnet API calls, not just describe them. Backed by metagraphed (api.metagraph.sh), the live operational + integration registry for ~129 subnets.",
-      "digest": "sha256:80c8a2ae9fe5138253dea4a5f4462d513f7f7242062c128796e1e4687d6cdc6c",
+      "digest": "sha256:d40c14a57ce34d6a7687d8b056686c6bce643c41b4af877e8a1dd8dd58143260",
       "name": "bittensor",
       "type": "skill-md",
       "url": "https://api.metagraph.sh/skills/bittensor/SKILL.md"

--- a/public/agent.md
+++ b/public/agent.md
@@ -8,8 +8,14 @@ the live metagraphed registry, not training-data guesses.
 The fastest path is the MCP server (one line, no key):
 
 ```
-claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp
+claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp/core
 ```
+
+That is the **core** profile: it lists 23 tools (~45k tokens) instead of 243
+(~400k), and can still call all 243 — the profile filters the tool _listing_,
+never dispatch, and `get_more_tools` reaches the rest. Use
+`https://api.metagraph.sh/mcp` instead only if you want every tool enumerated
+up front.
 
 No MCP host? Everything is also a plain `GET`/`POST` over HTTPS — see "REST
 fallback" at the bottom. For copyable REST/npm/Python/MCP examples, use

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1606,8 +1606,10 @@
             },
             "generated_at": "2026-06-01T00:00:00.000Z",
             "mcp": {
+              "core_endpoint": "https://api.metagraph.sh/example",
               "endpoint": "https://api.metagraph.sh/example",
               "install": "example",
+              "recommended_endpoint": "https://api.metagraph.sh/example",
               "server_card": "https://api.metagraph.sh/example",
               "tools": [
                 {
@@ -19471,11 +19473,21 @@
           "mcp": {
             "additionalProperties": false,
             "properties": {
+              "core_endpoint": {
+                "description": "The core listing profile: 23 tools instead of 243. Filters tools/list only -- a core session can still call every tool.",
+                "format": "uri",
+                "type": "string"
+              },
               "endpoint": {
                 "format": "uri",
                 "type": "string"
               },
               "install": {
+                "type": "string"
+              },
+              "recommended_endpoint": {
+                "description": "The endpoint a first-time caller should connect to, which `install` uses.",
+                "format": "uri",
                 "type": "string"
               },
               "server_card": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6088,9 +6088,19 @@ export interface components {
             };
             generated_at: string;
             mcp: {
+                /**
+                 * Format: uri
+                 * @description The core listing profile: 23 tools instead of 243. Filters tools/list only -- a core session can still call every tool.
+                 */
+                core_endpoint?: string;
                 /** Format: uri */
                 endpoint: string;
                 install: string;
+                /**
+                 * Format: uri
+                 * @description The endpoint a first-time caller should connect to, which `install` uses.
+                 */
+                recommended_endpoint?: string;
                 /** Format: uri */
                 server_card?: string;
                 tools: {
@@ -24657,8 +24667,10 @@ export interface operations {
                      *         },
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "mcp": {
+                     *           "core_endpoint": "https://api.metagraph.sh/example",
                      *           "endpoint": "https://api.metagraph.sh/example",
                      *           "install": "example",
+                     *           "recommended_endpoint": "https://api.metagraph.sh/example",
                      *           "server_card": "https://api.metagraph.sh/example",
                      *           "tools": [
                      *             {

--- a/public/skills/bittensor/SKILL.md
+++ b/public/skills/bittensor/SKILL.md
@@ -26,12 +26,17 @@ them live from metagraphed.
 ## Connect (one line)
 
 ```
-claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp
+claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp/core
 ```
 
 Cursor / other clients: add an MCP server with url
-`https://api.metagraph.sh/mcp`, transport `streamable-http`. Server descriptor:
-`https://api.metagraph.sh/.well-known/mcp/server-card.json`.
+`https://api.metagraph.sh/mcp/core`, transport `streamable-http`. Server
+descriptor: `https://api.metagraph.sh/.well-known/mcp/server-card.json`.
+
+`/mcp/core` lists the 23 tools of the workflow below (~45k tokens); `/mcp`
+lists all 243 (~400k). Either endpoint can **call** all 243 — the profile
+filters listing, never dispatch — so start with core and reach for
+`get_more_tools` when the workflow below runs out.
 
 ## The workflow
 

--- a/schemas-src/routes/agent-catalog.ts
+++ b/schemas-src/routes/agent-catalog.ts
@@ -303,7 +303,26 @@ export const AgentResourcesArtifactSchema = ArtifactBaseSchema.extend({
     .strict(),
   mcp: z
     .object({
+      // The server's identity, and what every existing consumer resolved.
       endpoint: z.url(),
+      // The two listing profiles, stated separately (#11164). `endpoint` is
+      // the full one; `recommended_endpoint` is what a reader should actually
+      // install, and `install` is built from it. They are distinct fields
+      // because they answer different questions -- "what is this server" and
+      // "what should I connect to" -- and collapsing them would make one of
+      // the two answers wrong.
+      core_endpoint: z
+        .url()
+        .optional()
+        .describe(
+          "The core listing profile: 23 tools instead of 243. Filters tools/list only -- a core session can still call every tool.",
+        ),
+      recommended_endpoint: z
+        .url()
+        .optional()
+        .describe(
+          "The endpoint a first-time caller should connect to, which `install` uses.",
+        ),
       transport: z.string().optional(),
       install: z.string(),
       server_card: z.url().optional(),

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2125,6 +2125,21 @@ await writeJson(artifactFile("coverage-depth.json"), coverageDepthArtifact);
 // The emerging standard for making a site/API legible to LLMs. Served from the
 // public/ root (and /.well-known) by the ASSETS handler at api.metagraph.sh.
 const llmsApiBase = `https://${PRIMARY_DOMAIN}`;
+const mcpEndpoint = `${llmsApiBase}/mcp`;
+/**
+ * The core listing profile, and the one an agent should install (#11164).
+ *
+ * MEASURED against production on 2026-08-22: `/mcp` lists 243 tools at
+ * ~396,000 tokens; `/mcp/core` lists 23 at ~44,500. Most clients hold tool
+ * definitions in model context, so the full list costs a caller nine tenths
+ * of a large context window BEFORE they ask anything.
+ *
+ * Recommending core is not a reduction. The profile filters `tools/list` and
+ * NEVER dispatch -- a core session can `tools/call` all 243, and carries
+ * `ask` and `get_more_tools` as escape hatches -- so the only thing a caller
+ * gives up is paying to read a catalogue they mostly will not use.
+ */
+const mcpCoreEndpoint = `${llmsApiBase}/mcp/core`;
 const llmsHeader = [
   "# metagraphed",
   "",
@@ -2140,7 +2155,7 @@ const llmsHeader = [
   `- [Coverage depth scorecard](${llmsApiBase}/api/v1/coverage-depth): one ranked view of which subnets are machine-usable, what is missing, and which enrichment actions should happen next`,
   `- [Copyable AI agent](${llmsApiBase}/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](${llmsApiBase}/api/v1/agent-resources).`,
   `- [Agent workflows](${llmsApiBase}/agent-workflows.md): task-oriented REST, MCP, npm, and Python examples for finding and calling subnets`,
-  `- [MCP server](${llmsApiBase}/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: \`claude mcp add --transport http metagraphed ${llmsApiBase}/mcp\``,
+  `- [MCP server](${mcpCoreEndpoint}): Model Context Protocol endpoint — agents query the registry as tools. Install: \`claude mcp add --transport http metagraphed ${mcpCoreEndpoint}\`. This is the CORE profile: it lists 23 tools (~45k tokens) instead of 243 (~400k), and can still call all 243 — the profile filters listing, never dispatch. Use [${mcpEndpoint}](${mcpEndpoint}) only if you want every tool enumerated up front.`,
   `- [MCP server card](${llmsApiBase}/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)`,
   `- [Content feeds](${llmsApiBase}/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}; ranked coverage gaps at /api/v1/feeds/gaps). Content-negotiated via Accept, or append .rss/.atom/.json.`,
   `- Embeddable badges: \`${llmsApiBase}/api/v1/subnets/{netuid}/badge.svg\` and \`/api/v1/providers/{slug}/badge.svg\` — SVG badges for READMEs (\`?metric=readiness\` default, \`?metric=completeness\` for coverage score, \`?metric=uptime\` for reliability).`,
@@ -2217,7 +2232,7 @@ await fs.writeFile(
 // PulseMCP, mcp.so, the official registry) autodiscover the server via
 // /.well-known/mcp.json. The server card (SEP-1649) is worker-computed from the
 // live tool registry; only this pointer document is a committed artifact.
-const mcpEndpoint = `${llmsApiBase}/mcp`;
+
 await fs.mkdir(path.join(repoRoot, "public/.well-known/mcp"), {
   recursive: true,
 });
@@ -2364,9 +2379,14 @@ const agentResourcesContent = {
       "Paste-ready system prompt that turns any agent (Claude, Cursor, …) into a metagraphed-powered Bittensor integration agent.",
   },
   mcp: {
+    // `endpoint` stays the full profile: it is the identity of the server and
+    // what every existing consumer resolved. What changes is which one is
+    // RECOMMENDED, which is what `install` and `core_endpoint` now say.
     endpoint: mcpEndpoint,
+    core_endpoint: mcpCoreEndpoint,
+    recommended_endpoint: mcpCoreEndpoint,
     transport: "streamable-http",
-    install: `claude mcp add --transport http metagraphed ${mcpEndpoint}`,
+    install: `claude mcp add --transport http metagraphed ${mcpCoreEndpoint}`,
     server_card: `${llmsApiBase}/.well-known/mcp/server-card.json`,
     tools: listToolDefinitions().map((tool) => ({
       name: tool.name,

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -423,10 +423,24 @@ assert.equal(
   MCP_SERVER_INFO.title,
   "server.json title must match MCP_SERVER_INFO.title (the title the server card renders)",
 );
+// THE CORE PROFILE, not the full one (#11164).
+//
+// A registry install is somebody meeting this server for the first time, and
+// `remotes[0]` is what the installer connects them to. Measured against
+// production on 2026-08-22: `/mcp` lists 243 tools at ~396,000 tokens,
+// `/mcp/core` lists 23 at ~44,500. Most clients hold tool definitions in
+// model context, so the full list spends nine tenths of a large context
+// window before the caller asks anything -- and Anthropic's directory
+// criteria require a server to be "frugal with their use of tokens".
+//
+// This is not a reduced install. The profile filters `tools/list` and NEVER
+// dispatch: a core session can `tools/call` all 243, with `ask` and
+// `get_more_tools` as escape hatches. `/mcp` stays served, documented, and is
+// still what `endpoint` on the server card reports as this server's identity.
 assert.equal(
   (serverManifest.remotes as Row[])?.[0]?.url,
-  `https://${PRIMARY_DOMAIN}/mcp`,
-  "server.json must point registry consumers at the endpoint the server actually serves",
+  `https://${PRIMARY_DOMAIN}/mcp/core`,
+  "server.json must point registry consumers at the core profile, which is the endpoint a first-time installer should get",
 );
 assert.equal(
   (serverManifest.remotes as Row[])?.[0]?.type,

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.JSONbored/metagraphed",
-  "title": "metagraphed — Bittensor in a box",
-  "description": "Bittensor in a box: the live operational + integration registry for every subnet — discover, verify, call, and screen subnet APIs, schemas, health, and economics through one MCP server.",
+  "title": "metagraphed \u2014 Bittensor in a box",
+  "description": "Bittensor in a box: the live operational + integration registry for every subnet \u2014 discover, verify, call, and screen subnet APIs, schemas, health, and economics through one MCP server.",
   "version": "1.78.22",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
@@ -12,7 +12,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://api.metagraph.sh/mcp"
+      "url": "https://api.metagraph.sh/mcp/core"
     }
   ]
 }

--- a/tests/mcp-core-recommendation.test.ts
+++ b/tests/mcp-core-recommendation.test.ts
@@ -1,0 +1,92 @@
+// #11164: the core profile has to be the one an agent is TOLD to install.
+//
+// `/mcp/core` has existed and been served for a while, and it appeared in
+// exactly one published artifact -- `core_endpoint` on the server card.
+// llms.txt, agent.md, SKILL.md and the MCP Registry listing all pointed at
+// `/mcp`, so every reader was handed the 243-tool endpoint.
+//
+// Measured against production 2026-08-22: /mcp lists 243 tools at ~396,000
+// tokens, /mcp/core lists 23 at ~44,500. Most clients hold tool definitions in
+// model context, so the difference is nine tenths of a large context window
+// spent before the caller asks anything. Anthropic's connector-directory
+// criteria require a server to be "frugal with their use of tokens".
+//
+// This is not a reduced install, and that is the load-bearing fact: the
+// profile filters `tools/list` and NEVER dispatch. A core session can
+// `tools/call` all 243.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import type { Row } from "./row-type.ts";
+
+const read = (relative: string) =>
+  readFileSync(new URL(`../${relative}`, import.meta.url), "utf8");
+
+const CORE = "https://api.metagraph.sh/mcp/core";
+const FULL = "https://api.metagraph.sh/mcp";
+
+/** The install line an agent copies, wherever it is published. */
+const INSTALL = /claude mcp add --transport http metagraphed (\S+)/g;
+
+describe("every published install snippet names the core profile", () => {
+  for (const file of [
+    "public/llms.txt",
+    "public/agent.md",
+    "public/skills/bittensor/SKILL.md",
+  ]) {
+    test(file, () => {
+      const urls = [...read(file).matchAll(INSTALL)].map((m) => m[1]);
+      assert.ok(urls.length > 0, `no install snippet found in ${file}`);
+      for (const url of urls) {
+        // Trailing punctuation/backticks are stripped by the capture already;
+        // compare on the URL itself.
+        assert.equal(
+          url.replace(/[`.,]+$/, ""),
+          CORE,
+          `${file} tells the reader to install the 243-tool endpoint`,
+        );
+      }
+    });
+  }
+});
+
+describe("the MCP Registry listing", () => {
+  const manifest = JSON.parse(read("server.json")) as Row;
+
+  test("connects a first-time installer to core", () => {
+    assert.equal((manifest.remotes as Row[])[0]!.url, CORE);
+  });
+
+  test("still declares streamable-http", () => {
+    assert.equal((manifest.remotes as Row[])[0]!.type, "streamable-http");
+  });
+});
+
+describe("the full endpoint stays reachable and documented", () => {
+  // Recommending core must never read as removing /mcp. A reader who wants
+  // every tool enumerated has to be able to find out how.
+  test("llms.txt still names it", () => {
+    assert.ok(read("public/llms.txt").includes(FULL));
+  });
+
+  test("agent.md and SKILL.md say what the trade is", () => {
+    for (const file of [
+      "public/agent.md",
+      "public/skills/bittensor/SKILL.md",
+    ]) {
+      const text = read(file);
+      assert.ok(text.includes(FULL), `${file} must still name ${FULL}`);
+      // Normalised before matching, because two things about these files are
+      // formatting rather than meaning: they are hand-wrapped (so the
+      // sentence straddles a newline in agent.md and not in SKILL.md), and
+      // prettier rewrites `*listing*` to `_listing_`. Pinning either would
+      // make this test fail on a reflow that changed nothing it cares about.
+      const normalised = text.replace(/\s+/g, " ").replace(/[*_]/g, "");
+      assert.match(
+        normalised,
+        /filters (the tool )?listing, never dispatch/,
+        `${file} must state that core can still call every tool`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## The gap

`/mcp/core` has been served since #11164 and appeared in exactly **one** published artifact — `core_endpoint` on the worker-computed server card. `llms.txt`, `agent.md`, `SKILL.md`, the agent-resources catalog and the MCP Registry listing all pointed at `/mcp`.

So every reader who followed our own documentation was handed the 243-tool endpoint. Measured against production on 2026-08-22:

| endpoint | tools listed | `tools/list` cost |
|---|---:|---:|
| `/mcp` | 243 | **~396,000 tokens** |
| `/mcp/core` | 23 | **~44,500 tokens** |

Most clients hold tool definitions in model context, so the full list spends nine tenths of a large context window before the caller asks anything. It is also the criterion Anthropic's connector directory states outright — a server *"must be frugal with their use of tokens"*.

## This is not a reduced install

The profile filters `tools/list` and **never dispatch**. Verified against production: `/mcp/core` successfully called `get_tao_usd`, a tool absent from its own listing.

```
POST https://api.metagraph.sh/mcp/core  {"method":"tools/call","params":{"name":"get_tao_usd"}}
→ 200  {"usd_per_tao":228.74…}
```

A core session can call all 243 tools and carries `ask` and `get_more_tools` as escape hatches. The only thing a caller gives up is paying to read a catalogue they mostly will not use.

`/mcp` stays served, stays documented, and stays the `endpoint` the server card reports as this server's identity. What changed is which one a *first encounter* gets.

## What moved

| artifact | change |
|---|---|
| `server.json` `remotes[0]` | → `/mcp/core`, with `validate-mcp` asserting it there. `remotes[0]` is what a registry installer connects to, which is exactly a first encounter. |
| `llms.txt`, `agent.md`, `SKILL.md` | the install snippet, plus one sentence on what the trade is — so recommending core never reads as removing `/mcp`. |
| `agent-resources.mcp` | `core_endpoint` and `recommended_endpoint` alongside `endpoint`. |

The three endpoint fields are deliberately separate: `endpoint` answers *"what is this server"* and `recommended_endpoint` answers *"what should I connect to"*. Collapsing them makes one of the two answers wrong.

`schemas-src/routes/agent-catalog.ts` is `.strict()`, which caught the new fields being served undeclared — they are declared there now rather than the schema being loosened.

## Verification

`tests/mcp-core-recommendation.test.ts` (7) pins it from both directions:

- every published install snippet resolves to core, across `llms.txt`, `agent.md` and `SKILL.md`
- the registry remote is core, and still `streamable-http`
- **and** `/mcp` is still named in all three, and both prose files still state that a core session can call every tool

That second group is the one that matters: a recommendation that quietly became a removal would fail this test.

22,353 tests, 70/70 validators, prettier/eslint/typecheck/build clean. No `src/**` or `workers/**` lines change, so there is no patch-coverage surface.