### PR TITLE
fix(openapi): open every published summary with an action verb

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -522,7 +522,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Registry coverage and completeness summary
+         * Fetch the registry coverage and completeness summary
          * @description Network-scoped form of /api/v1/coverage — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data.
          */
         get: operations["coverageByNetwork"];
@@ -576,7 +576,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Per-subnet validator and economic metrics
+         * List per-subnet validator and economic metrics
          * @description Network-scoped form of /api/v1/economics — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data.
          */
         get: operations["economicsByNetwork"];
@@ -840,7 +840,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Cross-subnet activity summary for one account
+         * Fetch a cross-subnet activity summary for one account
          * @description Fetch a cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to its current subnet registrations + stake. Computed live from the account_events lakehouse and the neurons tier -- the same rows /accounts/{ss58}/events and /accounts/{ss58}/subnets serve, so the three cannot disagree. A tier that exists and cannot answer declines with a typed 503 (account_summary_unavailable) rather than an all-zero card, which is indistinguishable from an account with no history.
          */
         get: operations["accountSummary"];
@@ -1372,7 +1372,7 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Ask a question, get a grounded answer with citations
+         * Generate a grounded answer with citations
          * @description Ask a natural-language question about the registry and get a grounded answer with citations. POST a JSON body `{ question }`; the answer carries inline [n] markers resolved by `citations`, each naming the surface it came from, so every claim is traceable to a registered surface rather than to the model. Use this when the question is exploratory ("which subnets expose a public inference API?"); use /api/v1/search/semantic when you want the ranked matches themselves rather than prose. Mirrored by the `ask` MCP tool. Served live (no static file); 503 ai_unavailable where no AI binding is configured.
          */
         post: operations["ask"];
@@ -2209,7 +2209,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Registry coverage and completeness summary
+         * Fetch the registry coverage and completeness summary
          * @description Fetch registry coverage summary.
          */
         get: operations["coverage"];
@@ -2331,7 +2331,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Per-subnet validator and economic metrics
+         * List per-subnet validator and economic metrics
          * @description List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, alpha FDV proxy, emission share, and registration block height). Default order is emission share descending — note that `emission_share` is the STAGE-1 PRICE SHARE of the v440 emission pipeline (alpha_price / sum of alpha_price), NOT the share of TAO a subnet receives: spec 440 separates the two by MinerBurned reweighting, the Hill emission gate, the SubnetEmissionEnabled filter, the alpha injection cap, and the liquidity balancer. See /api/v1/network/parameters for the gate parameters and docs/computed-metrics-methodology.md for the eight-stage decomposition. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token. Per-subnet recipient-class economics (who the emission actually goes to -- validators, miners, the burn sink, in alpha and derived USD per day) are NOT here: /subnets/{netuid}/emission-split/history measures that split per day; never reconstruct it from an assumed constant. Registry screening signals (repo health via github_commits_weekly/github_last_push_at, testnet lineage via also_on, the declared miner hardware floor via gpu_required/min_vram_gb) are also NOT here: /api/v1/subnets serves them in bulk behind its fields= projection, e.g. ?fields=netuid,github_commits_weekly,also_on,gpu_required.
          */
         get: operations["economics"];
@@ -3244,7 +3244,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Aggregate health across all probed surfaces
+         * Fetch aggregate health across all probed surfaces
          * @description Fetch global health summary.
          */
         get: operations["health"];
@@ -4109,7 +4109,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Live endpoints for one subnet, with probe results
+         * List live endpoints for one subnet, with probe results
          * @description List generalized endpoint resources for one subnet.
          */
         get: operations["subnetEndpoints"];
@@ -4197,7 +4197,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Probe-derived health for one subnet
+         * Fetch probe-derived health for one subnet
          * @description Fetch health detail for one subnet.
          */
         get: operations["subnetHealth"];
@@ -4795,7 +4795,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * The API surfaces one subnet publishes
+         * List the API surfaces one subnet publishes
          * @description List curated public surfaces for one subnet.
          */
         get: operations["subnetSurfaces"];
@@ -5087,7 +5087,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Every published surface across the registry
+         * List every published surface across the registry
          * @description List curated public surfaces.
          */
         get: operations["surfaces"];
@@ -5124,7 +5124,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Network-wide validator leaderboard
+         * Fetch the network-wide validator leaderboard
          * @description Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 2000). Computed live from the neurons store.
          */
         get: operations["globalValidators"];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -69739,7 +69739,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Registry coverage and completeness summary",
+        "summary": "Fetch the registry coverage and completeness summary",
         "tags": [
           "registry"
         ],
@@ -70230,7 +70230,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Per-subnet validator and economic metrics",
+        "summary": "List per-subnet validator and economic metrics",
         "tags": [
           "subnets"
         ],
@@ -72580,7 +72580,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Cross-subnet activity summary for one account",
+        "summary": "Fetch a cross-subnet activity summary for one account",
         "tags": [
           "accounts",
           "analytics"
@@ -76649,7 +76649,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Ask a question, get a grounded answer with citations",
+        "summary": "Generate a grounded answer with citations",
         "tags": [
           "search"
         ],
@@ -83391,7 +83391,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Registry coverage and completeness summary",
+        "summary": "Fetch the registry coverage and completeness summary",
         "tags": [
           "registry"
         ],
@@ -84509,7 +84509,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Per-subnet validator and economic metrics",
+        "summary": "List per-subnet validator and economic metrics",
         "tags": [
           "subnets"
         ],
@@ -90047,7 +90047,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Aggregate health across all probed surfaces",
+        "summary": "Fetch aggregate health across all probed surfaces",
         "tags": [
           "health"
         ],
@@ -98863,7 +98863,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Live endpoints for one subnet, with probe results",
+        "summary": "List live endpoints for one subnet, with probe results",
         "tags": [
           "endpoints",
           "subnets"
@@ -99870,7 +99870,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Probe-derived health for one subnet",
+        "summary": "Fetch probe-derived health for one subnet",
         "tags": [
           "health",
           "subnets"
@@ -104454,7 +104454,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "The API surfaces one subnet publishes",
+        "summary": "List the API surfaces one subnet publishes",
         "tags": [
           "surfaces",
           "subnets"
@@ -106946,7 +106946,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Every published surface across the registry",
+        "summary": "List every published surface across the registry",
         "tags": [
           "surfaces"
         ],
@@ -107208,7 +107208,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Network-wide validator leaderboard",
+        "summary": "Fetch the network-wide validator leaderboard",
         "tags": [
           "validators",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -522,7 +522,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Registry coverage and completeness summary
+         * Fetch the registry coverage and completeness summary
          * @description Network-scoped form of /api/v1/coverage — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data.
          */
         get: operations["coverageByNetwork"];
@@ -576,7 +576,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Per-subnet validator and economic metrics
+         * List per-subnet validator and economic metrics
          * @description Network-scoped form of /api/v1/economics — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data.
          */
         get: operations["economicsByNetwork"];
@@ -840,7 +840,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Cross-subnet activity summary for one account
+         * Fetch a cross-subnet activity summary for one account
          * @description Fetch a cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to its current subnet registrations + stake. Computed live from the account_events lakehouse and the neurons tier -- the same rows /accounts/{ss58}/events and /accounts/{ss58}/subnets serve, so the three cannot disagree. A tier that exists and cannot answer declines with a typed 503 (account_summary_unavailable) rather than an all-zero card, which is indistinguishable from an account with no history.
          */
         get: operations["accountSummary"];
@@ -1372,7 +1372,7 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Ask a question, get a grounded answer with citations
+         * Generate a grounded answer with citations
          * @description Ask a natural-language question about the registry and get a grounded answer with citations. POST a JSON body `{ question }`; the answer carries inline [n] markers resolved by `citations`, each naming the surface it came from, so every claim is traceable to a registered surface rather than to the model. Use this when the question is exploratory ("which subnets expose a public inference API?"); use /api/v1/search/semantic when you want the ranked matches themselves rather than prose. Mirrored by the `ask` MCP tool. Served live (no static file); 503 ai_unavailable where no AI binding is configured.
          */
         post: operations["ask"];
@@ -2209,7 +2209,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Registry coverage and completeness summary
+         * Fetch the registry coverage and completeness summary
          * @description Fetch registry coverage summary.
          */
         get: operations["coverage"];
@@ -2331,7 +2331,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Per-subnet validator and economic metrics
+         * List per-subnet validator and economic metrics
          * @description List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, alpha FDV proxy, emission share, and registration block height). Default order is emission share descending — note that `emission_share` is the STAGE-1 PRICE SHARE of the v440 emission pipeline (alpha_price / sum of alpha_price), NOT the share of TAO a subnet receives: spec 440 separates the two by MinerBurned reweighting, the Hill emission gate, the SubnetEmissionEnabled filter, the alpha injection cap, and the liquidity balancer. See /api/v1/network/parameters for the gate parameters and docs/computed-metrics-methodology.md for the eight-stage decomposition. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token. Per-subnet recipient-class economics (who the emission actually goes to -- validators, miners, the burn sink, in alpha and derived USD per day) are NOT here: /subnets/{netuid}/emission-split/history measures that split per day; never reconstruct it from an assumed constant. Registry screening signals (repo health via github_commits_weekly/github_last_push_at, testnet lineage via also_on, the declared miner hardware floor via gpu_required/min_vram_gb) are also NOT here: /api/v1/subnets serves them in bulk behind its fields= projection, e.g. ?fields=netuid,github_commits_weekly,also_on,gpu_required.
          */
         get: operations["economics"];
@@ -3244,7 +3244,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Aggregate health across all probed surfaces
+         * Fetch aggregate health across all probed surfaces
          * @description Fetch global health summary.
          */
         get: operations["health"];
@@ -4109,7 +4109,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Live endpoints for one subnet, with probe results
+         * List live endpoints for one subnet, with probe results
          * @description List generalized endpoint resources for one subnet.
          */
         get: operations["subnetEndpoints"];
@@ -4197,7 +4197,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Probe-derived health for one subnet
+         * Fetch probe-derived health for one subnet
          * @description Fetch health detail for one subnet.
          */
         get: operations["subnetHealth"];
@@ -4795,7 +4795,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * The API surfaces one subnet publishes
+         * List the API surfaces one subnet publishes
          * @description List curated public surfaces for one subnet.
          */
         get: operations["subnetSurfaces"];
@@ -5087,7 +5087,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Every published surface across the registry
+         * List every published surface across the registry
          * @description List curated public surfaces.
          */
         get: operations["surfaces"];
@@ -5124,7 +5124,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Network-wide validator leaderboard
+         * Fetch the network-wide validator leaderboard
          * @description Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 2000). Computed live from the neurons store.
          */
         get: operations["globalValidators"];

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -6233,20 +6233,27 @@ function rangeFilterDescription(name: string): string | null {
  * tracked in #11593 and should be added as prose is revisited, not in bulk.
  */
 export const OPERATION_SUMMARIES: Record<string, string> = {
-  ask: "Ask a question, get a grounded answer with citations",
+  // VERB FIRST, every one. `pay catalog check` -- the Solana Foundation's
+  // catalogue validator, which reads this spec the way an agent would --
+  // warns on a summary that opens with a noun phrase, because a label a
+  // reader scans should say what the call DOES. It named `Search`, `Create`,
+  // `Fetch` and `Generate` as examples and accepts `List` too; `Ask` it does
+  // not recognise, so /api/v1/ask leads with `Generate` and says what it
+  // generates.
+  ask: "Generate a grounded answer with citations",
   subnets: "List active Finney subnets",
   "subnet-detail": "Fetch one subnet's full profile",
-  "subnet-health": "Probe-derived health for one subnet",
-  "subnet-surfaces": "The API surfaces one subnet publishes",
-  "subnet-endpoints": "Live endpoints for one subnet, with probe results",
+  "subnet-health": "Fetch probe-derived health for one subnet",
+  "subnet-surfaces": "List the API surfaces one subnet publishes",
+  "subnet-endpoints": "List live endpoints for one subnet, with probe results",
   search: "Search the registry by keyword",
   "search-semantic": "Search the registry by meaning, not keyword",
-  surfaces: "Every published surface across the registry",
-  coverage: "Registry coverage and completeness summary",
-  economics: "Per-subnet validator and economic metrics",
-  "global-validators": "Network-wide validator leaderboard",
-  "account-summary": "Cross-subnet activity summary for one account",
-  health: "Aggregate health across all probed surfaces",
+  surfaces: "List every published surface across the registry",
+  coverage: "Fetch the registry coverage and completeness summary",
+  economics: "List per-subnet validator and economic metrics",
+  "global-validators": "Fetch the network-wide validator leaderboard",
+  "account-summary": "Fetch a cross-subnet activity summary for one account",
+  health: "Fetch aggregate health across all probed surfaces",
 };
 
 export function buildOpenApiArtifact(

--- a/tests/openapi-summary-description.test.ts
+++ b/tests/openapi-summary-description.test.ts
@@ -127,6 +127,20 @@ describe("OPERATION_SUMMARIES", () => {
     assert.deepEqual(long, []);
   });
 
+  test("opens with an action verb", () => {
+    // A label a reader scans should say what the call DOES.
+    // `pay catalog check` warns on a noun-phrase opener, naming `Search`,
+    // `Create`, `Fetch` and `Generate` as examples; `List` is accepted too.
+    // `Ask` is NOT recognised by it, which is why /api/v1/ask leads with
+    // `Generate` and says what it generates rather than arguing the point.
+    const VERBS =
+      /^(List|Fetch|Search|Create|Generate|Update|Delete|Read|Run|Query)\b/;
+    const nounPhrases = Object.entries(OPERATION_SUMMARIES)
+      .filter(([, summary]) => !VERBS.test(summary))
+      .map(([id, summary]) => `${id}: "${summary}"`);
+    assert.deepEqual(nounPhrases, []);
+  });
+
   test("actually reaches the document", () => {
     // The table and the emitter are separate; this proves they are connected,
     // rather than that the table is well-formed in isolation.


### PR DESCRIPTION
## What

`OPERATION_SUMMARIES` shipped noun phrases. `pay catalog check` — the Solana Foundation's catalogue validator, which reads our published spec the way an agent would — warns on those, and **10 of the 14 tripped it**.

Its reasoning is right: a label a reader scans should say what the call *does*, not what it is about.

```diff
- "Network-wide validator leaderboard"
+ "Fetch the network-wide validator leaderboard"
- "Probe-derived health for one subnet"
+ "Fetch probe-derived health for one subnet"
- "Every published surface across the registry"
+ "List every published surface across the registry"
```

It names `Search`, `Create`, `Fetch` and `Generate` as examples and accepts `List`. It does **not** recognise `Ask`, so `/api/v1/ask` now leads with `Generate` and says what it generates rather than arguing the point:

```diff
- "Ask a question, get a grounded answer with citations"
+ "Generate a grounded answer with citations"
```

## Why it's a test, not a one-time edit

The rule joins the length and route-id invariants already in `tests/openapi-summary-description.test.ts`, so the next summary added has to follow it — rather than being caught by an external tool weeks later, which is how this one surfaced.

## Effect on the listing

With this and #11594, `pay catalog check` on the metagraphed entry goes to **zero static validation warnings**. For scale, QuickNode — an already-published provider in that catalog — reports **136**.

## Verification

No generated doc page changes: `apps/ui` derives its sidebar titles from the operationId, not from `summary`, so this touches the published spec only.

22,347 tests, 70/70 validators, prettier/eslint/typecheck/build clean. No `src/**` runtime lines change (the map is data), so there is no patch-coverage surface.