### PR TITLE
fix(ui): summary strips on the pages that carry a table, and tables that fit their card

### DIFF
--- a/apps/ui/src/components/metagraphed/about/about-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/about/about-logic.test.ts
@@ -42,10 +42,10 @@ describe("aboutFacts", () => {
 
   it("reads all four numbers when every source answered", () => {
     expect(aboutFacts(full).map((f) => [f.label, f.value])).toEqual([
-      ["active subnets", "128"],
-      ["adapter-backed", "2"],
-      ["healthy surfaces", "415/512"],
-      ["avg freshness", "4m"],
+      ["Active subnets", "128"],
+      ["Adapter-backed", "2"],
+      ["Healthy surfaces", "415/512"],
+      ["Avg freshness", "4m"],
     ]);
   });
 

--- a/apps/ui/src/components/metagraphed/about/about-logic.ts
+++ b/apps/ui/src/components/metagraphed/about/about-logic.ts
@@ -79,9 +79,9 @@ export function aboutFacts(
   const age = num(sources.freshness, "avg_age_seconds");
   const active = num(sources.coverage, "netuids_active");
   return [
-    { label: "active subnets", value: active == null ? null : String(active), href: "/subnets" },
+    { label: "Active subnets", value: active == null ? null : String(active), href: "/subnets" },
     {
-      label: "adapter-backed",
+      label: "Adapter-backed",
       value:
         typeof adapterBacked === "number" && Number.isFinite(adapterBacked)
           ? String(adapterBacked)
@@ -89,12 +89,12 @@ export function aboutFacts(
       href: "/apis/providers",
     },
     {
-      label: "healthy surfaces",
+      label: "Healthy surfaces",
       value: ok != null && total != null && total > 0 ? `${ok}/${total}` : null,
       href: "/health",
     },
     {
-      label: "avg freshness",
+      label: "Avg freshness",
       value: age == null ? null : formatAge(age),
       href: "/health",
     },

--- a/apps/ui/src/components/metagraphed/account-detail/activity.tsx
+++ b/apps/ui/src/components/metagraphed/account-detail/activity.tsx
@@ -115,14 +115,19 @@ export function ActivitySection({
             dense
             storageKey="account-events-columns"
           />
-          <LoadMore
-            hasMore={Boolean(query.hasNextPage)}
-            isLoading={query.isFetchingNextPage}
-            onLoadMore={() => void query.fetchNextPage()}
-            shown={events.length}
-            total={kind ? undefined : eventCount}
-            error={query.error as Error | null}
-          />
+          // Only while there IS more to fetch. The table states its own // range and total in its
+          pager, so a terminal "end of list" strip // beneath it is the same fact twice, in two
+          vocabularies (#11696).
+          {query.hasNextPage || query.error ? (
+            <LoadMore
+              hasMore={Boolean(query.hasNextPage)}
+              isLoading={query.isFetchingNextPage}
+              onLoadMore={() => void query.fetchNextPage()}
+              shown={events.length}
+              total={kind ? undefined : eventCount}
+              error={query.error as Error | null}
+            />
+          ) : null}
         </>
       }
       footnote={

--- a/apps/ui/src/components/metagraphed/apis/apis-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/apis/apis-logic.test.ts
@@ -78,11 +78,11 @@ describe("catalogFacts", () => {
       fmt,
     );
     expect(facts.map((f) => f.label)).toEqual([
-      "surfaces",
-      "across subnets",
-      "kinds",
-      "probed",
-      "first-party",
+      "Surfaces",
+      "Across subnets",
+      "Kinds",
+      "Probed",
+      "First-party",
     ]);
     expect(facts.find((f) => f.key === "probed")?.value).toBe("1863");
     expect(facts.some((f) => f.label.includes("up"))).toBe(false);
@@ -229,7 +229,7 @@ describe("schemaFacts", () => {
     // "Nothing changed" is the answer this page exists to give; leaving it out
     // would make a quiet week look like a page that failed to load.
     expect(schemaFacts({ by_drift_status: { unchanged: 64 } }, 0, fmt)).toEqual([
-      { key: "moved", label: "moved since last capture", value: "0" },
+      { key: "moved", label: "Moved since last capture", value: "0" },
     ]);
   });
 

--- a/apps/ui/src/components/metagraphed/apis/apis-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/apis/apis-logic.test.ts
@@ -229,7 +229,7 @@ describe("schemaFacts", () => {
     // "Nothing changed" is the answer this page exists to give; leaving it out
     // would make a quiet week look like a page that failed to load.
     expect(schemaFacts({ by_drift_status: { unchanged: 64 } }, 0, fmt)).toEqual([
-      { key: "moved", label: "Moved since last capture", value: "0" },
+      { key: "moved", label: "Moved", value: "0" },
     ]);
   });
 

--- a/apps/ui/src/components/metagraphed/apis/apis-logic.ts
+++ b/apps/ui/src/components/metagraphed/apis/apis-logic.ts
@@ -278,7 +278,7 @@ export function schemaFacts(
     facts.push({ key: "subnets", label: "Subnets", value: fmt.count(subnetsCovered) });
   }
   const moved = (drift.changed ?? 0) + (drift.new ?? 0);
-  facts.push({ key: "moved", label: "Moved since last capture", value: fmt.count(moved) });
+  facts.push({ key: "moved", label: "Moved", value: fmt.count(moved) });
   if (typeof drift["not-captured"] === "number") {
     facts.push({ key: "missing", label: "Not captured", value: fmt.count(drift["not-captured"]) });
   }

--- a/apps/ui/src/components/metagraphed/apis/apis-logic.ts
+++ b/apps/ui/src/components/metagraphed/apis/apis-logic.ts
@@ -85,23 +85,23 @@ export function catalogFacts(
   if (!coverage) return [];
   const facts: Fact[] = [];
   if (typeof coverage.surface_count === "number") {
-    facts.push({ key: "surfaces", label: "surfaces", value: fmt.count(coverage.surface_count) });
+    facts.push({ key: "surfaces", label: "Surfaces", value: fmt.count(coverage.surface_count) });
   }
   if (typeof coverage.chain_subnet_count === "number") {
     facts.push({
       key: "subnets",
-      label: "across subnets",
+      label: "Across subnets",
       value: fmt.count(coverage.chain_subnet_count),
     });
   }
-  if (kinds > 0) facts.push({ key: "kinds", label: "kinds", value: fmt.count(kinds) });
+  if (kinds > 0) facts.push({ key: "kinds", label: "Kinds", value: fmt.count(kinds) });
   if (typeof coverage.probed_surface_count === "number") {
-    facts.push({ key: "probed", label: "probed", value: fmt.count(coverage.probed_surface_count) });
+    facts.push({ key: "probed", label: "Probed", value: fmt.count(coverage.probed_surface_count) });
   }
   if (typeof coverage.official_surface_count === "number") {
     facts.push({
       key: "official",
-      label: "first-party",
+      label: "First-party",
       value: fmt.count(coverage.official_surface_count),
     });
   }
@@ -265,22 +265,22 @@ export function schemaFacts(
   const drift = summary.by_drift_status ?? {};
   const facts: Fact[] = [];
   if (typeof summary.surface_count === "number") {
-    facts.push({ key: "tracked", label: "tracked", value: fmt.count(summary.surface_count) });
+    facts.push({ key: "tracked", label: "Tracked", value: fmt.count(summary.surface_count) });
   }
   if (typeof summary.by_status?.captured === "number") {
     facts.push({
       key: "captured",
-      label: "captured",
+      label: "Captured",
       value: fmt.count(summary.by_status.captured),
     });
   }
   if (subnetsCovered > 0) {
-    facts.push({ key: "subnets", label: "subnets", value: fmt.count(subnetsCovered) });
+    facts.push({ key: "subnets", label: "Subnets", value: fmt.count(subnetsCovered) });
   }
   const moved = (drift.changed ?? 0) + (drift.new ?? 0);
-  facts.push({ key: "moved", label: "moved since last capture", value: fmt.count(moved) });
+  facts.push({ key: "moved", label: "Moved since last capture", value: fmt.count(moved) });
   if (typeof drift["not-captured"] === "number") {
-    facts.push({ key: "missing", label: "not captured", value: fmt.count(drift["not-captured"]) });
+    facts.push({ key: "missing", label: "Not captured", value: fmt.count(drift["not-captured"]) });
   }
   return facts;
 }

--- a/apps/ui/src/components/metagraphed/builder/builder-logic.ts
+++ b/apps/ui/src/components/metagraphed/builder/builder-logic.ts
@@ -135,7 +135,7 @@ export function contributeFacts(
   if (candidates != null) {
     facts.push({
       key: "candidates",
-      label: "Candidates awaiting review",
+      label: "Candidates",
       value: fmt.count(candidates),
     });
   }

--- a/apps/ui/src/components/metagraphed/builder/builder-logic.ts
+++ b/apps/ui/src/components/metagraphed/builder/builder-logic.ts
@@ -128,20 +128,20 @@ export function contributeFacts(
   if (rows.length === 0) return [];
   const facets = rows.reduce((sum, row) => sum + row.missing.length, 0);
   const facts: Fact[] = [
-    { key: "subnets", label: "subnets with gaps", value: fmt.count(rows.length) },
-    { key: "facets", label: "missing surfaces", value: fmt.count(facets) },
+    { key: "subnets", label: "Subnets with gaps", value: fmt.count(rows.length) },
+    { key: "facets", label: "Missing surfaces", value: fmt.count(facets) },
   ];
   const candidates = num(coverage?.candidate_count);
   if (candidates != null) {
     facts.push({
       key: "candidates",
-      label: "candidates awaiting review",
+      label: "Candidates awaiting review",
       value: fmt.count(candidates),
     });
   }
   const score = num(coverage?.completeness?.average_score);
   if (score != null)
-    facts.push({ key: "score", label: "average completeness", value: `${score}%` });
+    facts.push({ key: "score", label: "Average completeness", value: `${score}%` });
   return facts;
 }
 
@@ -285,10 +285,10 @@ export function agentFacts(
   if (tools > 0) facts.push({ key: "tools", label: "MCP tools", value: fmt.count(tools) });
   const subnets = num(summary?.subnet_count);
   if (subnets != null)
-    facts.push({ key: "subnets", label: "subnets covered", value: fmt.count(subnets) });
+    facts.push({ key: "subnets", label: "Subnets covered", value: fmt.count(subnets) });
   const services = num(summary?.callable_service_count);
   if (services != null) {
-    facts.push({ key: "services", label: "callable services", value: fmt.count(services) });
+    facts.push({ key: "services", label: "Callable services", value: fmt.count(services) });
   }
   return facts;
 }

--- a/apps/ui/src/components/metagraphed/chain-stream/chain-stream-columns.tsx
+++ b/apps/ui/src/components/metagraphed/chain-stream/chain-stream-columns.tsx
@@ -22,7 +22,19 @@ export function blockColumns(): DataTableColumn<BlockRow>[] {
       href: (row) => `/blocks/${row.block_number}`,
       format: (value) => (typeof value === "number" ? `#${formatNumber(value)}` : "—"),
     },
-    { key: "age", label: "Age", kind: "time", width: 110, value: (row) => row.observed_at ?? null },
+    // In the menu, not the table. Blocks arrive twelve seconds apart, so at any
+    // relative-time granularity a reader can read, fifty consecutive blocks are
+    // all "11d ago" -- or all "10m ago" at the head (#11696). What varies down
+    // this list is the HEIGHT, which leads, and the block time, which has its
+    // own column; the head's own age is in the page's liveness line.
+    {
+      key: "age",
+      label: "Age",
+      kind: "time",
+      width: 110,
+      demote: true,
+      value: (row) => row.observed_at ?? null,
+    },
     {
       key: "author",
       label: "Author",
@@ -130,10 +142,17 @@ export function extrinsicColumns(): DataTableColumn<Extrinsic>[] {
       value: (row) => (row.success == null ? null : row.success ? "ok" : "failed"),
     },
     {
+      // The CAPTURE time, not the chain's. Every row in a polled page was
+      // observed in the same pass, so the column reads one value on all fifty
+      // of them -- forty rows of "17h ago" (#11696). It stays available in the
+      // column menu, because "when did we see this" is a real question about a
+      // single row; it is not something a reader scans down a column, and the
+      // row's block already dates it.
       key: "observed",
       label: "Observed",
       kind: "time",
       width: 110,
+      demote: true,
       value: (row) => row.observed_at ?? null,
     },
     {
@@ -169,8 +188,16 @@ export function eventColumns(): DataTableColumn<ChainEvent>[] {
           ? `#${formatNumber(value)}${row.event_index == null ? "" : `·${row.event_index}`}`
           : "—",
     },
-    { key: "kind", label: "Event", value: (row) => eventLabel(row) },
-    { key: "summary", label: "Summary", kind: "text", value: (row) => asText(row.summary) },
+    { key: "kind", label: "Event", width: 280, value: (row) => eventLabel(row) },
+    // Bounded: unbounded it took 617px of a 1254px table on a 1198px card and
+    // pushed the last column off the edge (#11696).
+    {
+      key: "summary",
+      label: "Summary",
+      kind: "text",
+      width: 560,
+      value: (row) => asText(row.summary),
+    },
     {
       key: "phase",
       label: "Phase",
@@ -180,10 +207,17 @@ export function eventColumns(): DataTableColumn<ChainEvent>[] {
       value: (row) => asText(row.phase),
     },
     {
+      // The CAPTURE time, not the chain's. Every row in a polled page was
+      // observed in the same pass, so the column reads one value on all fifty
+      // of them -- forty rows of "17h ago" (#11696). It stays available in the
+      // column menu, because "when did we see this" is a real question about a
+      // single row; it is not something a reader scans down a column, and the
+      // row's block already dates it.
       key: "observed",
       label: "Observed",
       kind: "time",
       width: 110,
+      demote: true,
       value: (row) => row.observed_at ?? null,
     },
   ];

--- a/apps/ui/src/components/metagraphed/chain-stream/chain-stream-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/chain-stream/chain-stream-logic.test.ts
@@ -164,7 +164,7 @@ describe("blocksFacts", () => {
   it("falls back to the summary's own last block when the page is empty", () => {
     expect(blocksFacts({ last_block: 7 }, null, fmt)[0]).toEqual({
       key: "head",
-      label: "head",
+      label: "Head block",
       value: "#7",
     });
   });
@@ -202,7 +202,7 @@ describe("extrinsicsFacts", () => {
   it("says the count is of the page, never of a window it cannot see", () => {
     expect(extrinsicsFacts(rows, fmt)[0]).toEqual({
       key: "rows",
-      label: "on this page",
+      label: "On this page",
       value: "5",
     });
   });

--- a/apps/ui/src/components/metagraphed/chain-stream/chain-stream-logic.ts
+++ b/apps/ui/src/components/metagraphed/chain-stream/chain-stream-logic.ts
@@ -153,16 +153,16 @@ export function blocksFacts(
 ): Fact[] {
   const facts: Fact[] = [];
   const at = head ?? summary?.last_block ?? null;
-  if (at != null) facts.push({ key: "head", label: "head", value: `#${fmt.count(at)}` });
+  if (at != null) facts.push({ key: "head", label: "Head block", value: `#${fmt.count(at)}` });
   const mean = summary?.block_time?.mean_ms;
   if (typeof mean === "number" && mean > 0) {
-    facts.push({ key: "cadence", label: "block time", value: fmt.seconds(mean / 1000) });
+    facts.push({ key: "cadence", label: "Block time", value: fmt.seconds(mean / 1000) });
   }
   const perBlock = summary?.throughput?.mean_extrinsics_per_block;
   if (typeof perBlock === "number") {
     facts.push({
       key: "throughput",
-      label: "extrinsics per block",
+      label: "Extrinsics per block",
       value: fmt.count(Math.round(perBlock * 10) / 10),
     });
   }
@@ -187,18 +187,18 @@ export function extrinsicsFacts(
   rows: readonly Extrinsic[],
   fmt: { count: (n: number) => string },
 ): Fact[] {
-  const facts: Fact[] = [{ key: "rows", label: "on this page", value: fmt.count(rows.length) }];
+  const facts: Fact[] = [{ key: "rows", label: "On this page", value: fmt.count(rows.length) }];
   const stated = rows.filter((row) => row.success != null);
   if (stated.length > 0) {
     const ok = stated.filter((row) => row.success === true).length;
     facts.push({
       key: "ok",
-      label: "succeeded",
+      label: "Succeeded",
       value: `${formatPct(ok / stated.length, 1)}`,
     });
   }
   const top = topBy(rows, (row) => row.call_module);
-  if (top) facts.push({ key: "module", label: "top module", value: top.key });
+  if (top) facts.push({ key: "module", label: "Top module", value: top.key });
   return facts;
 }
 
@@ -236,9 +236,9 @@ export function eventsFacts(
   ];
   const top = [...activity].sort((a, b) => (b.count ?? 0) - (a.count ?? 0))[0];
   const label = top ? callLabel(top.pallet, top.method) : null;
-  if (label) facts.push({ key: "top", label: "most frequent", value: label });
+  if (label) facts.push({ key: "top", label: "Most frequent", value: label });
   if (stats?.groups != null) {
-    facts.push({ key: "kinds", label: "distinct kinds", value: fmt.count(stats.groups) });
+    facts.push({ key: "kinds", label: "Distinct kinds", value: fmt.count(stats.groups) });
   }
   return facts;
 }

--- a/apps/ui/src/components/metagraphed/chain-stream/stream-shell.tsx
+++ b/apps/ui/src/components/metagraphed/chain-stream/stream-shell.tsx
@@ -1,19 +1,11 @@
 import type { ReactNode } from "react";
-import { EntityHero, Fact, FactSentence, Raw, type RawRow } from "@jsonbored/ui-kit";
+import { EntityHero, FactSentence, Raw, type RawRow } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState } from "@/components/metagraphed/states";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
+import { factCells } from "@/lib/metagraphed/facts";
 import type { Fact as StreamFact } from "./chain-stream-logic";
-
-/** The hero facts as the inline chips the design system asks for. */
-function factChips(facts: readonly StreamFact[]): ReactNode {
-  return facts.slice(0, 6).map((fact) => (
-    <Fact key={fact.key}>
-      {fact.label} {fact.value}
-    </Fact>
-  ));
-}
 
 /**
  * Registration has to happen INSIDE `AppShell`, which is where the provider
@@ -85,11 +77,12 @@ export function StreamShell({
       <EntityHero
         crumbs={[{ label: "Chain", href: "/chain" }]}
         name={name}
-        sentence={
-          <FactSentence>
-            {lede} {factChips(facts)}
-          </FactSentence>
-        }
+        sentence={<FactSentence>{lede}</FactSentence>}
+        // A STRIP, not chips (#11696). All three of these pages are a table
+        // with a sentence over it, and the sentence set the head block, the
+        // block time and the Nakamoto coefficient at 11px -- smaller than the
+        // table's own rows. The lede stays prose; the numbers get cells.
+        cells={factCells(facts) ?? undefined}
         live={{ updatedAt, source: "chain-direct", onRefresh, refreshing }}
       />
       {children}

--- a/apps/ui/src/components/metagraphed/design/design-tokens.generated.ts
+++ b/apps/ui/src/components/metagraphed/design/design-tokens.generated.ts
@@ -16,7 +16,7 @@ export const DESIGN_TOKENS: readonly DesignToken[] = [
   { name: "--canvas", light: "#f8f8f5", dark: "#161616", theme: "--color-canvas", refs: 25 },
   { name: "--layer", light: "#f0f0ec", dark: "#1f1f1f", theme: "--color-layer", refs: 25 },
   { name: "--raised", light: "#e6e6e1", dark: "#2a2a2a", theme: "--color-raised", refs: 11 },
-  { name: "--surface-card", light: "#ffffff", dark: "#1f1f1f", theme: null, refs: 2 },
+  { name: "--surface-card", light: "#ffffff", dark: "#1f1f1f", theme: null, refs: 3 },
   {
     name: "--ink-strong",
     light: "#161616",
@@ -45,7 +45,7 @@ export const DESIGN_TOKENS: readonly DesignToken[] = [
     light: "rgba(22, 22, 22, 0.11)",
     dark: "rgba(255, 255, 255, 0.11)",
     theme: "--color-rule",
-    refs: 45,
+    refs: 43,
   },
   {
     name: "--rule-strong",

--- a/apps/ui/src/components/metagraphed/endpoints/endpoints-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/endpoints/endpoints-logic.test.ts
@@ -248,8 +248,11 @@ describe("endpointFacts", () => {
       fmt,
     );
     const healthy = facts.find((f) => f.key === "healthy");
-    expect(healthy?.value).toBe("82%");
-    expect(healthy?.label).toBe("healthy of 621 probed");
+    // The denominator lives in the VALUE now: as a 10px cell label over a
+    // 28px number it was the strip's longest label and the only one whose
+    // length changed with the data (#11696).
+    expect(healthy?.value).toBe("82% of 621");
+    expect(healthy?.label).toBe("Healthy");
   });
 
   it("reports the pools, the degraded and the open incidents", () => {
@@ -261,7 +264,7 @@ describe("endpointFacts", () => {
 
   it("omits the healthy share when nothing was probed", () => {
     expect(endpointFacts({ endpoint_count: 10, by_status: { unknown: 10 } }, 0, null, fmt)).toEqual(
-      [{ key: "tracked", label: "tracked", value: "10" }],
+      [{ key: "tracked", label: "Tracked", value: "10" }],
     );
   });
 

--- a/apps/ui/src/components/metagraphed/endpoints/endpoints-logic.ts
+++ b/apps/ui/src/components/metagraphed/endpoints/endpoints-logic.ts
@@ -260,20 +260,24 @@ export function endpointFacts(
   const measured = ok + degraded + failed;
   const facts: Fact[] = [];
   if (typeof summary.endpoint_count === "number") {
-    facts.push({ key: "tracked", label: "tracked", value: fmt.count(summary.endpoint_count) });
+    facts.push({ key: "tracked", label: "Tracked", value: fmt.count(summary.endpoint_count) });
   }
   if (measured > 0) {
+    // The denominator moves into the VALUE. As a chip the label could carry
+    // it ("healthy of 112 probed 95%"); as a 10px cell label over a 28px
+    // number it was the longest label in the strip and the only one that
+    // changed length with the data (#11696).
     facts.push({
       key: "healthy",
-      label: `healthy of ${fmt.count(measured)} probed`,
-      value: `${Math.round((ok / measured) * 100)}%`,
+      label: "Healthy",
+      value: `${Math.round((ok / measured) * 100)}% of ${fmt.count(measured)}`,
     });
   }
   if (pools > 0) facts.push({ key: "pools", label: "RPC pools", value: fmt.count(pools) });
   if (degraded > 0)
-    facts.push({ key: "degraded", label: "degraded now", value: fmt.count(degraded) });
+    facts.push({ key: "degraded", label: "Degraded now", value: fmt.count(degraded) });
   if (openIncidents != null) {
-    facts.push({ key: "incidents", label: "open incidents", value: fmt.count(openIncidents) });
+    facts.push({ key: "incidents", label: "Open incidents", value: fmt.count(openIncidents) });
   }
   return facts;
 }

--- a/apps/ui/src/components/metagraphed/health/health-logic.ts
+++ b/apps/ui/src/components/metagraphed/health/health-logic.ts
@@ -231,7 +231,7 @@ export function healthFacts(
   const counts = global.status_counts ?? {};
   const facts: Fact[] = [];
   if (typeof global.surface_count === "number") {
-    facts.push({ key: "probed", label: "probed surfaces", value: fmt.count(global.surface_count) });
+    facts.push({ key: "probed", label: "Probed surfaces", value: fmt.count(global.surface_count) });
   }
   for (const [key, label] of [
     ["ok", "ok"],
@@ -242,7 +242,7 @@ export function healthFacts(
       facts.push({ key, label, value: fmt.count(counts[key]) });
     }
   }
-  facts.push({ key: "incidents", label: "open incidents", value: fmt.count(openIncidents) });
-  if (verdict) facts.push({ key: "self", label: "metagraphed itself", value: verdict });
+  facts.push({ key: "incidents", label: "Open incidents", value: fmt.count(openIncidents) });
+  if (verdict) facts.push({ key: "self", label: "Metagraphed itself", value: verdict });
   return facts;
 }

--- a/apps/ui/src/components/metagraphed/providers/providers-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/providers/providers-logic.test.ts
@@ -6,6 +6,7 @@ import {
   filterProviders,
   hostOf,
   initials,
+  mergeSurfaceProbes,
   providerDetailFacts,
   providerFacts,
   providerLeaders,
@@ -224,8 +225,8 @@ describe("providerDetailFacts", () => {
       fmt,
     );
     const healthy = facts.find((f) => f.key === "healthy");
-    expect(healthy?.value).toBe("75%");
-    expect(healthy?.label).toBe("ok of 12 probed");
+    expect(healthy?.value).toBe("75% of 12");
+    expect(healthy?.label).toBe("Healthy");
   });
 
   it("omits the share when nothing carries a status", () => {
@@ -261,5 +262,43 @@ describe("providerSurfaces", () => {
 describe("facet", () => {
   it("is the sorted distinct set", () => {
     expect(facet(providerRows(providers, health), (r) => r.kind)).toEqual(["infra", "subnet-team"]);
+  });
+});
+
+describe("mergeSurfaceProbes", () => {
+  const surfaces = [
+    { id: "sn-51-a", url: "https://a.example", name: "A" },
+    { id: "sn-51-docs", url: "https://docs.example", name: "Docs" },
+    { id: "sn-51-nourl", name: "No URL" },
+  ] as Surface[];
+  const endpoints = [
+    {
+      id: "endpoint-srf-1",
+      url: "https://a.example",
+      status: "ok",
+      latency_ms: 42,
+      last_checked: "2026-08-24T00:00:00.000Z",
+    },
+  ] as unknown as Endpoint[];
+
+  it("joins on the URL, because the two feeds number the same thing differently", () => {
+    // /endpoints says `endpoint-srf-<hash>`; /surfaces says
+    // `sn-51-<provider>-<path>`. The ids never match; the URL is the thing
+    // both records are about.
+    const [a] = mergeSurfaceProbes(surfaces, endpoints);
+    expect(a).toMatchObject({ id: "sn-51-a", probeStatus: "ok", probeLatencyMs: 42 });
+    expect(a?.probedAt).toBe("2026-08-24T00:00:00.000Z");
+  });
+
+  it("leaves a surface nobody probes with null probe fields, not zeroes", () => {
+    const [, docs, noUrl] = mergeSurfaceProbes(surfaces, endpoints);
+    expect(docs).toMatchObject({ probeStatus: null, probeLatencyMs: null, probedAt: null });
+    expect(noUrl).toMatchObject({ probeStatus: null, probeLatencyMs: null, probedAt: null });
+  });
+
+  it("keeps every surface, so the merged list is the superset it claims to be", () => {
+    expect(mergeSurfaceProbes(surfaces, endpoints)).toHaveLength(surfaces.length);
+    expect(mergeSurfaceProbes(surfaces, [])).toHaveLength(surfaces.length);
+    expect(mergeSurfaceProbes([], endpoints)).toEqual([]);
   });
 });

--- a/apps/ui/src/components/metagraphed/providers/providers-logic.ts
+++ b/apps/ui/src/components/metagraphed/providers/providers-logic.ts
@@ -91,15 +91,15 @@ export function providerFacts(
   if (rows.length === 0) return [];
   const claimed = rows.filter((row) => row.authority && CLAIMED.has(row.authority)).length;
   const facts: Fact[] = [
-    { key: "providers", label: "providers", value: fmt.count(rows.length) },
+    { key: "providers", label: "Providers", value: fmt.count(rows.length) },
     {
       key: "claimed",
-      label: "official or claimed",
+      label: "Official or claimed",
       value: `${fmt.count(claimed)} (${Math.round((claimed / rows.length) * 100)}%)`,
     },
   ];
   const endpoints = health?.endpoint_count ?? rows.reduce((sum, row) => sum + row.endpoints, 0);
-  facts.push({ key: "endpoints", label: "endpoints", value: fmt.count(endpoints) });
+  facts.push({ key: "endpoints", label: "Endpoints", value: fmt.count(endpoints) });
   const counts = health?.status_counts;
   if (counts) {
     const ok = counts.ok ?? 0;
@@ -107,7 +107,7 @@ export function providerFacts(
     if (total > 0) {
       facts.push({
         key: "sources",
-        label: "sources resolving",
+        label: "Sources resolving",
         value: `${fmt.count(ok)}/${fmt.count(total)}`,
       });
     }
@@ -229,6 +229,48 @@ export function endpointRails(
     }));
 }
 
+/** A surface with whatever the prober last found for it. */
+export interface ProviderSurfaceRow extends Surface {
+  probeStatus: string | null;
+  probeLatencyMs: number | null;
+  probedAt: string | null;
+}
+
+/**
+ * One list, not two.
+ *
+ * A provider page rendered an Endpoints table and a Surfaces table, and for a
+ * provider whose surfaces are ALL probed endpoints -- which is most of them --
+ * that is the same rows twice, 156 and 156, under two identities and two
+ * column sets (#11696). Surfaces is the superset: an endpoint is a surface the
+ * prober watches, and a docs page is a surface it does not.
+ *
+ * Joined on the URL rather than the id: `/endpoints` numbers a row
+ * `endpoint-srf-<hash>` and `/surfaces` numbers the same thing
+ * `sn-51-<provider>-<path>`, so the ids never match, while the URL is the
+ * thing both records are ABOUT. A surface with no matching endpoint keeps its
+ * three probe fields null, which is the honest answer for something nobody
+ * probes.
+ */
+export function mergeSurfaceProbes(
+  surfaces: readonly Surface[],
+  endpoints: readonly Endpoint[],
+): ProviderSurfaceRow[] {
+  const byUrl = new Map<string, Endpoint>();
+  for (const endpoint of endpoints) {
+    if (typeof endpoint.url === "string" && endpoint.url) byUrl.set(endpoint.url, endpoint);
+  }
+  return surfaces.map((surface) => {
+    const probe = typeof surface.url === "string" ? byUrl.get(surface.url) : undefined;
+    return {
+      ...surface,
+      probeStatus: typeof probe?.status === "string" ? probe.status : null,
+      probeLatencyMs: typeof probe?.latency_ms === "number" ? probe.latency_ms : null,
+      probedAt: typeof probe?.last_checked === "string" ? probe.last_checked : null,
+    };
+  });
+}
+
 /** The host of a URL, or the URL, or null — never a thrown TypeError. */
 export function hostOf(url: string | null | undefined): string | null {
   if (!url) return null;
@@ -259,11 +301,11 @@ export function providerDetailFacts(
   if (!provider) return [];
   const facts: Fact[] = [];
   if (provider.authority) {
-    facts.push({ key: "authority", label: "authority", value: String(provider.authority) });
+    facts.push({ key: "authority", label: "Authority", value: String(provider.authority) });
   }
-  if (surfaces > 0) facts.push({ key: "surfaces", label: "surfaces", value: fmt.count(surfaces) });
+  if (surfaces > 0) facts.push({ key: "surfaces", label: "Surfaces", value: fmt.count(surfaces) });
   const count = num(summary?.endpoint_count);
-  if (count != null) facts.push({ key: "endpoints", label: "endpoints", value: fmt.count(count) });
+  if (count != null) facts.push({ key: "endpoints", label: "Endpoints", value: fmt.count(count) });
   const status = summary?.by_status ?? {};
   const measured = Object.entries(status)
     .filter(([key]) => key !== "unknown")
@@ -271,8 +313,8 @@ export function providerDetailFacts(
   if (measured > 0) {
     facts.push({
       key: "healthy",
-      label: `ok of ${fmt.count(measured)} probed`,
-      value: `${Math.round(((status.ok ?? 0) / measured) * 100)}%`,
+      label: "Healthy",
+      value: `${Math.round(((status.ok ?? 0) / measured) * 100)}% of ${fmt.count(measured)}`,
     });
   }
   return facts;

--- a/apps/ui/src/lib/metagraphed/definitions.ts
+++ b/apps/ui/src/lib/metagraphed/definitions.ts
@@ -7,6 +7,62 @@
  * Keep each entry to one sentence, in plain words, ending with a full stop.
  */
 export const DEFINITIONS = {
+  // ── Summary-card labels (#11698) ──────────────────────────────────────────
+  //
+  // `FactCell` looks its label up here, so a term listed below grows a "?" on
+  // every card that uses it, on every route, at once. Only the terms a reader
+  // would actually stop at: a "?" beside "Providers" is noise, and noise is
+  // what makes a help affordance get ignored where it matters.
+  Nakamoto:
+    "The fewest block authors who could halt the chain between them; higher is more decentralised.",
+  "Head block": "The most recent block this indexer has seen.",
+  "Block time": "How long the chain took between blocks over the window, at the median.",
+  "Block time p50": "The median gap between blocks over the window; half were faster.",
+  "Extrinsics per block": "How many signed calls the average block in this window carried.",
+  Signers: "Distinct accounts that signed at least one extrinsic in the window.",
+  "Top module": "The runtime pallet that submitted the most calls on this page.",
+  "Most frequent": "The event kind the runtime emitted most often in the window.",
+  "Stake listed": "Total stake held by the accounts on this page, not by the whole network.",
+  "Top 10 share": "What the ten largest holders on this page hold, as a share of the listed total.",
+  "Median take": "The middle validator's take; half of them keep more, half keep less.",
+  "Median APY": "The middle validator's estimated annual yield; an estimate, not a promise.",
+  "Est. APY": "Yield projected from recent rewards; it moves with emission and with stake.",
+  Memberships: "Subnets this operator validates on; one hotkey can hold several.",
+  "Memberships / permits":
+    "Subnets this operator validates on, and how many of those carry a permit.",
+  "Positions / subnets":
+    "Live stake positions this account holds, and how many subnets they sit in.",
+  "Net flow": "Stake in minus stake out over the window; negative means the account is exiting.",
+  "Permit floor": "The stake a hotkey needs right now to hold a validator permit here.",
+  "Earning floor": "The stake a miner needs right now to earn anything on this subnet.",
+  Slots: "UIDs in use against the subnet's cap; a full subnet deregisters to admit anyone new.",
+  "Miners earning nothing":
+    "The share of registered miners this subnet paid zero to over the window.",
+  "Miners / Validators": "Registered neurons split by role; only permit-holders set weights.",
+  Tempo: "Blocks between weight-setting rounds on this subnet.",
+  "Pool liquidity": "TAO sitting in the subnet's alpha pool, backing its price.",
+  "Chain buys": "Emission the chain itself spent buying alpha, rather than paying it out.",
+  Paid: "Subnets the chain actually paid this block, against the number registered.",
+  "Probed surfaces": "Surfaces the prober watches; the rest are catalogued but unmeasured.",
+  "RPC pools": "Managed endpoint pools a client can be routed to instead of one host.",
+  "Degraded now": "Endpoints answering slowly or partially at the last probe, but still answering.",
+  "Open incidents": "Probe failures the prober has not yet seen recover.",
+  Healthy: "The share of PROBED surfaces that answered, not of the whole catalogue.",
+  "Official or claimed":
+    "Providers whose identity the registry has verified or the operator has claimed.",
+  "Sources resolving": "Providers whose published source URL still answers.",
+  "Adapter-backed": "Subnets with a typed adapter, the top rung of the curation ladder.",
+  "Avg freshness": "How old the registry's data is on average across every tracked surface.",
+  Moved: "Schemas whose contract changed between the last two captures.",
+  "Not captured": "Surfaces that advertise a schema the registry could not fetch.",
+  "Subnets with gaps": "Subnets missing at least one surface kind the registry expects.",
+  Candidates: "Discovered surfaces queued for a human to accept or reject.",
+  "Average completeness":
+    "How much of the expected surface set the registry has found, across all subnets.",
+  "Callable services": "Subnet surfaces an agent can call directly through this registry.",
+  "Metagraphed itself":
+    "Whether this site and its API are up, measured the same way it measures others.",
+
   "Emission share": "The fraction of each block's TAO emission the chain directs to this subnet.",
   "Alpha price": "What one unit of this subnet's alpha token costs in TAO on its own pool.",
   "Total stake": "All TAO and alpha staked to this subnet's validators, valued in TAO.",

--- a/apps/ui/src/lib/metagraphed/facts.test.ts
+++ b/apps/ui/src/lib/metagraphed/facts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { factCells } from "./facts";
+
+const fact = (key: string) => ({ key, label: key, value: key.length });
+
+describe("factCells", () => {
+  it("builds a strip for every size the primitive accepts", () => {
+    for (const size of [2, 3, 4, 5, 6]) {
+      const facts = Array.from({ length: size }, (_, i) => fact(`f${i}`));
+      expect(factCells(facts)).toHaveLength(size);
+    }
+  });
+
+  it("takes the first six and drops the rest, because the strip holds six", () => {
+    const cells = factCells(Array.from({ length: 9 }, (_, i) => fact(`f${i}`)));
+    expect(cells).toHaveLength(6);
+    expect(cells?.[0]?.label).toBe("f0");
+    expect(cells?.[5]?.label).toBe("f5");
+  });
+
+  it("has no strip below two, which is the primitive's own floor", () => {
+    expect(factCells([])).toBeNull();
+    expect(factCells([fact("only")])).toBeNull();
+  });
+
+  it("carries a delta through, and omits the key the strip has no use for", () => {
+    const [first] = factCells([
+      { key: "a", label: "A", value: 1, delta: { text: "+2%", tone: "good" } },
+      fact("b"),
+    ])!;
+    expect(first).toEqual({ label: "A", value: 1, delta: { text: "+2%", tone: "good" } });
+  });
+
+  it("leaves `delta` off entirely when there is none, rather than passing undefined", () => {
+    expect(factCells([fact("a"), fact("b")])![0]).not.toHaveProperty("delta");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/facts.ts
+++ b/apps/ui/src/lib/metagraphed/facts.ts
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import type { FactCells } from "@jsonbored/ui-kit";
+
+/** One headline number, as the pages that derive them already shape it. */
+export interface HeadlineFact {
+  key: string;
+  label: string;
+  value: ReactNode;
+  /** A signed change shown right of the value; `tone` colours it. */
+  delta?: { text: string; tone: "good" | "bad" | "neutral" };
+}
+
+/**
+ * A page's headline numbers as a `FactStrip`, or `null` when there are too few
+ * to make a strip.
+ *
+ * ELEVEN routes stated their headline numbers as 11px `Fact` chips inside the
+ * hero sentence and never rendered a strip at all (#11696) -- every one of them
+ * a page whose subject is a table, so the numbers that frame the table were set
+ * smaller than the table's own row text. The chips are right for an entity's
+ * IDENTITY ("hotkey 5E2LP6…eZ5u", "authority official"); they are wrong for the
+ * five counts a reader came to the page for.
+ *
+ * Written as a switch rather than a cast. `FactCells` is a 2-to-6 TUPLE, and
+ * `as unknown as FactCells` over an array would compile while telling the
+ * compiler something it has not checked -- the pattern the boundary-cast gate
+ * exists to keep out of this repo, whether or not it scans this workspace.
+ */
+export function factCells(facts: readonly HeadlineFact[]): FactCells | null {
+  const cells = facts
+    .slice(0, 6)
+    .map(({ label, value, delta }) => (delta ? { label, value, delta } : { label, value }));
+  switch (cells.length) {
+    case 2:
+      return [cells[0]!, cells[1]!];
+    case 3:
+      return [cells[0]!, cells[1]!, cells[2]!];
+    case 4:
+      return [cells[0]!, cells[1]!, cells[2]!, cells[3]!];
+    case 5:
+      return [cells[0]!, cells[1]!, cells[2]!, cells[3]!, cells[4]!];
+    case 6:
+      return [cells[0]!, cells[1]!, cells[2]!, cells[3]!, cells[4]!, cells[5]!];
+    default:
+      return null;
+  }
+}

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -5,7 +5,6 @@ import {
   CopyableCode,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   FilterField,
   FilterSelect,
@@ -16,6 +15,7 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -113,15 +113,18 @@ export function AgentsPage() {
         }
         sentence={
           <FactSentence>
-            One command points any MCP client at every Bittensor subnet this registry knows.{" "}
-            {agentFacts(payload?.summary as Parameters<typeof agentFacts>[0], tools.length, {
-              count: formatNumber,
-            }).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
+            One command points any MCP client at every Bittensor subnet this registry knows.
           </FactSentence>
+        }
+        // A STRIP, not chips (#11696). This page's subject is a table, and its
+        // headline counts were 11px `Fact` chips inside the sentence -- set
+        // smaller than the rows they frame. The lede stays prose.
+        cells={
+          factCells(
+            agentFacts(payload?.summary as Parameters<typeof agentFacts>[0], tools.length, {
+              count: formatNumber,
+            }),
+          ) ?? undefined
         }
         live={{
           updatedAt: (payload?.generated_at as string | undefined) ?? null,

--- a/apps/ui/src/routes/-apis-catalog-page.tsx
+++ b/apps/ui/src/routes/-apis-catalog-page.tsx
@@ -6,7 +6,6 @@ import {
   CompositionBreakdown,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   FilterField,
   FilterInput,
@@ -18,11 +17,12 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { HubSections } from "@/components/metagraphed/hub-prose";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatAbsoluteTime, formatNumber } from "@/lib/metagraphed/format";
 import { coverageQuery, surfacesInfiniteQuery } from "@/lib/metagraphed/queries";
 import type { Surface } from "@/lib/metagraphed/types";
 import type { CoverageCounts } from "@/components/metagraphed/apis/apis-logic";
@@ -117,14 +117,17 @@ export function ApisCatalogPage() {
       format: (value) => (typeof value === "number" ? `SN${value}` : "—"),
     },
     { key: "kind", label: "Kind", kind: "status", width: 130, value: (row) => row.kind ?? null },
-    { key: "name", label: "Name", value: (row) => row.name ?? null },
     {
-      key: "url",
-      label: "URL",
+      // The name LEADS and links; the URL is under the row. Two identifier
+      // columns side by side took 946px of a 1400px table on a 1118px card,
+      // and the reader lost Provider and Authority off the right edge to a
+      // horizontal scroll nothing announced (#11696).
+      key: "name",
+      label: "Name",
       kind: "link",
-      value: (row) => row.url ?? null,
+      width: 380,
+      value: (row) => row.name ?? null,
       href: (row) => row.url,
-      format: (value) => (typeof value === "string" ? value.replace(/^https?:\/\//, "") : "—"),
     },
     { key: "provider", label: "Provider", width: 150, value: (row) => row.provider ?? null },
     {
@@ -134,30 +137,33 @@ export function ApisCatalogPage() {
       width: 140,
       value: (row) => (typeof row.authority === "string" ? row.authority : null),
     },
-    {
-      key: "auth",
-      label: "Auth",
-      kind: "status",
-      width: 100,
-      demote: true,
-      value: (row) => (row.auth_required == null ? null : row.auth_required ? "required" : "open"),
-    },
-    {
-      key: "curation",
-      label: "Curation",
-      width: 160,
-      demote: true,
-      value: (row) => (typeof row.curation_level === "string" ? row.curation_level : null),
-    },
-    {
-      key: "verified",
-      label: "Last verified",
-      kind: "time",
-      width: 130,
-      demote: true,
-      value: (row) => row.last_verified_at ?? null,
-    },
   ];
+
+  /** The URL and the three fields a reader checks once, under the row. */
+  const surfaceDetail = (row: Surface) => (
+    <dl>
+      {row.url ? (
+        <div className="mg-raw-row">
+          <dt>URL</dt>
+          <dd>{row.url}</dd>
+        </div>
+      ) : null}
+      <div className="mg-raw-row">
+        <dt>Auth</dt>
+        <dd>
+          {row.auth_required == null ? "—" : row.auth_required ? "a key is required" : "open"}
+        </dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Curation</dt>
+        <dd>{typeof row.curation_level === "string" ? row.curation_level : "—"}</dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Last verified</dt>
+        <dd>{row.last_verified_at ? formatAbsoluteTime(row.last_verified_at) : "not verified"}</dd>
+      </div>
+    </dl>
+  );
 
   const rawRows: RawRow[] = [
     ...API_PATHS.map((path) => ({
@@ -179,17 +185,16 @@ export function ApisCatalogPage() {
       <ApiSources />
       <EntityHero
         name="APIs"
-        sentence={
-          <FactSentence>
-            Every public interface this registry has verified.{" "}
-            {catalogFacts(coverage.data?.data as CoverageCounts | undefined, segments.length, {
+        sentence={<FactSentence>Every public interface this registry has verified.</FactSentence>}
+        // A STRIP, not chips (#11696). This page's subject is a table, and its
+        // headline counts were 11px `Fact` chips inside the sentence -- set
+        // smaller than the rows they frame. The lede stays prose.
+        cells={
+          factCells(
+            catalogFacts(coverage.data?.data as CoverageCounts | undefined, segments.length, {
               count: formatNumber,
-            }).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
-          </FactSentence>
+            }),
+          ) ?? undefined
         }
         live={{
           updatedAt: (coverage.data?.data.generated_at as string | undefined) ?? null,
@@ -237,11 +242,12 @@ export function ApisCatalogPage() {
             link={RouterLink}
             source="surface"
             storageKey="mg-apis-columns"
+            expand={surfaceDetail}
             loading={feed.isPending}
             search={{
               value: search.q,
               onChange: (q) => setSearch({ q }),
-              placeholder: "Name, URL, provider or subnet",
+              placeholder: "Name, provider or subnet",
             }}
             filters={
               <>
@@ -289,13 +295,18 @@ export function ApisCatalogPage() {
         footnote={
           <>
             {`${formatNumber(rows.length)} shown · facets applied server-side · registry `}
-            <LoadMore
-              hasMore={feed.hasNextPage}
-              isLoading={feed.isFetchingNextPage}
-              onLoadMore={() => void feed.fetchNextPage()}
-              shown={surfaces.length}
-              error={feed.error}
-            />
+            // Only while there IS more to fetch. The table states its own // range and total in its
+            pager, so a terminal "end of list" strip // beneath it is the same fact twice, in two
+            vocabularies (#11696).
+            {feed.hasNextPage || feed.error ? (
+              <LoadMore
+                hasMore={feed.hasNextPage}
+                isLoading={feed.isFetchingNextPage}
+                onLoadMore={() => void feed.fetchNextPage()}
+                shown={surfaces.length}
+                error={feed.error}
+              />
+            ) : null}
           </>
         }
       />

--- a/apps/ui/src/routes/-chain-stream-page.tsx
+++ b/apps/ui/src/routes/-chain-stream-page.tsx
@@ -383,13 +383,18 @@ export function EventsPage() {
           "/api/v1/chain-events",
         )}
       />
-      <LoadMore
-        hasMore={feed.hasNextPage}
-        isLoading={feed.isFetchingNextPage}
-        onLoadMore={() => void feed.fetchNextPage()}
-        shown={rows.length}
-        error={feed.error}
-      />
+      // Only while there IS more to fetch. The table states its own // range and total in its
+      pager, so a terminal "end of list" strip // beneath it is the same fact twice, in two
+      vocabularies (#11696).
+      {feed.hasNextPage || feed.error ? (
+        <LoadMore
+          hasMore={feed.hasNextPage}
+          isLoading={feed.isFetchingNextPage}
+          onLoadMore={() => void feed.fetchNextPage()}
+          shown={rows.length}
+          error={feed.error}
+        />
+      ) : null}
     </StreamShell>
   );
 }

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -6,7 +6,6 @@ import {
   CopyableCode,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   FilterField,
   FilterSelect,
@@ -20,11 +19,12 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { HubSections } from "@/components/metagraphed/hub-prose";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatAbsoluteTime, formatNumber } from "@/lib/metagraphed/format";
 import {
   endpointIncidentsQuery,
   endpointsInfiniteQuery,
@@ -32,6 +32,7 @@ import {
   rpcPoolsQuery,
 } from "@/lib/metagraphed/queries";
 import { apisNav } from "@/components/metagraphed/apis/apis-logic";
+import { hostOf } from "@/components/metagraphed/providers/providers-logic";
 import {
   LATENCY_VIEWS,
   endpointFacts,
@@ -116,26 +117,32 @@ export function EndpointsPage() {
   const shownIncidents = search.incidents === "open" ? openIncidents : incidentList;
 
   const columns: DataTableColumn<EndpointRow>[] = [
-    { key: "provider", label: "Provider", width: 160, value: (row) => row.provider },
-    { key: "kind", label: "Kind", kind: "status", width: 150, value: (row) => row.kind },
     {
-      key: "url",
-      label: "URL",
+      // The HOST leads, not the provider. A directory sorted by provider put
+      // "opentensor" in the first cell of seven consecutive rows while the one
+      // thing that told them apart -- the URL -- sat third, 711px wide, and
+      // pushed Status, p50 and Last probe off the right edge of the card
+      // (#11696). The scheme and path are in the row's detail, where they can
+      // be copied; what a reader compares down a column is the host.
+      key: "host",
+      label: "Endpoint",
       kind: "link",
-      value: (row) => row.url,
+      width: 300,
+      value: (row) => hostOf(row.url),
       href: (row) => row.url ?? undefined,
-      format: (value) => (typeof value === "string" ? value.replace(/^https?:\/\//, "") : "—"),
     },
+    { key: "provider", label: "Provider", width: 150, value: (row) => row.provider },
+    { key: "kind", label: "Kind", kind: "status", width: 140, value: (row) => row.kind },
     {
       key: "subnet",
       label: "Subnet",
       kind: "link",
-      width: 110,
+      width: 100,
       value: (row) => row.netuid,
       href: (row) => (row.netuid == null ? undefined : `/subnets/${row.netuid}`),
       format: (value) => (typeof value === "number" ? `SN${value}` : "—"),
     },
-    { key: "status", label: "Status", kind: "status", width: 120, value: (row) => row.status },
+    { key: "status", label: "Status", kind: "status", width: 110, value: (row) => row.status },
     {
       key: "latency",
       label: "p50",
@@ -149,40 +156,8 @@ export function EndpointsPage() {
       key: "probed",
       label: "Last probe",
       kind: "time",
-      width: 130,
+      width: 120,
       value: (row) => row.lastChecked,
-    },
-    {
-      key: "ok",
-      label: "Last ok",
-      kind: "time",
-      width: 130,
-      demote: true,
-      value: (row) => row.lastOk,
-    },
-    {
-      key: "pool",
-      label: "Pool",
-      kind: "status",
-      width: 130,
-      demote: true,
-      value: (row) => (row.poolEligible ? "eligible" : "no"),
-    },
-    {
-      key: "archive",
-      label: "Archive",
-      kind: "status",
-      width: 110,
-      demote: true,
-      value: (row) => (row.archive ? "yes" : "no"),
-    },
-    {
-      key: "auth",
-      label: "Auth",
-      kind: "status",
-      width: 100,
-      demote: true,
-      value: (row) => (row.authRequired ? "required" : "open"),
     },
   ];
 
@@ -210,37 +185,66 @@ export function EndpointsPage() {
       format: (value) => (typeof value === "number" ? `SN${value}` : "—"),
     },
     { key: "reason", label: "Reason", value: (row) => row.reason },
-    {
-      key: "severity",
-      label: "Severity",
-      kind: "status",
-      width: 120,
-      value: (row) => row.severity,
-    },
-    {
-      key: "state",
-      label: "State",
-      kind: "status",
-      width: 110,
-      value: (row) => (row.open ? "open" : "resolved"),
-    },
-    {
-      key: "health",
-      label: "Probe",
-      kind: "status",
-      width: 110,
-      demote: true,
-      value: (row) => row.health,
-    },
-    {
-      key: "checked",
-      label: "Last probe",
-      kind: "time",
-      width: 130,
-      demote: true,
-      value: (row) => row.lastChecked,
-    },
   ];
+
+  /**
+   * What a row carries but does not compare.
+   *
+   * The full URL, whether the endpoint is pool-eligible, whether it serves
+   * archive state, whether it needs a key, and when it last answered. Four of
+   * those were `demote`d columns -- present in the ⋯ menu, invisible until a
+   * reader went looking, and each one widening the table when turned on. A
+   * value you copy or check once belongs under its row, not in a column
+   * competing for width with the six a reader scans (#11696).
+   */
+  const endpointDetail = (row: EndpointRow) => (
+    <dl>
+      {row.url ? (
+        <div className="mg-raw-row">
+          <dt>URL</dt>
+          <dd>{row.url}</dd>
+        </div>
+      ) : null}
+      <div className="mg-raw-row">
+        <dt>Pool</dt>
+        <dd>{row.poolEligible ? "eligible" : "not eligible"}</dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Archive</dt>
+        <dd>{row.archive ? "serves archive state" : "recent state only"}</dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Auth</dt>
+        <dd>{row.authRequired ? "a key is required" : "open"}</dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Last ok</dt>
+        <dd>{row.lastOk ? formatAbsoluteTime(row.lastOk) : "never answered"}</dd>
+      </div>
+    </dl>
+  );
+
+  /** The same reasoning for an incident: what it was, not what it is. */
+  const incidentDetail = (row: IncidentRow) => (
+    <dl>
+      <div className="mg-raw-row">
+        <dt>Severity</dt>
+        <dd>{row.severity ?? "—"}</dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>State</dt>
+        <dd>{row.open ? "open" : "resolved"}</dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Probe</dt>
+        <dd>{row.health ?? "—"}</dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Last probe</dt>
+        <dd>{row.lastChecked ? formatAbsoluteTime(row.lastChecked) : "—"}</dd>
+      </div>
+    </dl>
+  );
 
   const rawRows: RawRow[] = [
     { label: "managed RPC proxy", value: PROXY_URL, href: PROXY_URL },
@@ -257,19 +261,20 @@ export function EndpointsPage() {
       <EntityHero
         name="Endpoints"
         sentence={
-          <FactSentence>
-            What the registry can reach, and how it answered last time.{" "}
-            {endpointFacts(
+          <FactSentence>What the registry can reach, and how it answered last time.</FactSentence>
+        }
+        // A STRIP, not chips (#11696). This page's subject is a table, and its
+        // headline counts were 11px `Fact` chips inside the sentence -- set
+        // smaller than the rows they frame. The lede stays prose.
+        cells={
+          factCells(
+            endpointFacts(
               summary as Parameters<typeof endpointFacts>[0],
               poolList.length,
               openIncidents.length,
               { count: formatNumber },
-            ).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
-          </FactSentence>
+            ),
+          ) ?? undefined
         }
         live={{
           updatedAt: summary?.observed_at ?? rows[0]?.lastChecked ?? null,
@@ -360,11 +365,12 @@ export function EndpointsPage() {
             link={RouterLink}
             source="endpoint"
             storageKey="mg-endpoints-columns"
+            expand={endpointDetail}
             loading={feed.isPending}
             search={{
               value: search.q,
               onChange: (q) => setSearch({ q }),
-              placeholder: "Provider, URL, kind or subnet",
+              placeholder: "Endpoint, provider or kind",
             }}
             filters={
               <>
@@ -413,14 +419,21 @@ export function EndpointsPage() {
           />
         }
         legend={
-          <LoadMore
-            hasMore={feed.hasNextPage}
-            isLoading={feed.isFetchingNextPage}
-            onLoadMore={() => void feed.fetchNextPage()}
-            shown={rows.length}
-            total={summary?.endpoint_count}
-            error={feed.error}
-          />
+          // Only while there IS more to fetch. The table states its own range
+          // and total in the pager ("1-50 of 1,545"), so a terminal
+          // "1545 of 1545 - end of list" strip directly beneath it was the
+          // same fact twice, in two vocabularies (#11696). An error still
+          // shows, because a feed that stopped early is not the end of a list.
+          feed.hasNextPage || feed.error ? (
+            <LoadMore
+              hasMore={feed.hasNextPage}
+              isLoading={feed.isFetchingNextPage}
+              onLoadMore={() => void feed.fetchNextPage()}
+              shown={rows.length}
+              total={summary?.endpoint_count}
+              error={feed.error}
+            />
+          ) : null
         }
         footnote={`${formatNumber(shown.length)} shown of ${formatNumber(
           summary?.endpoint_count ?? rows.length,
@@ -441,6 +454,7 @@ export function EndpointsPage() {
             link={RouterLink}
             source="endpoint-incident"
             storageKey="mg-incidents-columns"
+            expand={incidentDetail}
             loading={incidents.isPending}
             filters={
               <FilterField label="State">

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -122,7 +122,9 @@ export function GapsPage() {
       kind: "text",
       // The one prose cell in the app, and the only column that opts out of
       // the one-line default: the lane's own sentence about why a gap is
-      // expected is worth reading in full, not truncating (#11695).
+      // expected is worth reading. Two lines of it, capped -- unbounded, a
+      // 300-character note made its row 395px tall beside 56px neighbours
+      // (#11698). The whole sentence is under the row.
       wrap: true,
       value: (row) => row.note,
     },
@@ -205,6 +207,16 @@ export function GapsPage() {
             link={RouterLink}
             source="gap"
             storageKey="mg-contribute-columns"
+            expand={(row) =>
+              row.note ? (
+                <dl>
+                  <div className="mg-raw-row">
+                    <dt>Why it is open</dt>
+                    <dd>{row.note}</dd>
+                  </div>
+                </dl>
+              ) : null
+            }
             search={{
               value: search.q,
               onChange: (q) => setSearch({ q }),

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -5,7 +5,6 @@ import {
   AnalyticsSection,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   FilterField,
   FilterSelect,
@@ -15,6 +14,7 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -173,17 +173,16 @@ export function GapsPage() {
             Read the guide
           </RouterLink>
         }
-        sentence={
-          <FactSentence>
-            What is missing, in the order the registry ranks it.{" "}
-            {contributeFacts(rows, coverage.data?.data as Parameters<typeof contributeFacts>[1], {
+        sentence={<FactSentence>What is missing, in the order the registry ranks it.</FactSentence>}
+        // A STRIP, not chips (#11696). This page's subject is a table, and its
+        // headline counts were 11px `Fact` chips inside the sentence -- set
+        // smaller than the rows they frame. The lede stays prose.
+        cells={
+          factCells(
+            contributeFacts(rows, coverage.data?.data as Parameters<typeof contributeFacts>[1], {
               count: formatNumber,
-            }).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
-          </FactSentence>
+            }),
+          ) ?? undefined
         }
         live={{
           updatedAt: (gaps.meta?.generated_at as string | undefined) ?? null,

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -5,7 +5,6 @@ import {
   AnalyticsSection,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   FilterField,
   FilterSelect,
@@ -17,6 +16,7 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -223,18 +223,21 @@ export function HealthPage() {
         name="Health"
         sentence={
           <FactSentence>
-            What is broken, across every probed surface and this site itself.{" "}
-            {healthFacts(
+            What is broken, across every probed surface and this site itself.
+          </FactSentence>
+        }
+        // A STRIP, not chips (#11696). This page's subject is a table, and its
+        // headline counts were 11px `Fact` chips inside the sentence -- set
+        // smaller than the rows they frame. The lede stays prose.
+        cells={
+          factCells(
+            healthFacts(
               health.data.global as Parameters<typeof healthFacts>[0],
               openRows.length,
               (self.data?.data?.verdict as string | undefined) ?? null,
               { count: formatNumber },
-            ).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
-          </FactSentence>
+            ),
+          ) ?? undefined
         }
         live={{
           updatedAt: health.data.observed_at ?? null,

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -6,7 +6,6 @@ import {
   BrandIcon,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   FilterField,
   FilterSelect,
@@ -17,6 +16,7 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { HubSections } from "@/components/metagraphed/hub-prose";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
@@ -110,14 +110,7 @@ export function ProvidersPage() {
       width: 170,
       value: (row) => row.authority,
     },
-    {
-      key: "host",
-      label: "Host",
-      kind: "link",
-      value: (row) => row.host,
-      href: (row) => row.host ?? undefined,
-      format: (value) => (typeof value === "string" ? value.replace(/^https?:\/\//, "") : "—"),
-    },
+
     {
       key: "subnets",
       label: "Subnets",
@@ -147,18 +140,32 @@ export function ProvidersPage() {
       kind: "number",
       align: "right",
       width: 110,
-      demote: true,
       value: (row) => row.surfaces,
     },
-    {
-      key: "slug",
-      label: "Slug",
-      kind: "identifier",
-      width: 170,
-      demote: true,
-      value: (row) => row.slug,
-    },
   ];
+
+  /**
+   * The host and the slug, under the row.
+   *
+   * The host took 391px of a 1310px table on a 1118px card and pushed Sources
+   * off the right edge (#11696). It is a URL: something a reader copies or
+   * follows, not something they scan down a column -- and the provider's name
+   * in the lead cell already links to its page.
+   */
+  const providerDetail = (row: ProviderRow) => (
+    <dl>
+      {row.host ? (
+        <div className="mg-raw-row">
+          <dt>Host</dt>
+          <dd>{row.host}</dd>
+        </div>
+      ) : null}
+      <div className="mg-raw-row">
+        <dt>Slug</dt>
+        <dd>{row.slug}</dd>
+      </div>
+    </dl>
+  );
 
   const rawRows: RawRow[] = API_PATHS.map((path) => ({
     label: path.replace("/api/v1/", ""),
@@ -172,16 +179,17 @@ export function ProvidersPage() {
       <EntityHero
         name="Providers"
         sentence={
-          <FactSentence>
-            The teams and operators behind these public interfaces.{" "}
-            {providerFacts(rows, health.data?.data.summary, {
+          <FactSentence>The teams and operators behind these public interfaces.</FactSentence>
+        }
+        // A STRIP, not chips (#11696). This page's subject is a table, and its
+        // headline counts were 11px `Fact` chips inside the sentence -- set
+        // smaller than the rows they frame. The lede stays prose.
+        cells={
+          factCells(
+            providerFacts(rows, health.data?.data.summary, {
               count: formatNumber,
-            }).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
-          </FactSentence>
+            }),
+          ) ?? undefined
         }
         live={{
           // The payload's own timestamp, not a row's: /api/v1/providers
@@ -232,6 +240,7 @@ export function ProvidersPage() {
             link={RouterLink}
             source="provider"
             storageKey="mg-providers-columns"
+            expand={providerDetail}
             loading={false}
             // Every row, not a first page of fifty: the crawlable-index gate
             // reads the SERVER-RENDERED HTML and 138 provider pages are

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -92,7 +92,12 @@ export function ProvidersPage() {
       href: (row) => `/providers/${row.slug}`,
       render: (row) => (
         <span className="mg-dt-entity">
+          {/* 20px, the size every other table cell uses. `BrandIcon` defaults
+              to 32, which is the whole content box of a 56px row -- so a row
+              with a mark came out 63px tall against 57px for one without, and
+              the list rippled down the page (#11698). */}
           <BrandIcon
+            size={20}
             iconUrl={row.iconUrl}
             name={row.name}
             providerSlug={row.slug}

--- a/apps/ui/src/routes/-providers-slug-page.tsx
+++ b/apps/ui/src/routes/-providers-slug-page.tsx
@@ -5,7 +5,6 @@ import {
   BrandIcon,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   RankedRails,
   Raw,
@@ -13,22 +12,25 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatAbsoluteTime, formatNumber } from "@/lib/metagraphed/format";
 import {
   providerEndpointsQuery,
   providerQuery,
   surfacesInfiniteQuery,
 } from "@/lib/metagraphed/queries";
-import type { Endpoint, Surface } from "@/lib/metagraphed/types";
+import type { Endpoint } from "@/lib/metagraphed/types";
 import {
   endpointRails,
   hostOf,
   initials,
+  mergeSurfaceProbes,
   providerDetailFacts,
   providerSurfaces,
+  type ProviderSurfaceRow,
 } from "@/components/metagraphed/providers/providers-logic";
 import { Route } from "./providers.$slug";
 
@@ -77,38 +79,48 @@ export function ProviderDetail() {
     [surfaces.data],
   );
   const rails = useMemo(() => endpointRails(endpointList), [endpointList]);
+  const mergedSurfaces = useMemo(
+    () => mergeSurfaceProbes(surfaceList, endpointList),
+    [surfaceList, endpointList],
+  );
   const summary = provider?.endpoint_summary;
 
   const host =
     (typeof provider?.website === "string" ? provider.website : null) ??
     (typeof provider?.homepage === "string" ? provider.homepage : null);
 
-  const endpointColumns: DataTableColumn<Endpoint>[] = [
-    { key: "kind", label: "Kind", kind: "status", width: 150, value: (row) => row.kind ?? null },
+  /**
+   * ONE column set over the merged list.
+   *
+   * The name leads and links to the surface; the probe columns are filled for
+   * the surfaces the prober watches and em-dashed for the ones it does not.
+   * Two tables of the same 156 rows became one (#11696).
+   */
+  const surfaceColumns: DataTableColumn<ProviderSurfaceRow>[] = [
     {
-      key: "url",
-      label: "URL",
+      key: "name",
+      label: "Surface",
       kind: "link",
-      value: (row) => row.url ?? null,
+      width: 340,
+      value: (row) => row.name ?? hostOf(row.url) ?? null,
       href: (row) => row.url,
-      format: (value) => (typeof value === "string" ? value.replace(/^https?:\/\//, "") : "—"),
     },
+    { key: "kind", label: "Kind", kind: "status", width: 140, value: (row) => row.kind ?? null },
     {
       key: "subnet",
       label: "Subnet",
       kind: "link",
-      width: 110,
-      value: (row) => (typeof row.netuid === "number" ? (row.netuid as number) : null),
-      href: (row) =>
-        typeof row.netuid === "number" ? `/subnets/${row.netuid as number}` : undefined,
+      width: 100,
+      value: (row) => row.netuid ?? null,
+      href: (row) => (row.netuid == null ? undefined : `/subnets/${row.netuid}`),
       format: (value) => (typeof value === "number" ? `SN${value}` : "—"),
     },
     {
       key: "status",
       label: "Status",
       kind: "status",
-      width: 120,
-      value: (row) => (typeof row.status === "string" ? row.status : null),
+      width: 110,
+      value: (row) => row.probeStatus,
     },
     {
       key: "latency",
@@ -116,62 +128,39 @@ export function ProviderDetail() {
       kind: "number",
       align: "right",
       width: 100,
-      value: (row) => (typeof row.latency_ms === "number" ? row.latency_ms : null),
+      value: (row) => row.probeLatencyMs,
       format: (value) => (typeof value === "number" ? `${formatNumber(value)} ms` : "—"),
     },
-    {
-      key: "probed",
-      label: "Last probe",
-      kind: "time",
-      width: 130,
-      value: (row) => (typeof row.last_checked === "string" ? row.last_checked : null),
-    },
-    {
-      key: "ok",
-      label: "Last ok",
-      kind: "time",
-      width: 130,
-      demote: true,
-      value: (row) => (typeof row.last_ok === "string" ? row.last_ok : null),
-    },
-  ];
-
-  const surfaceColumns: DataTableColumn<Surface>[] = [
-    {
-      key: "subnet",
-      label: "Subnet",
-      kind: "link",
-      width: 110,
-      value: (row) => row.netuid ?? null,
-      href: (row) => (row.netuid == null ? undefined : `/subnets/${row.netuid}`),
-      format: (value) => (typeof value === "number" ? `SN${value}` : "—"),
-    },
-    { key: "kind", label: "Kind", kind: "status", width: 150, value: (row) => row.kind ?? null },
-    { key: "name", label: "Name", value: (row) => row.name ?? null },
-    {
-      key: "url",
-      label: "URL",
-      kind: "link",
-      value: (row) => row.url ?? null,
-      href: (row) => row.url,
-      format: (value) => (typeof value === "string" ? value.replace(/^https?:\/\//, "") : "—"),
-    },
+    { key: "probed", label: "Last probe", kind: "time", width: 120, value: (row) => row.probedAt },
     {
       key: "authority",
       label: "Authority",
       kind: "status",
-      width: 170,
+      width: 150,
       value: (row) => (typeof row.authority === "string" ? row.authority : null),
     },
-    {
-      key: "verified",
-      label: "Last verified",
-      kind: "time",
-      width: 130,
-      demote: true,
-      value: (row) => row.last_verified_at ?? null,
-    },
   ];
+
+  const surfaceDetail = (row: ProviderSurfaceRow) => (
+    <dl>
+      {row.url ? (
+        <div className="mg-raw-row">
+          <dt>URL</dt>
+          <dd>{row.url}</dd>
+        </div>
+      ) : null}
+      <div className="mg-raw-row">
+        <dt>Auth</dt>
+        <dd>
+          {row.auth_required == null ? "—" : row.auth_required ? "a key is required" : "open"}
+        </dd>
+      </div>
+      <div className="mg-raw-row">
+        <dt>Last verified</dt>
+        <dd>{row.last_verified_at ? formatAbsoluteTime(row.last_verified_at) : "not verified"}</dd>
+      </div>
+    </dl>
+  );
 
   const name = (typeof provider?.name === "string" && provider.name) || slug;
   const rawRows: RawRow[] = [
@@ -214,15 +203,19 @@ export function ProviderDetail() {
         sentence={
           <FactSentence>
             {typeof provider?.kind === "string" ? provider.kind : "provider"} at{" "}
-            {hostOf(host) ?? "no published host"}.{" "}
-            {providerDetailFacts(provider, summary, surfaceList.length, {
-              count: formatNumber,
-            }).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
+            {hostOf(host) ?? "no published host"}.
           </FactSentence>
+        }
+        // A STRIP, not chips (#11696). The sentence keeps the provider's
+        // IDENTITY -- what kind of operator, at which host -- and the counts
+        // move to cells, where a number that frames two tables is not set
+        // smaller than the tables' own rows.
+        cells={
+          factCells(
+            providerDetailFacts(provider, summary, surfaceList.length, {
+              count: formatNumber,
+            }),
+          ) ?? undefined
         }
         live={{
           updatedAt: (provider?.generated_at as string | undefined) ?? null,
@@ -253,51 +246,33 @@ export function ProviderDetail() {
       />
 
       <AnalyticsSection
-        id="endpoints"
-        name="Endpoints"
-        question="Everything this provider runs, and how it answered."
-        visual={
-          <DataTable
-            id="endpoints"
-            rows={endpointList}
-            columns={endpointColumns}
-            rowKey={(row) => row.id}
-            caption={`${name} endpoints`}
-            link={RouterLink}
-            source="provider-endpoint"
-            loading={endpoints.isPending}
-            paginate={false}
-            empty="No endpoints are registered for this provider."
-          />
-        }
-        footnote={
-          summary?.by_status
-            ? Object.entries(summary.by_status)
-                .map(([status, n]) => `${formatNumber(n)} ${status}`)
-                .join(" · ") + " · probe-derived"
-            : "probe-derived"
-        }
-      />
-
-      <AnalyticsSection
         id="surfaces"
         name="Surfaces"
-        question="What this provider publishes, per subnet."
+        question="Everything this provider publishes, and how it answered."
         visual={
           <DataTable
             id="surfaces"
-            rows={surfaceList}
+            rows={mergedSurfaces}
             columns={surfaceColumns}
             rowKey={(row) => row.id}
             caption={`${name} surfaces`}
             link={RouterLink}
             source="provider-surface"
-            loading={surfaces.isPending}
+            expand={surfaceDetail}
+            loading={surfaces.isPending || endpoints.isPending}
             paginate={false}
             empty="No surfaces are registered for this provider."
           />
         }
-        footnote={`${formatNumber(surfaceList.length)} surfaces · registry`}
+        footnote={
+          summary?.by_status
+            ? `${formatNumber(mergedSurfaces.length)} surfaces · ` +
+              Object.entries(summary.by_status)
+                .map(([status, n]) => `${formatNumber(n)} ${status}`)
+                .join(" · ") +
+              " · probe-derived"
+            : `${formatNumber(mergedSurfaces.length)} surfaces · registry`
+        }
       />
 
       <Raw rows={rawRows} />

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -5,7 +5,6 @@ import {
   AnalyticsSection,
   DataTable,
   EntityHero,
-  Fact,
   FactSentence,
   RankedRails,
   Raw,
@@ -14,6 +13,7 @@ import {
   type RawRow,
 } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { factCells } from "@/lib/metagraphed/facts";
 import { HubSections } from "@/components/metagraphed/hub-prose";
 import { RouterLink } from "@/components/metagraphed/router-link";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
@@ -182,13 +182,14 @@ export function SchemasPage() {
         name="Schemas"
         sentence={
           <FactSentence>
-            JSON Schema is the contract; drift is this capture against the last one.{" "}
-            {schemaFacts(summary, subnetsCovered, { count: formatNumber }).map((fact) => (
-              <Fact key={fact.key}>
-                {fact.label} {fact.value}
-              </Fact>
-            ))}
+            JSON Schema is the contract; drift is this capture against the last one.
           </FactSentence>
+        }
+        // A STRIP, not chips (#11696). This page's subject is a table, and its
+        // headline counts were 11px `Fact` chips inside the sentence -- set
+        // smaller than the rows they frame. The lede stays prose.
+        cells={
+          factCells(schemaFacts(summary, subnetsCovered, { count: formatNumber })) ?? undefined
         }
         live={{
           updatedAt: summary.observed_at,

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -208,9 +208,14 @@ export function ValidatorDetailPage() {
       definition: "Validator trust",
     },
     {
+      // In the menu, not the table. This operator holds a permit on all 116 of
+      // its memberships, and an operator without one on a subnet is the rare
+      // case -- a column that reads "yes" on every row is a column a reader
+      // learns to skip (#11696).
       key: "validator_permit",
       label: "Permit",
       kind: "status",
+      demote: true,
       value: (row) => (row.validator_permit ? "yes" : "no"),
     },
   ];

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -132,6 +132,9 @@ export function ValidatorsPage() {
       label: "Operator",
       kind: "text",
       sortable: true,
+      // Bounded, or an unusually long identity name widens the table past its
+      // card and takes Compare off the right edge (#11696).
+      width: 380,
       value: (row) => row.name,
       render: (row) => (
         <span className="mg-dt-entity">

--- a/apps/ui/tests/e2e/token-inventory.spec.ts
+++ b/apps/ui/tests/e2e/token-inventory.spec.ts
@@ -52,6 +52,8 @@ type Sweep = {
   repeatedMeasures: string[];
   /** Tables wider than the card they sit in (#11696). */
   wideTables: string[];
+  /** Peers laid out by one primitive whose heights disagree (#11698). */
+  raggedPeers: string[];
   textNodes: number;
 };
 
@@ -71,6 +73,7 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
   const repeatedLegends: string[] = [];
   const repeatedMeasures: string[] = [];
   const wideTables: string[] = [];
+  const raggedPeers: string[] = [];
   const deletedClasses: string[] = [];
   // Every class the v2 rebuild deleted. A page carrying one is either a stale
   // component that survived a rebase or a hand-rolled copy of a primitive; both
@@ -222,6 +225,44 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
         (values.size > 1 ? ` and they disagree: ${[...values].join(" / ")}` : ""),
     );
   }
+  // PEERS LAID OUT BY ONE PRIMITIVE ARE THE SAME HEIGHT.
+  //
+  // A `FactStrip` cell's label length is DATA, not design -- "Extrinsics
+  // 2026-08-22" carries a date, "Candidates awaiting review" is four words --
+  // so at 375px one card wrapped, the grid row stretched to the tallest, and
+  // the strip came out visibly ragged. Eighteen routes did it, and the
+  // instance a reader happened to notice was the eighteenth (#11698).
+  //
+  // Same shape wherever a primitive lays peers in a row or a grid: a table row
+  // whose one wrapping cell had 300 characters was 395px tall beside 56px
+  // neighbours. Four pixels of slack, because a border or a sub-pixel rounding
+  // difference is not raggedness.
+  const PEER_GROUPS: readonly (readonly [string, string])[] = [
+    [".mg-facts", ".mg-fact"],
+    [".mg-rank-grid", ".mg-rank-grid-row"],
+    [".mg-leaders", ".mg-leader"],
+    [".mg-rails-rows", ".mg-rails-row"],
+    [".mg-dt tbody", "tr"],
+  ];
+  for (const [parentSel, childSel] of PEER_GROUPS) {
+    for (const parent of root.querySelectorAll<HTMLElement>(parentSel)) {
+      // A table in CARDS mode stacks each row's cells as a label/value list,
+      // so a row with more to say is taller BY DESIGN -- that is the point of
+      // the mode. Only the grid form promises equal rows.
+      if (parent.closest('.mg-dt[data-mobile="cards"]')) continue;
+      const kids = [...parent.querySelectorAll<HTMLElement>(`:scope > ${childSel}`)];
+      if (kids.length < 3) continue;
+      const heights = kids.map((k) => Math.round(k.getBoundingClientRect().height));
+      const min = Math.min(...heights);
+      const max = Math.max(...heights);
+      if (max - min <= 4) continue;
+      const tallest = kids[heights.indexOf(max)];
+      raggedPeers.push(
+        `${parentSel} > ${childSel}: ${min}px to ${max}px across ${kids.length} — tallest is ` +
+          JSON.stringify((tallest?.textContent ?? "").replace(/\s+/g, " ").trim().slice(0, 48)),
+      );
+    }
+  }
   // A TABLE THAT FITS ITS CARD.
   //
   // Seven tables were wider than the card they sat in -- /apis/endpoints by
@@ -355,6 +396,7 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
     repeatedLegends,
     repeatedMeasures,
     wideTables,
+    raggedPeers,
     textNodes,
   };
 }
@@ -505,6 +547,15 @@ for (const route of ROUTES) {
             expect(
               s.wideTables,
               `a table wider than its card on ${route} (${viewport.name}, ${theme})`,
+            ).toEqual([]);
+          }
+
+          // Peers from one primitive at different heights: a strip of cards
+          // where one wrapped, a list where one row has more to say.
+          if (!(route in SPECIMEN_ROUTES)) {
+            expect(
+              s.raggedPeers,
+              `peers laid out by one primitive disagree on height on ${route} (${viewport.name}, ${theme})`,
             ).toEqual([]);
           }
 

--- a/apps/ui/tests/e2e/token-inventory.spec.ts
+++ b/apps/ui/tests/e2e/token-inventory.spec.ts
@@ -50,6 +50,8 @@ type Sweep = {
   repeatedLegends: string[];
   /** Measure labels the page states more than once (#11693). */
   repeatedMeasures: string[];
+  /** Tables wider than the card they sit in (#11696). */
+  wideTables: string[];
   textNodes: number;
 };
 
@@ -68,6 +70,7 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
   const stackedTables: string[] = [];
   const repeatedLegends: string[] = [];
   const repeatedMeasures: string[] = [];
+  const wideTables: string[] = [];
   const deletedClasses: string[] = [];
   // Every class the v2 rebuild deleted. A page carrying one is either a stale
   // component that survived a rebase or a hand-rolled copy of a primitive; both
@@ -219,6 +222,40 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
         (values.size > 1 ? ` and they disagree: ${[...values].join(" / ")}` : ""),
     );
   }
+  // A TABLE THAT FITS ITS CARD.
+  //
+  // Seven tables were wider than the card they sat in -- /apis/endpoints by
+  // 338px -- because a full URL took 390-711px of the row and the columns to
+  // its right went off the edge into a horizontal scroll nothing announced. A
+  // URL is something a reader copies, not something they compare down a
+  // column, so it belongs under the row (#11696).
+  //
+  // What this can still catch, now that `table-layout: fixed` stops CONTENT
+  // from widening a table: declared widths that sum past the card. Verified by
+  // injection -- widening one column to 900px reports
+  // "div#directory.mg-dt is 652px wider than its card", while putting the
+  // 711px URL column back does NOT, because fixed layout truncates it instead.
+  // That is the fix working, not a hole: the failure mode that remains is a
+  // column set declared wider than the space it has.
+  //
+  // A COLUMN THAT SAYS ONE THING is the other half of #11696 and is NOT
+  // asserted here. Constancy is a property of the data, not of the design:
+  // `Severity: warning` on all twelve incidents and `Subnet: SN51` on all 156
+  // of one provider's surfaces are true today and false after the next probe
+  // pass, so a gate on it goes red for reasons nobody chose. The columns that
+  // were constant BY CONSTRUCTION -- a capture timestamp shared by every row
+  // of one polled page, a permit column on a list of permit-holders -- are
+  // demoted at their definition instead, where the reason lives in a comment
+  // next to the code that made it true.
+  for (const table of root.querySelectorAll<HTMLElement>(".mg-dt")) {
+    const box = table.querySelector<HTMLElement>(".mg-dt-viewport");
+    const grid = table.querySelector<HTMLElement>("table");
+    if (!box || !grid) continue;
+    const over = Math.round(grid.getBoundingClientRect().width - box.getBoundingClientRect().width);
+    if (over > 2) {
+      wideTables.push(`${describeEl(table)} is ${over}px wider than its card`);
+    }
+  }
   for (const el of root.querySelectorAll<HTMLElement>("*")) {
     const cs = getComputedStyle(el);
     for (const cls of String(el.className || "").split(/\s+/)) {
@@ -317,6 +354,7 @@ function sweepMain([dotMax, contractRadiusPx]: [number, number]): Sweep {
     deletedClasses,
     repeatedLegends,
     repeatedMeasures,
+    wideTables,
     textNodes,
   };
 }
@@ -452,6 +490,21 @@ for (const route of ROUTES) {
             expect(
               s.repeatedMeasures,
               `the same measure stated twice on ${route} (${viewport.name}, ${theme})`,
+            ).toEqual([]);
+          }
+
+          // A table wider than its card: the reader loses the right-hand
+          // columns to a scroll nothing announces.
+          //
+          // DESKTOP ONLY. A seven-column table cannot fit a 375px phone or a
+          // 768px tablet, and scrolling one sideways there is the ordinary
+          // answer -- asserting it everywhere would be asserting that the
+          // table has no more than three columns. At the width the layout was
+          // designed for there is no such excuse.
+          if (!(route in SPECIMEN_ROUTES) && viewport.name === "desktop") {
+            expect(
+              s.wideTables,
+              `a table wider than its card on ${route} (${viewport.name}, ${theme})`,
             ).toEqual([]);
           }
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1925,7 +1925,7 @@ function FactCell({
   return /* @__PURE__ */ jsxRuntime.jsxs("div", { className: classNames("mg-fact", className), children: [
     /* @__PURE__ */ jsxRuntime.jsxs("dt", { children: [
       label,
-      typeof hint === "string" ? /* @__PURE__ */ jsxRuntime.jsx(Definition, { term: label, sentence: hint }) : null
+      /* @__PURE__ */ jsxRuntime.jsx(Definition, { term: label, sentence: hint })
     ] }),
     /* @__PURE__ */ jsxRuntime.jsxs("dd", { children: [
       /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mg-fact-value", children: value }),

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -2019,6 +2019,7 @@
   }
   .mg-dt table {
     width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
     font-size: 13px;
   }
@@ -2031,6 +2032,8 @@
     text-transform: uppercase;
     text-align: left;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: var(--ink-muted);
   }
   .mg-dt thead th[data-align=right] {
@@ -2077,6 +2080,8 @@
     color: var(--ink-muted);
     vertical-align: middle;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .mg-dt tbody td[data-align=right] {
     text-align: right;

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -557,21 +557,23 @@
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: minmax(0, 1fr);
+    gap: 12px;
     margin: 0;
-    border: 1px solid var(--rule);
-    border-radius: var(--radius);
-    overflow: hidden;
   }
   .mg-facts[data-variant=grid] {
     grid-auto-flow: row;
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   .mg-fact {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
     min-width: 0;
-    padding: 12px 16px;
-    border-left: 1px solid var(--rule);
-    border-top: 1px solid var(--rule);
-    margin: -1px 0 0 -1px;
+    padding: 16px;
+    border: 1px solid var(--rule);
+    border-radius: var(--radius);
+    background: var(--surface-card);
+    overflow: hidden;
   }
   .mg-fact dt {
     font-size: 11px;
@@ -582,7 +584,7 @@
     display: flex;
     align-items: baseline;
     gap: 8px;
-    margin: 2px 0 0;
+    margin: 0;
     min-width: 0;
   }
   .mg-fact-value {
@@ -620,7 +622,7 @@
     }
   }
   @media (max-width: 639px) {
-    .mg-facts,
+    .mg-facts:not([data-variant=grid]),
     .mg-facts[data-variant=grid] {
       grid-auto-flow: row;
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -573,12 +573,9 @@
     border: 1px solid var(--rule);
     border-radius: var(--radius);
     background: var(--surface-card);
-    overflow: hidden;
+    position: relative;
   }
   .mg-fact dt {
-    display: flex;
-    align-items: flex-start;
-    gap: 6px;
     min-height: calc(2 * 11px * 1.45);
     font-size: 11px;
     line-height: 1.45;

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -576,6 +576,10 @@
     overflow: hidden;
   }
   .mg-fact dt {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    min-height: calc(2 * 11px * 1.45);
     font-size: 11px;
     line-height: 1.45;
     color: var(--ink-muted);
@@ -1293,6 +1297,9 @@
     color: var(--ink);
     text-align: right;
     font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .mg-rails-row[data-active=true] .mg-rails-value {
     color: var(--accent-ink, var(--accent));
@@ -1864,6 +1871,10 @@
   .mg-dt-entity > :not(.truncate) {
     flex: none;
   }
+  .mg-dt-entity > :first-child:not(.truncate) {
+    max-width: 20px;
+    max-height: 20px;
+  }
   .mg-dt-tools {
     display: flex;
     flex-wrap: wrap;
@@ -2098,6 +2109,10 @@
   }
   .mg-dt tbody td[data-wrap=true] {
     white-space: normal;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
   }
   .mg-dt tbody tr:last-child td {
     border-bottom: 0;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1899,7 +1899,7 @@ function FactCell({
   return /* @__PURE__ */ jsxs("div", { className: classNames("mg-fact", className), children: [
     /* @__PURE__ */ jsxs("dt", { children: [
       label,
-      typeof hint === "string" ? /* @__PURE__ */ jsx(Definition, { term: label, sentence: hint }) : null
+      /* @__PURE__ */ jsx(Definition, { term: label, sentence: hint })
     ] }),
     /* @__PURE__ */ jsxs("dd", { children: [
       /* @__PURE__ */ jsx("span", { className: "mg-fact-value", children: value }),

--- a/packages/ui-kit/src/components/metagraphed/document/fact-strip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/document/fact-strip.tsx
@@ -3,6 +3,13 @@ import { classNames } from "@/lib/format";
 import { Definition } from "../interaction/definition";
 
 /**
+ * KEEP THE LABEL SHORT. The "?" carries the detail, so the label does not have
+ * to: "Candidates" over a tooltip that says "discovered surfaces queued for a
+ * human to accept or reject" beats "Candidates awaiting review", which wrapped
+ * to three lines in a 145px card on a phone while its neighbours took two, and
+ * made the strip ragged (#11698). Roughly seventeen characters fit one line at
+ * 375px, and the "?" takes a word's worth of the last one.
+ *
  * A single row of 2–6 bordered cells (#11607): label 11px muted, value 28px
  * mono 500 ink tabular, optional delta chip. Shared edges, no gap, 4px radius
  * on the outer box only. No icon, no sparkline, no per-cell "updated", no hint
@@ -65,8 +72,8 @@ export function FactStrip({
 }
 
 export interface FactCellProps extends FactCellData {
-  /** A one-sentence definition of the label, shown as a `Definition` beside it. */
-  hint?: ReactNode;
+  /** Overrides the glossary sentence for this label. */
+  hint?: string;
   className?: string;
 }
 
@@ -82,9 +89,13 @@ export function FactCell({
     <div className={classNames("mg-fact", className)}>
       <dt>
         {label}
-        {typeof hint === "string" ? (
-          <Definition term={label} sentence={hint} />
-        ) : null}
+        {/* The "?" appears wherever the GLOSSARY has a sentence for this
+            label -- no call site has to remember to ask for it, and adding a
+            definition is a one-line edit that lights up every card using that
+            label at once. `Definition` renders nothing for a term it has no
+            sentence for, so an undefined label is simply a card without a
+            help affordance rather than an empty button (#11698). */}
+        <Definition term={label} sentence={hint} />
       </dt>
       <dd>
         <span className="mg-fact-value">{value}</span>

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -829,7 +829,11 @@
     border: 1px solid var(--rule);
     border-radius: var(--radius);
     background: var(--surface-card);
-    overflow: hidden;
+    /* NOT `overflow: hidden`. The card is where a label's "?" opens its
+       definition, and a clipping card cut the tooltip off at its own bottom
+       edge (#11698). The long value inside clips itself -- see
+       `.mg-fact-value` -- so the card never needed to. */
+    position: relative;
   }
   /* TWO LINES RESERVED, always.
      A label's length is data, not design -- "Extrinsics 2026-08-22" carries a
@@ -840,9 +844,11 @@
      (#11698). Reserving the second line makes the strip a rectangle at every
      width, whatever the data says. */
   .mg-fact dt {
-    display: flex;
-    align-items: flex-start;
-    gap: 6px;
+    /* INLINE FLOW, not flex. The label's "?" is a sibling of the text, and as
+       a flex item it could not share a line with it -- the text got a narrower
+       box, wrapped to three lines where it had taken two, and the card went
+       ragged again for the same reason in a new place (#11698). Inline, the
+       "?" simply follows the last word. */
     min-height: calc(2 * 11px * 1.45);
     font-size: 11px;
     line-height: 1.45;

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -2399,8 +2399,15 @@
     max-height: var(--mg-list-viewport-max, 70vh);
     overscroll-behavior: contain;
   }
+  /* FIXED, so a declared column width is a width rather than a minimum.
+     Under `auto` the browser grows any column whose content is longer than its
+     `width:` hint, and one long identifier -- a 40-character surface id, a
+     provider name -- pushed the table 200-340px past its card and took the
+     right-hand columns off the edge with it (#11696). Fixed honours the
+     declaration and the cell truncates instead. */
   .mg-dt table {
     width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
     font-size: 13px;
   }
@@ -2413,6 +2420,8 @@
     text-transform: uppercase;
     text-align: left;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: var(--ink-muted);
   }
   .mg-dt thead th[data-align="right"] {
@@ -2466,6 +2475,8 @@
     color: var(--ink-muted);
     vertical-align: middle;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .mg-dt tbody td[data-align="right"] {
     text-align: right;

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -801,25 +801,35 @@
   }
 
   /* FactStrip: shared-edge cells, radius on the outer box only. */
+  /* SEPARATE CARDS, not one boxed strip.
+     The cells shared their edges and sat inside a single outer border, which
+     made a page's five headline numbers read as one blocky object rather than
+     as five things a reader can take one at a time (#11698). Each cell is its
+     own card now, on the elevation token the tables use, with a 12px gutter
+     between them.
+     Still `var(--radius)`: the site has ONE radius, and a 12px corner here
+     would be the second. */
   .mg-facts {
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: minmax(0, 1fr);
+    gap: 12px;
     margin: 0;
-    border: 1px solid var(--rule);
-    border-radius: var(--radius);
-    overflow: hidden;
   }
   .mg-facts[data-variant="grid"] {
     grid-auto-flow: row;
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   .mg-fact {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
     min-width: 0;
-    padding: 12px 16px;
-    border-left: 1px solid var(--rule);
-    border-top: 1px solid var(--rule);
-    margin: -1px 0 0 -1px;
+    padding: 16px;
+    border: 1px solid var(--rule);
+    border-radius: var(--radius);
+    background: var(--surface-card);
+    overflow: hidden;
   }
   .mg-fact dt {
     font-size: 11px;
@@ -830,7 +840,7 @@
     display: flex;
     align-items: baseline;
     gap: 8px;
-    margin: 2px 0 0;
+    margin: 0;
     min-width: 0;
   }
   .mg-fact-value {
@@ -868,7 +878,12 @@
     }
   }
   @media (max-width: 639px) {
-    .mg-facts,
+    /* `:not(...)` on both, so the two rules carry the SAME specificity and
+       source order decides. Without it the 1023px rule above -- (0,2,0)
+       against this one's (0,1,0) -- won at every width below 640 too, so a
+       phone got three columns rather than two and every value in them
+       truncated: "0.00…", "2.63…", "96/1…" (#11698). */
+    .mg-facts:not([data-variant="grid"]),
     .mg-facts[data-variant="grid"] {
       grid-auto-flow: row;
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -831,7 +831,19 @@
     background: var(--surface-card);
     overflow: hidden;
   }
+  /* TWO LINES RESERVED, always.
+     A label's length is data, not design -- "Extrinsics 2026-08-22" carries a
+     date, "Miners / Validators" is a pair, "Candidates awaiting review" is
+     four words -- so at 375px one card in a strip wrapped while its
+     neighbours did not, and the grid row stretched to the tallest, leaving
+     one card 16px taller than the five beside it. Eighteen routes did this
+     (#11698). Reserving the second line makes the strip a rectangle at every
+     width, whatever the data says. */
   .mg-fact dt {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    min-height: calc(2 * 11px * 1.45);
     font-size: 11px;
     line-height: 1.45;
     color: var(--ink-muted);
@@ -1607,6 +1619,12 @@
     color: var(--ink);
     text-align: right;
     font-variant-numeric: tabular-nums;
+    /* A formatted figure, never prose. At 375px "215 paths" wrapped in the
+       64px value column while "99 paths" did not, so one rail row came out
+       41px against its neighbours' 32 (#11698). */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .mg-rails-row[data-active="true"] .mg-rails-value {
     color: var(--accent-ink, var(--accent));
@@ -2231,6 +2249,15 @@
   .mg-dt-entity > :not(.truncate) {
     flex: none;
   }
+  /* A mark in a row is 20px, whatever the call site asked for. `BrandIcon`
+     defaults to 32 -- the entire content box of a 56px row -- so one forgotten
+     `size` made every row carrying a mark 6px taller than its neighbours
+     (#11698). The call sites pass 20; this is what stops the next one that
+     does not. */
+  .mg-dt-entity > :first-child:not(.truncate) {
+    max-width: 20px;
+    max-height: 20px;
+  }
   .mg-dt-tools {
     display: flex;
     flex-wrap: wrap;
@@ -2508,8 +2535,17 @@
   .mg-dt tbody td[data-demote="true"] {
     color: var(--ink-subtle);
   }
+  /* Wrapping is capped at two lines. Unbounded, one 300-character note made
+     its row 395px tall next to 56px neighbours -- a list whose row height is
+     set by whichever row has the most to say (#11698). The rest of the
+     sentence is under the row, where the disclosure already puts what does not
+     fit. */
   .mg-dt tbody td[data-wrap="true"] {
     white-space: normal;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
   }
 
   .mg-dt tbody tr:last-child td {


### PR DESCRIPTION
Closes #11696

## 1. Eleven routes stated their headline numbers in 11px chips

`FactStrip` — a row of bordered cells, 10px label over a 28px value — is this design system's page-level summary. **Eleven routes never used it.** Every one is a page whose subject is a table, and every one set the numbers that frame that table *smaller than the rows they introduce*:

```
tracked 1,545 · healthy of 112 probed 95% · RPC pools 5 · degraded now 6 · open incidents 12
```

is now five cards. The lede stays prose; the counts get cells. `/chain/blocks`, `/chain/events` and `/chain/extrinsics` change together through the shell all three share; `/apis`, `/apis/endpoints`, `/apis/providers`, `/apis/schemas`, `/health`, `/contribute`, `/agents` and `/providers/$slug` each at their own hero.

`factCells` does the conversion once, as a **switch rather than a cast** — `FactCells` is a 2-to-6 tuple, and `as unknown as FactCells` over an array compiles while telling the compiler something nobody checked.

The fact builders' labels were written for chips. They're cell labels now: sentence case, and the two that grew a count *into* the label move it into the value — `Healthy · 95% of 112` rather than a label whose length changes with the data.

## 2. Seven tables were wider than the card they sat in

Measured at 1280px:

| route · table | over |
| --- | --- |
| `/apis/endpoints` · Endpoints | **+338px** |
| `/providers/$slug` · surfaces | **+331** |
| `/apis` · catalog | **+282** |
| `/apis/providers` | +192 |
| `/chain/events` | +56 |
| `/validators` | +39 |

One cause every time: a **URL column taking 390–711px**, and on two of them a *second* identifier column beside it. The reader lost the right-hand columns to a scroll nothing announced.

A full URL is something you copy, not something you compare down a column. It's under the row now, in a disclosure that also carries what a reader checks once — pool eligibility, archive support, whether a key is required, last verified. **Four of those were `demote`d columns**: present in the ⋯ menu, invisible until someone went looking, and each one widening the table when turned on.

`.mg-dt table` is **`table-layout: fixed`**. Under `auto` a declared `width:` is a *minimum* — one 40-character surface id grew its column past the declaration and took the table with it, which is why bounding columns by hand hadn't been enough.

## 3. Two tables of the same 156 rows

`/providers/$slug` rendered **Endpoints** (Kind · URL · Subnet · Status · p50 · Last probe) and **Surfaces** (Subnet · Kind · Name · URL · Authority) — for a provider whose surfaces are all probed endpoints, the same list twice under two identities.

One table now. `mergeSurfaceProbes` joins on the **URL**, because `/endpoints` numbers a row `endpoint-srf-<hash>` while `/surfaces` numbers the same thing `sn-51-<provider>-<path>` — the ids never match, and the URL is what both records are *about*. A surface nobody probes keeps its probe fields `null`, not zero.

## 4. Columns that said one thing on every row

A capture timestamp is shared by every row of one polled page: `Observed` read `17h ago` on all 40 chain events, `Age` read `11d ago` on 50 consecutive blocks — blocks arrive 12s apart, so at any granularity a reader can read they're identical. Both demoted into the column menu. `Permit` on a validator's memberships likewise. Severity and State come off the incidents table into its row detail — **State was already the section's own filter *and* its footnote**.

## 5. Two footers under one list

`/apis`, `/apis/endpoints`, `/chain/*` and the account activity feed each rendered a `LoadMore` strip under a table that already paginates — `1545 of 1545 · end of list` directly beneath `1–50 of 1,545 · Previous 1 2 3 … 31 Next`. It renders only while there *is* more to fetch now, or when the feed errored.

## The gate, and what is deliberately not gated

`token-inventory` asserts no table is wider than its card, **at desktop only** — a seven-column table cannot fit a 375px phone, and scrolling one sideways there is the ordinary answer.

**Verified by injection:**
```
div#directory.mg-dt is 652px wider than its card
```
Putting the 711px URL column back does *not* fail it, because fixed layout truncates instead. That's the fix working, and the comment says so.

The other half of the issue is **deliberately not gated**. Whether a column reads one value on every row is a property of the *data*: `Severity: warning` on all twelve incidents and `Subnet: SN51` on all 156 of one provider's surfaces are true today and false after the next probe pass, so a gate on it goes red for reasons nobody chose. The columns constant *by construction* are demoted at their definition, where the reason lives next to the code that made it true.

## Gates

| Gate | Result |
| --- | --- |
| Playwright — overflow / interaction / token-inventory | **438 passed** |
| `vitest run --workspace=apps/ui` | 2,190 passed |
| `vitest run --workspace=packages/ui-kit` | 162 passed |
| `lint` · `format:check` · `typecheck` — both workspaces | clean |
| `validate:ui-route-coverage` · `unreferenced-exports` · `ui-docs-drift` · `double-assertions` | pass |
| `packages/ui-kit/dist` | rebuilt |