### PR TITLE
perf(ui): skip unused analytics extensions

### DIFF
--- a/apps/ui/docs/sitewide-ux-audit.md
+++ b/apps/ui/docs/sitewide-ux-audit.md
@@ -420,6 +420,12 @@ Performance is part of the product contract, not a polish pass after visual work
 21. The subnet directory no longer probes arbitrary remote website/repository URLs through the icon
     proxy. Only curated icon evidence is rendered, eliminating the measured 404 fan-out while
     retaining deterministic monogram fallbacks.
+22. The browser analytics client now explicitly disables surveys, product tours, and conversations,
+    which have no application surface. Before this source change, a fresh production 375px homepage
+    read requested `surveys.js` despite all three project surveys being archived: 36,563 compressed
+    bytes and 102,609 decoded bytes. Replay, exception capture, Web Vitals, dead-click telemetry, and
+    feature flags remain enabled. Confirm the missing survey request after deployment; the current
+    numbers are the live baseline, not post-change production proof.
 
 ## Completion proof
 

--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -190,6 +190,17 @@ describe("analytics (PostHog web analytics)", () => {
       expect(options.capture_performance).toEqual({ web_vitals: true });
     });
 
+    it("disables unused interactive extension runtimes", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const { initAnalytics } = await import("./analytics");
+      initAnalytics();
+      await vi.waitFor(() => expect(init).toHaveBeenCalled());
+      const options = init.mock.calls[0][1];
+      expect(options.disable_surveys).toBe(true);
+      expect(options.disable_product_tours).toBe(true);
+      expect(options.disable_conversations).toBe(true);
+    });
+
     it("configures session replay with input/text masking and a conservative sample rate", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
       const { initAnalytics } = await import("./analytics");

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -166,6 +166,18 @@ function loadPostHog(): Promise<PostHog | null> {
         api_host: POSTHOG_API_HOST,
         ui_host: POSTHOG_UI_HOST,
         defaults: SDK_DEFAULTS_DATE,
+        // These remotely activatable UI products have no application surface.
+        // Leaving the SDK defaults in control still made a fresh configured
+        // page download surveys.js even though every project survey is
+        // archived (measured at 36,563 compressed / 102,609 decoded bytes on
+        // the production 375px homepage, #11744). Tours and conversations are
+        // disabled alongside it so a dashboard toggle cannot inject an
+        // unreviewed interface or a new runtime into the explorer. Feature
+        // flags, replay, exception capture, Web Vitals, and dead-click
+        // telemetry are independent and remain enabled.
+        disable_surveys: true,
+        disable_product_tours: true,
+        disable_conversations: true,
         // Landing directly on a blocked route must never start a recording
         // in the first place -- stopping one after init would already have
         // captured the first frames. SPA navigations are handled by


### PR DESCRIPTION
## Summary

- disable the unused survey, product-tour, and conversations browser extensions explicitly
- preserve page analytics, feature flags, sampled replay, exceptions, Web Vitals, and dead-click telemetry
- add analytics configuration regression coverage
- record the measured production baseline and the post-deployment verification boundary

## Evidence

A fresh 375px production homepage load requested `surveys.js` at 36,563 compressed bytes / 102,609 decoded bytes. The configured project contains three surveys and all three are archived; the application has no survey, tour, or conversations surface.

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm run format:check --workspace=apps/ui`
- `npm test --workspace=apps/ui` (2,303 tests)
- `npm run build:worker --workspace=apps/ui`

Closes #11744