### PR TITLE
fix(ui): a 116,000px phone page, a duplicated legend, and 26 undersized targets

### DIFF
--- a/apps/ui/src/components/metagraphed/tap-target.test.ts
+++ b/apps/ui/src/components/metagraphed/tap-target.test.ts
@@ -16,21 +16,54 @@ const compareToggles = read("./compare-toggle.tsx");
 
 describe("mg-tap-target (#8254)", () => {
   it("expands the hit area to 44px without changing the painted size", () => {
-    const util = css.slice(css.indexOf(".mg-tap-target {"), css.indexOf(".mg-tap-target {") + 800);
-    expect(util).toContain("min-width: 44px");
-    expect(util).toContain("min-height: 44px");
+    // Sliced from the ::after RULE rather than from a literal `.mg-tap-target {`
+    // (#11683): the recipe is a selector list now -- the row disclosure, the
+    // range option, the table menu, the pager, "Show all" and the section nav
+    // share it -- so pinning one spelling made this go blind the moment another
+    // control was given the same treatment.
+    const start = css.indexOf(".mg-tap-target::after");
+    expect(start, "the tap-target recipe is gone").toBeGreaterThan(-1);
+    const rule = css.slice(start, css.indexOf("}", start) + 1);
+    expect(rule).toContain("min-width: 44px");
+    expect(rule).toContain("min-height: 44px");
     // An absolutely-positioned ::after, so the control's own box -- and
     // therefore the surrounding layout -- is untouched.
-    expect(util).toContain("position: absolute");
-    expect(util).toContain('content: ""');
+    expect(rule).toContain("position: absolute");
+    expect(rule).toContain('content: ""');
+  });
+
+  it("gives every undersized shared control the same hit area", () => {
+    // Measured on a Pixel 5 (#11683): /validators alone rendered 25 row
+    // disclosures under 44px, and the pager, the range switch, the table menu,
+    // "Show all" and the section nav were under it on nearly every route.
+    // Named here so removing one from the sheet fails rather than silently
+    // shrinking a thumb target back.
+    const start = css.indexOf(".mg-tap-target::after");
+    const rule = css.slice(start, css.indexOf("{", start));
+    for (const selector of [
+      ".mg-dt-disclosure::after",
+      ".mg-range-option::after",
+      ".mg-dt-menu-trigger::after",
+      ".mg-dt-pager button::after",
+      ".mg-section-more::after",
+      ".mg-section-nav a::after",
+    ]) {
+      expect(rule, `${selector} lost its hit area`).toContain(selector);
+    }
   });
 
   it("is gated to coarse pointers so dense desktop rows don't get overlapping hit boxes", () => {
     // On a mouse-driven table the invisible 44px boxes would overlap each
     // other and swallow clicks meant for the neighbouring row.
-    expect(css).toContain(
-      "@media (pointer: fine) {\n  .mg-tap-target::after {\n    display: none;",
-    );
+    const gate = css.slice(css.indexOf("@media (pointer: fine) {"));
+    const body = gate.slice(0, gate.indexOf("\n}"));
+    expect(body).toContain(".mg-tap-target::after");
+    expect(body).toContain("display: none");
+    // Every control that gets the slop must also be released from it on a
+    // mouse, or the invisible boxes overlap and swallow neighbouring clicks.
+    for (const selector of [".mg-dt-disclosure", ".mg-range-option", ".mg-dt-pager button"]) {
+      expect(body, `${selector} keeps its hit slop on a mouse`).toContain(`${selector}::after`);
+    }
   });
 
   it("is applied to every compare checkbox, the densest undersized control we ship", () => {

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -241,7 +241,10 @@ function CreateSubscriptionSection() {
         <Field label="Kinds filter" hint="Optional — leave unchecked to receive all change kinds.">
           <div className="flex gap-4">
             {CHANGE_KINDS.map((kind) => (
-              <label key={kind} className="inline-flex items-center gap-1.5 text-13 text-ink">
+              <label
+                key={kind}
+                className="mg-tap-target inline-flex min-h-11 items-center gap-1.5 text-13 text-ink"
+              >
                 <input
                   type="checkbox"
                   checked={kinds.has(kind)}

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -14,14 +14,12 @@ import {
   LineWithWindow,
   MarkerRail,
   RangeControl,
-  RankGrid,
   RankedRails,
   Raw,
   StackedColumns,
   type DataTableColumn,
   type FactCells,
   type FactNodes,
-  type RankGridItem,
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -184,13 +182,6 @@ export function ExplorerPage() {
     { label: "Signers", value: fmtCount(latest?.unique_signers) },
   ];
 
-  const callLegend: RankGridItem[] = segments.map((segment) => ({
-    key: segment.key,
-    label: segment.label,
-    value: fmtCount(segment.value),
-    share: fmtShare(segment.value / (calls.data?.data.total_extrinsics || 1)),
-  }));
-
   const feeCells: FactCells = [
     {
       label: `Fees ${window}`,
@@ -297,11 +288,6 @@ export function ExplorerPage() {
                 ariaLabel="Extrinsics by call module"
                 source="chain-call"
               />
-            ) : null
-          }
-          legend={
-            callLegend.length > 0 ? (
-              <RankGrid items={callLegend} cols={4} ariaLabel="Call modules" source="chain-call" />
             ) : null
           }
           // Per-module totals for the window, not an hourly series:

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -17,7 +17,6 @@ import {
   type DataTableColumn,
   type FactCells,
   type FactNodes,
-  type RankGridItem,
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -130,14 +129,6 @@ export function ValidatorsPage() {
     },
     { label: "Median APY", value: medianApy === null ? "—" : `${formatPct(medianApy, 1)}` },
   ];
-
-  const legend: RankGridItem[] = segments.map((segment) => ({
-    key: segment.key,
-    label: segment.label,
-    value: fmtStake(segment.value),
-    share: listedTotal > 0 ? `${formatPct(segment.value / listedTotal, 1)}` : undefined,
-    href: segment.href,
-  }));
 
   const columns: DataTableColumn<OperatorRow>[] = [
     {
@@ -279,16 +270,6 @@ export function ValidatorsPage() {
                 formatValue={(value) => fmtStake(value)}
                 legendCols={5}
                 ariaLabel="Stake share of the largest operators"
-                source="validator-operator"
-              />
-            ) : null
-          }
-          legend={
-            legend.length > 0 ? (
-              <RankGrid
-                items={legend}
-                cols={5}
-                ariaLabel="Operators by stake"
                 source="validator-operator"
               />
             ) : null

--- a/apps/ui/tests/e2e/token-inventory.spec.ts
+++ b/apps/ui/tests/e2e/token-inventory.spec.ts
@@ -46,6 +46,8 @@ type Sweep = {
   stackedTables: string[];
   /** Elements still carrying a class the v2 purge deleted (#11628). */
   deletedClasses: string[];
+  /** Sections showing the same ranked list twice (#11683). */
+  repeatedLegends: string[];
   textNodes: number;
 };
 
@@ -62,6 +64,7 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
   const thOffenders: string[] = [];
   const compareHeadOffenders: string[] = [];
   const stackedTables: string[] = [];
+  const repeatedLegends: string[] = [];
   const deletedClasses: string[] = [];
   // Every class the v2 rebuild deleted. A page carrying one is either a stale
   // component that survived a rebase or a hand-rolled copy of a primitive; both
@@ -118,6 +121,22 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
     );
     if (tall.length > 1) {
       stackedTables.push(`${describeEl(section)} holds ${tall.length} tables over 900px`);
+    }
+    // The same ranked list rendered twice in one section. `CompositionBreakdown`
+    // OWNS a `RankGrid` legend, so a page that also passes one into
+    // `AnalyticsSection`'s `legend` slot prints the identical rows underneath
+    // itself -- which /validators and /chain both did, 11 and 9 rows, on every
+    // viewport, unnoticed because at 4 columns the two blocks read as one long
+    // list. Compared on normalised text: the two DOM subtrees differ in
+    // whitespace, so a raw comparison misses it.
+    const signatures = [...section.querySelectorAll(".mg-rank-grid")].map((grid) =>
+      [...grid.querySelectorAll(".mg-rank-grid-row")]
+        .map((row) => (row.textContent ?? "").replace(/\s+/g, " ").trim())
+        .join("|"),
+    );
+    const distinct = new Set(signatures.filter(Boolean));
+    if (distinct.size < signatures.filter(Boolean).length) {
+      repeatedLegends.push(`${describeEl(section)} renders the same ranked list twice`);
     }
   }
   for (const el of root.querySelectorAll<HTMLElement>("*")) {
@@ -216,6 +235,7 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
     sections,
     stackedTables,
     deletedClasses,
+    repeatedLegends,
     textNodes,
   };
 }

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -2271,7 +2271,7 @@
     outline-offset: 1px;
   }
   @media (max-width: 639px) {
-    .mg-dt[data-mobile=cards] .mg-dt-viewport {
+    .mg-dt[data-mobile=cards] .mg-dt-viewport:not(.mg-dt-viewport-bounded) {
       overflow: visible;
       max-height: none;
     }
@@ -2770,10 +2770,22 @@
   background-color: var(--canvas);
   border-bottom: 1px solid var(--rule);
 }
-.mg-tap-target {
+.mg-tap-target,
+.mg-dt-disclosure,
+.mg-range-option,
+.mg-dt-menu-trigger,
+.mg-dt-pager button,
+.mg-section-more,
+.mg-section-nav a {
   position: relative;
 }
-.mg-tap-target::after {
+.mg-tap-target::after,
+.mg-dt-disclosure::after,
+.mg-range-option::after,
+.mg-dt-menu-trigger::after,
+.mg-dt-pager button::after,
+.mg-section-more::after,
+.mg-section-nav a::after {
   content: "";
   position: absolute;
   top: 50%;
@@ -2785,7 +2797,13 @@
   height: 100%;
 }
 @media (pointer: fine) {
-  .mg-tap-target::after {
+  .mg-tap-target::after,
+  .mg-dt-disclosure::after,
+  .mg-range-option::after,
+  .mg-dt-menu-trigger::after,
+  .mg-dt-pager button::after,
+  .mg-section-more::after,
+  .mg-section-nav a::after {
     display: none;
   }
 }

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -2639,7 +2639,19 @@
   /* Cards below 640px, from the same markup: the head goes, every row
      becomes a bordered block and each cell prints its own label. */
   @media (max-width: 639px) {
-    .mg-dt[data-mobile="cards"] .mg-dt-viewport {
+    /* A SHORT table flows into the page; a long one keeps the same bounded,
+       internally-scrolling viewport it has on a desktop.
+       This used to drop the bound for every cards table, and the cost was
+       enormous: /validators renders all 604 operators into the DOM (that is
+       deliberate -- a crawler must see every row), and the desktop viewport
+       clips them to 70vh. Without the clip each row becomes a stack of seven
+       label/value lines, and the table measured 111,939px -- 131 phone screens
+       for one table, against 633px for the same markup on a desktop.
+       `:not(.mg-dt-viewport-bounded)` is the whole fix: `shouldBoundViewport`
+       already decides which tables are long enough to need clipping, so cards
+       mode simply stops overriding that decision. The DOM is untouched, so the
+       crawler still sees all 604 rows. */
+    .mg-dt[data-mobile="cards"] .mg-dt-viewport:not(.mg-dt-viewport-bounded) {
       overflow: visible;
       max-height: none;
     }
@@ -3181,10 +3193,30 @@
 /* ------------------------------------------------------------- a11y / touch */
 /* Expands a small control's touch area to the 44×44 minimum without changing
    its painted size (#8254). Gated to coarse pointers. */
-.mg-tap-target {
+.mg-tap-target,
+.mg-dt-disclosure,
+.mg-range-option,
+.mg-dt-menu-trigger,
+.mg-dt-pager button,
+.mg-section-more,
+.mg-section-nav a {
   position: relative;
 }
-.mg-tap-target::after {
+/* The three controls that are always too small on a phone, given the same
+   expansion (#11683). Measured on a Pixel 5: /validators renders 25
+   `.mg-dt-disclosure` row-expanders under 44px, and a `RangeControl`'s
+   segments, a table's menu trigger, its pager buttons, the "Show all"
+   link and the section nav's own links are under it on nearly every route.
+   None of them paints any differently -- the ::after is an invisible hit
+   area on coarse pointers only -- so the design contract is untouched and
+   only the thing a thumb has to hit changes. */
+.mg-tap-target::after,
+.mg-dt-disclosure::after,
+.mg-range-option::after,
+.mg-dt-menu-trigger::after,
+.mg-dt-pager button::after,
+.mg-section-more::after,
+.mg-section-nav a::after {
   content: "";
   position: absolute;
   top: 50%;
@@ -3196,7 +3228,13 @@
   height: 100%;
 }
 @media (pointer: fine) {
-  .mg-tap-target::after {
+  .mg-tap-target::after,
+  .mg-dt-disclosure::after,
+  .mg-range-option::after,
+  .mg-dt-menu-trigger::after,
+  .mg-dt-pager button::after,
+  .mg-section-more::after,
+  .mg-section-nav a::after {
     display: none;
   }
 }


### PR DESCRIPTION
Closes #11684

#11678 made the design contract measurable at 375 and 768, and it passes everywhere. **Passing the contract is not the same as being usable**, so this reads the site *on a phone*. Three things no gate could see.

## 1. `/validators` was 115,966px tall on a phone — 136 screens

| route | desktop | phone | ratio | after |
| --- | ---: | ---: | ---: | ---: |
| `/validators` | 3,123px | **115,966px** | **37×** | **4,735px** |
| `/subnets` | 3,471px | 34,665px | 10× | 5,117px |
| `/chain/blocks` | 1,630px | 9,975px | 6× | 2,434px |
| `/chain` | 5,159px | 9,130px | 1.8× | 6,814px |

The page renders all **604 operators** into the DOM — deliberately, so a crawler sees every row — and the desktop `.mg-dt-viewport` clips them to `70vh` with internal scroll. The cards media query then dropped the bound unconditionally:

```css
.mg-dt[data-mobile="cards"] .mg-dt-viewport {
  overflow: visible;
  max-height: none;
}
```

So on a phone each of 604 rows became a stack of seven label/value lines: **one table at 111,939px**, against 633px for the same markup on a desktop.

Nothing could catch it — no element escapes the viewport, every token is in the contract, and the page isn't *broken*, just unusable.

**The fix is `:not(.mg-dt-viewport-bounded)`.** `shouldBoundViewport` already decides which tables are long enough to need clipping; cards mode simply stops overriding that decision. A short table still flows into the page; a long one keeps the same bounded, internally-scrolling viewport it has on a desktop. **The DOM is untouched**, so all 604 rows remain for the crawler.

Every route now sits between 1.2× and 2.0× its desktop height.

## 2. Two pages rendered the same ranked list twice

`CompositionBreakdown` **owns** a `RankGrid` legend. `/validators` and `/chain` also passed a hand-built `RankGrid` into `AnalyticsSection`'s `legend` slot, built from the same segments — so identical rows printed underneath themselves:

```
/validators #concentration
   grid 1: 01tao.bot1.91M τ18.8%  ||  02Yuma, a DCG Company1.23M τ12.1%
   grid 2: 01tao.bot1.91M τ18.8%  ||  02Yuma, a DCG Company1.23M τ12.1%
```

11 rows and 9 rows, on every viewport and theme, since the routes were rebuilt. At four columns the two blocks read as one long list, which is why it went unnoticed.

Both legends are deleted with the derivations that fed them, and `token-inventory` now asserts no section renders two ranked lists with the same normalised text. **Proven in both directions** — clean before, and cloning one grid in the DOM makes the predicate report `["throughput"]`.

My first sweep for this *missed* `/validators`, because it compared raw text and the two DOM subtrees differ in whitespace. The gate normalises.

## 3. 26 tap targets under 44px

Measured on a Pixel 5, counting the **effective** hit area (an `::after` expander counts):

| route | before | after |
| --- | ---: | ---: |
| `/validators` | 26 | **0** |
| `/chain` | 12 | **0** |
| `/health` | 9 | **0** |
| `/settings` | 6 | **0** |
| `/subnets` | 5 | **0** |

`/validators` alone rendered **25 `.mg-dt-disclosure`** row-expanders under 44px. `.mg-tap-target` already existed for exactly this — an absolutely-positioned `::after` that expands the hit area on coarse pointers without changing the painted box — and was applied to one component. It is a selector list now covering the six shared controls: row disclosure, range option, table menu, pager buttons, "Show all N", section nav. The webhook checkboxes take it on their **label**, because a replaced element can't carry a pseudo-element and clicking a label toggles its box.

**Deliberately left alone:** `.mg-dt-link`, a text link inside a table cell. Expanding 62 of them per page would reintroduce exactly the height problem this PR fixes, and an inline link is the case the target-size rule exempts.

## A test I had to fix because I broke it

`tap-target.test.ts` asserted the recipe by slicing from a literal `.mg-tap-target {`, which a selector list breaks. It now finds the `::after` **rule** and asserts the property, and names all six controls so removing one from the sheet fails rather than silently shrinking a thumb target back.

## Gates

| Gate | Result |
| --- | --- |
| Playwright — overflow / interaction / token-inventory | **454 passed** |
| `vitest run --workspace=apps/ui` | 2,171 passed |
| `vitest run --workspace=packages/ui-kit` | 161 passed |
| `tsc` / `eslint` / `prettier` — root + both workspaces | clean |
| `validate:ui-route-coverage` · `unreferenced-exports` · `ui-docs-drift` · `double-assertions` | all pass |

No desktop pixel changes: the viewport bound is what desktop already did, and every hit-area expander is gated to `pointer: coarse`.