### PR TITLE
fix(publish): validate x402 payment challenges

### DIFF
--- a/scripts/smoke-live-api.ts
+++ b/scripts/smoke-live-api.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { API_ROUTES } from "../src/contracts.ts";
 import { MCP_TOOLS } from "../src/mcp-server.ts";
 import { QUERY_TIMEOUT_MS } from "../src/r2-sql.ts";
+import { X402_VERSION, x402RequiresPayment } from "../src/x402.ts";
 
 // Live production response bodies (API envelopes, MCP JSON-RPC results) --
 // every field below is read for assertion/reporting only, and an unexpected
@@ -59,10 +61,22 @@ async function runLiveSmoke(): Promise<void> {
   const fixtureSurfaceId =
     process.env.METAGRAPH_LIVE_FIXTURE_SURFACE_ID ||
     (await discoverFixtureSurfaceId());
-  const apiChecks = liveSmokeApiRoutes(fixtureSurfaceId).map((route) => ({
-    route: route.path,
-    url: apiRouteUrl(route.path, healthDate, { surfaceId: fixtureSurfaceId }),
-  }));
+  const apiChecks = [
+    ...liveSmokeApiRoutes(fixtureSurfaceId).map((route) => ({
+      expected: "public" as const,
+      route: route.path,
+      url: apiRouteUrl(route.path, healthDate, {
+        surfaceId: fixtureSurfaceId,
+      }),
+    })),
+    ...liveSmokePaymentRoutes(fixtureSurfaceId).map((route) => ({
+      expected: "payment" as const,
+      route: route.path,
+      url: apiRouteUrl(route.path, healthDate, {
+        surfaceId: fixtureSurfaceId,
+      }),
+    })),
+  ];
   const rawArtifactChecks = [
     "/metagraph/openapi.json",
     "/metagraph/r2-manifest.json",
@@ -84,6 +98,16 @@ async function runLiveSmoke(): Promise<void> {
   for (const check of apiChecks) {
     try {
       const result = await fetchJson(check.url);
+      if (check.expected === "payment") {
+        assertX402Challenge(check.route, check.url, result);
+        results.push({
+          path: new URL(check.url).pathname,
+          route: check.route,
+          status: result.status,
+          source: "x402-challenge",
+        });
+        continue;
+      }
       assert.equal(result.status, 200, `${check.route}: expected HTTP 200`);
       assertHeader(result, "access-control-allow-origin", "*", check.route);
       // AN ETAG IS REQUIRED OF CACHEABLE RESPONSES, not of all of them. A
@@ -650,11 +674,92 @@ export function liveSmokeApiRoutes(
   // Skipping rather than POSTing is deliberate. A smoke POST to a grounded-RAG
   // endpoint would invoke the AI binding on every publish, to assert response
   // properties that endpoint does not promise.
+  return liveSmokeGetRoutes(fixtureSurfaceId).filter(
+    (route) => !x402RequiresPayment(route.path),
+  );
+}
+
+/**
+ * GET routes that deliberately require payment from an anonymous caller.
+ *
+ * These still belong in the live publish smoke. They simply have a different
+ * success contract: a complete, actionable x402 challenge rather than the
+ * free route envelope asserted by `liveSmokeApiRoutes`.
+ */
+export function liveSmokePaymentRoutes(
+  fixtureSurfaceId: string | null = null,
+): Row[] {
+  return liveSmokeGetRoutes(fixtureSurfaceId).filter((route) =>
+    x402RequiresPayment(route.path),
+  );
+}
+
+function liveSmokeGetRoutes(fixtureSurfaceId: string | null): Row[] {
   return API_ROUTES.filter(
     (route) =>
       (route.method ?? "GET") === "GET" &&
       (route.id !== "fixture-detail" || fixtureSurfaceId) &&
       !CALLER_OWNED_ROUTE_IDS.has(route.id),
+  );
+}
+
+/** Validate the unpaid response from a route whose public contract is x402. */
+export function assertX402Challenge(
+  route: string,
+  url: string,
+  result: { body: Row; headers: Headers; status: number },
+): void {
+  assert.equal(result.status, 402, `${route}: expected HTTP 402`);
+  assertHeader(result, "access-control-allow-origin", "*", route);
+  assert.match(
+    result.headers.get("cache-control") || "",
+    /(?:^|,\s*)no-store(?:,|$)/i,
+    `${route}: x402 challenge must not be cached`,
+  );
+
+  const encoded = result.headers.get("payment-required");
+  assert.ok(encoded, `${route}: missing payment-required challenge header`);
+  const headerChallenge = JSON.parse(
+    Buffer.from(encoded, "base64").toString("utf8"),
+  ) as Row;
+  assert.deepEqual(
+    headerChallenge,
+    result.body,
+    `${route}: payment-required header and JSON body disagree`,
+  );
+
+  assert.equal(
+    result.body?.x402Version,
+    X402_VERSION,
+    `${route}: expected x402 v${X402_VERSION}`,
+  );
+  assert.equal(
+    result.body?.resource?.url,
+    url,
+    `${route}: challenge resource does not match the requested URL`,
+  );
+  assert.equal(
+    result.body?.resource?.mimeType,
+    "application/json",
+    `${route}: challenge resource must describe JSON`,
+  );
+
+  const accepts = result.body?.accepts;
+  assert.ok(
+    Array.isArray(accepts) && accepts.length > 0,
+    `${route}: challenge must offer at least one payment leg`,
+  );
+  assert.ok(
+    accepts.some(
+      (leg: Row) =>
+        typeof leg?.scheme === "string" &&
+        typeof leg?.network === "string" &&
+        /^[1-9]\d*$/.test(String(leg?.amount ?? "")) &&
+        typeof leg?.asset === "string" &&
+        typeof leg?.payTo === "string" &&
+        Number(leg?.maxTimeoutSeconds) > 0,
+    ),
+    `${route}: challenge has no actionable payment leg`,
   );
 }
 

--- a/tests/smoke-route-substitution.test.ts
+++ b/tests/smoke-route-substitution.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import { API_ROUTES } from "../src/contracts.ts";
 import {
   apiRouteUrl,
+  assertX402Challenge,
   fixtureSurfaceIdFromIndex,
   isTimeout,
   liveSmokeApiRoutes,
+  liveSmokePaymentRoutes,
   timeoutMs,
 } from "../scripts/smoke-live-api.ts";
 import { QUERY_TIMEOUT_MS } from "../src/r2-sql.ts";
@@ -111,6 +114,102 @@ describe("the live smoke set is GET-only (#9650)", () => {
       liveSmokeApiRoutes("7:subnet-api:new_v2").length < API_ROUTES.length,
       true,
       "the smoke set must be strictly smaller than the contract",
+    );
+  });
+});
+
+describe("payment-required routes stay in the live smoke (#11736)", () => {
+  const fixture = "7:subnet-api:new_v2";
+  const exportPath = "/api/v1/export/chain-events";
+
+  test("required-payment GETs are separated from the free 200 sweep", () => {
+    const publicRoutes = liveSmokeApiRoutes(fixture);
+    const paymentRoutes = liveSmokePaymentRoutes(fixture);
+    assert.equal(
+      publicRoutes.some((route) => route.path === exportPath),
+      false,
+    );
+    assert.equal(
+      paymentRoutes.some((route) => route.path === exportPath),
+      true,
+    );
+
+    const expected = API_ROUTES.filter(
+      (route) =>
+        (route.method ?? "GET") === "GET" &&
+        !["webhook-subscription", "alert-trigger"].includes(route.id),
+    )
+      .map((route) => route.id)
+      .sort();
+    const actual = [...publicRoutes, ...paymentRoutes]
+      .map((route) => route.id)
+      .sort();
+    assert.deepEqual(
+      actual,
+      expected,
+      "a GET route disappeared while the smoke set was partitioned",
+    );
+  });
+
+  test("accepts a complete production-shaped x402 challenge", () => {
+    const url = `https://api.metagraph.sh${exportPath}`;
+    const body = {
+      x402Version: 2,
+      error: "Payment required",
+      resource: {
+        url,
+        description: "metagraphed export call",
+        mimeType: "application/json",
+      },
+      accepts: [
+        {
+          scheme: "exact",
+          network: "eip155:84532",
+          amount: "24000",
+          asset: "0xasset",
+          payTo: "0xrecipient",
+          maxTimeoutSeconds: 60,
+        },
+      ],
+      extensions: {},
+    };
+    const headers = new Headers({
+      "access-control-allow-origin": "*",
+      "cache-control": "no-store",
+      "payment-required": Buffer.from(JSON.stringify(body)).toString("base64"),
+    });
+
+    assert.doesNotThrow(() =>
+      assertX402Challenge(exportPath, url, { body, headers, status: 402 }),
+    );
+  });
+
+  test("rejects a missing or malformed payment challenge", () => {
+    const url = `https://api.metagraph.sh${exportPath}`;
+    const body = {
+      x402Version: 2,
+      resource: { url, mimeType: "application/json" },
+      accepts: [],
+    };
+    const headers = new Headers({
+      "access-control-allow-origin": "*",
+      "cache-control": "no-store",
+    });
+
+    assert.throws(
+      () =>
+        assertX402Challenge(exportPath, url, { body, headers, status: 402 }),
+      /missing payment-required challenge header/,
+    );
+
+    headers.set(
+      "payment-required",
+      Buffer.from(JSON.stringify(body)).toString("base64"),
+    );
+    assert.throws(
+      () =>
+        assertX402Challenge(exportPath, url, { body, headers, status: 402 }),
+      /at least one payment leg/,
     );
   });
 });


### PR DESCRIPTION
## Summary

- keep payment-required GET routes in the live publish smoke
- validate their unpaid x402 challenge contract instead of requiring HTTP 200
- retain the existing HTTP 200 envelope checks for free public routes

## What Changed

- partitioned the generated GET route sweep by the route contract
- added strict checks for HTTP 402, CORS, no-store, payment-required header/body parity, x402 v2, matching resource URL, JSON content, and an actionable payment leg
- added coverage proving the two partitions still include every eligible GET route

## Registry Safety

- [x] Links a tracked, currently-open issue (Closes #11736).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. No public contract changed.

## Validation

- [x] npm run smoke:live against production: 215 API routes passed; the paid export was accepted as a valid x402 challenge
- [x] npx vitest run tests/smoke-route-substitution.test.ts: 234 tests passed
- [x] npm run test:coverage: 975 files, 22,385 tests passed, 11 skipped
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run format:check
- [x] npm run validate
- [x] git diff --check

Closes #11736