### PR TITLE
fix(ui): stop listing the same accounts twice, and make a dead-looking filter answer

### DIFF
--- a/apps/ui/src/components/metagraphed/accounts-index/accounts-index-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/accounts-index/accounts-index-logic.test.ts
@@ -164,3 +164,45 @@ describe("lookupVerdict", () => {
     });
   });
 });
+
+describe("holderCards carries the share the retired Concentration section showed (#11691)", () => {
+  const accounts = [
+    { coldkey: "5A", total_stake_tao: 250, subnet_count: 3, uid_count: 3 },
+    { coldkey: "5B", total_stake_tao: 750, subnet_count: 1, uid_count: 1 },
+  ] as never;
+
+  it("states each account's share of the listed total, share first", () => {
+    const [a, b] = holderCards(accounts, "stake", 18, 1000);
+    expect(a!.sub).toBe("25.0% of listed · 3 subnets");
+    expect(b!.sub).toBe("75.0% of listed · 1 subnet");
+  });
+
+  it("falls back to reach when there is no total to divide by", () => {
+    // A zero denominator is not "0%", it is "we cannot say" -- the card shows
+    // what it does know instead of a share of nothing.
+    const [a] = holderCards(accounts, "stake", 18, 0);
+    expect(a!.sub).toBe("3 subnets · 3 UIDs");
+  });
+
+  it("falls back when the stake itself is missing", () => {
+    const [a] = holderCards(
+      [{ coldkey: "5A", subnet_count: 2, uid_count: 2 }] as never,
+      "stake",
+      18,
+      1000,
+    );
+    expect(a!.sub).toBe("2 subnets · 2 UIDs");
+  });
+
+  it("uses one percent formatter, so two rows can never disagree", () => {
+    // The defect this replaced: the same account rendered "9%" in one section
+    // and "9.0%" in the other, 600px apart.
+    const [a] = holderCards(
+      [{ coldkey: "5A", total_stake_tao: 90, subnet_count: 1 }] as never,
+      "stake",
+      18,
+      1000,
+    );
+    expect(a!.sub.startsWith("9.0% of listed")).toBe(true);
+  });
+});

--- a/apps/ui/src/components/metagraphed/accounts-index/accounts-index-logic.ts
+++ b/apps/ui/src/components/metagraphed/accounts-index/accounts-index-logic.ts
@@ -3,7 +3,7 @@
  */
 import { RESIDUAL_KEY } from "@jsonbored/ui-kit";
 import type { AccountListEntry, ChainSignerEntry } from "@/lib/metagraphed/types";
-import { formatAmount } from "@/lib/metagraphed/format";
+import { formatAmount, formatPct } from "@/lib/metagraphed/format";
 
 export type HolderMetric = "stake" | "emission" | "reach";
 
@@ -44,10 +44,34 @@ export interface HolderCard {
 }
 
 /** The reading each metric puts on a card, so the card shows what it ranked by. */
+/**
+ * `25.9% of listed · 119 subnets` -- the share first, because that is the
+ * reading the retired Concentration section existed to give.
+ */
+function shareSub(account: AccountListEntry, listedTotal: number): string {
+  const subnets = plural(account.subnet_count ?? 0, "subnet");
+  const stake = account.total_stake_tao;
+  if (!listedTotal || typeof stake !== "number" || !Number.isFinite(stake)) {
+    return `${subnets} · ${plural(account.uid_count ?? 0, "UID")}`;
+  }
+  return `${formatPct(stake / listedTotal, 1)} of listed · ${subnets}`;
+}
+
 export function holderCards(
   accounts: readonly AccountListEntry[],
   metric: HolderMetric,
   limit = 18,
+  /**
+   * The listed total, so each card can carry its own share.
+   *
+   * #11691 folded the Concentration section into this one: it drew a bar and
+   * then re-listed the same eleven accounts that were already on the cards
+   * above it, 600px apart, with the address truncated differently in each and
+   * one showing "9%" where the other showed "9.0%". Its headline -- the top-10
+   * share -- was already a fact cell in the hero. What it uniquely carried was
+   * the per-account share, so that moved here.
+   */
+  listedTotal = 0,
 ): HolderCard[] {
   return accounts.slice(0, limit).flatMap((account) => {
     const address = account.coldkey ?? account.hotkey;
@@ -62,7 +86,7 @@ export function holderCards(
       {
         key: address,
         name: shortAddress(address),
-        sub: `${plural(account.subnet_count ?? 0, "subnet")} · ${plural(account.uid_count ?? 0, "UID")}`,
+        sub: shareSub(account, listedTotal),
         value,
         href: `/accounts/${address}`,
       },

--- a/apps/ui/src/components/metagraphed/address-label-portability.tsx
+++ b/apps/ui/src/components/metagraphed/address-label-portability.tsx
@@ -87,6 +87,8 @@ export function AddressLabelPortability() {
           ref={fileRef}
           type="file"
           accept="application/json,.json"
+          aria-label="Import an address-label JSON file"
+          tabIndex={-1}
           className="sr-only"
           onChange={(e) => {
             const file = e.target.files?.[0];

--- a/apps/ui/src/components/metagraphed/design/document-specimens.tsx
+++ b/apps/ui/src/components/metagraphed/design/document-specimens.tsx
@@ -82,6 +82,7 @@ export function HeroSection() {
       visual={
         <div className="rounded border border-rule">
           <EntityHero
+            headingLevel={3}
             crumbs={[{ label: "Subnets", href: "/subnets" }, { label: "SN19" }]}
             name="Nineteen"
             action={

--- a/apps/ui/src/components/metagraphed/watchlist-portability.tsx
+++ b/apps/ui/src/components/metagraphed/watchlist-portability.tsx
@@ -93,6 +93,8 @@ export function WatchlistPortability() {
           ref={fileRef}
           type="file"
           accept="application/json,.json"
+          aria-label="Import a watchlist JSON file"
+          tabIndex={-1}
           className="sr-only"
           onChange={(e) => {
             const file = e.target.files?.[0];

--- a/apps/ui/src/routes/-accounts-index-page.tsx
+++ b/apps/ui/src/routes/-accounts-index-page.tsx
@@ -3,20 +3,17 @@ import { useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-quer
 import {
   AnalyticsPage,
   AnalyticsSection,
-  CompositionBreakdown,
   DataTable,
   EntityHero,
   Fact,
   FactSentence,
   LeaderCards,
   RangeControl,
-  RankGrid,
   RESIDUAL_KEY,
   Raw,
   type DataTableColumn,
   type FactCells,
   type FactNodes,
-  type RankGridItem,
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -71,7 +68,7 @@ export function AccountsPage() {
 
   const accounts = byStake.data.accounts;
   const { segments, listedTotal } = useMemo(() => concentrationSegments(accounts, 10), [accounts]);
-  const cards = holderCards(ranked.data?.data.accounts ?? accounts, metric);
+  const cards = holderCards(ranked.data?.data.accounts ?? accounts, metric, 18, listedTotal);
   const active = useMemo(() => activeRows(signers.data?.data.signers ?? []), [signers.data]);
   const shownActive = useMemo(() => {
     const query = signerQuery.trim().toLowerCase();
@@ -111,14 +108,6 @@ export function AccountsPage() {
     { label: "Top 10 share", value: topShare === null ? "—" : `${formatPct(topShare, 1)}` },
     { label: "Signers 7d", value: formatNumber(active.length) },
   ];
-
-  const legend: RankGridItem[] = segments.map((segment) => ({
-    key: segment.key,
-    label: segment.label,
-    value: fmtTaoCompact(segment.value),
-    share: listedTotal > 0 ? `${formatPct(segment.value / listedTotal, 1)}` : undefined,
-    href: segment.href,
-  }));
 
   const activeColumns: DataTableColumn<ActiveRow>[] = [
     { key: "signer", label: "Account", kind: "identifier", value: (row) => row.signer },
@@ -190,34 +179,9 @@ export function AccountsPage() {
               />
             ) : null
           }
-          footnote={`top ${formatNumber(LISTED)} by ${metric} · chain-direct index`}
-        />
-        <AnalyticsSection
-          id="concentration"
-          name="Concentration"
-          question="How much of the listed stake the largest accounts hold."
-          visual={
-            segments.length > 0 ? (
-              <CompositionBreakdown
-                segments={segments}
-                formatValue={(value) => fmtTaoCompact(value)}
-                legendCols={5}
-                ariaLabel="Stake share of the largest listed accounts"
-                source="account-holder"
-              />
-            ) : null
-          }
-          legend={
-            legend.length > 0 ? (
-              <RankGrid items={legend} cols={5} ariaLabel="Listed accounts by stake" />
-            ) : null
-          }
-          // The denominator is stated because it is not the network: this reads
-          // the top-20 slice, and calling a share of it a share of all stake
-          // would overstate every segment by the whole untabulated tail.
-          footnote={`shares of the ${fmtTaoCompact(listedTotal)} held by the ${formatNumber(
-            accounts.length,
-          )} listed accounts, not of all stake`}
+          footnote={`top ${formatNumber(LISTED)} by ${metric} · shares are of the ${fmtTaoCompact(
+            listedTotal,
+          )} these ${formatNumber(accounts.length)} hold, not of all stake · chain-direct index`}
         />
         <AnalyticsSection
           id="active"

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -443,10 +443,20 @@ export function EndpointsPage() {
                 </FilterSelect>
               </FilterField>
             }
-            empty="No endpoint incidents are open."
+            empty={
+              search.incidents === "open"
+                ? "No endpoint incidents are open."
+                : "No endpoint incidents have been recorded."
+            }
           />
         }
-        footnote={`${formatNumber(openIncidents.length)} open · probe-derived`}
+        footnote={
+          incidentList.length === openIncidents.length
+            ? `${formatNumber(openIncidents.length)} recorded, all still open · probe-derived`
+            : `${formatNumber(openIncidents.length)} open of ${formatNumber(
+                incidentList.length,
+              )} recorded · probe-derived`
+        }
       />
 
       {/* #11320: below the data on purpose -- see hub-prose.tsx. */}

--- a/apps/ui/tests/e2e/token-inventory.spec.ts
+++ b/apps/ui/tests/e2e/token-inventory.spec.ts
@@ -127,11 +127,17 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
     // `AnalyticsSection`'s `legend` slot prints the identical rows underneath
     // itself -- which /validators and /chain both did, 11 and 9 rows, on every
     // viewport, unnoticed because at 4 columns the two blocks read as one long
-    // list. Compared on normalised text: the two DOM subtrees differ in
-    // whitespace, so a raw comparison misses it.
+    // list -- and /accounts, which this first MISSED. Compared on each row's
+    // ENTITY KEY, not its text: /accounts printed the same eleven accounts
+    // twice with two different percent formatters ("9%" against "9.0%"), so a
+    // text comparison called them two different lists while a reader saw one
+    // account listed twice showing two different numbers for it.
     const signatures = [...section.querySelectorAll(".mg-rank-grid")].map((grid) =>
       [...grid.querySelectorAll(".mg-rank-grid-row")]
-        .map((row) => (row.textContent ?? "").replace(/\s+/g, " ").trim())
+        .map(
+          (row) =>
+            row.getAttribute("data-entity") ?? (row.textContent ?? "").replace(/\s+/g, " ").trim(),
+        )
         .join("|"),
     );
     const distinct = new Set(signatures.filter(Boolean));

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2124,13 +2124,14 @@ function EntityHero({
   cells,
   facts,
   live,
+  headingLevel = 1,
   className
 }) {
   return /* @__PURE__ */ jsxRuntime.jsxs("header", { className: classNames("mg-hero", className), "data-mg-hero": "", children: [
     crumbs && crumbs.length > 0 ? /* @__PURE__ */ jsxRuntime.jsx("nav", { className: "mg-hero-crumbs", "aria-label": "Breadcrumb", children: crumbs.map((c, i) => /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-hero-crumb", children: c.href ? /* @__PURE__ */ jsxRuntime.jsx("a", { href: c.href, children: c.label }) : c.label }, `${c.label}-${i}`)) }) : null,
     /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-hero-title", children: [
       avatar ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-hero-avatar", children: avatar }) : null,
-      /* @__PURE__ */ jsxRuntime.jsx("h1", { children: name }),
+      headingLevel === 1 ? /* @__PURE__ */ jsxRuntime.jsx("h1", { children: name }) : headingLevel === 2 ? /* @__PURE__ */ jsxRuntime.jsx("h2", { children: name }) : /* @__PURE__ */ jsxRuntime.jsx("h3", { children: name }),
       action || secondary ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-hero-actions", children: [
         secondary,
         action

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2098,13 +2098,14 @@ function EntityHero({
   cells,
   facts,
   live,
+  headingLevel = 1,
   className
 }) {
   return /* @__PURE__ */ jsxs("header", { className: classNames("mg-hero", className), "data-mg-hero": "", children: [
     crumbs && crumbs.length > 0 ? /* @__PURE__ */ jsx("nav", { className: "mg-hero-crumbs", "aria-label": "Breadcrumb", children: crumbs.map((c, i) => /* @__PURE__ */ jsx("span", { className: "mg-hero-crumb", children: c.href ? /* @__PURE__ */ jsx("a", { href: c.href, children: c.label }) : c.label }, `${c.label}-${i}`)) }) : null,
     /* @__PURE__ */ jsxs("div", { className: "mg-hero-title", children: [
       avatar ? /* @__PURE__ */ jsx("span", { className: "mg-hero-avatar", children: avatar }) : null,
-      /* @__PURE__ */ jsx("h1", { children: name }),
+      headingLevel === 1 ? /* @__PURE__ */ jsx("h1", { children: name }) : headingLevel === 2 ? /* @__PURE__ */ jsx("h2", { children: name }) : /* @__PURE__ */ jsx("h3", { children: name }),
       action || secondary ? /* @__PURE__ */ jsxs("div", { className: "mg-hero-actions", children: [
         secondary,
         action

--- a/packages/ui-kit/src/components/metagraphed/document/entity-hero.tsx
+++ b/packages/ui-kit/src/components/metagraphed/document/entity-hero.tsx
@@ -39,6 +39,15 @@ export interface EntityHeroProps {
   /** A composed `<FactStrip>` (routes mid-migration that map legacy KPI arrays). */
   facts?: ReactNode;
   live?: LiveMetaProps;
+  /**
+   * The heading level for `name`. 1 on a route, which is every real use.
+   *
+   * 3 on /design/primitives, where a hero is a SPECIMEN inside a documented
+   * section rather than the page's own subject: emitting `<h1>` there gave that
+   * page two of them (#11691), which is a document with two titles as far as a
+   * screen reader is concerned.
+   */
+  headingLevel?: 1 | 2 | 3;
   className?: string;
 }
 
@@ -52,6 +61,7 @@ export function EntityHero({
   cells,
   facts,
   live,
+  headingLevel = 1,
   className,
 }: EntityHeroProps) {
   return (
@@ -67,7 +77,13 @@ export function EntityHero({
       ) : null}
       <div className="mg-hero-title">
         {avatar ? <span className="mg-hero-avatar">{avatar}</span> : null}
-        <h1>{name}</h1>
+        {headingLevel === 1 ? (
+          <h1>{name}</h1>
+        ) : headingLevel === 2 ? (
+          <h2>{name}</h2>
+        ) : (
+          <h3>{name}</h3>
+        )}
         {action || secondary ? (
           <div className="mg-hero-actions">
             {secondary}


### PR DESCRIPTION
Closes #11691

A sweep for the thing this redesign exists to remove: **the same information presented twice, in different shapes, with different numbers.**

## 1. `/accounts` listed the same accounts twice, disagreeing with itself

| section | showed |
| --- | --- |
| **Holders** | 18 leader cards — rank, address, `119 subnets · 119 UIDs`, stake |
| **Concentration** | a composition bar, then a ranked list of *the same eleven accounts in the same order* — rank, address, stake, share |

600px apart. The address was truncated differently in each (`5GsbTg…pZX9` vs `5GsbTg…`), and the share ran through two different formatters, so one row read **`9%`** where the other read **`9.0%`** for the same account.

And the section's headline was **already a fact cell in the hero** — `Top 10 share 80.6%`.

So Concentration was: a bar, a re-listing of what sat directly above it, and a number already stated at the top of the page. The one thing it uniquely carried was the *per-account* share — which now sits on the holder cards as `25.9% of listed · 119 subnets`, with the denominator moved into the surviving footnote, because a share means nothing without saying what it's a share of.

**Three sections became two. One formatter. No repetition.**

## 2. The gate that should have caught it, didn't

`token-inventory` asserts no section renders the same ranked list twice (#11684). It compared **rendered text** — and `9%` ≠ `9.0%`, so it called them two different lists while a reader saw one account listed twice showing two different numbers for it.

It compares each row's `data-entity` key now: **identity, not formatting**.

### What I deliberately left alone

The sweep also flags `/subnets` rankings vs directory, `/validators` concentration vs operators, and `/apis/providers` leaders vs directory. Those are the deliberate summary-then-detail pattern — each pair has its own window and measure controls, and the reference design uses it on purpose. Collapsing them would be flattening the design, not fixing a defect.

## 3. A filter that looked dead

`/apis/endpoints`' incidents **State** control offers "Open now" and "All recorded". Selecting "All recorded" set `?incidents=all` and changed nothing — 12 rows before, 12 after.

**The filter is correct.** `/api/v1/endpoint-incidents?state=resolved` returns an empty list — every recorded endpoint incident is currently open, so both options select the same set. The page said nothing about that, so a working control read as a broken one.

The footnote states both counts now and collapses to *"12 recorded, all still open"* when they agree — turning the control into an answer instead of a no-op. The empty state says which question was asked, too.

## 4. Two semantics defects

- **`/settings`** — two `input[type=file].sr-only` pickers with no accessible name, reachable by keyboard. They carry an `aria-label` and leave the tab order now; the visible button drives them.
- **`/design/primitives`** — **two `<h1>`s**, because `EntityHero` always emitted one and that page renders a hero *as a specimen* inside a documented section. `EntityHero` takes a `headingLevel` now: 1 everywhere real, 3 on the specimen.

A sweep of **all 30 routes** for heading order, landmarks, control names, table headers and input labels found **nothing else on any route we own**. The remaining reports are fumadocs' own markup, GraphiQL's, and MDX prose tables — which WCAG doesn't require captions on, so my sweep's bar was stricter than the standard.

## Also checked, no defects found

- **Tablet (768px)** — every route sits at 1.0–1.3× its desktop height, proportionate, no outliers.
- **Every `<select>` on 7 routes** — all filter correctly except the one above, and my first probe's two extra "failures" were false positives from counting visible rows across paginated tables rather than reported totals.

## Gates

| Gate | Result |
| --- | --- |
| Playwright — overflow / interaction / token-inventory | **458 passed** |
| `vitest run --workspace=apps/ui` | 2,175 passed |
| `vitest run --workspace=packages/ui-kit` | 161 passed |
| `tsc` / `eslint` / `prettier` — root + both workspaces | clean |
| `validate:ui-route-coverage` · `unreferenced-exports` · `ui-docs-drift` · `double-assertions` | all pass |
| `packages/ui-kit/dist` | rebuilt, drift-free |