### PR TITLE
fix(ui): say something when a section is empty, and keep the site when data fails

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -77,12 +77,25 @@ function Brand({ onNavigate }: { onNavigate?: () => void }) {
 export function AppShell({
   children,
   fullBleedMain = false,
+  chromeOnly = false,
 }: {
   children: ReactNode;
   // Fumadocs' DocsLayout manages its own full-height sidebar/content grid
   // and expects to control its own padding -- the standard max-w-shell-max
   // + px/py wrapper below would squeeze its sidebar into the content column.
   fullBleedMain?: boolean;
+  /**
+   * Render the chrome without the two lines that read data.
+   *
+   * For the router's error and pending fallbacks (#11686), which render where
+   * no `QueryClientProvider` is in scope: `SourcesLine`'s `useQuery` throws
+   * "No QueryClient set" there, and an error fallback that throws takes the
+   * whole SSR stream down -- every route then answered with the dependency-free
+   * recovery HTML, which is not this design system at all. The header, the nav
+   * and the footer links need no data and are exactly what a reader whose data
+   * failed still needs.
+   */
+  chromeOnly?: boolean;
 }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -203,15 +216,17 @@ export function AppShell({
                   })}
                 </nav>
                 <div className="flex-1 min-w-0 flex justify-end items-center gap-2">
-                  <NavOmnibox
-                    onOpenPalette={() =>
-                      openPaletteFrom(
-                        document.activeElement instanceof HTMLElement
-                          ? document.activeElement
-                          : null,
-                      )
-                    }
-                  />
+                  {chromeOnly ? null : (
+                    <NavOmnibox
+                      onOpenPalette={() =>
+                        openPaletteFrom(
+                          document.activeElement instanceof HTMLElement
+                            ? document.activeElement
+                            : null,
+                        )
+                      }
+                    />
+                  )}
                   {/* Below md the omnibox is hidden, which would leave the palette
                     reachable only via keyboard shortcuts -- none of which exist
                     on a touch device. */}
@@ -290,7 +305,7 @@ export function AppShell({
               {children}
             </main>
 
-            <SiteFooter />
+            <SiteFooter chromeOnly={chromeOnly} />
             <CommandPalette open={paletteOpen} onOpenChange={handlePaletteOpenChange} />
             <BackToTop />
           </div>
@@ -300,7 +315,7 @@ export function AppShell({
   );
 }
 
-function SiteFooter() {
+function SiteFooter({ chromeOnly }: { chromeOnly: boolean }) {
   return (
     <footer className="mt-24 border-t border-border">
       <div className="max-w-shell-max mx-auto px-4 md:px-10 py-12 grid gap-10 md:grid-cols-5 text-13 text-ink-muted">
@@ -381,12 +396,12 @@ function SiteFooter() {
       </div>
       <div className="border-t border-border">
         <div className="max-w-shell-max mx-auto px-4 md:px-10 py-4 flex flex-col gap-3 text-11 text-ink-muted">
-          <PageSourcesLine />
+          {chromeOnly ? null : <PageSourcesLine />}
           <div className="flex flex-wrap items-center justify-between gap-2">
             <span>
               © {new Date().getFullYear()} Metagraphed · Not an OpenTensor/Bittensor product
             </span>
-            <SourcesLine />
+            {chromeOnly ? null : <SourcesLine />}
           </div>
         </div>
       </div>

--- a/apps/ui/src/components/metagraphed/design/design-tokens.generated.ts
+++ b/apps/ui/src/components/metagraphed/design/design-tokens.generated.ts
@@ -24,7 +24,7 @@ export const DESIGN_TOKENS: readonly DesignToken[] = [
     refs: 60,
   },
   { name: "--ink", light: "#4a4a47", dark: "#d4d4d4", theme: "--color-ink", refs: 26 },
-  { name: "--ink-muted", light: "#6b6b67", dark: "#a3a3a3", theme: "--color-ink-muted", refs: 52 },
+  { name: "--ink-muted", light: "#6b6b67", dark: "#a3a3a3", theme: "--color-ink-muted", refs: 53 },
   {
     name: "--ink-subtle",
     light: "#8c8c87",

--- a/apps/ui/src/router-fallbacks.tsx
+++ b/apps/ui/src/router-fallbacks.tsx
@@ -1,10 +1,23 @@
 import { useRouter } from "@tanstack/react-router";
 import { ErrorState, Skeleton } from "./components/metagraphed/states";
+import { AppShell } from "@/components/metagraphed/app-shell";
 import { recoverFromChunkLoadFailure } from "@/lib/chunk-reload-recovery";
 
 // Outlet-scoped default boundary: a loader error in any route that doesn't
-// define its own errorComponent renders here, INSIDE the root shell, instead of
-// bubbling to __root's full-page errorComponent and replacing the chrome.
+// define its own errorComponent renders here instead of bubbling to __root's
+// full-page errorComponent.
+//
+// It mounts `AppShell` ITSELF (#11686). This comment used to claim the fallback
+// rendered "inside the root shell", and that was true when the shell lived at
+// the root -- but every page mounts its own `AppShell` now, so replacing the
+// page replaced the chrome with it. Measured against an API answering 503 for
+// everything: /subnets, /validators, /chain, /health and /contribute each
+// collapsed to a 231px page holding one card, with no header, no nav and no
+// footer -- a reader whose data failed could not navigate anywhere at all.
+//
+// If the SHELL is what threw, this re-throws into `GlobalErrorBoundary` above,
+// which is the full-page card. That is the right order: try to keep the chrome,
+// and fall back to the bare page only when the chrome is the thing that broke.
 // Retry invalidates the route so a transient failure can re-run the loader.
 //
 // This is also where a `React.lazy()` chunk failure surfaces (e.g. the nav
@@ -23,26 +36,35 @@ export function DefaultRouteError({ error, reset }: { error: unknown; reset: () 
     return null;
   }
   return (
-    <div className="mx-auto max-w-3xl px-4 py-10">
-      <ErrorState
-        error={error}
-        onRetry={() => {
-          void router.invalidate();
-          reset();
-        }}
-      />
-    </div>
+    <AppShell chromeOnly>
+      <div className="mx-auto w-full max-w-3xl py-10">
+        <ErrorState
+          error={error}
+          onRetry={() => {
+            void router.invalidate();
+            reset();
+          }}
+        />
+      </div>
+    </AppShell>
   );
 }
 
-// Outlet-scoped pending state while a route loader resolves. Sits inside the
-// shell so navigation never blanks the page chrome.
+// Pending state while a route loader resolves, in the shell for the same reason
+// the error fallback is: a navigation that blanks the header and the nav makes
+// the site look like it went down for as long as the loader runs.
 export function DefaultRoutePending() {
   return (
-    <div className="mx-auto max-w-3xl space-y-3 px-4 py-10" role="status" aria-busy="true">
-      <Skeleton className="h-6 w-1/3" />
-      <Skeleton className="h-4 w-2/3" />
-      <Skeleton className="h-32 w-full" />
-    </div>
+    <AppShell chromeOnly>
+      <div
+        className="mx-auto flex w-full max-w-3xl flex-col gap-3 py-10"
+        role="status"
+        aria-busy="true"
+      >
+        <Skeleton className="h-6 w-1/3" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    </AppShell>
   );
 }

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -378,12 +378,13 @@ export function ExplorerPage() {
               />
             ) : null
           }
+          empty="No concentration measure for this window."
           footnote={
             stake
               ? `${formatNumber(stake.holders ?? 0)} holders · Nakamoto ${formatNumber(
                   stake.nakamoto_coefficient ?? 0,
                 )} — the smallest number of holders that together control half the stake · chain-direct`
-              : "concentration unavailable"
+              : undefined
           }
         />
         <AnalyticsSection

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1752,9 +1752,12 @@ function AnalyticsSection({
   footnote,
   controls,
   children,
+  empty,
   className
 }) {
   const headingId = `${id}-heading`;
+  const blank = (node) => node === null || node === void 0 || node === false;
+  const showEmpty = blank(visual) && blank(children) && blank(legend) && empty !== false;
   return /* @__PURE__ */ jsxRuntime.jsxs(
     "section",
     {
@@ -1776,6 +1779,7 @@ function AnalyticsSection({
         visual ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-section-visual", children: visual }) : null,
         children,
         legend ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-section-legend", children: legend }) : null,
+        showEmpty ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mg-section-empty", children: empty ?? "No data in this window." }) : null,
         footnote ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mg-section-note", children: footnote }) : null
       ]
     }

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -460,6 +460,11 @@
   .mg-section-legend {
     margin-top: 24px;
   }
+  .mg-section-empty {
+    margin: 0;
+    font-size: 13px;
+    color: var(--ink-muted);
+  }
   .mg-section-note {
     margin: 16px 0 0;
     font-size: 11px;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1726,9 +1726,12 @@ function AnalyticsSection({
   footnote,
   controls,
   children,
+  empty,
   className
 }) {
   const headingId = `${id}-heading`;
+  const blank = (node) => node === null || node === void 0 || node === false;
+  const showEmpty = blank(visual) && blank(children) && blank(legend) && empty !== false;
   return /* @__PURE__ */ jsxs(
     "section",
     {
@@ -1750,6 +1753,7 @@ function AnalyticsSection({
         visual ? /* @__PURE__ */ jsx("div", { className: "mg-section-visual", children: visual }) : null,
         children,
         legend ? /* @__PURE__ */ jsx("div", { className: "mg-section-legend", children: legend }) : null,
+        showEmpty ? /* @__PURE__ */ jsx("p", { className: "mg-section-empty", children: empty ?? "No data in this window." }) : null,
         footnote ? /* @__PURE__ */ jsx("p", { className: "mg-section-note", children: footnote }) : null
       ]
     }

--- a/packages/ui-kit/src/components/metagraphed/document/analytics-section.tsx
+++ b/packages/ui-kit/src/components/metagraphed/document/analytics-section.tsx
@@ -30,6 +30,21 @@ export interface AnalyticsSectionProps {
   controls?: ReactNode;
   /** Content that is not yet a `visual` (a route mid-migration). */
   children?: ReactNode;
+  /**
+   * What to say when there is nothing to draw.
+   *
+   * A section whose `visual` resolves to `null` still renders its heading and
+   * its footnote, so the reader gets a sentence promising an answer and then
+   * blank space before the next rule. #11686 measured it against an API
+   * serving empty collections: `/chain` left two of six sections that way,
+   * `/health` three, `/subnets` three -- every route had at least one.
+   *
+   * Defaults to a quiet line rather than nothing, because the honest answer to
+   * "what is the chain's throughput" over a window with no extrinsics is "no
+   * data in this window", not silence. Pass a string to say it better, or
+   * `false` for the rare section whose footnote already says it.
+   */
+  empty?: ReactNode;
   className?: string;
 }
 
@@ -42,9 +57,16 @@ export function AnalyticsSection({
   footnote,
   controls,
   children,
+  empty,
   className,
 }: AnalyticsSectionProps) {
   const headingId = `${id}-heading`;
+  // `null` and `false` are what a page passes for "no data"; `0` and `""` are
+  // not, so this checks for the two rather than for falsiness.
+  const blank = (node: ReactNode) =>
+    node === null || node === undefined || node === false;
+  const showEmpty =
+    blank(visual) && blank(children) && blank(legend) && empty !== false;
   return (
     <section
       id={id}
@@ -66,6 +88,9 @@ export function AnalyticsSection({
       {visual ? <div className="mg-section-visual">{visual}</div> : null}
       {children}
       {legend ? <div className="mg-section-legend">{legend}</div> : null}
+      {showEmpty ? (
+        <p className="mg-section-empty">{empty ?? "No data in this window."}</p>
+      ) : null}
       {footnote ? <p className="mg-section-note">{footnote}</p> : null}
     </section>
   );

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -685,6 +685,15 @@
   .mg-section-legend {
     margin-top: 24px;
   }
+  /* What a section says when it has nothing to draw. Deliberately the same
+     size and colour as the footnote: an empty answer is a quiet fact, not an
+     error, and giving it a bordered box would make every sparse window look
+     like a failure. */
+  .mg-section-empty {
+    margin: 0;
+    font-size: 13px;
+    color: var(--ink-muted);
+  }
   .mg-section-note {
     margin: 16px 0 0;
     font-size: 11px;


### PR DESCRIPTION
Closes #11687

Every gate so far measures the site **with data**. I pointed it at an API serving empty collections, then at one answering 503 for everything. Two systemic defects, neither visible to any existing gate.

## 1. A section with no data rendered a heading and a hole

`visual={rows.length > 0 ? <Chart/> : null}` is the pattern on every route, so an empty collection left the name, the question and the footnote with nothing between them — *"Throughput. What the chain's extrinsics are actually doing."* followed by blank space.

| route | sections that said nothing |
| --- | --- |
| `/chain` | throughput, fees, stake-flow, concentration, emission |
| `/health` | by-subnet, trend, self-health |
| `/subnets` | rankings, domains, churn |
| `/` | value, emission, chain, health |

**Every route had at least one.** Some sections already degraded well — `DataTable` says "Nothing to show.", a fact strip shows `0 / 0` — and that is the inconsistency itself: the treatment depended on which primitive happened to be inside.

`AnalyticsSection` owns it now. When `visual`, `children` and `legend` are all absent it renders one quiet line: *"No data in this window."* by default, a string to say it better, `false` for a section whose footnote already does. Same size and colour as the footnote on purpose — an empty answer is a quiet fact, not an error, and a bordered box would make every sparse window look like a failure.

```
bare sections, empty API:   17 → 0
```

`/chain`'s concentration section then said it **twice**, because its footnote fell back to `"concentration unavailable"` — a source line doing an empty state's job. The footnote is `undefined` when there's nothing to source now.

## 2. A failed API replaced the entire site with one card

Against a 503 API, `/subnets`, `/validators`, `/chain`, `/health` and `/contribute` each collapsed to a **231px page holding one card** — no header, no nav, no footer. A reader whose data failed could not navigate anywhere.

`router-fallbacks.tsx` claimed the fallback rendered "INSIDE the root shell". That was true when the shell lived at the root; every page mounts its own `AppShell` now, so replacing the page replaced the chrome with it.

### This first made it worse, and that's worth stating

Mounting `AppShell` in the fallbacks broke SSR entirely: `SourcesLine` and `NavOmnibox` run queries, no `QueryClientProvider` is in scope in the error path, and `No QueryClient set` took the stream down — so every route answered with the **dependency-free pre-hydration recovery HTML**, which is a completely different visual language (system sans, `rounded-lg`, a black filled button). I caught it because the "after" screenshot didn't look like our site.

So `AppShell` gained `chromeOnly`: the header, the nav and the footer links, which need no data and are exactly what a reader whose data failed still needs. If the *shell* is what threw, this re-throws into `GlobalErrorBoundary` — the full-page card. Keep the chrome; fall back to the bare page only when the chrome is the broken thing.

## The happy path is unchanged

Every route's height and section count is identical against the recorded fixtures — `/` 4,354px, `/subnets` 3,541px, `/chain` 5,099px, zero empty lines, zero bare sections.

## Gates

| Gate | Result |
| --- | --- |
| Playwright — overflow / interaction / token-inventory | **454 passed** |
| `vitest run --workspace=apps/ui` | 2,171 passed |
| `vitest run --workspace=packages/ui-kit` | 161 passed |
| `tsc` / `eslint` / `prettier` — root + both workspaces | clean |
| `validate:ui-route-coverage` · `unreferenced-exports` · `ui-docs-drift` · `double-assertions` | all pass |
| `packages/ui-kit/dist` | rebuilt, drift-free |

One process note: `packages/ui-kit` has **no `format:check` script**, so `npm run format:check --workspace=packages/ui-kit` silently passes without checking anything. Running prettier there directly reformats the committed `dist/` bundles (the root `.prettierignore` covers `packages/*/dist`; the workspace has no ignore file). I hit that, rebuilt, and verified drift-free — flagging it because the next person will hit it too.