### PR TITLE
fix(ui): match event detail loading skeleton

### DIFF
--- a/apps/ui/src/components/metagraphed/route-loading-skeleton.test.tsx
+++ b/apps/ui/src/components/metagraphed/route-loading-skeleton.test.tsx
@@ -25,6 +25,7 @@ describe("routeLoadingArchetype", () => {
     ["/accounts/5Fabc", "entity"],
     ["/providers/example", "entity"],
     ["/extrinsics/0xabc", "entity"],
+    ["/events/8713384/320?source=block#arguments", "entity"],
     ["/blocks/8942103", "block"],
     ["/chain", "operational"],
     ["/health", "operational"],

--- a/apps/ui/src/components/metagraphed/route-loading-skeleton.tsx
+++ b/apps/ui/src/components/metagraphed/route-loading-skeleton.tsx
@@ -55,7 +55,10 @@ export function routeLoadingArchetype(pathname: string): RouteLoadingArchetype {
 
   if (path === "/") return "landing";
   if (/^\/blocks\/[^/]+$/.test(path)) return "block";
-  if (/^\/(subnets|validators|accounts|providers|extrinsics)\/[^/]+$/.test(path)) {
+  if (
+    /^\/(subnets|validators|accounts|providers|extrinsics)\/[^/]+$/.test(path) ||
+    /^\/events\/[^/]+\/[^/]+$/.test(path)
+  ) {
     return "entity";
   }
   if (path === "/compare") return "compare";


### PR DESCRIPTION
## Summary

- classify canonical event-detail coordinates as explorer entities during route transitions
- preserve block-specific and prose loading grammars
- cover query and hash normalization on the dynamic event path

## Validation

- route loading skeleton: 41 tests passed
- UI lint and typecheck
- production Cloudflare Worker build

Closes #11782
Part of #11731
