### PR TITLE
fix(api): version chain-detail cache responses

### DIFF
--- a/tests/chain-detail-edge-cache.test.ts
+++ b/tests/chain-detail-edge-cache.test.ts
@@ -325,10 +325,10 @@ describe("chain-detail cache key (#11001)", () => {
     );
   });
 
-  test("namespaces by contract version, so a contract change invalidates", () => {
+  test("namespaces by contract version and response shape generation", () => {
     assert.match(
       chainDetailCacheKey(env, url, "mainnet").url,
-      /\/chain-detail\//,
+      /\/chain-detail\/[^/]+\/2\/mainnet\/api\/v1\/blocks\/8803541$/,
     );
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -4382,7 +4382,8 @@ function cacheWrite(ctx: Ctx | undefined, write: () => Promise<unknown>): void {
  * than a guess: chainDetailGapResponse states the lane "closes [a gap] within
  * the hour", so an hour is the longest a re-decode can leave a stored answer
  * disagreeing with the store behind it. The key is already namespaced by
- * contract version, so a contract change invalidates independently of this.
+ * contract version and response-shape generation, so either kind of change
+ * invalidates independently of this.
  *
  * Deliberately longer than the 600 s `static` profile the response advertises to
  * clients: that number is a browser's revalidation interval, this one is how
@@ -4390,6 +4391,16 @@ function cacheWrite(ctx: Ctx | undefined, write: () => Promise<unknown>): void {
  * different questions and were never the same number.
  */
 const CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS = 3600;
+
+/**
+ * Cache namespace for the serialized chain-detail response shape.
+ *
+ * The public contract version is intentionally long-lived across compatible
+ * field additions. Those additions can still make a previously cached body
+ * fail the current response audit, so advance this generation whenever a
+ * chain-detail response gains required fields or changes serialization.
+ */
+const CHAIN_DETAIL_CACHE_SCHEMA_GENERATION = "2";
 
 /**
  * Edge-cache key for one chain-detail answer (block / extrinsic detail).
@@ -4408,7 +4419,7 @@ export function chainDetailCacheKey(
   return new Request(
     `https://edge-cache.metagraph.sh/chain-detail/${encodeURIComponent(
       contractVersion(env),
-    )}/${network}${url.pathname}${url.search}`,
+    )}/${CHAIN_DETAIL_CACHE_SCHEMA_GENERATION}/${network}${url.pathname}${url.search}`,
   );
 }
 


### PR DESCRIPTION
Closes #11771

## Summary

- add an explicit serialized-response generation to the chain-detail edge cache namespace
- document when compatible response-shape changes must advance it
- pin the versioned, contract-scoped, network-scoped block-detail key in regression coverage

This invalidates pre-economics cached block bodies once while preserving the existing one-hour edge-cache behavior for subsequent reads.

## Validation

- `npm test -- --run tests/chain-detail-edge-cache.test.ts` (16/16)
- `npx eslint workers/api.ts tests/chain-detail-edge-cache.test.ts --no-cache`
- `npm run typecheck`
- `npm run worker:deploy:dry-run`
- `npm run build`
- `npm run validate`