### PR TITLE
fix(analytics): reject stale chain activity projections

### DIFF
--- a/src/chain-activity-artifact.ts
+++ b/src/chain-activity-artifact.ts
@@ -18,6 +18,7 @@ import {
   ANALYTICS_WINDOW_DAYS,
   DEFAULT_ANALYTICS_WINDOW,
 } from "../workers/config.ts";
+import { DECODE_STALE_MS } from "./decode-freshness.ts";
 
 export const CHAIN_ACTIVITY_PROJECTION_KEY =
   "metagraph/projections/chain-activity.json";
@@ -37,6 +38,46 @@ const ChainActivityCellSchema = z.object({
 });
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+type ChainActivityCoverage = {
+  newest_observed?: unknown;
+  extrinsic_rows: Array<Record<string, unknown>>;
+  block_rows: Array<Record<string, unknown>>;
+};
+
+/**
+ * Whether a freshly generated activity card is backed by current decoded data.
+ *
+ * The projection cron can run successfully while the decoder feeding the
+ * lakehouse is stopped. In that state `generated_at` advances every 30 minutes
+ * even though `newest_observed` and the daily buckets do not. Compare the two
+ * clocks, and require the last fully closed UTC day on both source tables, so a
+ * publication timestamp can never make an old or partial rollup look current.
+ */
+export function chainActivityCoverageIsCurrent(
+  coverage: ChainActivityCoverage,
+  generatedAt: string,
+  options: { requireCompleteDay?: boolean } = {},
+): boolean {
+  const generatedMs = Date.parse(generatedAt);
+  const observedMs = Number(coverage.newest_observed);
+  if (!Number.isFinite(generatedMs) || !Number.isFinite(observedMs))
+    return false;
+  if (observedMs <= 0 || generatedMs - observedMs > DECODE_STALE_MS)
+    return false;
+
+  // A source stamp from the previous UTC day cannot prove that previous day is
+  // complete, even when it is only a few minutes old just after midnight.
+  const generatedDay = new Date(generatedMs).toISOString().slice(0, 10);
+  const observedDay = new Date(observedMs).toISOString().slice(0, 10);
+  if (generatedDay !== observedDay) return false;
+
+  if (options.requireCompleteDay !== true) return true;
+  const completeDay = new Date(generatedMs - DAY_MS).toISOString().slice(0, 10);
+  const hasDay = (rows: Array<Record<string, unknown>>) =>
+    rows.some((row) => row.day === completeDay);
+  return hasDay(coverage.extrinsic_rows) && hasDay(coverage.block_rows);
+}
 
 /** Render one integer UTC epoch-day (the day key the lane GROUPs BY, since
  * R2 SQL has no proven date-render function) as the 'YYYY-MM-DD' label
@@ -86,6 +127,16 @@ export async function loadChainActivityFromArtifact(
     cell: ChainActivityCellSchema,
   });
   if (!read) return null;
+  // Legacy cards written before generated_at was required are allowed through
+  // until their next scheduled rewrite. Every current producer writes the
+  // stamp; once present, stale decoded rows must decline instead of being
+  // served under a fresh publication time.
+  if (
+    read.generatedAt !== null &&
+    !chainActivityCoverageIsCurrent(read.cell, read.generatedAt)
+  ) {
+    return null;
+  }
   return buildChainActivity({
     window: read.label,
     observedAt: newestObservedIso(read.cell.newest_observed),

--- a/src/decode-freshness.ts
+++ b/src/decode-freshness.ts
@@ -1,0 +1,11 @@
+/**
+ * How long decoded chain data may stop advancing before consumers must treat
+ * it as stale. The decoder runs hourly and exhausts its own retry budget after
+ * three failures, so three hours distinguishes a delayed run from a stopped
+ * lane.
+ *
+ * This constant lives in a dependency-free leaf because both the watchdog and
+ * slim data-serving bundles need it; importing either consumer from the other
+ * would pull operational dependencies across Worker bundle boundaries.
+ */
+export const DECODE_STALE_MS = 3 * 60 * 60 * 1000;

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -50,6 +50,8 @@ import {
 import { watermarkRead } from "./raw-capture-sync.ts";
 import { readStore } from "./read-store.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
+export { DECODE_STALE_MS } from "./decode-freshness.ts";
+import { DECODE_STALE_MS } from "./decode-freshness.ts";
 
 /**
  * How long the decode lane may go without publishing before that is a fault.
@@ -62,8 +64,6 @@ import { laneHealthStore } from "./lane-health-store.ts";
  * long run plus cron jitter, and anything past three is time spent serving
  * detail-less blocks while the lane sits idle at its failure cap.
  */
-export const DECODE_STALE_MS = 3 * 60 * 60 * 1000;
-
 /**
  * How far the seam may trail the raw capture before that is a fault.
  *

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -58,6 +58,7 @@ import {
 } from "./chain-transfer-pairs.ts";
 import {
   CHAIN_ACTIVITY_PROJECTION_KEY,
+  chainActivityCoverageIsCurrent,
   epochDayIso,
 } from "./chain-activity-artifact.ts";
 import {
@@ -451,12 +452,27 @@ async function computeChainActivity(
     if (extrinsicRows === null) return null;
     const blockRows = withDayLabels(blocks);
     if (blockRows === null) return null;
-    windows[label] = {
+    const window = {
       days,
       extrinsic_rows: extrinsicRows,
       block_rows: blockRows,
       newest_observed: fresh[0]?.newest_observed ?? null,
     };
+    // A successful query is not necessarily current: when the decoder stops,
+    // R2 SQL keeps returning the last rows and the cron would otherwise stamp
+    // them with a new generated_at forever. Decline the whole write so the
+    // previous artifact ages into the projection watchdog, and only recover
+    // once both source tables cover the last complete UTC day again.
+    if (
+      !chainActivityCoverageIsCurrent(
+        window,
+        new Date(generatedAt).toISOString(),
+        { requireCompleteDay: true },
+      )
+    ) {
+      return null;
+    }
+    windows[label] = window;
     rowCount += extrinsicRows.length + blockRows.length;
   }
   return {

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3397,9 +3397,26 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     event_index: 1,
     observed_at: Date.now(),
   };
+  const ACTIVITY_DAY = Math.floor(Date.now() / 86_400_000);
+  const activityDays = (values: Record<string, unknown>) => [
+    { day_index: ACTIVITY_DAY, ...values },
+    { day_index: ACTIVITY_DAY - 1, ...values },
+  ];
   const laneRows = (sql: string) => {
     if (isBlocksLaneQuery(sql)) return [BLOCKS_ROW];
     if (isDeregistrationLaneQuery(sql)) return [REGISTRATION_ROW];
+    if (sql.includes("AS extrinsic_count"))
+      return activityDays({ extrinsic_count: 1, successful_extrinsics: 1 });
+    if (sql.includes("AS unique_signers"))
+      return activityDays({ unique_signers: 1 });
+    if (sql.includes("AS block_count"))
+      return activityDays({ block_count: 1, event_count: 1 });
+    if (
+      sql.includes("AS newest_observed") &&
+      /FROM chain(?:_testnet)?\.blocks/.test(sql)
+    ) {
+      return [{ newest_observed: Date.now() - 1_000 }];
+    }
     // The identity rollup's two ungrouped legs (#11418). Both always return
     // exactly one row from a real engine, so an empty result there is a
     // DECLINE by design -- feeding them is what makes chain-weight-setters

--- a/tests/chain-activity-artifact.test.ts
+++ b/tests/chain-activity-artifact.test.ts
@@ -9,6 +9,7 @@ import { describe, test } from "vitest";
 import {
   CHAIN_ACTIVITY_PROJECTION_KEY,
   epochDayIso,
+  chainActivityCoverageIsCurrent,
   loadChainActivityFromArtifact,
 } from "../src/chain-activity-artifact.ts";
 
@@ -92,6 +93,80 @@ describe("epochDayIso", () => {
   });
 });
 
+describe("chainActivityCoverageIsCurrent", () => {
+  const current = {
+    newest_observed: Date.parse("2026-08-02T14:00:00.000Z"),
+    extrinsic_rows: [{ day: "2026-08-01" }, { day: "2026-08-02" }],
+    block_rows: [{ day: "2026-08-01" }, { day: "2026-08-02" }],
+  };
+
+  test("accepts current source data with the last complete UTC day on both tables", () => {
+    assert.equal(
+      chainActivityCoverageIsCurrent(current, "2026-08-02T15:00:00.000Z", {
+        requireCompleteDay: true,
+      }),
+      true,
+    );
+  });
+
+  test("rejects a fresh publication over stale decoded rows", () => {
+    assert.equal(
+      chainActivityCoverageIsCurrent(
+        { ...current, newest_observed: Date.parse("2026-07-29T12:00:00Z") },
+        "2026-08-02T15:00:00.000Z",
+      ),
+      false,
+    );
+  });
+
+  test("rejects unreadable publication and source clocks", () => {
+    assert.equal(chainActivityCoverageIsCurrent(current, "not-a-date"), false);
+    assert.equal(
+      chainActivityCoverageIsCurrent(
+        { ...current, newest_observed: "not-a-number" },
+        "2026-08-02T15:00:00.000Z",
+      ),
+      false,
+    );
+    assert.equal(
+      chainActivityCoverageIsCurrent(
+        { ...current, newest_observed: null },
+        "2026-08-02T15:00:00.000Z",
+      ),
+      false,
+    );
+  });
+
+  test("rejects a source that has not crossed today's UTC boundary", () => {
+    assert.equal(
+      chainActivityCoverageIsCurrent(
+        { ...current, newest_observed: Date.parse("2026-08-01T23:59:00Z") },
+        "2026-08-02T00:10:00.000Z",
+      ),
+      false,
+    );
+  });
+
+  test("requires the last complete day from both source tables for a new write", () => {
+    assert.equal(
+      chainActivityCoverageIsCurrent(
+        { ...current, block_rows: [{ day: "2026-08-02" }] },
+        "2026-08-02T15:00:00.000Z",
+        { requireCompleteDay: true },
+      ),
+      false,
+    );
+    assert.equal(
+      chainActivityCoverageIsCurrent(
+        { ...current, extrinsic_rows: [{ day: "2026-08-02" }] },
+        "2026-08-02T15:00:00.000Z",
+        { requireCompleteDay: true },
+      ),
+      false,
+    );
+  });
+});
+
 describe("loadChainActivityFromArtifact", () => {
   test("serves the default window through the shared formatter", async () => {
     const { env, gets } = bucketWith(artifact());
@@ -115,12 +190,24 @@ describe("loadChainActivityFromArtifact", () => {
     assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
   });
 
-  test("every precomputed window is servable, and a null freshness stays null", async () => {
+  test("a precomputed window with no source freshness declines", async () => {
     const { env } = bucketWith(artifact());
     const data = await loadChainActivityFromArtifact(env, { window: "30d" });
-    assert.equal(data!.window, "30d");
-    assert.equal(data!.day_count, 1);
-    assert.equal(data!.observed_at, null);
+    assert.equal(data, null);
+  });
+
+  test("a newly published card over stale decoded rows declines", async () => {
+    const body = artifact();
+    body.generated_at = "2026-08-06T12:00:00.000Z";
+    const { env } = bucketWith(body);
+    assert.equal(await loadChainActivityFromArtifact(env, {}), null);
+  });
+
+  test("a legacy card without generated_at remains readable until its next rewrite", async () => {
+    const { generated_at: _generatedAt, ...legacy } = artifact();
+    const { env } = bucketWith(legacy);
+    const data = await loadChainActivityFromArtifact(env, {});
+    assert.equal(data!.observed_at, new Date(NEWEST).toISOString());
   });
 
   test("a window outside the route's set declines — never a different window's numbers", async () => {

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -102,6 +102,40 @@ function lakeFetchWithBlocks(onFail?: (sql: string) => boolean) {
           observed_at: NOW - 12_000,
         },
       ];
+    } else if (
+      /FROM chain(?:_testnet)?\.extrinsics/.test(sql) &&
+      sql.includes("AS extrinsic_count")
+    ) {
+      rows = [
+        {
+          day_index: NOW_DAY,
+          extrinsic_count: 2,
+          successful_extrinsics: 2,
+        },
+        {
+          day_index: NOW_DAY - 1,
+          extrinsic_count: 2,
+          successful_extrinsics: 2,
+        },
+      ];
+    } else if (sql.includes("COUNT(DISTINCT signer) AS unique_signers")) {
+      rows = [
+        { day_index: NOW_DAY, unique_signers: 1 },
+        { day_index: NOW_DAY - 1, unique_signers: 1 },
+      ];
+    } else if (
+      /FROM chain(?:_testnet)?\.blocks/.test(sql) &&
+      sql.includes("AS block_count")
+    ) {
+      rows = [
+        { day_index: NOW_DAY, block_count: 2, event_count: 4 },
+        { day_index: NOW_DAY - 1, block_count: 2, event_count: 4 },
+      ];
+    } else if (
+      /FROM chain(?:_testnet)?\.blocks/.test(sql) &&
+      sql.includes("AS newest_observed")
+    ) {
+      rows = [{ newest_observed: NOW - 1000 }];
     } else if (sql.includes("ORDER BY weight_sets DESC")) {
       // The identity rollup's GROUPED leg, matched on its ORDER BY rather than
       // its GROUP BY: the DISTINCT leg wraps the same `GROUP BY netuid, uid`
@@ -813,13 +847,30 @@ describe("chain-activity lane compute", () => {
       // The older day is missing here on purpose: data-api's merge defaults
       // an unmatched day's unique_signers to 0, and so must this one.
       [{ day_index: NOW_DAY, unique_signers: 9 }],
-      [{ day_index: NOW_DAY, block_count: 7200, event_count: 40000 }],
+      [
+        { day_index: NOW_DAY, block_count: 7200, event_count: 40000 },
+        { day_index: NOW_DAY - 1, block_count: 7200, event_count: 39000 },
+      ],
       [{ newest_observed: NOW - 1000 }],
-      // 30d: an empty window is a legitimate answer, not a decline.
-      [],
-      [],
-      [],
-      [],
+      // 30d: the same current source must cover the last complete UTC day.
+      [
+        {
+          day_index: NOW_DAY,
+          extrinsic_count: 100,
+          successful_extrinsics: 97,
+        },
+        {
+          day_index: NOW_DAY - 1,
+          extrinsic_count: 50,
+          successful_extrinsics: 50,
+        },
+      ],
+      [{ day_index: NOW_DAY, unique_signers: 9 }],
+      [
+        { day_index: NOW_DAY, block_count: 7200, event_count: 40000 },
+        { day_index: NOW_DAY - 1, block_count: 7200, event_count: 39000 },
+      ],
+      [{ newest_observed: NOW - 1000 }],
     );
     const body = (await laneNamed("chain-activity").compute(
       LAKE_ENV as unknown as Env,
@@ -852,7 +903,7 @@ describe("chain-activity lane compute", () => {
 
     assert.equal(body.schema_version, 1);
     assert.equal(body.generated_at, new Date(NOW).toISOString());
-    assert.equal(body.row_count, 3);
+    assert.equal(body.row_count, 8);
     const w7 = (body.windows as Row)["7d"] as Row;
     assert.equal(w7.days, 7);
     // Day indexes rendered as data-api's 'YYYY-MM-DD' labels, DISTINCT
@@ -873,15 +924,32 @@ describe("chain-activity lane compute", () => {
     ]);
     assert.deepEqual(w7.block_rows, [
       { day: "2026-08-02", block_count: 7200, event_count: 40000 },
+      { day: "2026-08-01", block_count: 7200, event_count: 39000 },
     ]);
     assert.equal(w7.newest_observed, NOW - 1000);
     const w30 = (body.windows as Row)["30d"] as Row;
-    assert.deepEqual(w30, {
-      days: 30,
-      extrinsic_rows: [],
-      block_rows: [],
-      newest_observed: null,
-    });
+    assert.equal(w30.days, 30);
+    assert.equal((w30.extrinsic_rows as Row[]).length, 2);
+    assert.equal((w30.block_rows as Row[]).length, 2);
+    assert.equal(w30.newest_observed, NOW - 1000);
+  });
+
+  test("declines when a successful query only sees stale decoded rows", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+    const previous = NOW_DAY - 1;
+    lakeFetch(
+      [{ day_index: previous, extrinsic_count: 1, successful_extrinsics: 1 }],
+      [{ day_index: previous, unique_signers: 1 }],
+      [{ day_index: previous, block_count: 7200, event_count: 1 }],
+      [{ newest_observed: NOW - 4 * DAY_MS }],
+    );
+    assert.equal(
+      await laneNamed("chain-activity").compute(
+        LAKE_ENV as unknown as Env,
+        "mainnet",
+      ),
+      null,
+    );
   });
 
   test("one failed statement declines the WHOLE compute — no partial artifact", async () => {
@@ -1572,6 +1640,7 @@ describe("runProjectionLanes", () => {
   });
 
   test("runs every registered lane and writes every artifact", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
     lakeFetchWithBlocks();
     const { puts, bucket } = archiveBucket();
     const result = await runProjectionLanes({
@@ -1641,6 +1710,7 @@ describe("runProjectionLanes", () => {
   });
 
   test("one failed lane never skips the next — failures are isolated", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
     // The transfers and transfer-pairs lanes' statements all filter on the
     // Transfer kind; fail exactly those so every other lane still sees a
     // healthy engine.
@@ -1702,6 +1772,7 @@ describe("runProjectionLanes", () => {
   // letting it set `ok: false` would drain the meaning out of the one signal
   // that says mainnet is broken.
   test("only mainnet decides the tick verdict", async () => {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
     // EVERY testnet query fails; every mainnet one succeeds.
     lakeFetchWithBlocks((sql) => sql.includes("chain_testnet."));
     const { puts, bucket } = archiveBucket();

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -2272,6 +2272,42 @@ describe("projection artifact answers when Postgres misses (windowed aggregates)
     assert.equal(body.data.observed_at, new Date(NEWEST).toISOString());
   });
 
+  test("handleChainActivity does not publish stale decoded rows as current", async () => {
+    const env = archiveEnv({
+      schema_version: 1,
+      generated_at: "2026-08-06T12:00:00.000Z",
+      row_count: 2,
+      windows: {
+        "7d": {
+          days: 7,
+          extrinsic_rows: [
+            {
+              day: "2026-08-02",
+              extrinsic_count: 100,
+              successful_extrinsics: 97,
+              unique_signers: 9,
+            },
+          ],
+          block_rows: [
+            { day: "2026-08-02", block_count: 7200, event_count: 40000 },
+          ],
+          newest_observed: NEWEST,
+        },
+      },
+    });
+    const p = "/api/v1/chain/activity";
+    const response = await handleChainActivity(req(p), env, url(p));
+    const body = await json(response);
+    assert.equal(
+      response.headers.get("x-metagraph-degraded"),
+      "tier_unavailable",
+    );
+    assert.equal(body.data.day_count, 0);
+    assert.deepEqual(body.data.days, []);
+    assert.equal(body.data.observed_at, null);
+    assert.equal(body.meta.generated_at, null);
+  });
+
   test("handleChainCalls serves the projected call mix, sliced to ?limit=, unmarked as degraded", async () => {
     const env = archiveEnv({
       schema_version: 1,

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -1303,7 +1303,6 @@ export async function handleChainActivity(
     env,
     edgeCacheScope("chain-activity", network),
     async (cacheRequest) => {
-      const meta = await readHealthMetaKv(env);
       // #4909 D1 retirement: extrinsics'/blocks' D1 write path is retired
       // (#4772) and the tables are dropped in production, so a D1 query here
       // would always miss. Postgres → schema-stable empty stub, never a live
@@ -1328,7 +1327,11 @@ export async function handleChainActivity(
           unmeasured(
             buildChainActivity({
               window: label,
-              observedAt: meta?.last_run_at || null,
+              // The health sweep's last_run_at is not a chain observation.
+              // Reusing it here made a missing or stale activity projection
+              // look freshly measured. Unknown activity stays explicitly
+              // unmeasured until the projection can prove current coverage.
+              observedAt: null,
             }),
           ),
         windowDays,


### PR DESCRIPTION
## Summary

- Refuse to republish chain-activity projections when decoded source timestamps are stale or the last complete UTC day is missing.
- Refuse stale projected reads and return an explicitly unmeasured fallback without borrowing a health-sweep timestamp.
- Share the decoder freshness threshold through a dependency-free leaf so the data-API bundle stays within its performance budget.

## What Changed

- Added source-time and complete-day coverage checks to the chain-activity writer and reader.
- Left the previous artifact in place on producer decline so its age becomes visible to the existing projection watchdog and recovers automatically after current data returns.
- Added writer, reader, handler, runner, and bundle-boundary regression coverage.

Refs #11776

## Registry Safety

- [x] Links a tracked, currently-open issue.
- [x] No secrets, credentials, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts were hand-edited.
- [x] No R2-only or high-churn artifacts are committed.
- [x] No public API, OpenAPI, or schema contract changed.

## Validation

- [x] npm run build
- [x] npm run validate
- [x] npm run validate:contract-drift
- [x] npm run validate:api
- [x] npm run format:check
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test:coverage
- [x] Focused affected suite: 556 tests
- [x] git diff --check

Operational decoder recovery remains tracked in #11776; this change prevents the stalled source from being presented as current and makes the missed cadence deterministic to detect.