### PR TITLE
fix(ui): recover newest block details

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-detail/block-detail-retry.test.ts
+++ b/apps/ui/src/components/metagraphed/chain-detail/block-detail-retry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/metagraphed/client";
+import {
+  BLOCK_DETAIL_RETRY_COUNT,
+  BLOCK_DETAIL_RETRY_DELAYS_MS,
+  blockDetailRetryDelay,
+  isBlockDetailUnavailable,
+  shouldRetryBlockDetail,
+} from "./block-detail-retry";
+
+const pending = new ApiError("coverage gap", {
+  status: 503,
+  code: "block_detail_unavailable",
+  url: "https://api.example.test/api/v1/blocks/42/extrinsics",
+});
+
+describe("newest block detail retry", () => {
+  it("recognizes only the API's explicit temporary coverage state", () => {
+    expect(isBlockDetailUnavailable(pending)).toBe(true);
+    expect(
+      isBlockDetailUnavailable(
+        new ApiError("service unavailable", {
+          status: 503,
+          code: "data_tier_unavailable",
+          url: "https://api.example.test/api/v1/blocks/42/extrinsics",
+        }),
+      ),
+    ).toBe(false);
+    expect(isBlockDetailUnavailable(new Error("coverage gap"))).toBe(false);
+  });
+
+  it("spends a bounded browser retry budget and never amplifies SSR", () => {
+    expect(shouldRetryBlockDetail(0, pending, true)).toBe(true);
+    expect(shouldRetryBlockDetail(BLOCK_DETAIL_RETRY_COUNT - 1, pending, true)).toBe(true);
+    expect(shouldRetryBlockDetail(BLOCK_DETAIL_RETRY_COUNT, pending, true)).toBe(false);
+    expect(shouldRetryBlockDetail(0, pending, false)).toBe(false);
+  });
+
+  it("does not retry unrelated failures even when their status is also 503", () => {
+    const unrelated = new ApiError("upstream unavailable", {
+      status: 503,
+      code: "upstream_unavailable",
+      url: "https://api.example.test/api/v1/blocks/42/extrinsics",
+    });
+    expect(shouldRetryBlockDetail(0, unrelated, true)).toBe(false);
+  });
+
+  it("backs off across the measured handoff window and caps later indexes", () => {
+    expect(BLOCK_DETAIL_RETRY_DELAYS_MS.reduce((sum, delay) => sum + delay, 0)).toBe(32_000);
+    expect(BLOCK_DETAIL_RETRY_DELAYS_MS.map((_, index) => blockDetailRetryDelay(index))).toEqual(
+      BLOCK_DETAIL_RETRY_DELAYS_MS,
+    );
+    expect(blockDetailRetryDelay(-1)).toBe(1_000);
+    expect(blockDetailRetryDelay(99)).toBe(10_000);
+  });
+});

--- a/apps/ui/src/components/metagraphed/chain-detail/block-detail-retry.ts
+++ b/apps/ui/src/components/metagraphed/chain-detail/block-detail-retry.ts
@@ -1,0 +1,30 @@
+import { ApiError } from "@/lib/metagraphed/client";
+
+// A current production observation took 26.79 seconds for a newly visible
+// block to move into the decoded-detail window (#11758). Six deliberately
+// spaced reads cover that normal handoff without turning a real coverage gap
+// into an unbounded polling loop.
+export const BLOCK_DETAIL_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 7_000, 8_000, 10_000] as const;
+export const BLOCK_DETAIL_RETRY_COUNT = BLOCK_DETAIL_RETRY_DELAYS_MS.length;
+
+export function isBlockDetailUnavailable(error: unknown): error is ApiError {
+  return error instanceof ApiError && error.code === "block_detail_unavailable";
+}
+
+export function shouldRetryBlockDetail(
+  failureCount: number,
+  error: unknown,
+  client = typeof window !== "undefined",
+): boolean {
+  // Keep SSR to one upstream read. The browser owns this recovery because it
+  // can preserve the rendered block while the index catches up.
+  return client && isBlockDetailUnavailable(error) && failureCount < BLOCK_DETAIL_RETRY_COUNT;
+}
+
+export function blockDetailRetryDelay(attemptIndex: number): number {
+  const index = Math.min(
+    Math.max(0, Math.floor(attemptIndex)),
+    BLOCK_DETAIL_RETRY_DELAYS_MS.length - 1,
+  );
+  return BLOCK_DETAIL_RETRY_DELAYS_MS[index]!;
+}

--- a/apps/ui/src/components/metagraphed/states.test.tsx
+++ b/apps/ui/src/components/metagraphed/states.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { ApiError } from "@/lib/metagraphed/client";
-import { ErrorState } from "./states";
+import { BlockDetailCatchupStatus, ErrorState } from "./states";
 
 describe("ErrorState", () => {
   it("keeps a block-detail coverage gap distinct from an empty or generic error", () => {
@@ -25,5 +25,18 @@ describe("ErrorState", () => {
     expect(html).toContain("not an empty block");
     expect(html).toContain("Retry");
     expect(html).not.toContain("Couldn't load block extrinsics");
+  });
+
+  it("announces a bounded automatic newest-block recovery without calling it an error", () => {
+    const html = renderToStaticMarkup(
+      <BlockDetailCatchupStatus detail="extrinsics" attempt={2} total={6} />,
+    );
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain("Decoding this new block");
+    expect(html).toContain("decoded extrinsics are catching up");
+    expect(html).toContain("Attempt 2 of 6");
+    expect(html).not.toContain('role="alert"');
   });
 });

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -80,6 +80,44 @@ function BlockDetailUnavailableNotice({
   );
 }
 
+export function BlockDetailCatchupStatus({
+  detail,
+  attempt,
+  total,
+}: {
+  detail: string;
+  attempt: number;
+  total: number;
+}) {
+  const shownAttempt = Math.min(Math.max(1, attempt), total);
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Decoded block detail is catching up"
+      className="rounded border border-border bg-surface p-3"
+    >
+      <div className="flex items-start gap-3">
+        <Hourglass
+          aria-hidden
+          className="size-4 shrink-0 text-ink-muted motion-safe:animate-pulse"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="font-display text-13 font-medium text-ink-strong">
+            Decoding this new block
+          </div>
+          <p className="mt-1 text-13 leading-relaxed text-ink-muted">
+            The block is live. Its decoded {detail} are catching up and will refresh automatically.
+            <span className="ml-1 whitespace-nowrap tabular-nums">
+              Attempt {shownAttempt} of {total}.
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /**
  * #8384: shown instead of a red error card when a request fails because the
  * visitor is genuinely offline (apiFetch's own catch turns a rejected fetch

--- a/apps/ui/src/routes/-block-detail-page.test.ts
+++ b/apps/ui/src/routes/-block-detail-page.test.ts
@@ -60,4 +60,13 @@ describe("block detail loading contract", () => {
     expect(page).toContain('empty="No decoded events for this block."');
     expect(extrinsicPage).toContain('empty="No events are decoded for this extrinsic."');
   });
+
+  it("self-heals only the explicit newest-block detail handoff", () => {
+    expect(page).toContain("retry: shouldRetryBlockDetail");
+    expect(page).toContain("retryDelay: blockDetailRetryDelay");
+    expect(page).toContain("isBlockDetailUnavailable(extrinsics.failureReason)");
+    expect(page).toContain("isBlockDetailUnavailable(events.failureReason)");
+    expect(page).toContain("<BlockDetailCatchupStatus");
+    expect(page).toContain("total={BLOCK_DETAIL_RETRY_COUNT}");
+  });
 });

--- a/apps/ui/src/routes/-block-detail-page.tsx
+++ b/apps/ui/src/routes/-block-detail-page.tsx
@@ -19,7 +19,7 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { RouterLink } from "@/components/metagraphed/router-link";
-import { ErrorState } from "@/components/metagraphed/states";
+import { BlockDetailCatchupStatus, ErrorState } from "@/components/metagraphed/states";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { formatDecimal, formatNumber } from "@/lib/metagraphed/format";
@@ -43,6 +43,12 @@ import {
   neighbourHrefs,
   shouldFetchCountedBlockDetail,
 } from "@/components/metagraphed/chain-detail/chain-detail-logic";
+import {
+  BLOCK_DETAIL_RETRY_COUNT,
+  blockDetailRetryDelay,
+  isBlockDetailUnavailable,
+  shouldRetryBlockDetail,
+} from "@/components/metagraphed/chain-detail/block-detail-retry";
 import { Route } from "./blocks.$ref";
 
 const API_PATHS = [
@@ -97,7 +103,8 @@ export function BlockDetailPage() {
   const extrinsics = useInfiniteQuery({
     ...blockExtrinsicsInfiniteQuery(ref, BLOCK_EXTRINSIC_PAGE_SIZE, block?.extrinsic_count),
     enabled: shouldFetchExtrinsics,
-    retry: 0,
+    retry: shouldRetryBlockDetail,
+    retryDelay: blockDetailRetryDelay,
   });
   // Decoded events can be a substantial all-events payload. The block header
   // already gives the exact count, so keep the primary extrinsic ledger fast
@@ -105,7 +112,8 @@ export function BlockDetailPage() {
   const events = useQuery({
     ...blockChainEventsQuery(ref),
     enabled: shouldFetchEvents,
-    retry: 0,
+    retry: shouldRetryBlockDetail,
+    retryDelay: blockDetailRetryDelay,
   });
   const [start, end] = number == null ? [0, 0] : cadenceRange(number);
   const window = useQuery({
@@ -149,6 +157,9 @@ export function BlockDetailPage() {
   const heroFacts = blockFacts(block, { count: formatNumber });
   const heroCells = blockFactCells(block, { count: formatNumber });
   const eventCount = block?.event_count;
+  const extrinsicsCatchingUp =
+    extrinsics.isFetching && isBlockDetailUnavailable(extrinsics.failureReason);
+  const eventsCatchingUp = events.isFetching && isBlockDetailUnavailable(events.failureReason);
 
   const eventColumns: DataTableColumn<ChainEvent>[] = [
     {
@@ -247,6 +258,13 @@ export function BlockDetailPage() {
         live={{ updatedAt: block?.observed_at ?? null, source: "chain-direct" }}
       />
 
+      {extrinsicsCatchingUp ? (
+        <BlockDetailCatchupStatus
+          detail="extrinsics"
+          attempt={extrinsics.failureCount}
+          total={BLOCK_DETAIL_RETRY_COUNT}
+        />
+      ) : null}
       <DataTable
         id="contents"
         rows={rows}
@@ -331,6 +349,13 @@ export function BlockDetailPage() {
 
         {technicalDetailsOpen ? (
           <div id="block-technical-record" className="mg-block-event-stream-body">
+            {eventsCatchingUp ? (
+              <BlockDetailCatchupStatus
+                detail="events"
+                attempt={events.failureCount}
+                total={BLOCK_DETAIL_RETRY_COUNT}
+              />
+            ) : null}
             {shouldFetchEvents && events.isPending ? (
               <CompositionBreakdown
                 formatValue={(value) => formatNumber(value)}

--- a/apps/ui/tests/e2e/block-detail.spec.ts
+++ b/apps/ui/tests/e2e/block-detail.spec.ts
@@ -68,6 +68,70 @@ test.describe("block detail progressive technical record", () => {
     await expect(pending).toBeHidden();
   });
 
+  test("recovers a newly visible block when decoded extrinsics catch up", async ({ page }) => {
+    const extrinsicsFixture = await page.request.get(
+      "http://127.0.0.1:8081/api/v1/blocks/8713384/extrinsics?limit=100",
+    );
+    expect(extrinsicsFixture.ok()).toBe(true);
+    const extrinsicsBody = await extrinsicsFixture.body();
+    let reads = 0;
+    let releaseRetry: (() => void) | undefined;
+    const retryReleased = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+
+    await page.route("**/api/v1/blocks/8713384/extrinsics*", async (route) => {
+      reads += 1;
+      if (reads === 1) {
+        await route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: false,
+            schema_version: 1,
+            data: null,
+            error: {
+              code: "block_detail_unavailable",
+              message: "Decoded detail is catching up",
+            },
+          }),
+        });
+        return;
+      }
+      await retryReleased;
+      await route.fulfill({
+        status: extrinsicsFixture.status(),
+        contentType: extrinsicsFixture.headers()["content-type"] ?? "application/json",
+        body: extrinsicsBody,
+      });
+    });
+
+    await page.setViewportSize({ width: 375, height: 812 });
+    await gotoThroughRestart(page, ROUTE);
+
+    const catchup = page.getByRole("status", {
+      name: "Decoded block detail is catching up",
+    });
+    const ledger = page.getByRole("table", { name: /Extrinsics in this block/ });
+    await expect(catchup).toBeVisible();
+    await expect(catchup).toContainText("decoded extrinsics are catching up");
+    await expect(catchup).toContainText("Attempt 1 of 6");
+    await expect(ledger).toHaveAttribute("aria-busy", "true");
+    expect(reads).toBeGreaterThanOrEqual(1);
+
+    const dimensions = await catchup.evaluate(() => ({
+      viewport: window.innerWidth,
+      document: document.documentElement.scrollWidth,
+    }));
+    expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
+
+    releaseRetry?.();
+    await expect(catchup).toHaveCount(0);
+    await expect(ledger).not.toHaveAttribute("aria-busy", "true");
+    await expect(ledger.locator("tbody tr").first()).not.toHaveClass(/mg-dt-skeleton/);
+    expect(reads).toBeGreaterThanOrEqual(2);
+  });
+
   test("loads the primary ledger first and starts forensic reads only when requested", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- recover newly visible block extrinsics and decoded events only when the API reports the explicit temporary detail-window handoff
- use a measured, bounded six-read backoff window instead of generic or unlimited retries
- keep a responsive ledger skeleton and accessible live catch-up status visible while decoding completes
- preserve the existing truthful coverage-gap notice and manual retry after the automatic budget is exhausted

## Evidence

- live production observation: a new block reached the head feed immediately and its extrinsics became readable 26.79 seconds later
- UI lint and typecheck pass
- all 2,357 UI unit tests pass
- Worker production build and SSR content-isolation gate pass
- all four focused block-detail browser tests pass, including the 503-to-200 recovery at 375px with overflow and `aria-busy` checks

Closes #11758
