### PR TITLE
fix(ui): make the skip link skip, return focus after ⌘K, and give search a border

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -113,7 +113,7 @@ export default defineConfig({
       // peak.
       name: "interaction",
       testMatch:
-        /(active-entity|charts|rank|crawlable-subnet-index|evidence-deep-link|indexable-routes|multisig-related-error|offline|sticky-table-header)\.spec\.ts$/,
+        /(active-entity|charts|rank|crawlable-subnet-index|evidence-deep-link|indexable-routes|keyboard|multisig-related-error|offline|sticky-table-header)\.spec\.ts$/,
       dependencies: ["overflow"],
       // Serial within the phase costs a few seconds and removes the last
       // source of self-contention for exactly the tests that proved sensitive

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -52,6 +52,12 @@ const PRIMARY_NAV: ReadonlyArray<{ to: string; label: string }> = [
   { to: "/apis", label: "APIs" },
 ];
 
+/** The element to return focus to when an overlay opened from the keyboard closes. */
+function activeElement(): HTMLElement | null {
+  const el = document.activeElement;
+  return el instanceof HTMLElement && el !== document.body ? el : null;
+}
+
 function isActive(pathname: string, to: string): boolean {
   if (to === "/chain") return pathname === "/chain" || pathname.startsWith("/chain/");
   if (to === "/apis")
@@ -117,7 +123,10 @@ export function AppShell({
     if (!open) {
       const trigger = paletteTriggerRef.current;
       paletteTriggerRef.current = null;
-      if (trigger) requestAnimationFrame(() => trigger.focus());
+      // `isConnected` guards a trigger that was unmounted while the palette was
+      // open (a route change closes it), which would otherwise focus a detached
+      // node and drop focus to <body> anyway.
+      if (trigger?.isConnected) requestAnimationFrame(() => trigger.focus());
     }
   }, []);
 
@@ -156,13 +165,17 @@ export function AppShell({
         tgt && (tgt.tagName === "INPUT" || tgt.tagName === "TEXTAREA" || tgt.isContentEditable);
       if ((e.key === "k" || e.key === "K") && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        paletteTriggerRef.current = null;
+        // What had focus IS the thing to come back to (#11689). Setting this to
+        // null meant a keyboard user who pressed Escape landed on <body>, so
+        // the next Tab restarted from the top of the document -- back through
+        // the skip link and the whole nav to wherever they had been.
+        paletteTriggerRef.current = activeElement();
         setPaletteOpen((v) => !v);
         return;
       }
       if (e.key === "/" && !inField) {
         e.preventDefault();
-        paletteTriggerRef.current = null;
+        paletteTriggerRef.current = activeElement();
         setPaletteOpen(true);
       }
     }
@@ -296,6 +309,13 @@ export function AppShell({
 
             <main
               id="main-content"
+              // Focusable so the skip link actually skips (#11689). `<main>` is
+              // not focusable by default, so activating the link scrolled the
+              // page and left focus on the link itself -- the very next Tab
+              // went back into the nav the reader had just asked to skip, which
+              // made the control decorative. -1 keeps it out of the tab order
+              // while letting the hash jump land focus here.
+              tabIndex={-1}
               key={pathname}
               className={classNames(
                 "flex-1 w-full",

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -406,11 +406,25 @@ export function NavOmnibox({ onOpenPalette }: Props) {
       className="hidden md:block relative flex-1 max-w-xl lg:max-w-2xl xl:max-w-3xl min-w-0"
     >
       {/* Input */}
+      {/* The resting state carries a border and a surface, like every other
+          field on the site (`CONTROL_CLASSES` in filter-controls.tsx). It did
+          not until #11689: the wrapper set `border-accent/60` when open and no
+          border WIDTH at any point, so the computed width was 0px in both
+          states and the site's primary control rendered as an icon and some
+          placeholder text floating in the header, with nothing to say it was
+          an input. The `!border-accent/60` this inherited was already inert --
+          the `Panel` it overrode had had no border for some time. */}
       <div
         className={classNames(
-          "w-full min-w-0 rounded text-left text-13 transition-all",
+          "w-full min-w-0 rounded border bg-card text-left text-13 transition-colors",
           "inline-flex items-center gap-2 pl-3 pr-2 py-2 min-h-10",
-          open ? "border-accent/60 ring-2 ring-accent/20" : "hover:border-accent/40",
+          // `focus-within`, not the `open` state: a composed field shows ONE
+          // indicator and it belongs on the field, not on the bare <input>
+          // inside it. Driving it from CSS also means it cannot drift out of
+          // step with focus the way an `open`-derived ring can -- `open` is set
+          // by onFocus today, and nothing guarantees it stays that way.
+          "focus-within:border-accent/60 focus-within:ring-2 focus-within:ring-accent/20",
+          open ? "border-accent/60" : "border-border hover:border-ink/25",
         )}
       >
         <Search className="size-3.5 shrink-0 text-ink-muted" />

--- a/apps/ui/tests/e2e/keyboard.spec.ts
+++ b/apps/ui/tests/e2e/keyboard.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "@playwright/test";
+import { gotoThroughRestart } from "./server-restart.ts";
+
+// The keyboard path, which nothing measured until #11689. Three defects it
+// found, each invisible to the design gates because none of them changes a
+// token, a size or a layout:
+//
+//   - the skip link scrolled but did not move focus, so the next Tab went back
+//     into the nav the reader had just asked to skip;
+//   - ⌘K discarded the invoking element, so Escape dropped focus to <body> and
+//     the next Tab restarted from the top of the document;
+//   - the omnibox rendered with no border width in any state, so the site's
+//     primary control had nothing to say it was a field.
+//
+// Driven on /subnets because it carries the full chrome plus a table: the
+// header, the omnibox, the palette and a page's worth of links.
+const ROUTE = "/subnets";
+
+test.describe("keyboard", () => {
+  test("the skip link moves focus into main, not just the scroll", async ({ page }) => {
+    await gotoThroughRestart(page, ROUTE);
+    await page.keyboard.press("Tab");
+    await expect(page.locator("a:focus")).toHaveText(/skip to main content/i);
+    await page.keyboard.press("Enter");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const el = document.activeElement;
+          const main = document.querySelector("main");
+          return Boolean(el && main && (el === main || main.contains(el)));
+        }),
+      )
+      .toBe(true);
+  });
+
+  test("the palette returns focus to whatever opened it", async ({ page }) => {
+    await gotoThroughRestart(page, ROUTE);
+    // A real starting point inside the page, so "returned" means something
+    // more than "not body".
+    const anchor = page.locator("main a").first();
+    await anchor.focus();
+    const before = await page.evaluate(() => (document.activeElement as HTMLElement).outerHTML);
+
+    await page.keyboard.press("ControlOrMeta+k");
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const dialog = document.querySelector('[role="dialog"]');
+          return Boolean(dialog && dialog.contains(document.activeElement));
+        }),
+      )
+      .toBe(true);
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator('[role="dialog"]')).toBeHidden();
+    await expect
+      .poll(() => page.evaluate(() => (document.activeElement as HTMLElement).outerHTML))
+      .toBe(before);
+  });
+
+  test("the omnibox looks like a field before it is focused", async ({ page }) => {
+    await gotoThroughRestart(page, ROUTE);
+    const box = await page.evaluate(() => {
+      const wrap = document.querySelector<HTMLElement>("header.mg-header input")?.parentElement;
+      if (!wrap) return null;
+      const cs = getComputedStyle(wrap);
+      return { width: parseFloat(cs.borderTopWidth), bg: cs.backgroundColor };
+    });
+    expect(box, "no omnibox in the header").not.toBeNull();
+    // The defect was a border COLOUR with no width: computed 0px in every
+    // state, so the control rendered as an icon and placeholder text.
+    expect(box!.width).toBeGreaterThan(0);
+    expect(box!.bg).not.toBe("rgba(0, 0, 0, 0)");
+  });
+
+  test("every focus stop in the header is visible", async ({ page }) => {
+    await gotoThroughRestart(page, ROUTE);
+    for (let i = 0; i < 8; i++) {
+      await page.keyboard.press("Tab");
+      const state = await page.evaluate(() => {
+        const el = document.activeElement as HTMLElement | null;
+        if (!el || el === document.body) return null;
+        const header = document.querySelector("header.mg-header");
+        if (!header?.contains(el)) return null;
+        const shows = (node: HTMLElement | null) => {
+          if (!node) return false;
+          const cs = getComputedStyle(node);
+          const outline = cs.outlineStyle !== "none" && parseFloat(cs.outlineWidth) > 0;
+          return outline || cs.boxShadow !== "none";
+        };
+        return {
+          visible: shows(el) || shows(el.parentElement),
+          what: `${el.tagName.toLowerCase()} ${el.getAttribute("aria-label") ?? (el.textContent ?? "").trim().slice(0, 18)}`,
+        };
+      });
+      if (!state) continue;
+      expect(state.visible, `no focus indicator on ${state.what}`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #11689

Nothing had measured the keyboard path. Three defects — **none of which changes a token, a size or a layout**, so no design gate could have seen any of them.

## 1. The skip link scrolled but did not skip

`<main id="main-content">` had no `tabIndex`, and `<main>` isn't focusable by default. Activating "Skip to main content" moved the scroll and left focus on the link — so the **very next Tab went back into the nav the reader had just asked to skip**. The control was decorative.

```
before:  skip link -> {"id":"","inMain":false}
after:   skip link -> {"id":"main-content","inMain":true}
```

## 2. ⌘K dropped focus to `<body>` on close

`app-shell.tsx` keeps a `paletteTriggerRef` and restores focus on close — the comment even says *"capture the invoking element"* — but both keyboard paths set it to `null` explicitly. A keyboard user who opened the palette with ⌘K or `/` and pressed Escape landed on `<body>`, so the next Tab restarted from the top of the document: back through the skip link and the whole nav to wherever they'd been.

```
before:  focus on "Directory" → ⌘K → Escape → body
after:   focus on "Directory" → ⌘K → Escape → "Directory"
```

The mobile sheet already did this correctly, which is what makes it an omission rather than a decision. The restore now guards `isConnected`, so a trigger unmounted while the palette was open doesn't focus a detached node and drop to `<body>` anyway.

## 3. The site's primary control had no border in any state

The omnibox wrapper set `border-accent/60` when open and **no border width at any point** — computed `0px` at rest *and* focused. The search rendered as an icon and some placeholder text floating in the header, with nothing to say it was a field.

**Pre-existing, not a v2 regression:** the `Panel` that `!border-accent/60` used to override had had no border for some time, so the override was already inert. I checked the pre-D1 source before claiming either way.

It now carries `border border-border bg-card` at rest, matching `CONTROL_CLASSES` — what every other field on the site uses.

### The focus indicator took two attempts

Giving the `<input>` `mg-focus-ring` satisfied my check but drew an outline **inside** the wrapper's ring — two indicators for one field, which I only saw in the screenshot. It's `focus-within` on the wrapper instead: one indicator, on the field, driven by CSS rather than by the `open` state (which is set by `onFocus` today, with nothing guaranteeing that stays true).

## The spec

`tests/e2e/keyboard.spec.ts`, **registered in the `interaction` project's `testMatch`** — an unmatched spec silently never runs, as that config's own comment warns.

It covers the skip link, focus restoration (compared against the element's `outerHTML`, so "returned" means more than "not body"), the omnibox's resting border, and that every focus stop in the header shows an indicator on the focused element **or its wrapper** — because a composed field carries its indicator on the wrapper, and demanding one on the bare input is exactly what produced the doubled ring.

That fourth assertion is what caught the doubling. It failed before the fix and passes after.

## What I checked and found already correct

- **No positive `tabindex`** anywhere — tab order follows the DOM on every route.
- **The command palette traps focus** correctly and closes on Escape.
- **The mobile sheet** opens, traps, and restores focus to the hamburger.
- **13 of 14 header focus stops** already had visible indicators before this PR.

## Gates

| Gate | Result |
| --- | --- |
| Playwright — overflow / interaction / token-inventory | **458 passed** (was 454) |
| `vitest run --workspace=apps/ui` | 2,171 passed |
| `tsc` / `eslint` / `prettier` — root + both workspaces | clean |
| `validate:ui-route-coverage` · `unreferenced-exports` · `ui-docs-drift` · `double-assertions` | all pass |