### PR TITLE
fix(openapi): declare the 402, and publish `q` as the required parameter it is

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -14860,6 +14860,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -14982,6 +14991,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -15088,6 +15106,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -15216,6 +15243,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -15354,6 +15390,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -15501,6 +15546,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -15636,6 +15690,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -15743,6 +15806,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19066,6 +19138,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -19185,6 +19266,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -21888,6 +21978,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -22156,6 +22255,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -22781,6 +22889,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -23919,6 +24036,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -24975,6 +25101,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25121,6 +25256,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25241,6 +25385,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25345,6 +25498,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -25471,6 +25633,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -25614,6 +25785,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25744,6 +25924,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -26210,6 +26399,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -26314,6 +26512,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -33873,6 +34080,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -33990,6 +34206,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -41097,9 +41322,9 @@ export interface operations {
     };
     searchSemantic: {
         parameters: {
-            query?: {
+            query: {
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
-                q?: string;
+                q: string;
                 /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10. */
                 limit?: number;
                 type?: "subnet" | "surface" | "provider";
@@ -41182,6 +41407,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -65704,6 +65704,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -65829,6 +65839,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -65953,6 +65973,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -66130,6 +66160,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -66305,6 +66345,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -66420,6 +66470,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -66634,6 +66694,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -66761,6 +66831,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -70598,6 +70678,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -70722,6 +70812,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -73485,6 +73585,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -73871,6 +73981,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -74470,6 +74590,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -75654,6 +75784,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -76618,6 +76758,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -76855,6 +77005,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -76965,6 +77125,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -77074,6 +77244,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -77236,6 +77416,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -77396,6 +77586,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -77495,6 +77695,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -78060,6 +78270,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -78172,6 +78392,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -85945,6 +86175,16 @@
             },
             "description": "Query parameters were malformed or unsupported."
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
           "404": {
             "content": {
               "application/json": {
@@ -86054,6 +86294,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {
@@ -95867,7 +96117,7 @@
             "description": "Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing.",
             "in": "query",
             "name": "q",
-            "required": false,
+            "required": true,
             "schema": {
               "maxLength": 1000,
               "type": "string"
@@ -95951,6 +96201,16 @@
               }
             },
             "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
           },
           "404": {
             "content": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -14860,6 +14860,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -14982,6 +14991,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -15088,6 +15106,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -15216,6 +15243,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -15354,6 +15390,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -15501,6 +15546,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -15636,6 +15690,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -15743,6 +15806,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19066,6 +19138,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -19185,6 +19266,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -21888,6 +21978,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -22156,6 +22255,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -22781,6 +22889,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -23919,6 +24036,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -24975,6 +25101,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25121,6 +25256,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25241,6 +25385,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25345,6 +25498,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -25471,6 +25633,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -25614,6 +25785,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -25744,6 +25924,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -26210,6 +26399,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -26314,6 +26512,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -33873,6 +34080,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
             /** @description Artifact or API route was not found. */
             404: {
                 headers: {
@@ -33990,6 +34206,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -41097,9 +41322,9 @@ export interface operations {
     };
     searchSemantic: {
         parameters: {
-            query?: {
+            query: {
                 /** @description Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing. */
-                q?: string;
+                q: string;
                 /** @description Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10. */
                 limit?: number;
                 type?: "subnet" | "surface" | "provider";
@@ -41182,6 +41407,15 @@ export interface operations {
             };
             /** @description Query parameters were malformed or unsupported. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -446,7 +446,18 @@ export const ROUTE_QUERY_SCHEMAS = {
     // The bounds come FROM src/route-limits.ts rather than being restated
     // here -- that module is the owner, and schemas-src/mcp-tools/ has read it
     // directly since #9127.
-    q: querySchema(SEMANTIC_QUERY_MAX_LENGTH).optional(),
+    // REQUIRED, and published that way (#11599). The handler has always
+    // rejected a call without it -- `GET /api/v1/search/semantic` returns 400
+    // `invalid_query`, "Query parameter `q` is required.", verified against
+    // production -- while this schema said `.optional()`, so the spec told a
+    // client the one mandatory input was optional. That is the third time this
+    // route published something it does not do (see #10075 and #10065 above);
+    // the derivation in isRequiredQueryParameter reads THIS, so the fix
+    // belongs here rather than in a hand-written `required: true`.
+    //
+    // /api/v1/search is genuinely different and stays optional: it returns 200
+    // with no `q`. The two routes are not the same contract.
+    q: querySchema(SEMANTIC_QUERY_MAX_LENGTH),
     limit: limitSchema(SEMANTIC_LIMIT_MAX, SEMANTIC_LIMIT_DEFAULT).optional(),
     // #10065: the handler has scoped on this since semantic search shipped --
     // it filters the results and rejects an unknown value by name ("Unknown

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -42,6 +42,7 @@ import {
   CHAIN_FIREHOSE_TOPICS,
 } from "./chain-firehose-topics.ts";
 import { DOMAIN_TAGS } from "./domain-tags.ts";
+import { x402PriceFor } from "./x402.ts";
 import { sampleFromSchema } from "./openapi-sample.ts";
 import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
@@ -6374,6 +6375,35 @@ export function buildOpenApiArtifact(
           304: {
             description: "ETag matched and the cached response is still valid.",
           },
+          // DERIVED FROM THE GATE, not from a list (infra#629, #11599).
+          //
+          // x402 added a live 402 path to every route in a payable family and
+          // declared it nowhere, so the contract said 402 was impossible on
+          // routes that return it. `x402PriceFor` is the same function the
+          // gate prices with, so a family joining or leaving it moves this
+          // declaration with it -- a hand-kept list is how the two drift.
+          //
+          // Only on routes that can actually return it. Declaring 402 on all
+          // 296 would be the opposite error: telling a caller that /api/v1/
+          // subnets might demand payment, which it never will.
+          ...(x402PriceFor(entry.path)
+            ? {
+                402: {
+                  description:
+                    "A payment was presented and could not be verified or settled. " +
+                    "The response carries a fresh x402 quote in the `accepts` array and " +
+                    "the PAYMENT-REQUIRED header. A request with NO payment is never " +
+                    "answered with 402 -- it is served on the anonymous tier.",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/ErrorEnvelope",
+                      },
+                    },
+                  },
+                },
+              }
+            : {}),
           400: {
             description: "Query parameters were malformed or unsupported.",
             content: {

--- a/tests/openapi-declared-statuses.test.ts
+++ b/tests/openapi-declared-statuses.test.ts
@@ -1,0 +1,106 @@
+// #11599: the spec has to declare the statuses the routes actually return.
+//
+// Two published lies, both found by pointing an external catalogue validator
+// at our own spec and reading what it complained about:
+//
+//   1. x402 (infra#629) added a live 402 path to every route in a payable
+//      family and declared it NOWHERE. The contract said 402 was impossible on
+//      routes that return it.
+//   2. /api/v1/search/semantic published `q` as optional while the handler
+//      returns 400 `invalid_query`, "Query parameter `q` is required." A client
+//      generated from the spec would omit the one mandatory input.
+//
+// Both are asserted against the PUBLISHED document, because that file is what
+// a consumer fetches -- and both are derived rather than listed, so a family
+// or a schema changing moves the assertion with it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { x402PriceFor } from "../src/x402.ts";
+import type { Row } from "./row-type.ts";
+
+const METHODS = ["get", "post", "put", "patch", "delete"];
+
+const doc = JSON.parse(
+  readFileSync(
+    new URL("../public/metagraph/openapi.json", import.meta.url),
+    "utf8",
+  ),
+) as { paths: Record<string, Row> };
+
+function operations(): Array<{ path: string; method: string; op: Row }> {
+  const out: Array<{ path: string; method: string; op: Row }> = [];
+  for (const [path, item] of Object.entries(doc.paths)) {
+    for (const [method, op] of Object.entries(item)) {
+      if (METHODS.includes(method)) out.push({ path, method, op: op as Row });
+    }
+  }
+  return out;
+}
+
+describe("the 402 declaration tracks the gate", () => {
+  const ops = operations();
+
+  test("there are operations to check", () => {
+    assert.ok(ops.length > 250, `only ${ops.length} operations`);
+  });
+
+  test("every x402-payable route declares 402", () => {
+    // `x402PriceFor` is the same function the gate prices with, so this is a
+    // comparison between the spec and the behaviour -- not between the spec
+    // and a second list that can drift with it.
+    const missing = ops
+      .filter(({ path }) => x402PriceFor(stripNetworkPrefix(path)))
+      .filter(({ op }) => !(op.responses as Row)["402"])
+      .map(({ method, path }) => `${method} ${path}`);
+    assert.deepEqual(missing, []);
+  });
+
+  test("no route declares 402 unless it can return one", () => {
+    // The opposite error, and the more misleading one: telling a caller that
+    // /api/v1/subnets might demand payment.
+    const spurious = ops
+      .filter(({ op }) => (op.responses as Row)["402"])
+      .filter(({ path }) => !x402PriceFor(stripNetworkPrefix(path)))
+      .map(({ method, path }) => `${method} ${path}`);
+    assert.deepEqual(spurious, []);
+  });
+
+  test("at least one route declares it, so the checks above can fail", () => {
+    const declared = ops.filter(({ op }) => (op.responses as Row)["402"]);
+    assert.ok(declared.length > 0, "no 402 reached the document");
+  });
+
+  test("the 402 description states that an unpaid call is NOT refused", () => {
+    // The invariant, restated where a spec reader will meet it. A caller who
+    // reads "402 Payment Required" and concludes the route needs payment
+    // would not call it at all.
+    const declared = ops.find(({ op }) => (op.responses as Row)["402"])!;
+    const description = String(
+      ((declared.op.responses as Row)["402"] as Row).description,
+    );
+    assert.match(description, /NO payment is never/);
+  });
+});
+
+/** `/api/v1/{network}/blocks` prices as `/api/v1/blocks`. */
+function stripNetworkPrefix(path: string): string {
+  return path.replace("/{network}", "");
+}
+
+describe("required query parameters are published as required", () => {
+  test("semantic search publishes `q` as required", () => {
+    const q = ((doc.paths["/api/v1/search/semantic"]!.get as Row)
+      .parameters as Row[])!.find((p) => p.name === "q");
+    assert.equal(q?.required, true);
+  });
+
+  test("keyword search still publishes `q` as OPTIONAL", () => {
+    // Not the same contract: /api/v1/search returns 200 with no `q`. A blanket
+    // "search routes require q" would have made this one a lie in the other
+    // direction.
+    const q = ((doc.paths["/api/v1/search"]!.get as Row)
+      .parameters as Row[])!.find((p) => p.name === "q");
+    assert.equal(q?.required, false);
+  });
+});


### PR DESCRIPTION
Two published lies, both found by pointing an external catalogue validator at our own spec and reading what it complained about.

## 1. The 402 was never declared

[#11588](https://github.com/JSONbored/metagraphed/pull/11588) added a live 402 path to every route in a payable family and declared it in the contract **nowhere**:

```
routes declaring a 402 response, across all 296 operations:  0
```

So the published contract said 402 was impossible on routes that return it, and a client generated from the spec had no case for the one status that carries a payment quote.

Declared now on the **26** routes that can return it, and **derived from `x402PriceFor`** — the same function the gate prices with:

```ts
...(x402PriceFor(entry.path) ? { 402: { … } } : {}),
```

A family joining or leaving the payable set moves the declaration with it. A hand-kept list is how the two drift apart.

**Only on those 26.** Declaring it on all 296 is the opposite error and the more misleading one — it would tell a caller that `/api/v1/subnets` might demand payment, which it never will.

The description says outright that *a request with no payment is never answered with 402*. A reader who meets "402 Payment Required" and concludes the route needs paying would not call it at all, which would turn the invariant into exactly the paywall it exists to prevent.

## 2. `q` was published as optional on a route that requires it

```
GET /api/v1/search/semantic          → 400 invalid_query
                                       "Query parameter `q` is required."
spec:  q  required = false
```

A client generated from the spec omits the one mandatory input.

Fixed at the Zod, which is what `isRequiredQueryParameter` derives from — not with a hand-written `required: true` that would drift from it. This is the **third** time this route has published something it does not do; the two before it (#10075, #10065) are documented in the same block.

`/api/v1/search` is genuinely different and **stays optional** — it returns 200 with no `q`. A blanket "search routes require q" would have made that one a lie in the other direction.

## Verification

`tests/openapi-declared-statuses.test.ts` (7) asserts against the **published** document, in both directions:

- every x402-payable route declares 402
- **no** non-payable route declares it
- at least one does, so the two checks above can actually fail
- the 402 description still states that an unpaid call is not refused
- the two search routes keep their *different* contracts

22,360 tests, 70/70 validators, 100% patch coverage (2/2 branches), prettier/eslint/typecheck/build clean, docs regenerated.