### PR TITLE
fix(ui): clarify homepage live data

### DIFF
--- a/apps/ui/src/components/metagraphed/design/design-tokens.generated.ts
+++ b/apps/ui/src/components/metagraphed/design/design-tokens.generated.ts
@@ -25,7 +25,7 @@ export const DESIGN_TOKENS: readonly DesignToken[] = [
     refs: 88,
   },
   { name: "--ink", light: "#4a4a47", dark: "#d4d4d4", theme: "--color-ink", refs: 27 },
-  { name: "--ink-muted", light: "#6b6b67", dark: "#a3a3a3", theme: "--color-ink-muted", refs: 86 },
+  { name: "--ink-muted", light: "#6b6b67", dark: "#a3a3a3", theme: "--color-ink-muted", refs: 87 },
   {
     name: "--ink-subtle",
     light: "#8c8c87",

--- a/apps/ui/src/components/metagraphed/home/home-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/home/home-logic.test.ts
@@ -3,7 +3,10 @@ import { RESIDUAL_KEY } from "@jsonbored/ui-kit";
 import type { ChainActivityDay, SubnetEconomics, SubnetMover } from "@/lib/metagraphed/types";
 import {
   chainPoints,
+  completeChainDays,
+  emissionComparisonNote,
   emissionRails,
+  fmtAlphaDelta,
   fmtCount,
   fmtShare,
   healthRail,
@@ -46,6 +49,13 @@ describe("formatters", () => {
     expect(fmtShare(0.00821, 3)).toBe("0.821%");
     expect(fmtShare(undefined)).toBe("—");
   });
+
+  it("keeps tiny alpha movement visible and signs its direction", () => {
+    expect(fmtAlphaDelta(5_608.831)).toBe("+5.6k");
+    expect(fmtAlphaDelta(0.000001034)).toBe("+1.03e−6");
+    expect(fmtAlphaDelta(-0.25)).toBe("−0.25");
+    expect(fmtAlphaDelta(0)).toBe("0");
+  });
 });
 
 describe("valueSegments", () => {
@@ -77,27 +87,74 @@ describe("valueSegments", () => {
 
 describe("emissionRails", () => {
   const movers = [
-    mover({ netuid: 1, emission_end_alpha: 10, emission_share_pct: 1, emission_pct_change: 5 }),
-    mover({ netuid: 2, emission_end_alpha: 50 }),
+    mover({
+      netuid: 1,
+      emission_end_alpha: 10,
+      emission_delta_alpha: 5,
+      emission_share_pct: 1,
+      emission_pct_change: 5,
+    }),
+    mover({ netuid: 2, emission_end_alpha: 50, emission_delta_alpha: 20 }),
     mover({ netuid: 3, emission_end_alpha: 0 }),
   ];
 
-  it("ranks by the window's END reading, so the rail and its change agree", () => {
+  it("ranks by start-to-end gain, so the selected window changes the primary reading", () => {
     expect(emissionRails(movers, nameOf).map((r) => r.key)).toEqual(["2", "1"]);
   });
 
-  it("drops a subnet that emitted nothing", () => {
+  it("drops a subnet with no positive movement", () => {
     expect(emissionRails(movers, nameOf).some((r) => r.key === "3")).toBe(false);
   });
 
-  it("converts the API's percentage share into a fraction for display", () => {
+  it("keeps the end level, network share, and relative change inspectable", () => {
     const [, first] = emissionRails(movers, nameOf);
-    expect(first?.detail[0]).toEqual({ key: "share", label: "Share", value: "1.00%" });
-    expect(first?.detail[1]?.value).toBe("+5.0%");
+    expect(first?.detail[0]).toEqual({ key: "end", label: "End daily α", value: "10.00 α" });
+    expect(first?.detail[1]).toEqual({
+      key: "share",
+      label: "Network share",
+      value: "1.00%",
+    });
+    expect(first?.detail[2]?.value).toBe("+5.0%");
   });
 
   it("honours the limit", () => {
     expect(emissionRails(movers, nameOf, 1)).toHaveLength(1);
+  });
+});
+
+describe("emissionComparisonNote", () => {
+  it("states exact boundaries, coverage, measure, and provenance", () => {
+    expect(
+      emissionComparisonNote(
+        {
+          window: "30d",
+          start_date: "2026-07-30",
+          end_date: "2026-08-29",
+          covered_days: 30,
+          requested_days: 30,
+          window_truncated: false,
+        },
+        "30d",
+      ),
+    ).toBe(
+      "2026-07-30 → 2026-08-29 · 30/30 days · bars show start-to-end daily α gains · open a row for end level and network share · chain-derived snapshots",
+    );
+  });
+
+  it("does not hide a truncated comparison", () => {
+    expect(
+      emissionComparisonNote(
+        {
+          window: "90d",
+          start_date: null,
+          end_date: null,
+          covered_days: 42,
+          requested_days: 90,
+          window_truncated: true,
+        },
+        "90d",
+      ),
+    ).toContain("42/90 days (partial)");
   });
 });
 
@@ -117,6 +174,21 @@ describe("chainPoints / lastCompleteDay", () => {
     // The newest row is today so far -- 1,588 blocks against a full day's
     // 7,200 -- and quoting it reads as a collapse in throughput, not a clock.
     expect(lastCompleteDay(days, "2026-08-23")?.day).toBe("2026-08-22");
+  });
+
+  it("removes only an incomplete oldest boundary day from every metric", () => {
+    const boundaryDays = [
+      { day: "2026-07-30", block_count: 4881, extrinsic_count: 149452, event_count: 2091499 },
+      { day: "2026-07-31", block_count: 7194, extrinsic_count: 194310, event_count: 2884427 },
+      { day: "2026-08-01", block_count: 7197, extrinsic_count: 185950, event_count: 2925250 },
+      { day: "2026-08-02", block_count: 7200, extrinsic_count: 169769, event_count: 2823934 },
+    ] as ChainActivityDay[];
+    expect(completeChainDays(boundaryDays).map((day) => day.day)).toEqual([
+      "2026-07-31",
+      "2026-08-01",
+      "2026-08-02",
+    ]);
+    expect(chainPoints(boundaryDays, "blocks").map((point) => point.v)).toEqual([7194, 7197, 7200]);
   });
 
   it("keeps the newest row when it is already complete", () => {

--- a/apps/ui/src/components/metagraphed/home/home-logic.ts
+++ b/apps/ui/src/components/metagraphed/home/home-logic.ts
@@ -3,7 +3,13 @@
  */
 import { RESIDUAL_KEY } from "@jsonbored/ui-kit";
 import type { ChainActivityDay, SubnetEconomics, SubnetMover } from "@/lib/metagraphed/types";
-import { formatCompact, formatAmount, formatDecimal, formatPct } from "@/lib/metagraphed/format";
+import {
+  formatAmount,
+  formatCompact,
+  formatCompactDelta,
+  formatDecimal,
+  formatPct,
+} from "@/lib/metagraphed/format";
 
 export type EmissionWindow = "7d" | "30d" | "90d";
 export type ChainMetric = "extrinsics" | "events" | "blocks";
@@ -30,6 +36,11 @@ export const fmtCount = (value: number | null | undefined): string => formatComp
  * column, and the long one wrapped onto a second line.
  */
 export const fmtAlpha = (value: number | null | undefined): string => formatAmount(value, "α");
+
+/** A signed alpha change; the column header carries the unit. */
+export const fmtAlphaDelta = (value: number | null | undefined): string => {
+  return formatCompactDelta(value);
+};
 
 export const fmtShare = (fraction: number | null | undefined, places = 2): string =>
   formatPct(fraction, places);
@@ -84,12 +95,45 @@ export interface EmissionRail {
   detail: { key: string; label: string; value: string }[];
 }
 
+export interface EmissionComparisonWindow {
+  window: string;
+  start_date: string | null;
+  end_date: string | null;
+  covered_days: number | null;
+  requested_days: number | null;
+  window_truncated: boolean;
+}
+
+/** Plain-language provenance for the exact snapshot boundaries behind a rail. */
+export function emissionComparisonNote(
+  comparison: EmissionComparisonWindow | null | undefined,
+  fallbackWindow: EmissionWindow,
+): string {
+  const range =
+    comparison?.start_date && comparison.end_date
+      ? `${comparison.start_date} → ${comparison.end_date}`
+      : `${comparison?.window ?? fallbackWindow} comparison`;
+  const coverage =
+    comparison?.covered_days != null && comparison.requested_days != null
+      ? `${comparison.covered_days}/${comparison.requested_days} days${comparison.window_truncated ? " (partial)" : ""}`
+      : null;
+  return [
+    range,
+    coverage,
+    "bars show start-to-end daily α gains",
+    "open a row for end level and network share",
+    "chain-derived snapshots",
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" · ");
+}
+
 /**
- * Subnets by emission over a window, with the change as detail.
+ * Subnets by positive emission movement over a window, with end state as detail.
  *
- * The LEVEL comes from the movers' end-of-window reading so the rail and its
- * change describe the same window; the current snapshot would describe a
- * different one and the two would disagree at every boundary.
+ * `/subnets/movers?sort=emission` is already ranked by signed emission delta.
+ * Keep that meaning at the display boundary: a selected window changes the
+ * gains, rather than merely reloading the same end-state allocation.
  */
 export function emissionRails(
   movers: readonly SubnetMover[],
@@ -97,25 +141,35 @@ export function emissionRails(
   limit = 15,
 ): EmissionRail[] {
   return movers
-    .filter((mover) => Number.isFinite(mover.emission_end_alpha) && mover.emission_end_alpha > 0)
-    .sort((a, b) => b.emission_end_alpha - a.emission_end_alpha)
+    .filter(
+      (mover) => Number.isFinite(mover.emission_delta_alpha) && mover.emission_delta_alpha > 0,
+    )
+    .sort((a, b) => b.emission_delta_alpha - a.emission_delta_alpha)
     .slice(0, limit)
     .map((mover) => ({
       key: String(mover.netuid),
       label: nameOf(mover.netuid),
-      value: mover.emission_end_alpha,
+      value: mover.emission_delta_alpha,
       href: `/subnets/${mover.netuid}`,
       detail: [
-        { key: "share", label: "Share", value: fmtShare((mover.emission_share_pct ?? 0) / 100) },
+        {
+          key: "end",
+          label: "End daily α",
+          value: fmtAlpha(mover.emission_end_alpha),
+        },
+        {
+          key: "share",
+          label: "Network share",
+          value: fmtShare((mover.emission_share_pct ?? 0) / 100),
+        },
         {
           key: "change",
-          label: "Change",
+          label: "Relative change",
           value:
             typeof mover.emission_pct_change === "number"
               ? `${mover.emission_pct_change >= 0 ? "+" : ""}${formatDecimal(mover.emission_pct_change, 1)}%`
               : "—",
         },
-        { key: "validators", label: "Validators", value: String(mover.validators_end) },
       ],
     }));
 }
@@ -132,23 +186,50 @@ export function chainPoints(
       : metric === "events"
         ? day.event_count
         : day.block_count;
-  return (
-    days
-      // `/chain/activity` includes the current UTC day while it is still being
-      // accumulated. A partial bar beside complete days reads as a throughput
-      // collapse, so the public chart ends on the day before the response was
-      // generated. Keep the filter tied to API time, not the visitor's clock.
-      .filter((day) => !asOfDay || day.day < asOfDay)
-      .map((day) => {
-        const value = pick(day);
-        const t = Date.parse(`${day.day}T00:00:00Z`);
-        return typeof value === "number" && Number.isFinite(value) && Number.isFinite(t)
-          ? { t, v: value }
-          : null;
-      })
-      .filter((point): point is { t: number; v: number } => point !== null)
-      .sort((a, b) => a.t - b.t)
-  );
+  return completeChainDays(days, asOfDay)
+    .map((day) => {
+      const value = pick(day);
+      const t = Date.parse(`${day.day}T00:00:00Z`);
+      return typeof value === "number" && Number.isFinite(value) && Number.isFinite(t)
+        ? { t, v: value }
+        : null;
+    })
+    .filter((point): point is { t: number; v: number } => point !== null)
+    .sort((a, b) => a.t - b.t);
+}
+
+/**
+ * Daily chain rows that are safe to compare as whole UTC days.
+ *
+ * The source includes the day containing its observation time, so that newest
+ * row is still accumulating. Some windows also begin part-way through their
+ * oldest day; only that boundary row is removed, and only when its block
+ * coverage is materially below the later-day median. Interior lows remain
+ * visible because they may represent real chain behavior rather than a window
+ * boundary.
+ */
+export function completeChainDays(
+  days: readonly ChainActivityDay[],
+  asOfDay?: string,
+): ChainActivityDay[] {
+  const ordered = days
+    .filter((day) => !asOfDay || day.day < asOfDay)
+    .sort((a, b) => a.day.localeCompare(b.day));
+  if (ordered.length < 3) return ordered;
+
+  const oldest = ordered[0]!;
+  const laterBlockCounts = ordered
+    .slice(1)
+    .map((day) => day.block_count)
+    .filter((count) => Number.isFinite(count) && count > 0)
+    .sort((a, b) => a - b);
+  if (laterBlockCounts.length < 2) return ordered;
+  const middle = Math.floor(laterBlockCounts.length / 2);
+  const median =
+    laterBlockCounts.length % 2 === 0
+      ? (laterBlockCounts[middle - 1]! + laterBlockCounts[middle]!) / 2
+      : laterBlockCounts[middle]!;
+  return oldest.block_count < median * 0.9 ? ordered.slice(1) : ordered;
 }
 
 /**
@@ -162,10 +243,8 @@ export function lastCompleteDay(
   days: readonly ChainActivityDay[],
   asOfDay?: string,
 ): ChainActivityDay | null {
-  const sorted = days
-    .filter((day) => !asOfDay || day.day < asOfDay)
-    .sort((a, b) => b.day.localeCompare(a.day));
-  return sorted[0] ?? null;
+  const complete = completeChainDays(days, asOfDay);
+  return complete[complete.length - 1] ?? null;
 }
 
 export interface SurfaceRail {

--- a/apps/ui/src/components/metagraphed/live-block-rail.test.tsx
+++ b/apps/ui/src/components/metagraphed/live-block-rail.test.tsx
@@ -42,7 +42,15 @@ describe("LiveBlockRail", () => {
         economic_activity_tao: 2.5,
         economic_activity_usd: 600,
       }),
-    ).toBe("2.50 τ · $600");
+    ).toBe("2.50τ · $600");
+    expect(
+      blockEconomicLabel({
+        ...base,
+        decode_status: "complete",
+        economic_activity_tao: 62.85,
+        economic_activity_usd: 14_734.55,
+      }),
+    ).toBe("62.85τ · $14.7k");
   });
 
   it("renders the bounded twelve-block window newest-first, with every block inspectable", async () => {

--- a/apps/ui/src/components/metagraphed/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/live-block-rail.tsx
@@ -10,7 +10,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { TimeAgo } from "@jsonbored/ui-kit";
-import { formatNumber, formatTao, formatUsd } from "@/lib/metagraphed/format";
+import { formatCompactAmount, formatCompactUsd, formatNumber } from "@/lib/metagraphed/format";
 import { blockExtrinsicsInfiniteQuery } from "@/lib/metagraphed/queries";
 import type { Block } from "@/lib/metagraphed/types";
 import { arrivedBlock } from "./chain-stream/block-activity-window-logic";
@@ -57,15 +57,29 @@ function countLabel(value: number | null | undefined, noun: string): string {
   return `${formatNumber(value)} ${noun}${value === 1 ? "" : "s"}`;
 }
 
-export function blockEconomicLabel(block: Block): string {
-  if (block.decode_status === "pending") return "Decoding value…";
-  if (block.decode_status !== "complete" || typeof block.economic_activity_tao !== "number") {
-    return "Value unavailable";
+export interface BlockEconomicReading {
+  label: string;
+  tao: string | null;
+  usd: string | null;
+}
+
+export function blockEconomicReading(block: Block): BlockEconomicReading {
+  if (block.decode_status === "pending") {
+    return { label: "Decoding value…", tao: null, usd: null };
   }
-  const tao = formatTao(block.economic_activity_tao);
+  if (block.decode_status !== "complete" || typeof block.economic_activity_tao !== "number") {
+    return { label: "Value unavailable", tao: null, usd: null };
+  }
+  const tao = `${formatCompactAmount(block.economic_activity_tao)}τ`;
   const usd =
-    typeof block.economic_activity_usd === "number" ? formatUsd(block.economic_activity_usd) : null;
-  return usd ? `${tao} · ${usd}` : tao;
+    typeof block.economic_activity_usd === "number"
+      ? formatCompactUsd(block.economic_activity_usd)
+      : null;
+  return { label: usd ? `${tao} · ${usd}` : tao, tao, usd };
+}
+
+export function blockEconomicLabel(block: Block): string {
+  return blockEconomicReading(block).label;
 }
 
 export function LiveBlockRail({
@@ -205,7 +219,7 @@ export function LiveBlockRail({
               const number = formatNumber(block.block_number);
               const extrinsics = countLabel(block.extrinsic_count, "extrinsic");
               const events = countLabel(block.event_count, "event");
-              const economics = blockEconomicLabel(block);
+              const economics = blockEconomicReading(block);
               const key = blockKey(block);
               return (
                 <li key={key}>
@@ -226,7 +240,7 @@ export function LiveBlockRail({
                       if (element) itemElements.current.set(key, element);
                       else itemElements.current.delete(key);
                     }}
-                    aria-label={`Open block #${number}: ${extrinsics}, ${events}, economic activity ${economics}`}
+                    aria-label={`Open block #${number}: ${extrinsics}, ${events}, economic activity ${economics.label}`}
                   >
                     <span className="mg-live-block-label">Block</span>
                     <span className="mg-live-block-open" aria-hidden="true">
@@ -240,9 +254,19 @@ export function LiveBlockRail({
                     </span>
                     <span
                       className="mg-live-block-value"
+                      aria-label={economics.label}
                       title="Native TAO transfers plus stake added or removed in this block. USD uses the current source-linked TAO/USD reading. Fees and issuance are excluded."
                     >
-                      {economics}
+                      {economics.tao ? (
+                        <>
+                          <span>{economics.tao}</span>
+                          {economics.usd ? (
+                            <span className="mg-live-block-value-usd">· {economics.usd}</span>
+                          ) : null}
+                        </>
+                      ) : (
+                        economics.label
+                      )}
                     </span>
                     <span className="mg-live-block-activity" aria-hidden="true">
                       <span

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -6,6 +6,8 @@ import {
   formatAmountFixed,
   formatCompact,
   formatCompactAmount,
+  formatCompactDelta,
+  formatCompactUsd,
   formatDecimal,
   formatNumber,
   formatPct,
@@ -241,6 +243,17 @@ describe("formatUsd", () => {
     expect(formatUsd(0.0125)).toBe("$0.0125");
     expect(formatUsd(-15.5)).toBe("−$15.5");
     expect(formatUsd(undefined, "unavailable")).toBe("unavailable");
+  });
+});
+
+describe("formatCompactUsd", () => {
+  it("keeps narrow analytical readings complete instead of clipping them", () => {
+    expect(formatCompactUsd(null)).toBe("—");
+    expect(formatCompactUsd(999.45)).toBe("$999.45");
+    expect(formatCompactUsd(14_734.55)).toBe("$14.7k");
+    expect(formatCompactUsd(1_250_000)).toBe("$1.3M");
+    expect(formatCompactUsd(3_450_000_000)).toBe("$3.5B");
+    expect(formatCompactUsd(-14_734.55)).toBe("−$14.7k");
   });
 });
 
@@ -501,6 +514,17 @@ describe("formatCompact never leaks precision below a thousand (#11681)", () => 
       const decimals = (formatCompact(v).split(".")[1] ?? "").length;
       expect(decimals, `formatCompact(${v}) = ${formatCompact(v)}`).toBeLessThanOrEqual(2);
     }
+  });
+});
+
+describe("formatCompactDelta", () => {
+  it("signs movement and keeps microscopic values complete in narrow columns", () => {
+    expect(formatCompactDelta(null)).toBe("—");
+    expect(formatCompactDelta(0)).toBe("0");
+    expect(formatCompactDelta(5_608.831)).toBe("+5.6k");
+    expect(formatCompactDelta(0.003252)).toBe("+3.25e−3");
+    expect(formatCompactDelta(0.000000482)).toBe("+4.82e−7");
+    expect(formatCompactDelta(-0.00004)).toBe("−4e−5");
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -77,6 +77,27 @@ export function formatCompactAmount(v: number | null | undefined): string {
   return v.toFixed(4);
 }
 
+/**
+ * A signed, unitless delta for narrow ranked columns. Values below 0.01 use
+ * three-significant-digit scientific notation so a real microscopic movement
+ * never becomes either `0.0000` or an ellipsis.
+ */
+export function formatCompactDelta(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v === 0) return "0";
+  const sign = v > 0 ? "+" : "−";
+  const magnitude = Math.abs(v);
+  if (magnitude >= 1) return `${sign}${formatCompactAmount(magnitude)}`;
+  if (magnitude >= 0.01) return `${sign}${formatNumber(magnitude)}`;
+  const scientific = magnitude
+    .toExponential(2)
+    .replace(/\.0+(?=e)/, "")
+    .replace(/(\.\d*?)0+(?=e)/, "$1")
+    .replace("e-", "e−")
+    .replace("e+", "e+");
+  return `${sign}${scientific}`;
+}
+
 /** An amount at a fixed precision with its unit: `12.50 τ`. */
 export function formatAmountFixed(v: number | null | undefined, places = 2, unit = "τ"): string {
   if (v == null || !Number.isFinite(v)) return "—";
@@ -138,6 +159,21 @@ export function formatUsd(value: number | null | undefined, fallback = "—"): s
   if (amount >= 1_000_000) return `${sign}$${(amount / 1_000_000).toFixed(2)}M`;
   if (amount >= 1) return `${sign}$${formatNumber(Number(amount.toFixed(2)))}`;
   return `${sign}$${formatNumber(amount)}`;
+}
+
+/**
+ * A compact USD reading for narrow analytical marks. Unlike {@link formatUsd},
+ * this abbreviates at the thousand boundary so a live block tile can retain
+ * both its TAO and dollar readings without clipping either one.
+ */
+export function formatCompactUsd(value: number | null | undefined, fallback = "—"): string {
+  if (value == null || !Number.isFinite(value)) return fallback;
+  const sign = value < 0 ? "−" : "";
+  const amount = Math.abs(value);
+  if (amount >= 1_000_000_000) return `${sign}$${(amount / 1_000_000_000).toFixed(1)}B`;
+  if (amount >= 1_000_000) return `${sign}$${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `${sign}$${(amount / 1_000).toFixed(1)}k`;
+  return formatUsd(value, fallback);
 }
 
 /**

--- a/apps/ui/src/lib/metagraphed/queries.subnet-movers.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-movers.test.ts
@@ -33,6 +33,11 @@ describe("normalizeSubnetMovers", () => {
     const card = normalizeSubnetMovers({
       schema_version: 1,
       window: "30d",
+      start_date: "2026-07-30",
+      end_date: "2026-08-29",
+      covered_days: 30,
+      requested_days: 30,
+      window_truncated: false,
       sort: "stake",
       subnet_count: 1,
       network: { gainers: 5, losers: 3, unchanged: 2 },
@@ -51,6 +56,13 @@ describe("normalizeSubnetMovers", () => {
       ],
     });
     expect(card.network).toEqual({ gainers: 5, losers: 3, unchanged: 2 });
+    expect(card).toMatchObject({
+      start_date: "2026-07-30",
+      end_date: "2026-08-29",
+      covered_days: 30,
+      requested_days: 30,
+      window_truncated: false,
+    });
     expect(card.movers).toHaveLength(1);
     expect(card.movers[0]?.netuid).toBe(64);
     expect(card.movers[0]?.stake_delta_alpha).toBe(150);
@@ -64,6 +76,11 @@ describe("normalizeSubnetMovers", () => {
       expect(card.network).toBeNull();
       expect(card.window).toBe("30d");
       expect(card.sort).toBe("stake");
+      expect(card.start_date).toBeNull();
+      expect(card.end_date).toBeNull();
+      expect(card.covered_days).toBeNull();
+      expect(card.requested_days).toBeNull();
+      expect(card.window_truncated).toBe(false);
     }
   });
 

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1024,6 +1024,11 @@ export function normalizeSubnetMovers(raw: unknown): SubnetMovers {
   return {
     schema_version: firstFiniteNumber(d.schema_version) ?? 1,
     window: firstString(d.window) ?? "30d",
+    start_date: firstString(d.start_date) ?? null,
+    end_date: firstString(d.end_date) ?? null,
+    covered_days: coerceFiniteNumber(d.covered_days) ?? null,
+    requested_days: coerceFiniteNumber(d.requested_days) ?? null,
+    window_truncated: d.window_truncated === true,
     sort: firstString(d.sort) ?? "stake",
     subnet_count: firstFiniteNumber(d.subnet_count) ?? movers.length,
     network: net

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2592,6 +2592,11 @@ export interface SubnetMoversNetwork {
 export interface SubnetMovers {
   schema_version: number;
   window: string;
+  start_date: string | null;
+  end_date: string | null;
+  covered_days: number | null;
+  requested_days: number | null;
+  window_truncated: boolean;
   sort: string;
   subnet_count: number;
   network: SubnetMoversNetwork | null;

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -22,8 +22,10 @@ import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import {
   CHAIN_METRICS,
   chainPoints,
+  completeChainDays,
+  emissionComparisonNote,
   emissionRails,
-  fmtAlpha,
+  fmtAlphaDelta,
   fmtCount,
   fmtShare,
   healthRail,
@@ -41,10 +43,10 @@ import {
   economicsQuery,
   subnetMoversQuery,
 } from "@/lib/metagraphed/queries";
-import { formatDecimal, formatNumber } from "@/lib/metagraphed/format";
+import { formatDecimal, formatNumber, formatRelative } from "@/lib/metagraphed/format";
 
 const SECTIONS = [
-  { id: "emission", name: "Emission movement" },
+  { id: "emission", name: "Emission gains" },
   { id: "chain", name: "Chain activity" },
   { id: "health", name: "Surface health" },
 ] as const;
@@ -121,7 +123,7 @@ export function OverviewPage() {
 
   const { data: economics } = useSuspenseQuery(economicsQuery({ fields: "identity" }));
   const movers = useQuery({
-    ...subnetMoversQuery({ window: emissionWindow, sort: "emission", limit: 100 }),
+    ...subnetMoversQuery({ window: emissionWindow, sort: "emission", limit: 15 }),
     retry: 0,
   });
   const activity = useQuery({ ...chainActivityQuery("30d"), retry: 0 });
@@ -157,8 +159,12 @@ export function OverviewPage() {
   );
   const days = activity.data?.data.days ?? [];
   const activityAsOfDay = activity.data?.meta.generated_at?.slice(0, 10);
-  const points = chainPoints(days, chainMetric, activityAsOfDay);
-  const complete = lastCompleteDay(days, activityAsOfDay);
+  const completeDays = completeChainDays(days, activityAsOfDay);
+  const points = chainPoints(completeDays, chainMetric);
+  const complete = lastCompleteDay(completeDays);
+  const firstComplete = completeDays[0] ?? null;
+  const activityObservedAt =
+    activity.data?.data.observed_at ?? activity.data?.meta.generated_at ?? null;
   const healthSubnets = health.data?.data.windows?.["7d"]?.subnets ?? [];
   const worst = healthRail(healthSubnets, nameOf);
   const healthy = healthSubnets.filter((subnet) => (subnet.uptime_ratio ?? 0) >= 0.99).length;
@@ -296,8 +302,8 @@ export function OverviewPage() {
       >
         <AnalyticsSection
           id="emission"
-          name="Emission movement"
-          question="Where daily alpha moved after the comparison opened."
+          name="Emission gains"
+          question="Which subnets gained daily alpha during the selected window."
           className="mg-home-story mg-home-story--emission"
           controls={
             <RangeControl
@@ -310,17 +316,18 @@ export function OverviewPage() {
           visual={
             movers.isPending ? (
               <RankedRails
+                className="mg-home-emission-rails"
                 items={[]}
                 loading
                 loadingRows={10}
-                formatValue={(value) => fmtAlpha(value)}
+                formatValue={(value) => fmtAlphaDelta(value)}
                 scale="sqrt"
                 columns={{
-                  value: "Daily emission",
+                  value: "Gain α",
                   name: "Subnet",
-                  track: "Relative to the top 15",
+                  track: "Relative gain",
                 }}
-                ariaLabel={`Daily subnet emission at the end of the ${emissionWindow} comparison`}
+                ariaLabel={`Subnet daily alpha gains over the ${emissionWindow} comparison`}
                 source="home-subnet"
               />
             ) : movers.isError ? (
@@ -331,15 +338,16 @@ export function OverviewPage() {
               />
             ) : rails.length > 0 ? (
               <RankedRails
+                className="mg-home-emission-rails"
                 items={rails}
-                formatValue={(value) => fmtAlpha(value)}
+                formatValue={(value) => fmtAlphaDelta(value)}
                 scale="sqrt"
                 columns={{
-                  value: "Daily emission",
+                  value: "Gain α",
                   name: "Subnet",
-                  track: "Relative to the top 15",
+                  track: "Relative gain",
                 }}
-                ariaLabel={`Daily subnet emission at the end of the ${emissionWindow} comparison`}
+                ariaLabel={`Subnet daily alpha gains over the ${emissionWindow} comparison`}
                 source="home-subnet"
               />
             ) : (
@@ -348,16 +356,16 @@ export function OverviewPage() {
           }
           footnote={
             movers.isPending
-              ? `Loading ${emissionWindow} emission comparison · chain-direct`
+              ? `Loading ${emissionWindow} emission comparison · chain-derived snapshots`
               : movers.isError
-                ? "Emission comparison unavailable · chain-direct"
-                : `${emissionWindow} comparison · bars show end-date daily alpha; tooltips show change from the start · chain-direct`
+                ? "Emission comparison unavailable · chain-derived snapshots"
+                : emissionComparisonNote(movers.data?.data, emissionWindow)
           }
         />
         <AnalyticsSection
           id="chain"
-          name="Chain"
-          question="What moved after the final UTC day closed."
+          name="Chain activity"
+          question="Daily totals across complete UTC days."
           className="mg-home-story mg-home-story--chain"
           controls={
             <RangeControl
@@ -370,6 +378,7 @@ export function OverviewPage() {
           visual={
             activity.isPending ? (
               <LineWithWindow
+                key={chainMetric}
                 id="home-chain"
                 points={[]}
                 window={{ from: 0, to: 0 }}
@@ -377,6 +386,8 @@ export function OverviewPage() {
                 formatValue={(value) => fmtCount(value)}
                 ariaLabel={`Complete-day ${chainMetric}, trailing 30 days`}
                 source="home-chain"
+                zeroBaseline
+                animate
                 loading
               />
             ) : activity.isError ? (
@@ -387,6 +398,7 @@ export function OverviewPage() {
               />
             ) : points.length > 1 ? (
               <LineWithWindow
+                key={chainMetric}
                 id="home-chain"
                 points={points}
                 window={{ from: points[0]!.t, to: points[points.length - 1]!.t }}
@@ -394,6 +406,8 @@ export function OverviewPage() {
                 formatValue={(value) => fmtCount(value)}
                 ariaLabel={`Complete-day ${chainMetric}, trailing 30 days`}
                 source="home-chain"
+                zeroBaseline
+                animate
               />
             ) : (
               <p className="text-13 text-ink-muted">No complete-day chain activity is available.</p>
@@ -405,10 +419,10 @@ export function OverviewPage() {
           // excludes it makes the two summaries contradict one another.
           footnote={
             activity.isPending
-              ? "Loading 30d complete-day chain activity · chain-direct"
+              ? "Loading complete-day chain activity · indexed chain data"
               : activity.isError
-                ? "Complete-day chain activity unavailable · chain-direct"
-                : `30d · chart and strip end ${complete?.day ?? "—"}, the last complete UTC day · chain-direct`
+                ? "Complete-day chain activity unavailable · indexed chain data"
+                : `${completeDays.length} complete UTC days · ${firstComplete?.day ?? "—"} → ${complete?.day ?? "—"} · indexed activity observed ${formatRelative(activityObservedAt)}`
           }
         />
         <AnalyticsSection

--- a/apps/ui/tests/e2e/home-secondary-state.spec.ts
+++ b/apps/ui/tests/e2e/home-secondary-state.spec.ts
@@ -48,7 +48,7 @@ test.describe("homepage secondary analytics", () => {
     await gotoThroughRestart(page, "/");
 
     const emission = page.getByRole("group", {
-      name: "Daily subnet emission at the end of the 30d comparison",
+      name: "Subnet daily alpha gains over the 30d comparison",
       exact: true,
     });
     const activity = page.locator("#home-chain .mg-line-plot");
@@ -59,9 +59,11 @@ test.describe("homepage secondary analytics", () => {
     for (const instrument of [emission, activity, health]) {
       await expect(instrument).toHaveAttribute("aria-busy", "true");
     }
-    await expect(page.getByText("Loading 30d emission comparison · chain-direct")).toBeVisible();
     await expect(
-      page.getByText("Loading 30d complete-day chain activity · chain-direct"),
+      page.getByText("Loading 30d emission comparison · chain-derived snapshots"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Loading complete-day chain activity · indexed chain data"),
     ).toBeVisible();
     await expect(page.getByText("Loading 7d surface health · live prober")).toBeVisible();
 
@@ -75,5 +77,45 @@ test.describe("homepage secondary analytics", () => {
     for (const instrument of [emission, activity, health]) {
       await expect(instrument).not.toHaveAttribute("aria-busy", "true");
     }
+  });
+
+  test("keeps live readings legible and redraws the selected chain metric", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await gotoThroughRestart(page, "/");
+
+    const economicReading = page.locator(".mg-live-block-value").first();
+    await expect(economicReading).toBeVisible();
+    const valueLayout = await economicReading.evaluate((element) => {
+      const styles = getComputedStyle(element);
+      return {
+        overflow: styles.overflow,
+        textOverflow: styles.textOverflow,
+        whiteSpace: styles.whiteSpace,
+      };
+    });
+    expect(valueLayout).toEqual({
+      overflow: "visible",
+      textOverflow: "clip",
+      whiteSpace: "normal",
+    });
+
+    await expect(page.getByText("Emission gains", { exact: true })).toBeVisible();
+    await expect(page.getByText("Gain α", { exact: true })).toBeVisible();
+
+    await page.getByRole("radio", { name: "Blocks", exact: true }).click();
+    const chart = page.locator("#home-chain");
+    await expect(chart).toHaveAttribute("data-animate", "true");
+    const activePath = chart.locator(".mg-line-active");
+    await expect(activePath).toHaveAttribute("pathLength", "1");
+    expect(
+      await activePath.evaluate((element) => getComputedStyle(element).animationName),
+    ).toContain("mg-line-draw");
+
+    const separation = await chart.evaluate((element) => {
+      const range = element.querySelector(".mg-line-range")?.getBoundingClientRect();
+      const plot = element.querySelector(".mg-line-plot")?.getBoundingClientRect();
+      return range && plot ? plot.top - range.bottom : -1;
+    });
+    expect(separation).toBeGreaterThanOrEqual(20);
   });
 });

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2952,9 +2952,10 @@ function stackedSpecimen() {
 
 // src/components/metagraphed/charts/line-geometry.ts
 var LINE_VIEWBOX = { width: 1200, height: 370 };
-var PAD_Y = 8;
+var PAD_TOP = 20;
+var PAD_BOTTOM = 8;
 var PLOT_RIGHT = 0.94;
-function placePoints(points, box = LINE_VIEWBOX) {
+function placePoints(points, box = LINE_VIEWBOX, { zeroBaseline = false } = {}) {
   if (points.length === 0) return [];
   const t0 = points[0].t;
   const t1 = points[points.length - 1].t;
@@ -2965,11 +2966,12 @@ function placePoints(points, box = LINE_VIEWBOX) {
     if (p.v < min) min = p.v;
     if (p.v > max) max = p.v;
   }
+  if (zeroBaseline && min >= 0) min = 0;
   const range = max - min || 1;
   return points.map((p) => ({
     ...p,
     x: points.length === 1 ? box.width * PLOT_RIGHT / 2 : (p.t - t0) / span * box.width * PLOT_RIGHT,
-    y: box.height - PAD_Y - (p.v - min) / range * (box.height - PAD_Y * 2)
+    y: box.height - PAD_BOTTOM - (p.v - min) / range * (box.height - PAD_TOP - PAD_BOTTOM)
   }));
 }
 function smoothPath(points) {
@@ -3066,9 +3068,14 @@ function LineWithWindow({
   marker,
   markerLabel,
   className,
-  loading = false
+  loading = false,
+  zeroBaseline = false,
+  animate = false
 }) {
-  const placed = React2.useMemo(() => placePoints(points), [points]);
+  const placed = React2.useMemo(
+    () => placePoints(points, LINE_VIEWBOX, { zeroBaseline }),
+    [points, zeroBaseline]
+  );
   const inside = React2.useMemo(() => windowPoints(placed, window2), [placed, window2]);
   const delta = React2.useMemo(() => windowDelta(points, window2), [points, window2]);
   const months = React2.useMemo(() => monthTicks(points), [points]);
@@ -3106,6 +3113,7 @@ function LineWithWindow({
       "data-mg-line": "",
       "data-compact": compact ? "true" : void 0,
       "data-state": delta.state,
+      "data-animate": animate ? "true" : void 0,
       children: [
         compact ? null : /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-line-summary", children: [
           /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mg-line-total", children: [
@@ -3135,8 +3143,22 @@ function LineWithWindow({
                   "aria-hidden": "true",
                   focusable: "false",
                   children: [
-                    /* @__PURE__ */ jsxRuntime.jsx("path", { className: "mg-line-muted", d: smoothPath(placed) }),
-                    /* @__PURE__ */ jsxRuntime.jsx("path", { className: "mg-line-active", d: smoothPath(inside) }),
+                    /* @__PURE__ */ jsxRuntime.jsx(
+                      "path",
+                      {
+                        className: "mg-line-muted",
+                        d: smoothPath(placed),
+                        pathLength: "1"
+                      }
+                    ),
+                    /* @__PURE__ */ jsxRuntime.jsx(
+                      "path",
+                      {
+                        className: "mg-line-active",
+                        d: smoothPath(inside),
+                        pathLength: "1"
+                      }
+                    ),
                     markerPoint ? /* @__PURE__ */ jsxRuntime.jsx(
                       "line",
                       {

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -2025,14 +2025,22 @@
     line-height: 1.4;
   }
   .mg-live-block-value {
-    overflow: hidden;
+    display: flex;
+    flex-wrap: wrap;
+    align-content: start;
+    gap: 0 5px;
+    min-width: 0;
     color: var(--ink-strong);
     font-family: var(--font-mono);
     font-size: 10px;
     font-variant-numeric: tabular-nums;
     line-height: 1.4;
-    text-overflow: ellipsis;
+  }
+  .mg-live-block-value > span {
     white-space: nowrap;
+  }
+  .mg-live-block-value-usd {
+    color: var(--ink-muted);
   }
   .mg-live-block-activity {
     display: block;
@@ -3016,6 +3024,10 @@
     gap: 16px;
     min-width: 0;
   }
+  .mg-home-story--chain .mg-line {
+    --mg-line-plot: 280px;
+    gap: 24px;
+  }
   .mg-line[data-compact=true] {
     --mg-line-plot: 120px;
     gap: 0;
@@ -3094,6 +3106,47 @@
   }
   .mg-line-active {
     stroke: var(--good);
+  }
+  @keyframes mg-line-draw {
+    from {
+      stroke-dashoffset: 1;
+    }
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
+  @keyframes mg-line-enter {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @keyframes mg-line-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  .mg-line[data-animate=true] .mg-line-muted,
+  .mg-line[data-animate=true] .mg-line-active {
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+    animation: mg-line-draw 560ms cubic-bezier(0.2, 0.7, 0, 1) forwards;
+  }
+  .mg-line[data-animate=true] .mg-line-summary,
+  .mg-line[data-animate=true] .mg-line-months {
+    animation: mg-line-enter 300ms ease-out both;
+  }
+  .mg-line[data-animate=true] .mg-line-marker,
+  .mg-line[data-animate=true] .mg-line-end {
+    animation: mg-line-fade 300ms ease-out both;
+    animation-delay: 360ms;
   }
   .mg-line[data-state=negative] .mg-line-active {
     stroke: var(--bad);
@@ -3195,6 +3248,17 @@
       transform: translate(calc(-100% - 8px), calc(-100% - 6px));
     }
   }
+  @media (prefers-reduced-motion: reduce) {
+    .mg-line[data-animate=true] .mg-line-muted,
+    .mg-line[data-animate=true] .mg-line-active,
+    .mg-line[data-animate=true] .mg-line-summary,
+    .mg-line[data-animate=true] .mg-line-months,
+    .mg-line[data-animate=true] .mg-line-marker,
+    .mg-line[data-animate=true] .mg-line-end {
+      animation: none;
+      stroke-dashoffset: 0;
+    }
+  }
   .mg-swatch {
     display: inline-block;
     width: 6px;
@@ -3230,6 +3294,13 @@
   }
   .mg-rails-head > span:first-child {
     text-align: right;
+  }
+  .mg-home-emission-rails .mg-rails-head,
+  .mg-home-emission-rails .mg-rails-row {
+    grid-template-columns: 76px 168px minmax(0, 1fr);
+  }
+  .mg-home-emission-rails .mg-rails-head > span:first-child {
+    white-space: nowrap;
   }
   .mg-rails-head > span:nth-child(3),
   .mg-rails-head > span:nth-child(4) {
@@ -3407,6 +3478,10 @@
       row-gap: 2px;
       height: auto;
       padding-block: 4px;
+    }
+    .mg-home-emission-rails .mg-rails-head,
+    .mg-home-emission-rails .mg-rails-row {
+      grid-template-columns: 56px minmax(0, 1fr);
     }
     .mg-rails-head > span:nth-child(3),
     .mg-rails-head > span:nth-child(4) {

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2926,9 +2926,10 @@ function stackedSpecimen() {
 
 // src/components/metagraphed/charts/line-geometry.ts
 var LINE_VIEWBOX = { width: 1200, height: 370 };
-var PAD_Y = 8;
+var PAD_TOP = 20;
+var PAD_BOTTOM = 8;
 var PLOT_RIGHT = 0.94;
-function placePoints(points, box = LINE_VIEWBOX) {
+function placePoints(points, box = LINE_VIEWBOX, { zeroBaseline = false } = {}) {
   if (points.length === 0) return [];
   const t0 = points[0].t;
   const t1 = points[points.length - 1].t;
@@ -2939,11 +2940,12 @@ function placePoints(points, box = LINE_VIEWBOX) {
     if (p.v < min) min = p.v;
     if (p.v > max) max = p.v;
   }
+  if (zeroBaseline && min >= 0) min = 0;
   const range = max - min || 1;
   return points.map((p) => ({
     ...p,
     x: points.length === 1 ? box.width * PLOT_RIGHT / 2 : (p.t - t0) / span * box.width * PLOT_RIGHT,
-    y: box.height - PAD_Y - (p.v - min) / range * (box.height - PAD_Y * 2)
+    y: box.height - PAD_BOTTOM - (p.v - min) / range * (box.height - PAD_TOP - PAD_BOTTOM)
   }));
 }
 function smoothPath(points) {
@@ -3040,9 +3042,14 @@ function LineWithWindow({
   marker,
   markerLabel,
   className,
-  loading = false
+  loading = false,
+  zeroBaseline = false,
+  animate = false
 }) {
-  const placed = useMemo(() => placePoints(points), [points]);
+  const placed = useMemo(
+    () => placePoints(points, LINE_VIEWBOX, { zeroBaseline }),
+    [points, zeroBaseline]
+  );
   const inside = useMemo(() => windowPoints(placed, window2), [placed, window2]);
   const delta = useMemo(() => windowDelta(points, window2), [points, window2]);
   const months = useMemo(() => monthTicks(points), [points]);
@@ -3080,6 +3087,7 @@ function LineWithWindow({
       "data-mg-line": "",
       "data-compact": compact ? "true" : void 0,
       "data-state": delta.state,
+      "data-animate": animate ? "true" : void 0,
       children: [
         compact ? null : /* @__PURE__ */ jsxs("div", { className: "mg-line-summary", children: [
           /* @__PURE__ */ jsxs("p", { className: "mg-line-total", children: [
@@ -3109,8 +3117,22 @@ function LineWithWindow({
                   "aria-hidden": "true",
                   focusable: "false",
                   children: [
-                    /* @__PURE__ */ jsx("path", { className: "mg-line-muted", d: smoothPath(placed) }),
-                    /* @__PURE__ */ jsx("path", { className: "mg-line-active", d: smoothPath(inside) }),
+                    /* @__PURE__ */ jsx(
+                      "path",
+                      {
+                        className: "mg-line-muted",
+                        d: smoothPath(placed),
+                        pathLength: "1"
+                      }
+                    ),
+                    /* @__PURE__ */ jsx(
+                      "path",
+                      {
+                        className: "mg-line-active",
+                        d: smoothPath(inside),
+                        pathLength: "1"
+                      }
+                    ),
                     markerPoint ? /* @__PURE__ */ jsx(
                       "line",
                       {

--- a/packages/ui-kit/src/components/metagraphed/charts/charts.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/charts.test.ts
@@ -135,6 +135,20 @@ describe("LineWithWindow", () => {
     expect(html).not.toContain("fill=");
   });
 
+  it("opts into a replayable path draw while preserving a stable SVG length", () => {
+    const animated = render(
+      h(LineWithWindow, {
+        ...spec,
+        unit: "blocks",
+        ariaLabel: "Daily blocks",
+        animate: true,
+        zeroBaseline: true,
+      }),
+    );
+    expect(animated).toContain('data-animate="true"');
+    expect(animated.match(/pathLength="1"/g)).toHaveLength(2);
+  });
+
   it("is one mark per point, named by date and value, plus a months row", () => {
     const hits = html.match(/class="mg-line-hit"/g) ?? [];
     expect(hits.length).toBe(spec.points.length);

--- a/packages/ui-kit/src/components/metagraphed/charts/line-geometry.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/line-geometry.test.ts
@@ -39,6 +39,18 @@ describe("placePoints", () => {
     ]);
     expect(flat[0]!.y).toBe(flat[1]!.y);
   });
+  it("can anchor non-negative count series to zero without exaggerating tiny variance", () => {
+    const placed = placePoints(
+      [
+        { t: 0, v: 7192 },
+        { t: 1, v: 7200 },
+      ],
+      LINE_VIEWBOX,
+      { zeroBaseline: true },
+    );
+    expect(Math.abs(placed[0]!.y - placed[1]!.y)).toBeLessThan(1);
+    expect(placed[1]!.y).toBe(20);
+  });
 });
 
 describe("smoothPath", () => {

--- a/packages/ui-kit/src/components/metagraphed/charts/line-geometry.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/line-geometry.ts
@@ -16,8 +16,9 @@ export interface LineWindow {
 }
 
 export const LINE_VIEWBOX = { width: 1200, height: 370 } as const;
-/** Room for the end marker and the line's stroke at the edges. */
-const PAD_Y = 8;
+/** Room for the line and labels; the larger top inset keeps peaks out of the summary band. */
+const PAD_TOP = 20;
+const PAD_BOTTOM = 8;
 /**
  * The last point lands at 94% of the width (the reference's
  * `--momentum-end-x: 94%`): the right 6% is the gutter the delta chip hangs
@@ -34,6 +35,7 @@ export interface PlacedPoint extends LinePoint {
 export function placePoints(
   points: readonly LinePoint[],
   box = LINE_VIEWBOX,
+  { zeroBaseline = false }: { zeroBaseline?: boolean } = {},
 ): PlacedPoint[] {
   if (points.length === 0) return [];
   const t0 = points[0]!.t;
@@ -45,6 +47,7 @@ export function placePoints(
     if (p.v < min) min = p.v;
     if (p.v > max) max = p.v;
   }
+  if (zeroBaseline && min >= 0) min = 0;
   const range = max - min || 1;
   return points.map((p) => ({
     ...p,
@@ -52,7 +55,10 @@ export function placePoints(
       points.length === 1
         ? (box.width * PLOT_RIGHT) / 2
         : ((p.t - t0) / span) * box.width * PLOT_RIGHT,
-    y: box.height - PAD_Y - ((p.v - min) / range) * (box.height - PAD_Y * 2),
+    y:
+      box.height -
+      PAD_BOTTOM -
+      ((p.v - min) / range) * (box.height - PAD_TOP - PAD_BOTTOM),
   }));
 }
 

--- a/packages/ui-kit/src/components/metagraphed/charts/line-with-window.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/line-with-window.tsx
@@ -60,6 +60,10 @@ export interface LineWithWindowProps {
   className?: string;
   /** Reserve the summary and plot geometry until a time-series source answers. */
   loading?: boolean;
+  /** Anchor non-negative count series to zero instead of exaggerating a narrow extent. */
+  zeroBaseline?: boolean;
+  /** Draw the line on mount; pair with a keyed metric switch to replay the transition. */
+  animate?: boolean;
 }
 
 const defaultFormat = (v: number) => String(v);
@@ -93,8 +97,13 @@ export function LineWithWindow({
   markerLabel,
   className,
   loading = false,
+  zeroBaseline = false,
+  animate = false,
 }: LineWithWindowProps) {
-  const placed = useMemo(() => placePoints(points), [points]);
+  const placed = useMemo(
+    () => placePoints(points, LINE_VIEWBOX, { zeroBaseline }),
+    [points, zeroBaseline],
+  );
   const inside = useMemo(() => windowPoints(placed, window), [placed, window]);
   const delta = useMemo(() => windowDelta(points, window), [points, window]);
   const months = useMemo(() => monthTicks(points), [points]);
@@ -142,6 +151,7 @@ export function LineWithWindow({
       data-mg-line=""
       data-compact={compact ? "true" : undefined}
       data-state={delta.state}
+      data-animate={animate ? "true" : undefined}
     >
       {compact ? null : (
         <div className="mg-line-summary">
@@ -169,8 +179,16 @@ export function LineWithWindow({
           aria-hidden="true"
           focusable="false"
         >
-          <path className="mg-line-muted" d={smoothPath(placed)} />
-          <path className="mg-line-active" d={smoothPath(inside)} />
+          <path
+            className="mg-line-muted"
+            d={smoothPath(placed)}
+            pathLength="1"
+          />
+          <path
+            className="mg-line-active"
+            d={smoothPath(inside)}
+            pathLength="1"
+          />
           {markerPoint ? (
             <line
               className="mg-line-subject"

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -2467,14 +2467,22 @@
     line-height: 1.4;
   }
   .mg-live-block-value {
-    overflow: hidden;
+    display: flex;
+    flex-wrap: wrap;
+    align-content: start;
+    gap: 0 5px;
+    min-width: 0;
     color: var(--ink-strong);
     font-family: var(--font-mono);
     font-size: 10px;
     font-variant-numeric: tabular-nums;
     line-height: 1.4;
-    text-overflow: ellipsis;
+  }
+  .mg-live-block-value > span {
     white-space: nowrap;
+  }
+  .mg-live-block-value-usd {
+    color: var(--ink-muted);
   }
   .mg-live-block-activity {
     display: block;
@@ -3521,6 +3529,10 @@
     gap: 16px;
     min-width: 0;
   }
+  .mg-home-story--chain .mg-line {
+    --mg-line-plot: 280px;
+    gap: 24px;
+  }
   .mg-line[data-compact="true"] {
     --mg-line-plot: 120px;
     gap: 0;
@@ -3599,6 +3611,47 @@
   }
   .mg-line-active {
     stroke: var(--good);
+  }
+  @keyframes mg-line-draw {
+    from {
+      stroke-dashoffset: 1;
+    }
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
+  @keyframes mg-line-enter {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @keyframes mg-line-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  .mg-line[data-animate="true"] .mg-line-muted,
+  .mg-line[data-animate="true"] .mg-line-active {
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+    animation: mg-line-draw 560ms cubic-bezier(0.2, 0.7, 0, 1) forwards;
+  }
+  .mg-line[data-animate="true"] .mg-line-summary,
+  .mg-line[data-animate="true"] .mg-line-months {
+    animation: mg-line-enter 300ms ease-out both;
+  }
+  .mg-line[data-animate="true"] .mg-line-marker,
+  .mg-line[data-animate="true"] .mg-line-end {
+    animation: mg-line-fade 300ms ease-out both;
+    animation-delay: 360ms;
   }
   .mg-line[data-state="negative"] .mg-line-active {
     stroke: var(--bad);
@@ -3704,6 +3757,17 @@
       transform: translate(calc(-100% - 8px), calc(-100% - 6px));
     }
   }
+  @media (prefers-reduced-motion: reduce) {
+    .mg-line[data-animate="true"] .mg-line-muted,
+    .mg-line[data-animate="true"] .mg-line-active,
+    .mg-line[data-animate="true"] .mg-line-summary,
+    .mg-line[data-animate="true"] .mg-line-months,
+    .mg-line[data-animate="true"] .mg-line-marker,
+    .mg-line[data-animate="true"] .mg-line-end {
+      animation: none;
+      stroke-dashoffset: 0;
+    }
+  }
 
   /* A legend swatch: the reference's 6×6 square in the series colour. */
   .mg-swatch {
@@ -3749,6 +3813,13 @@
   }
   .mg-rails-head > span:first-child {
     text-align: right;
+  }
+  .mg-home-emission-rails .mg-rails-head,
+  .mg-home-emission-rails .mg-rails-row {
+    grid-template-columns: 76px 168px minmax(0, 1fr);
+  }
+  .mg-home-emission-rails .mg-rails-head > span:first-child {
+    white-space: nowrap;
   }
   .mg-rails-head > span:nth-child(3),
   .mg-rails-head > span:nth-child(4) {
@@ -3948,6 +4019,10 @@
       row-gap: 2px;
       height: auto;
       padding-block: 4px;
+    }
+    .mg-home-emission-rails .mg-rails-head,
+    .mg-home-emission-rails .mg-rails-row {
+      grid-template-columns: 56px minmax(0, 1fr);
     }
     .mg-rails-head > span:nth-child(3),
     .mg-rails-head > span:nth-child(4) {


### PR DESCRIPTION
Closes #11773
Closes #11774
Closes #11775

## Summary
- keep latest-block TAO and USD values compact, readable, and accessible
- present subnet emission gains as actual window deltas with clear provenance instead of ambiguous end levels
- exclude an incomplete boundary day from chain comparisons, separate the plot from its copy, and redraw the line when the selected metric changes
- disclose stale chain observations honestly while the upstream freshness work remains tracked in #11776

## Validation
- npm test --workspace=apps/ui (2372 passed)
- npm test --workspace=packages/ui-kit (190 passed)
- npm run lint --workspace=apps/ui
- npm run lint --workspace=packages/ui-kit
- npm run typecheck --workspace=apps/ui
- npm run typecheck --workspace=packages/ui-kit
- npm run format:check --workspace=apps/ui
- npm run check:ssr-content-isolation --workspace=apps/ui
- npm run build:worker --workspace=apps/ui
- npm run test:e2e --workspace=apps/ui (responsive route coverage and homepage interactions passed locally)