### PR TITLE
fix(ui): stabilize analytics loading geometry

### DIFF
--- a/apps/ui/src/components/metagraphed/apis/apis-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/apis/apis-logic.test.ts
@@ -3,11 +3,13 @@ import type { SchemaInfo, Surface } from "@/lib/metagraphed/types";
 import {
   apisNav,
   catalogFacts,
+  catalogHeadlineFacts,
   driftRails,
   facet,
   interfaceCoverage,
   kindSegments,
   schemaFacts,
+  schemaHeadlineFacts,
   schemaRows,
   schemaSummary,
   shortHash,
@@ -117,6 +119,27 @@ describe("catalogFacts", () => {
   it("omits what the response does not carry, and is empty with no response", () => {
     expect(catalogFacts({ surface_count: 5 }, 0, fmt).map((f) => f.key)).toEqual(["surfaces"]);
     expect(catalogFacts(null, 3, fmt)).toEqual([]);
+  });
+});
+
+describe("catalogHeadlineFacts", () => {
+  const labels = ["Surfaces", "Across subnets", "Coverage dimensions", "Probed", "First-party"];
+
+  it("keeps the same five slots while loading and on error", () => {
+    for (const state of ["pending", "error"] as const) {
+      const facts = catalogHeadlineFacts(undefined, 0, state, fmt);
+      expect(facts.map((fact) => fact.label)).toEqual(labels);
+      expect(facts.map((fact) => fact.value)).toEqual(["—", "—", "—", "—", "—"]);
+      expect(facts.map((fact) => fact.loading)).toEqual(
+        Array(5).fill(state === "pending" ? true : undefined),
+      );
+    }
+  });
+
+  it("fills a missing ready value without collapsing the strip", () => {
+    const facts = catalogHeadlineFacts({ surface_count: 5 }, 0, "ready", fmt);
+    expect(facts.map((fact) => fact.label)).toEqual(labels);
+    expect(facts.map((fact) => fact.value)).toEqual(["5", "—", "—", "—", "—"]);
   });
 });
 
@@ -261,6 +284,36 @@ describe("schemaFacts", () => {
 
   it("is empty with no summary", () => {
     expect(schemaFacts(null, 5, fmt)).toEqual([]);
+  });
+});
+
+describe("schemaHeadlineFacts", () => {
+  const labels = ["Tracked", "Captured", "Subnets", "Moved", "Not captured"];
+
+  it("keeps the same five slots while loading and on error", () => {
+    for (const state of ["pending", "error"] as const) {
+      const facts = schemaHeadlineFacts(undefined, 0, state, fmt);
+      expect(facts.map((fact) => fact.label)).toEqual(labels);
+      expect(facts.map((fact) => fact.value)).toEqual(["—", "—", "—", "—", "—"]);
+      expect(facts.map((fact) => fact.loading)).toEqual(
+        Array(5).fill(state === "pending" ? true : undefined),
+      );
+    }
+  });
+
+  it("uses the same ordered slots for settled data", () => {
+    const facts = schemaHeadlineFacts(
+      {
+        surface_count: 64,
+        by_status: { captured: 57 },
+        by_drift_status: { changed: 1, new: 1, "not-captured": 7 },
+      },
+      59,
+      "ready",
+      fmt,
+    );
+    expect(facts.map((fact) => fact.label)).toEqual(labels);
+    expect(facts.map((fact) => fact.value)).toEqual(["64", "57", "59", "2", "7"]);
   });
 });
 

--- a/apps/ui/src/components/metagraphed/apis/apis-logic.ts
+++ b/apps/ui/src/components/metagraphed/apis/apis-logic.ts
@@ -106,6 +106,49 @@ export interface Fact {
   key: string;
   label: string;
   value: string;
+  loading?: boolean;
+}
+
+export type HeadlineFactState = "pending" | "error" | "ready";
+
+const CATALOG_FACT_SLOTS = [
+  { key: "surfaces", label: "Surfaces" },
+  { key: "subnets", label: "Across subnets" },
+  { key: "interface-dimensions", label: "Coverage dimensions" },
+  { key: "probed", label: "Probed" },
+  { key: "official", label: "First-party" },
+] as const;
+
+const SCHEMA_FACT_SLOTS = [
+  { key: "tracked", label: "Tracked" },
+  { key: "captured", label: "Captured" },
+  { key: "subnets", label: "Subnets" },
+  { key: "moved", label: "Moved" },
+  { key: "missing", label: "Not captured" },
+] as const;
+
+/**
+ * Preserve the hero's information architecture while its values change.
+ *
+ * Inserting new fact cells after a cold query resolves moves every section
+ * below the hero. A stable set of semantic slots lets the loading and error
+ * states tell the truth with an em dash without changing the page geometry.
+ */
+function stableFactSlots(
+  slots: readonly { key: string; label: string }[],
+  facts: readonly Fact[],
+  state: HeadlineFactState,
+): Fact[] {
+  const byKey = new Map(facts.map((fact) => [fact.key, fact]));
+  return slots.map((slot) => {
+    const fact = state === "ready" ? byKey.get(slot.key) : undefined;
+    if (fact) return { ...fact, label: slot.label };
+    return {
+      ...slot,
+      value: "—",
+      ...(state === "pending" ? { loading: true } : {}),
+    };
+  });
 }
 
 /**
@@ -162,6 +205,20 @@ export function catalogFacts(
     });
   }
   return facts;
+}
+
+/** Five stable catalog hero slots across pending, error, and ready states. */
+export function catalogHeadlineFacts(
+  coverage: CoverageCounts | null | undefined,
+  interfaceDimensions: number,
+  state: HeadlineFactState,
+  fmt: { count: (n: number) => string },
+): Fact[] {
+  return stableFactSlots(
+    CATALOG_FACT_SLOTS,
+    catalogFacts(coverage, interfaceDimensions, fmt),
+    state,
+  );
 }
 
 export interface SchemaRow {
@@ -339,4 +396,14 @@ export function schemaFacts(
     facts.push({ key: "missing", label: "Not captured", value: fmt.count(drift["not-captured"]) });
   }
   return facts;
+}
+
+/** Five stable schema hero slots across pending, error, and ready states. */
+export function schemaHeadlineFacts(
+  summary: Parameters<typeof schemaFacts>[0],
+  subnetsCovered: number,
+  state: HeadlineFactState,
+  fmt: { count: (n: number) => string },
+): Fact[] {
+  return stableFactSlots(SCHEMA_FACT_SLOTS, schemaFacts(summary, subnetsCovered, fmt), state);
 }

--- a/apps/ui/src/routes/-apis-catalog-page.tsx
+++ b/apps/ui/src/routes/-apis-catalog-page.tsx
@@ -27,7 +27,11 @@ import { formatAbsoluteTime, formatNumber, formatPct } from "@/lib/metagraphed/f
 import { coverageQuery, surfacesInfiniteQuery } from "@/lib/metagraphed/queries";
 import type { Surface } from "@/lib/metagraphed/types";
 import type { CoverageCounts } from "@/components/metagraphed/apis/apis-logic";
-import { apisNav, catalogFacts, interfaceCoverage } from "@/components/metagraphed/apis/apis-logic";
+import {
+  apisNav,
+  catalogHeadlineFacts,
+  interfaceCoverage,
+} from "@/components/metagraphed/apis/apis-logic";
 import { matchesSurfaceFilters } from "@/lib/metagraphed/surface-filters";
 import { Route } from "./apis.index";
 
@@ -201,9 +205,12 @@ export function ApisCatalogPage() {
         // smaller than the rows they frame. The lede stays prose.
         cells={
           factCells(
-            catalogFacts(coverageData, coverageRows.length, {
-              count: formatNumber,
-            }),
+            catalogHeadlineFacts(
+              coverageData,
+              coverageRows.length,
+              coverage.isPending ? "pending" : coverage.isError ? "error" : "ready",
+              { count: formatNumber },
+            ),
           ) ?? undefined
         }
         live={{
@@ -232,7 +239,7 @@ export function ApisCatalogPage() {
               ariaLabel="Subnet coverage by public interface type"
               source="interface-coverage"
               loading
-              loadingRows={6}
+              loadingRows={7}
             />
           ) : coverage.isError ? (
             <ErrorState
@@ -268,13 +275,10 @@ export function ApisCatalogPage() {
           ) : null
         }
         empty={coverage.isPending ? false : "No public interface coverage is published."}
-        footnote={
-          coverage.isPending
-            ? "Loading published interface coverage · registry"
-            : coverage.isError
-              ? "Published interface coverage is temporarily unavailable · registry"
-              : "of all chain subnets · one subnet may publish more than one interface · registry"
-        }
+        // Methodology does not change with query state. Keeping this note
+        // stable also avoids replacing a short loading sentence with a
+        // two-line settled sentence after the rails resolve on mobile.
+        footnote="of all chain subnets · one subnet may publish more than one interface · registry"
       />
 
       <AnalyticsSection

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -23,7 +23,7 @@ import { schemasQuery } from "@/lib/metagraphed/queries";
 import {
   apisNav,
   driftRails,
-  schemaFacts,
+  schemaHeadlineFacts,
   schemaRows,
   schemaSummary,
   shortHash,
@@ -78,14 +78,12 @@ export function SchemasPage() {
   );
   const driftShown = showAllDrift ? rows : rows.filter((row) => row.drift !== "unchanged");
   const headlineFacts = useMemo(() => {
-    if (schemas.isPending) {
-      return [
-        { key: "tracked", label: "Tracked", value: "—", loading: true },
-        { key: "moved", label: "Moved", value: "—", loading: true },
-      ];
-    }
-    if (schemas.isError) return [];
-    return schemaFacts(summary, subnetsCovered, { count: formatNumber });
+    return schemaHeadlineFacts(
+      summary,
+      subnetsCovered,
+      schemas.isPending ? "pending" : schemas.isError ? "error" : "ready",
+      { count: formatNumber },
+    );
   }, [schemas.isError, schemas.isPending, subnetsCovered, summary]);
 
   const columns: DataTableColumn<SchemaRow>[] = [

--- a/apps/ui/tests/e2e/api-directory-state.spec.ts
+++ b/apps/ui/tests/e2e/api-directory-state.spec.ts
@@ -8,6 +8,73 @@ const DELAYED_READS = [
 ];
 
 test.describe("API directory query states", () => {
+  test("keeps the catalog hero and coverage geometry stable while coverage resolves", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.emulateMedia({ colorScheme: "dark", reducedMotion: "reduce" });
+
+    let release: (() => void) | undefined;
+    const continueRead = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route("**/api/v1/coverage*", async (route) => {
+      await continueRead;
+      await route.continue();
+    });
+
+    await gotoThroughRestart(page, "/apis");
+    await page.evaluate(() => document.fonts.ready);
+
+    const hero = page.locator(".mg-hero").first();
+    const coverage = page.getByRole("group", {
+      name: "Subnet coverage by public interface type",
+    });
+    const catalog = page.locator("section#catalog");
+    await expect(hero.locator(".mg-fact")).toHaveCount(5);
+    await expect(hero.locator(".mg-fact dt")).toHaveText([
+      "Surfaces",
+      "Across subnets",
+      "Coverage dimensions",
+      "Probed",
+      "First-party",
+    ]);
+    await expect(hero.locator(".mg-fact-loading")).toHaveCount(5);
+    await expect(coverage.locator(".mg-rails-row--skeleton")).toHaveCount(7);
+    const coverageLayoutBefore = await page.locator("section#coverage").evaluate((section) => ({
+      height: section.getBoundingClientRect().height,
+      head: section.querySelector(".mg-rails-head")?.getBoundingClientRect().height,
+      rows: Array.from(
+        section.querySelectorAll(".mg-rails-row"),
+        (row) => row.getBoundingClientRect().height,
+      ),
+      footnote: section.querySelector(".mg-section-note")?.getBoundingClientRect().height,
+    }));
+    const catalogTopBefore = await catalog.evaluate(
+      (element) => element.getBoundingClientRect().top + window.scrollY,
+    );
+
+    release?.();
+    await expect(hero.locator(".mg-fact-loading")).toHaveCount(0);
+    await expect(coverage).not.toHaveAttribute("aria-busy", "true");
+    const coverageLayoutAfter = await page.locator("section#coverage").evaluate((section) => ({
+      height: section.getBoundingClientRect().height,
+      head: section.querySelector(".mg-rails-head")?.getBoundingClientRect().height,
+      rows: Array.from(
+        section.querySelectorAll(".mg-rails-row"),
+        (row) => row.getBoundingClientRect().height,
+      ),
+      footnote: section.querySelector(".mg-section-note")?.getBoundingClientRect().height,
+    }));
+    const catalogTopAfter = await catalog.evaluate(
+      (element) => element.getBoundingClientRect().top + window.scrollY,
+    );
+    expect(
+      Math.abs(catalogTopAfter - catalogTopBefore),
+      JSON.stringify({ coverageLayoutBefore, coverageLayoutAfter }),
+    ).toBeLessThanOrEqual(1);
+  });
+
   test("starts the catalog page only when a reader reaches its rows", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
 
@@ -158,6 +225,9 @@ test.describe("API directory query states", () => {
     await gotoThroughRestart(page, "/apis");
 
     await expect(page.getByText("Couldn't load published interface coverage")).toBeVisible();
+    const hero = page.locator(".mg-hero").first();
+    await expect(hero.locator(".mg-fact")).toHaveCount(5);
+    await expect(hero.locator(".mg-fact-loading")).toHaveCount(0);
     await page.locator("section#catalog").scrollIntoViewIfNeeded();
     await expect(page.getByText("Couldn't load verified interfaces")).toBeVisible();
     await expect(page.getByText("No public interface coverage is published.")).toHaveCount(0);

--- a/apps/ui/tests/e2e/schemas-state.spec.ts
+++ b/apps/ui/tests/e2e/schemas-state.spec.ts
@@ -6,6 +6,7 @@ test.describe("Schema capture query state", () => {
     page,
   }) => {
     await page.setViewportSize({ width: 375, height: 812 });
+    await page.emulateMedia({ colorScheme: "dark", reducedMotion: "reduce" });
 
     let release: (() => void) | undefined;
     const continueRead = new Promise<void>((resolve) => {
@@ -17,7 +18,9 @@ test.describe("Schema capture query state", () => {
     });
 
     await gotoThroughRestart(page, "/apis/schemas");
+    await page.evaluate(() => document.fonts.ready);
 
+    const hero = page.locator(".mg-hero").first();
     const drift = page.getByRole("group", {
       name: "Schemas that changed since the last capture",
     });
@@ -29,12 +32,21 @@ test.describe("Schema capture query state", () => {
     await expect(drift.locator(".mg-rails-row--skeleton")).toHaveCount(10);
     await expect(size.locator(".mg-rails-row--skeleton")).toHaveCount(10);
     await expect(table.locator(".mg-dt-skeleton")).toHaveCount(8);
+    await expect(hero.locator(".mg-fact")).toHaveCount(5);
+    await expect(hero.locator(".mg-fact dt")).toHaveText([
+      "Tracked",
+      "Captured",
+      "Subnets",
+      "Moved?",
+      "Not captured?",
+    ]);
+    await expect(hero.locator(".mg-fact-loading")).toHaveCount(5);
     await expect(page.getByText("Loading schema captures · snapshot")).toBeVisible();
     await expect(page.getByText("Loading captured schemas · snapshot")).toBeVisible();
     await expect(page.getByText("Show all 0")).toHaveCount(0);
-    await expect(page.getByText("Tracked").locator("..").locator(".mg-fact-loading")).toHaveCount(
-      1,
-    );
+    const driftTopBefore = await page
+      .locator("section#drift")
+      .evaluate((element) => element.getBoundingClientRect().top + window.scrollY);
 
     const dimensions = await page.evaluate(() => ({
       document: document.documentElement.scrollWidth,
@@ -43,8 +55,13 @@ test.describe("Schema capture query state", () => {
     expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
 
     release?.();
+    await expect(hero.locator(".mg-fact-loading")).toHaveCount(0);
     await expect(drift).not.toHaveAttribute("aria-busy", "true");
     await expect(size).not.toHaveAttribute("aria-busy", "true");
     await expect(table.locator(".mg-dt-skeleton")).toHaveCount(0);
+    const driftTopAfter = await page
+      .locator("section#drift")
+      .evaluate((element) => element.getBoundingClientRect().top + window.scrollY);
+    expect(Math.abs(driftTopAfter - driftTopBefore)).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -3061,6 +3061,9 @@
     cursor: default;
     pointer-events: none;
   }
+  .mg-rails-row--skeleton .mg-rails-name {
+    min-height: 1lh;
+  }
   .mg-rails-value {
     font-size: 11px;
     font-weight: 600;

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -3578,6 +3578,13 @@
     cursor: default;
     pointer-events: none;
   }
+  /* The settled name occupies one text line. The loading name used a 12px
+     skeleton instead, making every mobile rail row 4.5px shorter and moving
+     the rest of the page when a ranked list resolved. Reserve the inherited
+     line box; desktop rows remain pinned to their explicit 28px height. */
+  .mg-rails-row--skeleton .mg-rails-name {
+    min-height: 1lh;
+  }
   .mg-rails-value {
     font-size: 11px;
     font-weight: 600;


### PR DESCRIPTION
## Summary

- keep the API catalog and schema headline facts in five stable semantic slots across pending, error, partial, and settled data
- make mobile ranked-rail skeleton rows match settled line geometry and keep the API coverage methodology note stable
- reserve the seven published coverage dimensions and add deterministic dark-mode, reduced-motion geometry assertions
- verify error states retain truthful em-dash facts without loading treatment

## Measured result

At 375px, delayed production-worker fixture reads now leave the next section at the same document position before and after settlement (within the 1px test tolerance). The prior production measurements were approximately 0.23 CLS on `/apis` and 0.10 on `/apis/schemas`.

## Validation

- UI unit tests: 2,302 passed
- UI-kit unit tests: 181 passed
- full production-worker Playwright suite: 577 passed
- responsive API-route sweep: 16 passed at 375, 768, 1024, and 1280px
- UI and UI-kit typecheck, lint, and format checks passed
- Cloudflare production Worker build passed
- maintainer-directed screenshot attachment waiver applied; rendered responsive and interaction validation retained

Closes #11738