### PR TITLE
feat(openapi): publish a valid example for each stable path parameter

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -612,7 +612,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Network-scoped form of /api/v1/export/chain-events — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data. */
+        /**
+         * Fetch up to 25,000 chain events in one paid call
+         * @description Network-scoped form of /api/v1/export/chain-events — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data.
+         */
         get: operations["exportChainEventsByNetwork"];
         put?: never;
         post?: never;
@@ -2469,7 +2472,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Fetch up to 25,000 chain events in one call -- the same rows, filters and ordering as /api/v1/chain-events, without the 100-row page ceiling or the cursor bookkeeping that comes with it. ?pallet / ?method narrow by event id; ?before reads down from a block number, which is how a caller walks a large range in deliberate chunks; ?limit caps the call (<=25000, default 5000). REQUIRES PAYMENT: this route answers 402 with an x402 quote when no payment is presented, on Base or Solana -- see /.well-known/x402. It is the one family that does; every other route on this API serves an unpaid caller normally. Served live, no static file. */
+        /**
+         * Fetch up to 25,000 chain events in one paid call
+         * @description Fetch up to 25,000 chain events in one call -- the same rows, filters and ordering as /api/v1/chain-events, without the 100-row page ceiling or the cursor bookkeeping that comes with it. ?pallet / ?method narrow by event id; ?before reads down from a block number, which is how a caller walks a large range in deliberate chunks; ?limit caps the call (<=25000, default 5000). REQUIRES PAYMENT: this route answers 402 with an x402 quote when no payment is presented, on Base or Solana -- see /.well-known/x402. It is the one family that does; every other route on this API serves an unpaid caller normally. Served live, no static file.
+         */
         get: operations["exportChainEvents"];
         put?: never;
         post?: never;
@@ -14285,7 +14291,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -14399,7 +14408,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -14524,7 +14536,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -14649,7 +14664,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -20168,7 +20186,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -20523,7 +20544,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -20637,7 +20661,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -20762,7 +20789,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -21126,7 +21156,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21277,7 +21310,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21398,7 +21434,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21510,7 +21549,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21639,7 +21681,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21794,7 +21839,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21922,7 +21970,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22058,7 +22109,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22199,7 +22253,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22343,7 +22400,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22470,7 +22530,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22592,7 +22655,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22711,7 +22777,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22834,7 +22903,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22975,7 +23047,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23107,7 +23182,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23231,7 +23309,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23348,7 +23429,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23481,7 +23565,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23603,7 +23690,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23735,7 +23825,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23857,7 +23950,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23974,9 +24070,15 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -24115,7 +24217,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -24247,7 +24352,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -24774,7 +24882,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42332,7 +42443,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42688,7 +42802,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42801,7 +42918,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42916,7 +43036,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43051,7 +43174,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43180,7 +43306,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43363,7 +43492,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43479,7 +43611,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43601,7 +43736,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43801,7 +43939,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43938,7 +44079,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44071,7 +44215,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44208,7 +44355,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44371,7 +44521,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44532,7 +44685,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44692,7 +44848,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44824,7 +44983,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44962,7 +45124,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45181,7 +45346,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45320,7 +45488,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45450,7 +45621,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45571,7 +45745,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45701,7 +45878,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45818,7 +45998,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45943,7 +46126,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46094,7 +46280,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46222,7 +46411,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46341,7 +46533,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46449,7 +46644,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46572,7 +46770,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46695,7 +46896,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46823,7 +47027,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46953,7 +47160,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -47108,9 +47318,15 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
-                /** @description A neuron's UID within its subnet's metagraph. */
+                /**
+                 * @description A neuron's UID within its subnet's metagraph.
+                 * @example 0
+                 */
                 uid: number;
             };
             cookie?: never;
@@ -47243,9 +47459,15 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
-                /** @description A neuron's UID within its subnet's metagraph. */
+                /**
+                 * @description A neuron's UID within its subnet's metagraph.
+                 * @example 0
+                 */
                 uid: number;
             };
             cookie?: never;
@@ -47371,7 +47593,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -47506,7 +47731,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -47856,7 +48084,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48000,7 +48231,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48139,7 +48373,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48254,7 +48491,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48428,7 +48668,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48547,7 +48790,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48991,7 +49237,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49104,7 +49353,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49219,7 +49471,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49335,7 +49590,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49496,7 +49754,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49614,7 +49875,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49727,7 +49991,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49845,7 +50112,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49962,7 +50232,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50078,7 +50351,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50218,7 +50494,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50357,7 +50636,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50478,7 +50760,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50608,7 +50893,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50760,7 +51048,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50900,7 +51191,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51055,7 +51349,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51186,7 +51483,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51307,7 +51607,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51441,7 +51744,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51597,7 +51903,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51713,7 +52022,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51845,7 +52157,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51992,7 +52307,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -52947,7 +53265,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded hotkey address identifying one validator identity. */
+                /**
+                 * @description An SS58-encoded hotkey address identifying one validator identity.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 hotkey: string;
             };
             cookie?: never;
@@ -53111,7 +53432,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded hotkey address identifying one validator identity. */
+                /**
+                 * @description An SS58-encoded hotkey address identifying one validator identity.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 hotkey: string;
             };
             cookie?: never;
@@ -53246,7 +53570,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded hotkey address identifying one validator identity. */
+                /**
+                 * @description An SS58-encoded hotkey address identifying one validator identity.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 hotkey: string;
             };
             cookie?: never;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -65019,6 +65019,7 @@
           },
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -65143,6 +65144,7 @@
           },
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -65267,6 +65269,7 @@
           },
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -65391,6 +65394,7 @@
           },
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -70603,6 +70607,7 @@
             "description": "Unexpected backend error."
           }
         },
+        "summary": "Fetch up to 25,000 chain events in one paid call",
         "tags": [
           "chain",
           "analytics"
@@ -71989,6 +71994,7 @@
           },
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -72125,6 +72131,7 @@
           },
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -72251,6 +72258,7 @@
           },
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -72377,6 +72385,7 @@
           },
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -72758,6 +72767,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -72867,6 +72877,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -72990,6 +73001,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -73099,6 +73111,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -73208,6 +73221,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -73364,6 +73378,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -73487,6 +73502,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -73595,6 +73611,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -73812,6 +73829,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -73999,6 +74017,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -74209,6 +74228,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -74316,6 +74336,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -74483,6 +74504,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -74592,6 +74614,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -74700,6 +74723,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -74818,6 +74842,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -74941,6 +74966,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -75064,6 +75090,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -75173,6 +75200,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -75296,6 +75324,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -75433,6 +75462,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -75556,6 +75586,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -75664,6 +75695,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -75673,6 +75705,7 @@
           },
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -75800,6 +75833,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -76011,6 +76045,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "ss58",
             "required": true,
@@ -76554,6 +76589,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -86269,6 +86305,7 @@
             "description": "Unexpected backend error."
           }
         },
+        "summary": "Fetch up to 25,000 chain events in one paid call",
         "tags": [
           "chain",
           "analytics"
@@ -97393,6 +97430,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -97514,6 +97552,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -97637,6 +97676,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -97748,6 +97788,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -97873,6 +97914,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98142,6 +98184,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98251,6 +98294,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98399,6 +98443,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98508,6 +98553,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98617,6 +98663,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98742,6 +98789,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98865,6 +98913,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -98990,6 +99039,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -99138,6 +99188,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -99464,6 +99515,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -99601,6 +99653,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -99798,6 +99851,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -99977,6 +100031,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -100225,6 +100280,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -100471,6 +100527,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -100595,6 +100652,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -100719,6 +100777,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -100828,6 +100887,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -100954,6 +101014,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -101076,6 +101137,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -101185,6 +101247,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -101353,6 +101416,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -101521,6 +101585,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -101630,6 +101695,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -101741,6 +101807,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -101850,6 +101917,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102009,6 +102077,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102163,6 +102232,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102287,6 +102357,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102297,6 +102368,7 @@
           },
           {
             "description": "A neuron's UID within its subnet's metagraph.",
+            "example": 0,
             "in": "path",
             "name": "uid",
             "required": true,
@@ -102416,6 +102488,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102426,6 +102499,7 @@
           },
           {
             "description": "A neuron's UID within its subnet's metagraph.",
+            "example": 0,
             "in": "path",
             "name": "uid",
             "required": true,
@@ -102552,6 +102626,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102699,6 +102774,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102819,6 +102895,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -102943,6 +103020,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103052,6 +103130,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103161,6 +103240,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103270,6 +103350,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103418,6 +103499,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103537,6 +103619,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103660,6 +103743,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103771,6 +103855,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -103894,6 +103979,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -104018,6 +104104,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -104141,6 +104228,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -104279,6 +104367,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -104402,6 +104491,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -104535,6 +104625,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -104658,6 +104749,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -104780,6 +104872,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -105055,6 +105148,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -105248,6 +105342,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -105357,6 +105452,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -105495,6 +105591,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -105653,6 +105750,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -105763,6 +105861,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -105888,6 +105987,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -106031,6 +106131,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -106140,6 +106241,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -106249,6 +106351,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -106372,6 +106475,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -106495,6 +106599,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -106628,6 +106733,7 @@
         "parameters": [
           {
             "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
             "in": "path",
             "name": "netuid",
             "required": true,
@@ -107809,6 +107915,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded hotkey address identifying one validator identity.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "hotkey",
             "required": true,
@@ -107917,6 +108024,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded hotkey address identifying one validator identity.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "hotkey",
             "required": true,
@@ -108053,6 +108161,7 @@
         "parameters": [
           {
             "description": "An SS58-encoded hotkey address identifying one validator identity.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
             "in": "path",
             "name": "hotkey",
             "required": true,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -612,7 +612,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Network-scoped form of /api/v1/export/chain-events — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data. */
+        /**
+         * Fetch up to 25,000 chain events in one paid call
+         * @description Network-scoped form of /api/v1/export/chain-events — prefix the route with a network to choose which chain answers it. `mainnet`/`finney` return the same data as the unprefixed path; `testnet`/`test` return testnet data.
+         */
         get: operations["exportChainEventsByNetwork"];
         put?: never;
         post?: never;
@@ -2469,7 +2472,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Fetch up to 25,000 chain events in one call -- the same rows, filters and ordering as /api/v1/chain-events, without the 100-row page ceiling or the cursor bookkeeping that comes with it. ?pallet / ?method narrow by event id; ?before reads down from a block number, which is how a caller walks a large range in deliberate chunks; ?limit caps the call (<=25000, default 5000). REQUIRES PAYMENT: this route answers 402 with an x402 quote when no payment is presented, on Base or Solana -- see /.well-known/x402. It is the one family that does; every other route on this API serves an unpaid caller normally. Served live, no static file. */
+        /**
+         * Fetch up to 25,000 chain events in one paid call
+         * @description Fetch up to 25,000 chain events in one call -- the same rows, filters and ordering as /api/v1/chain-events, without the 100-row page ceiling or the cursor bookkeeping that comes with it. ?pallet / ?method narrow by event id; ?before reads down from a block number, which is how a caller walks a large range in deliberate chunks; ?limit caps the call (<=25000, default 5000). REQUIRES PAYMENT: this route answers 402 with an x402 quote when no payment is presented, on Base or Solana -- see /.well-known/x402. It is the one family that does; every other route on this API serves an unpaid caller normally. Served live, no static file.
+         */
         get: operations["exportChainEvents"];
         put?: never;
         post?: never;
@@ -14285,7 +14291,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -14399,7 +14408,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -14524,7 +14536,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -14649,7 +14664,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -20168,7 +20186,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -20523,7 +20544,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -20637,7 +20661,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -20762,7 +20789,10 @@ export interface operations {
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
                 network: "finney" | "mainnet" | "test" | "testnet";
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -21126,7 +21156,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21277,7 +21310,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21398,7 +21434,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21510,7 +21549,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21639,7 +21681,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21794,7 +21839,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -21922,7 +21970,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22058,7 +22109,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22199,7 +22253,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22343,7 +22400,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22470,7 +22530,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22592,7 +22655,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22711,7 +22777,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22834,7 +22903,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -22975,7 +23047,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23107,7 +23182,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23231,7 +23309,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23348,7 +23429,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23481,7 +23565,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23603,7 +23690,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23735,7 +23825,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23857,7 +23950,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -23974,9 +24070,15 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -24115,7 +24217,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -24247,7 +24352,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded account address -- a hotkey or coldkey. */
+                /**
+                 * @description An SS58-encoded account address -- a hotkey or coldkey.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 ss58: string;
             };
             cookie?: never;
@@ -24774,7 +24882,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42332,7 +42443,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42688,7 +42802,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42801,7 +42918,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -42916,7 +43036,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43051,7 +43174,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43180,7 +43306,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43363,7 +43492,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43479,7 +43611,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43601,7 +43736,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43801,7 +43939,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -43938,7 +44079,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44071,7 +44215,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44208,7 +44355,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44371,7 +44521,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44532,7 +44685,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44692,7 +44848,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44824,7 +44983,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -44962,7 +45124,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45181,7 +45346,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45320,7 +45488,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45450,7 +45621,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45571,7 +45745,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45701,7 +45878,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45818,7 +45998,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -45943,7 +46126,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46094,7 +46280,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46222,7 +46411,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46341,7 +46533,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46449,7 +46644,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46572,7 +46770,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46695,7 +46896,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46823,7 +47027,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -46953,7 +47160,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -47108,9 +47318,15 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
-                /** @description A neuron's UID within its subnet's metagraph. */
+                /**
+                 * @description A neuron's UID within its subnet's metagraph.
+                 * @example 0
+                 */
                 uid: number;
             };
             cookie?: never;
@@ -47243,9 +47459,15 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
-                /** @description A neuron's UID within its subnet's metagraph. */
+                /**
+                 * @description A neuron's UID within its subnet's metagraph.
+                 * @example 0
+                 */
                 uid: number;
             };
             cookie?: never;
@@ -47371,7 +47593,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -47506,7 +47731,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -47856,7 +48084,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48000,7 +48231,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48139,7 +48373,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48254,7 +48491,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48428,7 +48668,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48547,7 +48790,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -48991,7 +49237,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49104,7 +49353,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49219,7 +49471,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49335,7 +49590,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49496,7 +49754,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49614,7 +49875,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49727,7 +49991,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49845,7 +50112,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -49962,7 +50232,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50078,7 +50351,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50218,7 +50494,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50357,7 +50636,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50478,7 +50760,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50608,7 +50893,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50760,7 +51048,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -50900,7 +51191,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51055,7 +51349,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51186,7 +51483,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51307,7 +51607,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51441,7 +51744,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51597,7 +51903,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51713,7 +52022,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51845,7 +52157,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -51992,7 +52307,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description The subnet's numeric id on the Bittensor network, as used by the chain itself. */
+                /**
+                 * @description The subnet's numeric id on the Bittensor network, as used by the chain itself.
+                 * @example 1
+                 */
                 netuid: number;
             };
             cookie?: never;
@@ -52947,7 +53265,10 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description An SS58-encoded hotkey address identifying one validator identity. */
+                /**
+                 * @description An SS58-encoded hotkey address identifying one validator identity.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 hotkey: string;
             };
             cookie?: never;
@@ -53111,7 +53432,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded hotkey address identifying one validator identity. */
+                /**
+                 * @description An SS58-encoded hotkey address identifying one validator identity.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 hotkey: string;
             };
             cookie?: never;
@@ -53246,7 +53570,10 @@ export interface operations {
             };
             header?: never;
             path: {
-                /** @description An SS58-encoded hotkey address identifying one validator identity. */
+                /**
+                 * @description An SS58-encoded hotkey address identifying one validator identity.
+                 * @example 5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3
+                 */
                 hotkey: string;
             };
             cookie?: never;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -6005,6 +6005,29 @@ export const SHARED_PATH_PARAMETER_DESCRIPTIONS: Record<string, string> = {
 };
 
 /**
+ * A VALID value for each path parameter, published as `example` (#11602).
+ *
+ * A description says what a parameter MEANS; an example says what to SEND. The
+ * difference is not cosmetic -- a consumer that builds a request from this
+ * document substitutes the example, and with none it substitutes the template.
+ * Measured with `pay catalog check`: five of our fourteen catalogued endpoints
+ * probed as `/api/v1/subnets/{netuid}` and answered 404. With these, the same
+ * five probe `/api/v1/subnets/1` and answer 200.
+ *
+ * STABLE VALUES ONLY, which is what decides who gets one. Subnet 1 has existed
+ * since genesis and the address below is long-lived. A block number or an
+ * extrinsic hash is NOT stable -- any concrete one starts 404ing weeks after
+ * it is written, which is worse than no example. Those keep their prose and no
+ * example, deliberately.
+ */
+export const SHARED_PATH_PARAMETER_EXAMPLES: Record<string, string | number> = {
+  netuid: 1,
+  ss58: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  hotkey: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+  uid: 0,
+};
+
+/**
  * Apply the shared path-parameter prose, without overriding an inline one.
  *
  * Exported for its own test: the "name not in the table" arm is unreachable
@@ -6020,7 +6043,20 @@ export function withSharedPathParameterDescription<T extends object>(
   const spec = parameter as { name?: unknown; description?: unknown };
   if (typeof spec.name !== "string" || spec.description) return parameter;
   const shared = SHARED_PATH_PARAMETER_DESCRIPTIONS[spec.name];
-  return shared ? { ...parameter, description: shared } : parameter;
+  // The description gates BOTH. An example for a parameter with no prose
+  // publishes a value with nothing saying what it means, and
+  // tests/openapi-summary-description.test.ts forbids that pairing outright --
+  // so returning early here is what keeps this function free of an arm no
+  // input can reach.
+  if (!shared) return parameter;
+  const example = SHARED_PATH_PARAMETER_EXAMPLES[spec.name];
+  return {
+    ...parameter,
+    description: shared,
+    // Only where a STABLE value exists; see the table's header for why `ref`
+    // and `hash` deliberately have none.
+    ...(example === undefined ? {} : { example }),
+  };
 }
 
 export const SHARED_QUERY_PARAMETER_DESCRIPTIONS: Record<
@@ -6276,6 +6312,13 @@ export const OPERATION_SUMMARIES: Record<string, string> = {
   "global-validators": "Fetch the network-wide validator leaderboard",
   "account-summary": "Fetch a cross-subnet activity summary for one account",
   health: "Fetch aggregate health across all probed surfaces",
+  // The paid export tier. Needs a label for the same reason the other
+  // catalogued routes do, and for one more: `pay catalog check` falls back to
+  // `description` when `summary` is absent and then applies its 63-character
+  // limit to THAT -- so a route with no short label is reported as having a
+  // 633-character one. Publishing a real summary is the fix; shortening a
+  // description that is doing its own job would not be.
+  "export-chain-events": "Fetch up to 25,000 chain events in one paid call",
 };
 
 export function buildOpenApiArtifact(

--- a/tests/openapi-summary-description.test.ts
+++ b/tests/openapi-summary-description.test.ts
@@ -18,6 +18,7 @@ import {
   FEED_ROUTES,
   OPERATION_SUMMARIES,
   SHARED_PATH_PARAMETER_DESCRIPTIONS,
+  SHARED_PATH_PARAMETER_EXAMPLES,
   SHARED_QUERY_PARAMETER_DESCRIPTIONS,
   withSharedPathParameterDescription,
 } from "../src/contracts.ts";
@@ -35,6 +36,16 @@ const METHODS = ["get", "post", "put", "patch", "delete"];
  * already guarantees it matches source -- so asserting on it covers both the
  * emit logic and the commit.
  */
+/** The published document, parsed once per call site that needs it. */
+function doc(): { paths: Record<string, Row> } {
+  return JSON.parse(
+    readFileSync(
+      new URL("../public/metagraph/openapi.json", import.meta.url),
+      "utf8",
+    ),
+  ) as { paths: Record<string, Row> };
+}
+
 function operations(): Array<{ path: string; method: string; op: Row }> {
   const doc = JSON.parse(
     readFileSync(
@@ -212,5 +223,37 @@ describe("the derived query descriptions stay grammatical without a schema", () 
   test("`days` without a default", () => {
     const text = SHARED_QUERY_PARAMETER_DESCRIPTIONS.days!({});
     assert.match(text, /history to return\.$/);
+  });
+});
+
+describe("SHARED_PATH_PARAMETER_EXAMPLES", () => {
+  test("every example names a parameter that is also described", () => {
+    // An example for a parameter nothing declares is inert -- it reads as
+    // coverage and publishes nothing, the same failure the key check above
+    // exists for.
+    const undescribed = Object.keys(SHARED_PATH_PARAMETER_EXAMPLES).filter(
+      (name) => !SHARED_PATH_PARAMETER_DESCRIPTIONS[name],
+    );
+    assert.deepEqual(undescribed, []);
+  });
+
+  test("examples reach the published document", () => {
+    const netuid = (
+      (doc().paths["/api/v1/subnets/{netuid}"]!.get as Row).parameters as Row[]
+    ).find((p) => p.name === "netuid");
+    assert.equal(netuid?.example, SHARED_PATH_PARAMETER_EXAMPLES.netuid);
+  });
+
+  test("no example is given for a value that goes stale", () => {
+    // A concrete block number or extrinsic hash starts 404ing weeks after it
+    // is written, which is worse than publishing none. Pinned so a future
+    // "let's be thorough" pass does not add one.
+    for (const unstable of ["ref", "hash", "date", "crowdloan_id"]) {
+      assert.equal(
+        SHARED_PATH_PARAMETER_EXAMPLES[unstable],
+        undefined,
+        `${unstable} is not stable enough to publish an example for`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## What

A description says what a parameter **means**. An example says what to **send** — and a consumer that builds a request from this document substitutes it. With none, it substitutes the template.

Measured with `pay catalog check`:

```
before:  GET /api/v1/subnets/{netuid}   → 404   (5 endpoints)
after:   GET /api/v1/subnets/1          → 200
```

**107 of 180** published path parameters now carry one.

## Stable values only

That constraint is what decides who gets an example. Subnet 1 has existed since genesis and the SS58 is long-lived. A block number or an extrinsic hash is **not** stable — any concrete one starts 404ing weeks after it is written, which is worse than publishing none, because a caller who copies a broken example concludes the *route* is broken.

`ref`, `hash`, `date` and `crowdloan_id` keep their prose and no example. A test pins that, so a future "let's be thorough" pass doesn't add one.

## One seam, one gate

Applied at the same emit-time seam as the descriptions, and gated on one — `withSharedPathParameterDescription` returns early when a parameter has no prose, so an example can never be published for a value with nothing saying what it means.

That early return is also what keeps the function free of an arm no input can reach. The first version had one (`shared ? {description} : {}`, unreachable because the test forbids an example without a description) and the branch-counted patch coverage found it.

## Verification

3 new tests: every example names a described parameter, examples reach the published document, and the unstable parameters have none.

22,376 tests, 70/70 validators, **100% patch coverage** (8/8 lines + branches), prettier/eslint/typecheck/build clean, docs and client package regenerated.