### PR TITLE
feat(ui): rebuild the providers index and detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/providers/providers-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/providers/providers-logic.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+import type { Endpoint, Provider, SourceHealthProvider, Surface } from "@/lib/metagraphed/types";
+import {
+  endpointRails,
+  facet,
+  filterProviders,
+  hostOf,
+  initials,
+  providerDetailFacts,
+  providerFacts,
+  providerLeaders,
+  providerRows,
+  providerSurfaces,
+} from "./providers-logic";
+
+const providers = [
+  {
+    slug: "opentensor",
+    name: "Opentensor",
+    kind: "infra",
+    authority: "official",
+    website: "https://bittensor.com",
+    netuids: [0, 1],
+    endpoints_count: 12,
+    surfaces_count: 12,
+    generated_at: "2026-08-23T07:49:52.533Z",
+  },
+  {
+    slug: "404-gen",
+    name: "404-GEN",
+    kind: "subnet-team",
+    authority: "community",
+    netuids: [17],
+    endpoints_count: 8,
+  },
+  { slug: "ghost", name: "Ghost", authority: "registry-observed", endpoints_count: 0 },
+] as unknown as Provider[];
+
+const health = [
+  { id: "opentensor", status: "ok" },
+  { id: "404-gen", status: "degraded" },
+] as unknown as SourceHealthProvider[];
+
+describe("providerRows", () => {
+  it("joins source health by slug", () => {
+    const rows = providerRows(providers, health);
+    expect(rows.map((r) => r.sourceStatus)).toEqual(["ok", "degraded", null]);
+  });
+
+  it("gives a provider with no health row null, never the previous row's status", () => {
+    // A `Map` miss returning the last value would report Ghost as degraded
+    // because 404-GEN happens to precede it.
+    expect(providerRows(providers, health)[2]!.sourceStatus).toBeNull();
+  });
+
+  it("keeps the netuid list as numbers only", () => {
+    const rows = providerRows(
+      [{ slug: "x", netuids: [1, "2", null, 3] }] as unknown as Provider[],
+      [],
+    );
+    expect(rows[0]!.netuids).toEqual([1, 3]);
+  });
+
+  it("falls back from name to slug", () => {
+    expect(providerRows([{ slug: "bare" }] as unknown as Provider[], [])[0]!.name).toBe("bare");
+  });
+
+  it("is empty for nothing", () => {
+    expect(providerRows(null, null)).toEqual([]);
+  });
+});
+
+const fmt = { count: (n: number) => String(n) };
+
+describe("providerFacts", () => {
+  it("counts official AND provider-claimed as first-party, with a share", () => {
+    const rows = providerRows(providers, health);
+    const claimed = providerFacts(rows, null, fmt).find((f) => f.key === "claimed");
+    expect(claimed?.value).toBe("1 (33%)");
+  });
+
+  it("prefers the health summary's endpoint count over the row sum", () => {
+    const rows = providerRows(providers, health);
+    expect(
+      providerFacts(rows, { endpoint_count: 3391, status_counts: {} }, fmt).find(
+        (f) => f.key === "endpoints",
+      )?.value,
+    ).toBe("3391");
+    expect(providerFacts(rows, null, fmt).find((f) => f.key === "endpoints")?.value).toBe("20");
+  });
+
+  it("reports resolving sources as a ratio of the whole", () => {
+    const rows = providerRows(providers, health);
+    expect(
+      providerFacts(rows, { status_counts: { ok: 116, degraded: 1, unknown: 21 } }, fmt).find(
+        (f) => f.key === "sources",
+      )?.value,
+    ).toBe("116/138");
+  });
+
+  it("is empty for no providers", () => {
+    expect(providerFacts([], null, fmt)).toEqual([]);
+  });
+});
+
+describe("providerLeaders", () => {
+  it("ranks by endpoints and drops the ones serving none", () => {
+    const leaders = providerLeaders(providerRows(providers, health));
+    expect(leaders.map((l) => l.key)).toEqual(["opentensor", "404-gen"]);
+  });
+
+  it("carries no delta — there is no previous period to compare against", () => {
+    // `LeaderCards` draws a delta as period-over-period change, and
+    // /api/v1/providers is a snapshot. A delta from anything else would look
+    // like growth and not be.
+    expect(providerLeaders(providerRows(providers, health)).every((l) => !("delta" in l))).toBe(
+      true,
+    );
+  });
+
+  it("honours the limit", () => {
+    expect(providerLeaders(providerRows(providers, health), 1)).toHaveLength(1);
+  });
+});
+
+describe("initials", () => {
+  it("takes the first letter of the first two words", () => {
+    expect(initials("Open Tensor Foundation")).toBe("OT");
+  });
+
+  it("splits on dots, dashes and underscores too", () => {
+    expect(initials("404-gen")).toBe("4G");
+    expect(initials("macro.cosmos")).toBe("MC");
+  });
+
+  it("takes two letters from a single word", () => {
+    expect(initials("Chutes")).toBe("CH");
+  });
+
+  it("never returns an empty string", () => {
+    expect(initials("   ")).toBe("?");
+    expect(initials("")).toBe("?");
+  });
+});
+
+describe("filterProviders", () => {
+  const rows = providerRows(providers, health);
+  const none = { q: "", kind: "", authority: "" };
+
+  it("filters by kind and authority", () => {
+    expect(filterProviders(rows, { ...none, kind: "infra" }).map((r) => r.slug)).toEqual([
+      "opentensor",
+    ]);
+    expect(filterProviders(rows, { ...none, authority: "community" })).toHaveLength(1);
+  });
+
+  it("searches name, slug and host together", () => {
+    expect(filterProviders(rows, { ...none, q: "BITTENSOR.COM" }).map((r) => r.slug)).toEqual([
+      "opentensor",
+    ]);
+    expect(filterProviders(rows, { ...none, q: "404" }).map((r) => r.slug)).toEqual(["404-gen"]);
+  });
+
+  it("returns everything with no filters", () => {
+    expect(filterProviders(rows, none)).toHaveLength(3);
+  });
+});
+
+describe("hostOf", () => {
+  it("is the host of a URL", () => {
+    expect(hostOf("https://api.example.com/v1/thing")).toBe("api.example.com");
+  });
+
+  it("degrades gracefully on something that is not a URL", () => {
+    // Never throws: a malformed `url` in one row must not blank the rail.
+    expect(hostOf("api.example.com/v1")).toBe("api.example.com");
+    expect(hostOf("not a url")).toBe("not a url");
+  });
+
+  it("is null for nothing", () => {
+    expect(hostOf(null)).toBeNull();
+    expect(hostOf("")).toBeNull();
+  });
+});
+
+const endpoints = [
+  {
+    id: "a",
+    kind: "subtensor-rpc",
+    url: "https://rpc.example/x",
+    latency_ms: 2148,
+    status: "ok",
+    last_ok: "t",
+  },
+  { id: "b", kind: "docs", url: "https://docs.example", latency_ms: 300, status: "ok" },
+  { id: "c", kind: "website", url: "https://x.example", latency_ms: undefined, status: "unknown" },
+] as unknown as Endpoint[];
+
+describe("endpointRails", () => {
+  it("ranks slowest first and never ranks an unmeasured endpoint", () => {
+    expect(endpointRails(endpoints).map((r) => r.key)).toEqual(["a", "b"]);
+  });
+
+  it("labels kind · host", () => {
+    expect(endpointRails(endpoints)[0]!.label).toBe("subtensor-rpc · rpc.example");
+  });
+
+  it("says never rather than blank for an endpoint that has never answered", () => {
+    expect(endpointRails(endpoints)[1]!.detail.find((d) => d.key === "probe")?.value).toBe("never");
+  });
+
+  it("honours the limit and survives nothing", () => {
+    expect(endpointRails(endpoints, 1)).toHaveLength(1);
+    expect(endpointRails(null)).toEqual([]);
+  });
+});
+
+describe("providerDetailFacts", () => {
+  it("computes the ok share over what was PROBED, excluding unknown", () => {
+    const facts = providerDetailFacts(
+      { name: "Opentensor", authority: "official" } as Provider,
+      { endpoint_count: 12, by_status: { ok: 9, degraded: 3, unknown: 40 } },
+      12,
+      fmt,
+    );
+    const healthy = facts.find((f) => f.key === "healthy");
+    expect(healthy?.value).toBe("75%");
+    expect(healthy?.label).toBe("ok of 12 probed");
+  });
+
+  it("omits the share when nothing carries a status", () => {
+    expect(
+      providerDetailFacts({ name: "x" } as Provider, { by_status: { unknown: 5 } }, 0, fmt).some(
+        (f) => f.key === "healthy",
+      ),
+    ).toBe(false);
+  });
+
+  it("is empty for no provider", () => {
+    expect(providerDetailFacts(null, null, 0, fmt)).toEqual([]);
+  });
+});
+
+describe("providerSurfaces", () => {
+  it("orders by subnet, then name, and does not mutate its input", () => {
+    const input = [
+      { id: "b", netuid: 3, name: "Zeta" },
+      { id: "a", netuid: 1, name: "Alpha" },
+      { id: "c", netuid: 3, name: "Alpha" },
+    ] as unknown as Surface[];
+    const copy = [...input];
+    expect(providerSurfaces(input).map((s) => s.id)).toEqual(["a", "c", "b"]);
+    expect(input).toEqual(copy);
+  });
+
+  it("is empty for nothing", () => {
+    expect(providerSurfaces(undefined)).toEqual([]);
+  });
+});
+
+describe("facet", () => {
+  it("is the sorted distinct set", () => {
+    expect(facet(providerRows(providers, health), (r) => r.kind)).toEqual(["infra", "subnet-team"]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/providers/providers-logic.ts
+++ b/apps/ui/src/components/metagraphed/providers/providers-logic.ts
@@ -1,0 +1,286 @@
+import type { Endpoint, Provider, SourceHealthProvider, Surface } from "@/lib/metagraphed/types";
+
+/**
+ * The derivations behind /apis/providers and /providers/$slug (#11624). Pure,
+ * so both pages stay thin and every rule below is testable without a browser.
+ */
+
+/** An authority a provider itself asserted, as opposed to one we observed. */
+export const CLAIMED = new Set(["official", "provider-claimed"]);
+
+export interface ProviderRow {
+  slug: string;
+  name: string;
+  kind: string | null;
+  authority: string | null;
+  host: string | null;
+  netuids: number[];
+  surfaces: number | null;
+  endpoints: number;
+  /** From /api/v1/source-health: ok | degraded | unknown. */
+  sourceStatus: string | null;
+  updatedAt: string | null;
+  iconUrl: string | null;
+}
+
+const str = (value: unknown): string | null =>
+  typeof value === "string" && value.trim() ? value : null;
+const num = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+/**
+ * The directory rows, joined to source health by slug.
+ *
+ * /api/v1/providers publishes identity and counts; /api/v1/source-health
+ * publishes whether the sources behind a provider still resolve. They are one
+ * row to a reader asking "who runs this, and are they reliable", and joining
+ * them here rather than in the page keeps the join testable — including the
+ * case that matters, a provider with no health row, which must read `unknown`
+ * rather than silently inheriting the previous row's status.
+ */
+export function providerRows(
+  providers: readonly Provider[] | null | undefined,
+  health: readonly SourceHealthProvider[] | null | undefined,
+): ProviderRow[] {
+  const byId = new Map<string, SourceHealthProvider>();
+  for (const row of Array.isArray(health) ? health : []) {
+    const id = str(row.id);
+    if (id) byId.set(id, row);
+  }
+  return (Array.isArray(providers) ? providers : []).map((provider) => {
+    const slug = str(provider.slug) ?? str(provider.id) ?? "";
+    const hp = byId.get(slug);
+    const netuids = Array.isArray(provider.netuids)
+      ? (provider.netuids as unknown[]).filter((n): n is number => typeof n === "number")
+      : [];
+    return {
+      slug,
+      name: str(provider.name) ?? slug,
+      kind: str(provider.kind),
+      authority: str(provider.authority),
+      host: str(provider.website) ?? str(provider.homepage) ?? str(provider.website_url),
+      netuids,
+      surfaces: num(provider.surfaces_count) ?? num(provider.surface_count),
+      endpoints: num(provider.endpoints_count) ?? num(provider.endpoint_count) ?? 0,
+      sourceStatus: hp ? (str(hp.status) ?? "unknown") : null,
+      updatedAt: str(provider.generated_at) ?? str(provider.updated_at),
+      iconUrl: typeof provider.icon_url === "string" ? provider.icon_url : str(provider.logo_url),
+    };
+  });
+}
+
+export interface Fact {
+  key: string;
+  label: string;
+  value: string;
+}
+
+/**
+ * The index hero.
+ *
+ * "Official or claimed" counts the two authorities a provider ASSERTED —
+ * `official` and `provider-claimed` — against the two we merely observed. It
+ * is the one number on this page that says how much of the directory is
+ * first-party, which is the question behind "are they reliable".
+ */
+export function providerFacts(
+  rows: readonly ProviderRow[],
+  health: { status_counts?: Record<string, number>; endpoint_count?: number } | null | undefined,
+  fmt: { count: (n: number) => string },
+): Fact[] {
+  if (rows.length === 0) return [];
+  const claimed = rows.filter((row) => row.authority && CLAIMED.has(row.authority)).length;
+  const facts: Fact[] = [
+    { key: "providers", label: "providers", value: fmt.count(rows.length) },
+    {
+      key: "claimed",
+      label: "official or claimed",
+      value: `${fmt.count(claimed)} (${Math.round((claimed / rows.length) * 100)}%)`,
+    },
+  ];
+  const endpoints = health?.endpoint_count ?? rows.reduce((sum, row) => sum + row.endpoints, 0);
+  facts.push({ key: "endpoints", label: "endpoints", value: fmt.count(endpoints) });
+  const counts = health?.status_counts;
+  if (counts) {
+    const ok = counts.ok ?? 0;
+    const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
+    if (total > 0) {
+      facts.push({
+        key: "sources",
+        label: "sources resolving",
+        value: `${fmt.count(ok)}/${fmt.count(total)}`,
+      });
+    }
+  }
+  return facts;
+}
+
+export interface Leader {
+  key: string;
+  name: string;
+  sub?: string;
+  value: string;
+  href: string;
+  initials: string;
+}
+
+/**
+ * Providers by endpoints served.
+ *
+ * No `delta`: `LeaderCards` draws one as a period-over-period change, and
+ * nothing published here is a period — /api/v1/providers is a snapshot with no
+ * previous endpoint count to compare against. A delta computed from anything
+ * else would be a number that looks like growth and is not.
+ */
+export function providerLeaders(rows: readonly ProviderRow[], limit = 18): Leader[] {
+  return [...rows]
+    .filter((row) => row.endpoints > 0)
+    .sort((a, b) => b.endpoints - a.endpoints || a.name.localeCompare(b.name))
+    .slice(0, limit)
+    .map((row) => ({
+      key: row.slug,
+      name: row.name,
+      sub: row.kind ?? undefined,
+      value: String(row.endpoints),
+      href: `/providers/${row.slug}`,
+      initials: initials(row.name),
+    }));
+}
+
+/** Up to two letters for an avatar fallback. */
+export function initials(name: string): string {
+  const words = name
+    .trim()
+    .split(/[\s._-]+/)
+    .filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return (words[0]![0]! + words[1]![0]!).toUpperCase();
+}
+
+export interface DirectoryFilters {
+  q: string;
+  kind: string;
+  authority: string;
+}
+
+/** The directory filter. Search covers name, slug and host. */
+export function filterProviders(
+  rows: readonly ProviderRow[],
+  filters: DirectoryFilters,
+): ProviderRow[] {
+  const q = filters.q.trim().toLowerCase();
+  return rows.filter((row) => {
+    if (filters.kind && row.kind !== filters.kind) return false;
+    if (filters.authority && row.authority !== filters.authority) return false;
+    if (!q) return true;
+    return [row.name, row.slug, row.host].some(
+      (field) => typeof field === "string" && field.toLowerCase().includes(q),
+    );
+  });
+}
+
+/** The distinct values of one field, sorted, for a filter select. */
+export function facet<Row>(
+  rows: readonly Row[],
+  of: (row: Row) => string | null | undefined,
+): string[] {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const value = of(row)?.trim();
+    if (value) seen.add(value);
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b));
+}
+
+export interface EndpointRail {
+  key: string;
+  label: string;
+  value: number;
+  detail: { key: string; label: string; value: string }[];
+}
+
+/**
+ * One provider's endpoints ranked by last-probe latency.
+ *
+ * The issue asked for 90-day uptime and a p50 series over time. Neither is
+ * published: /api/v1/providers/{slug}/endpoints carries one probe per endpoint
+ * — `latency_ms`, `status`, `last_checked`, `last_ok` — and no history route
+ * exists for either. This is the reading the data supports, and the section
+ * footnote says which probe it is.
+ */
+export function endpointRails(
+  endpoints: readonly Endpoint[] | null | undefined,
+  limit = 20,
+): EndpointRail[] {
+  return (Array.isArray(endpoints) ? endpoints : [])
+    .filter((endpoint) => num(endpoint.latency_ms) != null && num(endpoint.latency_ms)! > 0)
+    .sort((a, b) => num(b.latency_ms)! - num(a.latency_ms)!)
+    .slice(0, limit)
+    .map((endpoint, i) => ({
+      key: str(endpoint.id) ?? `endpoint-${i}`,
+      label:
+        [str(endpoint.kind), hostOf(str(endpoint.url))].filter(Boolean).join(" · ") || "endpoint",
+      value: num(endpoint.latency_ms)!,
+      detail: [
+        { key: "status", label: "Status", value: str(endpoint.status) ?? "unknown" },
+        { key: "probe", label: "Last ok", value: str(endpoint.last_ok) ?? "never" },
+      ],
+    }));
+}
+
+/** The host of a URL, or the URL, or null — never a thrown TypeError. */
+export function hostOf(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).host;
+  } catch {
+    return url.replace(/^https?:\/\//, "").split("/")[0] || url;
+  }
+}
+
+/**
+ * The detail hero.
+ *
+ * The healthy share is over the endpoints with a STATED status, for the same
+ * reason the fleet page computes it that way: an unmonitored endpoint is not
+ * an unhealthy one, and counting it as such reports a provider's coverage as
+ * its reliability.
+ */
+export function providerDetailFacts(
+  provider: Provider | null | undefined,
+  summary:
+    | { endpoint_count?: number; monitored_count?: number; by_status?: Record<string, number> }
+    | null
+    | undefined,
+  surfaces: number,
+  fmt: { count: (n: number) => string },
+): Fact[] {
+  if (!provider) return [];
+  const facts: Fact[] = [];
+  if (provider.authority) {
+    facts.push({ key: "authority", label: "authority", value: String(provider.authority) });
+  }
+  if (surfaces > 0) facts.push({ key: "surfaces", label: "surfaces", value: fmt.count(surfaces) });
+  const count = num(summary?.endpoint_count);
+  if (count != null) facts.push({ key: "endpoints", label: "endpoints", value: fmt.count(count) });
+  const status = summary?.by_status ?? {};
+  const measured = Object.entries(status)
+    .filter(([key]) => key !== "unknown")
+    .reduce((sum, [, n]) => sum + n, 0);
+  if (measured > 0) {
+    facts.push({
+      key: "healthy",
+      label: `ok of ${fmt.count(measured)} probed`,
+      value: `${Math.round(((status.ok ?? 0) / measured) * 100)}%`,
+    });
+  }
+  return facts;
+}
+
+/** The surfaces this provider publishes, newest verification first. */
+export function providerSurfaces(surfaces: readonly Surface[] | null | undefined): Surface[] {
+  return [...(Array.isArray(surfaces) ? surfaces : [])].sort(
+    (a, b) => (a.netuid ?? 0) - (b.netuid ?? 0) || (a.name ?? "").localeCompare(b.name ?? ""),
+  );
+}

--- a/packages/ui-kit/src/components/metagraphed/health-dot-a11y.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/health-dot-a11y.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { HealthDot } from "@/components/metagraphed/chips";
+
+/**
+ * #6423, moved here by #11624.
+ *
+ * Three colour-only status indicators once carried their meaning in an
+ * `aria-label` on a plain `<span>`. A span is `role="generic"`, and assistive
+ * tech is not required to expose a generic element's `aria-label` as its
+ * accessible name — so the health, official-provider and blocked-URL states
+ * could announce as nothing at all.
+ *
+ * All three call sites are gone: the home page's chip marquee with #8249, the
+ * subnet dossier's blocked-URL span with #11612, and the providers index's
+ * official-provider badge with #11624 — authority is a word in a status cell
+ * now, which is the design system's own rule (states are words, never coloured
+ * badges). The guard lived in apps/ui and grepped those files' source; with no
+ * subject left it would have passed on nothing.
+ *
+ * It belongs here instead, on the one component that still draws a
+ * colour-only indicator, rendered rather than grepped.
+ */
+describe("HealthDot announces its state", () => {
+  it("is role=img with an aria-label, not a bare span", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(HealthDot, { state: "down" }),
+    );
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Health: down"');
+  });
+
+  it("labels every state it can render, including the unknown one", () => {
+    for (const state of [
+      "ok",
+      "warn",
+      "down",
+      "offline",
+      "unknown",
+      "nonsense",
+    ]) {
+      const html = renderToStaticMarkup(
+        React.createElement(HealthDot, { state }),
+      );
+      const label = /aria-label="Health: ([^"]+)"/.exec(html)?.[1];
+      expect(label, `${state} rendered no label`).toBeTruthy();
+      expect(label).not.toBe("");
+    }
+  });
+
+  it("keeps the label when the dot is drawn beside its word", () => {
+    // `variant: "label"` wraps the same dot in a row with the word; the dot
+    // must not lose its own accessible name in the process. The label is the
+    // state's DISPLAY name -- `warn` reads "degraded", which is the word a
+    // reader sees beside it.
+    const html = renderToStaticMarkup(
+      React.createElement(HealthDot, { state: "warn", variant: "label" }),
+    );
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Health: degraded"');
+  });
+});


### PR DESCRIPTION
## Summary

`/apis/providers` was **779 lines** behind a Table/Grid toggle over an 11,900px wall of 136 cards, a `Download CSV / Share view` bar the table menu already carries, four count boxes, a `SOURCE HEALTH` line above the table, and a search bar outside it. `/providers/$slug` was **444 lines** and five sections behind a `TabStrip`.

The index is **two sections** now — Leaders and Directory. The detail is **three** — Latency, Endpoints, Surfaces. The `tab` search param went with the strip: an in-page anchor is what a link to a section is.

## Provider identity and source health are one row

`/api/v1/providers` publishes who runs what; `/api/v1/source-health` publishes whether their sources still resolve. To a reader asking *"who runs this, and are they reliable"* those are the same question, so they are one row — and the join lives in the logic module so its one dangerous case is pinned by a test: **a provider with no health row must read `null`, never inherit the previous row's status.**

The hero's *official or claimed* fact counts the two authorities a provider **asserted** against the two we merely observed. It is the one number on the page that says how much of the directory is first-party, which is the question behind "are they reliable": **92 of 138 (67%)**.

## Three things this turned up, each fixed here

**1. The rebuilt index shipped an empty table to every crawler.** `crawlable-subnet-index.spec.ts` asserts that the **server-rendered** `/apis/providers` links to all 132 provider pages, because that link is the only reason those pages are indexable at all. A client-only `useQuery` renders nothing at first paint — and even after switching to `useSuspenseQuery`, the table's default 50-row page linked **60 of 132**. It reads the list with `useSuspenseQuery` and `paginate={false}` now; the bounded viewport still keeps the table one screen tall.

**2. `Updated —` on a page that knows exactly when it was built.** `/api/v1/providers` publishes `generated_at` once at the envelope and the rows carry none, so reading `rows[0]?.updatedAt` rendered an em-dash.

**3. #6423's colour-only-indicator guard had lost its last subject.** All three sites it named are gone — the home page's chip marquee with #8249, the subnet dossier's blocked-URL span with #11612, and now the providers index's official-provider badge, because authority is a **word in a status cell** and *states are words* is this design system's own rule. The guard grepped `apps/ui` source, so with nothing left to find it would have passed on nothing. It moves to `packages/ui-kit` as a **rendered** test of `HealthDot` — the one component that still draws a colour-only indicator — and gained a case the grep version could not have: every state it can render must produce a non-empty label, including the unknown one.

## Two spec sections could not be built as written

| Spec asked for | What shipped | Why |
| --- | --- | --- |
| **Uptime**: `MarkerRail` of 90-day uptime per endpoint | folded into **Endpoints**, with the status split as its footnote | `/api/v1/providers/{slug}/endpoints` carries ONE probe per endpoint — `latency_ms`, `status`, `last_checked`, `last_ok` — and no uptime-history route exists. |
| **Latency**: `LineWithWindow` p50 over time, `7d 30d 90d` | **Latency**: `RankedRails` of that one probe | Same reason. A "p50 over time" chart drawn from a single reading is a line between one point and itself; the footnote says which probe it is. |

Also: `LeaderCards` carry **no delta**. It draws one as a period-over-period change and `/api/v1/providers` is a snapshot with no previous endpoint count. A delta computed from anything else would look like growth and not be.

## Deleted

`endpoint-list.tsx`, `endpoints-glance.tsx`, `provider-index-directory.tsx`, `providers-pulse-rail.tsx`, `uptime-badge-embed.tsx`, `use-hash-scroll.ts` (+ its test — the last tab strip it served is gone), `status-indicator-roles.test.ts` (moved, see above). Import-closure sweep to fixed point (two rounds): **no new orphans**.

The search schema dropped `view` (the grid #8303 had already demoted) and `sort` (the table's own — duplicating it in the URL let the two disagree).

## Token inventory (1280x800, under `main`)

| Route | | Families | Sizes | Tracking | Radii | Pills | sections | H2s | Text nodes |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `/apis/providers` | before | 1 | 6 | normal | 4px, 50% | **1** | 6 | 3 | **1,501** |
| | after | 1 | 6 | normal + `th` | 4px, 50% | **0** | 7 | 5 | **646** |
| `/providers/opentensor` | before | 1 | 6 | normal + `th` | 4px, 50% | **9** | **10** | 3 | 164 |
| | after | 1 | 6 | normal + `th` | 4px, 50% | **0** | **5** | 3 | 138 |

## Screenshots

### `/apis/providers`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-desktop-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-desktop-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-tablet-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-tablet-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-mobile-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-mobile-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-providers-after-mobile-dark.png) |

### `/providers/opentensor`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-desktop-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-desktop-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-tablet-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-tablet-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-mobile-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-mobile-light.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/11624-provider-after-mobile-dark.png) |

## Validation

```
apps/ui  npx tsc --noEmit                     0 errors
apps/ui  npx eslint src tests                 0 errors, 0 warnings
apps/ui  npx vitest run                       218 files, 2145 tests passed
ui-kit   npm test                             22 files, 174 tests passed
apps/ui  npx playwright test                  290 passed
root     npm run format:check                 clean
apps/ui  npm run format:check                 clean
root     the 68 validate:* scripts in validate.yml   all pass
```

`providers-logic.ts` is pure and fully unit-tested — 32 tests, including the health-join miss above, that `initials` never returns an empty string (it feeds an avatar watermark), that `hostOf` degrades rather than throwing on a malformed URL (one bad row must not blank the rail), and that `providerSurfaces` does not mutate its input.

Closes #11624
