### PR TITLE
fix(ui): deduplicate block ledger prefetch

### DIFF
--- a/apps/ui/src/components/metagraphed/live-block-rail.test.ts
+++ b/apps/ui/src/components/metagraphed/live-block-rail.test.ts
@@ -9,7 +9,9 @@ const source = readFileSync(
 
 describe("live block rail intent prefetch", () => {
   it("aligns the route record preload and primary ledger warm behind sustained reader intent", () => {
-    expect(source).toContain("blockExtrinsicsInfiniteQuery(String(blockNumber), 100)");
+    expect(source).toContain(
+      "blockExtrinsicsInfiniteQuery(String(blockNumber), BLOCK_EXTRINSIC_PAGE_SIZE)",
+    );
     expect(source).toContain("preloadDelay={140}");
     expect(source).toContain("}, 140);");
     expect(source).toContain('event.pointerType === "mouse"');

--- a/apps/ui/src/components/metagraphed/live-block-rail.tsx
+++ b/apps/ui/src/components/metagraphed/live-block-rail.tsx
@@ -11,6 +11,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { TimeAgo } from "@jsonbored/ui-kit";
 import { formatCompactAmount, formatCompactUsd, formatNumber } from "@/lib/metagraphed/format";
+import { BLOCK_EXTRINSIC_PAGE_SIZE } from "@/lib/metagraphed/block-route-loader";
 import { blockExtrinsicsInfiniteQuery } from "@/lib/metagraphed/queries";
 import type { Block } from "@/lib/metagraphed/types";
 import { arrivedBlock } from "./chain-stream/block-activity-window-logic";
@@ -124,7 +125,7 @@ export function LiveBlockRail({
   const warmExtrinsics = useCallback(
     (blockNumber: number) => {
       void queryClient.prefetchInfiniteQuery({
-        ...blockExtrinsicsInfiniteQuery(String(blockNumber), 100),
+        ...blockExtrinsicsInfiniteQuery(String(blockNumber), BLOCK_EXTRINSIC_PAGE_SIZE),
         retry: 0,
       });
     },

--- a/apps/ui/src/routes/-chain-stream-page.tsx
+++ b/apps/ui/src/routes/-chain-stream-page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@jsonbored/ui-kit";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
+import { BLOCK_EXTRINSIC_PAGE_SIZE } from "@/lib/metagraphed/block-route-loader";
 import {
   blocksQuery,
   blocksSummaryQuery,
@@ -102,7 +103,7 @@ const BlockStreamLink: SectionNavLink = ({ href, children, ...rest }) => {
     intentTimer.current = window.setTimeout(() => {
       intentTimer.current = null;
       void queryClient.prefetchInfiniteQuery({
-        ...blockExtrinsicsInfiniteQuery(blockNumber, 100),
+        ...blockExtrinsicsInfiniteQuery(blockNumber, BLOCK_EXTRINSIC_PAGE_SIZE),
         retry: 0,
       });
     }, 140);


### PR DESCRIPTION
Closes #11788

## Summary

- share the compact first-ledger page size across block detail, the live block rail, and the block stream
- keep hover/focus intent prefetch and route navigation on the same React Query key
- prevent a deliberate hover followed by navigation from issuing a second ledger request

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- focused Vitest: 7 passed
- `npm run build:worker:e2e --workspace=apps/ui`
- focused Playwright prefetch + block-detail suite: 7 passed