### PR TITLE
fix(ui): prefer exact provider thumbnails

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -719,8 +719,8 @@ function buildCandidateChain({
     if (!out.includes(safe)) out.push(safe);
   };
   const primary = pickIconSource(iconUrl, theme);
-  push(providerDisplayLogoUrl(lookup?.providerSlug, primary, size));
   push(firstPartyDisplayLogoUrl(primary, size));
+  push(providerDisplayLogoUrl(lookup?.providerSlug, primary, size));
   push(primary);
   if (lookup) {
     const override = resolveBrandOverride(lookup, theme);

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -693,8 +693,8 @@ function buildCandidateChain({
     if (!out.includes(safe)) out.push(safe);
   };
   const primary = pickIconSource(iconUrl, theme);
-  push(providerDisplayLogoUrl(lookup?.providerSlug, primary, size));
   push(firstPartyDisplayLogoUrl(primary, size));
+  push(providerDisplayLogoUrl(lookup?.providerSlug, primary, size));
   push(primary);
   if (lookup) {
     const override = resolveBrandOverride(lookup, theme);

--- a/packages/ui-kit/src/components/metagraphed/brand-icon.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/brand-icon.test.ts
@@ -84,4 +84,19 @@ describe("providerDisplayLogoUrl", () => {
     );
     expect(html).toContain('src="/logos/display/actual-computer.webp"');
   });
+
+  it("prefers an exact cached derivative over a speculative provider-slug path", () => {
+    const hash =
+      "3c51fd4083332f8a4b32b2af7793b7481e9774ec8e26d40857d72a7d46a15704";
+    const html = renderToStaticMarkup(
+      h(BrandIcon, {
+        iconUrl: `https://metagraph.sh/logos/cache/${hash}.jpg`,
+        name: "ByteLeap",
+        providerSlug: "byteleap",
+        size: 20,
+      }),
+    );
+    expect(html).toContain(`src="/logos/display/cache/${hash}.webp"`);
+    expect(html).not.toContain("/logos/display/byteleap.webp");
+  });
 });

--- a/packages/ui-kit/src/components/metagraphed/brand-icon.tsx
+++ b/packages/ui-kit/src/components/metagraphed/brand-icon.tsx
@@ -245,8 +245,13 @@ function buildCandidateChain({
   };
 
   const primary = pickIconSource(iconUrl, theme);
-  push(providerDisplayLogoUrl(lookup?.providerSlug, primary, size));
+  // An exact first-party source path proves its derivative exists because the
+  // thumbnail manifest is generated from that source tree. Prefer it over the
+  // provider-slug inference, which is only needed when a remote registry mark
+  // has a separately committed local thumbnail. This avoids a speculative 404
+  // for providers whose first-party mark lives under /logos/cache/.
   push(firstPartyDisplayLogoUrl(primary, size));
+  push(providerDisplayLogoUrl(lookup?.providerSlug, primary, size));
   push(primary);
   if (lookup) {
     const override = resolveBrandOverride(lookup, theme);


### PR DESCRIPTION
Closes #11752

## Summary
- prefer the exact source-derived first-party display asset before provider-slug inference
- retain slug-based optimized thumbnails for remote provider marks
- add regression coverage and rebuild committed UI-kit artifacts

## Validation
- `npm run test --workspace=@metagraphed/ui-kit` — 188 tests
- `npm run test --workspace=apps/ui` — 2,350 tests
- UI-kit and app typecheck/lint; app format check
- production Worker build and E2E Worker build
- provider interaction E2E — 4 tests
- live provider asset audit — 102/102 expected first-choice display assets available