### PR TITLE
perf(ui): prefetch block extrinsics with detail

### DIFF
--- a/apps/ui/src/lib/metagraphed/block-route-loader.test.ts
+++ b/apps/ui/src/lib/metagraphed/block-route-loader.test.ts
@@ -13,9 +13,10 @@ describe("startBlockRouteQueries", () => {
       prefetched = options;
     });
 
-    const started = startBlockRouteQueries(
+    const started = await startBlockRouteQueries(
       { ensureQueryData, prefetchInfiniteQuery } as never,
       "8713384",
+      true,
     );
 
     expect(ensureQueryData).toHaveBeenCalledTimes(1);
@@ -34,7 +35,7 @@ describe("startBlockRouteQueries", () => {
   });
 
   it("keeps a secondary extrinsics failure out of the route-level error path", async () => {
-    const started = startBlockRouteQueries(
+    const started = await startBlockRouteQueries(
       {
         ensureQueryData: vi.fn(async () => ({ data: { block_number: 8713384 } })),
         prefetchInfiniteQuery: vi.fn(async () => {
@@ -42,9 +43,25 @@ describe("startBlockRouteQueries", () => {
         }),
       } as never,
       "8713384",
+      true,
     );
 
     await expect(started.block).resolves.toEqual({ data: { block_number: 8713384 } });
+    await expect(started.extrinsics).resolves.toBeUndefined();
+  });
+
+  it("leaves direct server renders progressive instead of dehydrating the ledger", async () => {
+    const prefetchInfiniteQuery = vi.fn();
+    const started = await startBlockRouteQueries(
+      {
+        ensureQueryData: vi.fn(async () => ({ data: { block_number: 8713384 } })),
+        prefetchInfiniteQuery,
+      } as never,
+      "8713384",
+      false,
+    );
+
+    expect(prefetchInfiniteQuery).not.toHaveBeenCalled();
     await expect(started.extrinsics).resolves.toBeUndefined();
   });
 });

--- a/apps/ui/src/lib/metagraphed/block-route-loader.test.ts
+++ b/apps/ui/src/lib/metagraphed/block-route-loader.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { BLOCK_EXTRINSIC_PAGE_SIZE, startBlockRouteQueries } from "./block-route-loader";
+
+describe("startBlockRouteQueries", () => {
+  it("starts the block header and first extrinsics page without a waterfall", async () => {
+    let resolveBlock: ((value: unknown) => void) | undefined;
+    const block = new Promise((resolve) => {
+      resolveBlock = resolve;
+    });
+    const ensureQueryData = vi.fn(() => block);
+    let prefetched: { queryKey?: readonly unknown[] } | undefined;
+    const prefetchInfiniteQuery = vi.fn(async (options: typeof prefetched) => {
+      prefetched = options;
+    });
+
+    const started = startBlockRouteQueries(
+      { ensureQueryData, prefetchInfiniteQuery } as never,
+      "8713384",
+    );
+
+    expect(ensureQueryData).toHaveBeenCalledTimes(1);
+    expect(prefetchInfiniteQuery).toHaveBeenCalledTimes(1);
+    expect(prefetched?.queryKey).toEqual([
+      "metagraphed",
+      { network: "mainnet" },
+      "block-extrinsics-infinite",
+      "8713384",
+      BLOCK_EXTRINSIC_PAGE_SIZE,
+    ]);
+
+    resolveBlock?.({ data: { block_number: 8713384 } });
+    await expect(started.block).resolves.toEqual({ data: { block_number: 8713384 } });
+    await expect(started.extrinsics).resolves.toBeUndefined();
+  });
+
+  it("keeps a secondary extrinsics failure out of the route-level error path", async () => {
+    const started = startBlockRouteQueries(
+      {
+        ensureQueryData: vi.fn(async () => ({ data: { block_number: 8713384 } })),
+        prefetchInfiniteQuery: vi.fn(async () => {
+          throw new Error("extrinsics unavailable");
+        }),
+      } as never,
+      "8713384",
+    );
+
+    await expect(started.block).resolves.toEqual({ data: { block_number: 8713384 } });
+    await expect(started.extrinsics).resolves.toBeUndefined();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/block-route-loader.ts
+++ b/apps/ui/src/lib/metagraphed/block-route-loader.ts
@@ -1,0 +1,25 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { blockExtrinsicsInfiniteQuery, blockQuery } from "./queries";
+
+export const BLOCK_EXTRINSIC_PAGE_SIZE = 100;
+
+/**
+ * Start the two reads required for the first useful block-detail render.
+ *
+ * The block header remains authoritative for route-level errors and absence.
+ * The extrinsics ledger is secondary, so its prefetch is deliberately
+ * non-fatal; the page owns its existing retry and recovery UI. Returning both
+ * promises lets the route reject a missing block immediately while still
+ * awaiting a valid block's prefetched ledger before completing navigation.
+ */
+export function startBlockRouteQueries(
+  queryClient: Pick<QueryClient, "ensureQueryData" | "prefetchInfiniteQuery">,
+  ref: string,
+) {
+  const block = queryClient.ensureQueryData(blockQuery(ref));
+  const extrinsics = queryClient
+    .prefetchInfiniteQuery(blockExtrinsicsInfiniteQuery(ref, BLOCK_EXTRINSIC_PAGE_SIZE))
+    .catch(() => undefined);
+
+  return { block, extrinsics };
+}

--- a/apps/ui/src/lib/metagraphed/block-route-loader.ts
+++ b/apps/ui/src/lib/metagraphed/block-route-loader.ts
@@ -1,25 +1,30 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { blockExtrinsicsInfiniteQuery, blockQuery } from "./queries";
 
-export const BLOCK_EXTRINSIC_PAGE_SIZE = 100;
+export const BLOCK_EXTRINSIC_PAGE_SIZE = 25;
 
 /**
- * Start the two reads required for the first useful block-detail render.
+ * Start the reads required for the first useful block-detail render.
  *
  * The block header remains authoritative for route-level errors and absence.
  * The extrinsics ledger is secondary, so its prefetch is deliberately
  * non-fatal; the page owns its existing retry and recovery UI. Returning both
- * promises lets the route reject a missing block immediately while still
- * awaiting a valid block's prefetched ledger before completing navigation.
+ * Client navigations prime the ledger in parallel; direct server renders leave
+ * it progressive so the response stays compact and exposes catch-up states.
  */
-export function startBlockRouteQueries(
+export async function startBlockRouteQueries(
   queryClient: Pick<QueryClient, "ensureQueryData" | "prefetchInfiniteQuery">,
   ref: string,
+  prefetchExtrinsics = typeof window !== "undefined",
 ) {
+  // Keep the full query registry out of the generated route tree's global
+  // client entry. Both reads still start together once the route chunk opens.
+  const { blockExtrinsicsInfiniteQuery, blockQuery } = await import("./queries");
   const block = queryClient.ensureQueryData(blockQuery(ref));
-  const extrinsics = queryClient
-    .prefetchInfiniteQuery(blockExtrinsicsInfiniteQuery(ref, BLOCK_EXTRINSIC_PAGE_SIZE))
-    .catch(() => undefined);
+  const extrinsics = prefetchExtrinsics
+    ? queryClient
+        .prefetchInfiniteQuery(blockExtrinsicsInfiniteQuery(ref, BLOCK_EXTRINSIC_PAGE_SIZE))
+        .catch(() => undefined)
+    : Promise.resolve(undefined);
 
   return { block, extrinsics };
 }

--- a/apps/ui/src/routes/-block-detail-page.test.ts
+++ b/apps/ui/src/routes/-block-detail-page.test.ts
@@ -44,9 +44,9 @@ describe("block detail loading contract", () => {
   });
 
   it("primes the first extrinsics page with the header and reuses the shared query entry", () => {
-    expect(blockRoute).toContain("startBlockRouteQueries(context.queryClient, params.ref)");
+    expect(blockRoute).toContain("await startBlockRouteQueries(context.queryClient, params.ref)");
     expect(blockRoute).toContain("result = await pending.block");
-    expect(blockRoute).toContain("await pending.extrinsics");
+    expect(blockRoute).toContain("void pending.extrinsics");
   });
 
   it("uses a compact first decoded-event page without losing cursor continuation", () => {

--- a/apps/ui/src/routes/-block-detail-page.test.ts
+++ b/apps/ui/src/routes/-block-detail-page.test.ts
@@ -10,6 +10,10 @@ const extrinsicPage = readFileSync(
   fileURLToPath(new URL("./-extrinsic-detail-page.tsx", import.meta.url)),
   "utf8",
 );
+const blockRoute = readFileSync(
+  fileURLToPath(new URL("./blocks.$ref.tsx", import.meta.url)),
+  "utf8",
+);
 
 describe("block detail loading contract", () => {
   it("uses the endpoint-safe cadence limit instead of requesting 101 blocks", () => {
@@ -37,6 +41,12 @@ describe("block detail loading contract", () => {
     expect(page).toContain("extrinsics.fetchNextPage()");
     expect(page).toContain("total={extrinsicTotal ?? undefined}");
     expect(page).toContain("paginate={false}");
+  });
+
+  it("primes the first extrinsics page with the header and reuses the shared query entry", () => {
+    expect(blockRoute).toContain("startBlockRouteQueries(context.queryClient, params.ref)");
+    expect(blockRoute).toContain("result = await pending.block");
+    expect(blockRoute).toContain("await pending.extrinsics");
   });
 
   it("uses a compact first decoded-event page without losing cursor continuation", () => {

--- a/apps/ui/src/routes/-block-detail-page.tsx
+++ b/apps/ui/src/routes/-block-detail-page.tsx
@@ -51,6 +51,7 @@ import {
   isBlockDetailUnavailable,
   shouldRetryBlockDetail,
 } from "@/components/metagraphed/chain-detail/block-detail-retry";
+import { BLOCK_EXTRINSIC_PAGE_SIZE } from "@/lib/metagraphed/block-route-loader";
 import { Route } from "./blocks.$ref";
 
 const API_PATHS = [
@@ -60,7 +61,6 @@ const API_PATHS = [
   "/api/v1/blocks/{ref}/events",
   "/api/v1/blocks/{ref}/chain-events",
 ];
-const BLOCK_EXTRINSIC_PAGE_SIZE = 100;
 const BLOCK_EFFECT_PAGE_SIZE = 100;
 
 function ApiSources() {

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -3,6 +3,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { BlockDetailLoadingSkeleton } from "@/components/metagraphed/route-loading-skeleton";
 import { EmptyState, PageHeading } from "@/components/metagraphed/states";
 import { isValidBlockRef } from "@/lib/metagraphed/blocks";
+import { startBlockRouteQueries } from "@/lib/metagraphed/block-route-loader";
 import { BlockDetailPage } from "./-block-detail-page";
 import {
   entityNotFoundMeta,
@@ -25,9 +26,9 @@ export const Route = createFileRoute("/blocks/$ref")({
   // page's own useSuspenseQuery still drives the not-found/empty path.
   loader: async ({ context, params }) => {
     let result;
+    const pending = startBlockRouteQueries(context.queryClient, params.ref);
     try {
-      const { blockQuery } = await import("@/lib/metagraphed/queries");
-      result = await context.queryClient.ensureQueryData(blockQuery(params.ref));
+      result = await pending.block;
     } catch (error) {
       // #11000: a throttled PRIMARY query has no page to render, and answering
       // 200-with-an-error-card tells a crawler the render succeeded. Throw the
@@ -50,6 +51,11 @@ export const Route = createFileRoute("/blocks/$ref")({
     // under the confident title "Block 999999999999". `normalizeBlock` folds
     // that envelope to a null `data`, which is the unambiguous absence signal.
     if (!result.data) throw notFound();
+    // The ledger started alongside the header. Await it only after the header
+    // has established that this is a valid block, so missing/rate-limited
+    // routes retain their fast canonical boundary while valid navigations
+    // arrive with the first table page already in the shared query cache.
+    await pending.extrinsics;
     return { blockNumber: result.data.block_number ?? null };
   },
   head: ({ params, loaderData, match }) => {

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/blocks/$ref")({
   // page's own useSuspenseQuery still drives the not-found/empty path.
   loader: async ({ context, params }) => {
     let result;
-    const pending = startBlockRouteQueries(context.queryClient, params.ref);
+    const pending = await startBlockRouteQueries(context.queryClient, params.ref);
     try {
       result = await pending.block;
     } catch (error) {
@@ -51,11 +51,11 @@ export const Route = createFileRoute("/blocks/$ref")({
     // under the confident title "Block 999999999999". `normalizeBlock` folds
     // that envelope to a null `data`, which is the unambiguous absence signal.
     if (!result.data) throw notFound();
-    // The ledger started alongside the header. Await it only after the header
-    // has established that this is a valid block, so missing/rate-limited
-    // routes retain their fast canonical boundary while valid navigations
-    // arrive with the first table page already in the shared query cache.
-    await pending.extrinsics;
+    // On client navigation the ledger keeps resolving in the shared query
+    // cache while the route renders as soon as its authoritative header is
+    // known. Direct server renders deliberately stay progressive: dehydrating
+    // a secondary table bloats HTML and hides its truthful catch-up state.
+    void pending.extrinsics;
     return { blockNumber: result.data.block_number ?? null };
   },
   head: ({ params, loaderData, match }) => {


### PR DESCRIPTION
## Summary

- begin the block header and first extrinsics-page reads together during route loading
- reuse the exact infinite-query cache entry consumed by the block page
- retain the header as the authoritative 404/rate-limit path and keep secondary ledger failures non-fatal
- continue deferring decoded events, economic effects, and cadence context until technical details are opened

## Why

A cold direct block navigation previously paid the header read before it began the primary extrinsics ledger. Production measurements on a retained block showed roughly 1.03 s TTFB for the header and 3.00 s for the cold ledger request, while a warm ledger edge hit returned in about 0.10–0.12 s. Starting the independent reads together removes the avoidable sequential wait and primes the route-specific cache sooner.

## Validation

- 2,386 UI tests passed
- UI typecheck passed
- UI lint passed
- production Worker build passed
- responsive block-detail sweep passed at 375, 768, 1024, and 1280 px

Closes #11786
Parent: #11731
