### PR TITLE
fix(ui): attach TAO suffix to amounts

### DIFF
--- a/apps/ui/src/components/metagraphed/account-detail/account-detail-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/account-detail/account-detail-logic.test.ts
@@ -25,20 +25,20 @@ const position = (): AccountPosition =>
 
 describe("formatters", () => {
   it("renders TAO at the requested precision and a dash for nothing", () => {
-    expect(fmtTao(1.23456, 4)).toBe("1.2346 τ");
+    expect(fmtTao(1.23456, 4)).toBe("1.2346τ");
     expect(fmtTao(null)).toBe("—");
     expect(fmtTao(Number.NaN)).toBe("—");
   });
 
   it("compacts at each magnitude", () => {
-    expect(fmtCompactTao(2_691_628)).toBe("2.69M τ");
-    expect(fmtCompactTao(2_500)).toBe("2.5k τ");
-    expect(fmtCompactTao(2.5)).toBe("2.50 τ");
+    expect(fmtCompactTao(2_691_628)).toBe("2.69Mτ");
+    expect(fmtCompactTao(2_500)).toBe("2.5kτ");
+    expect(fmtCompactTao(2.5)).toBe("2.50τ");
   });
 
   it("keeps the sign on a net figure, where the sign is the point", () => {
-    expect(fmtSignedTao(5)).toBe("+5.00 τ");
-    expect(fmtSignedTao(-5)).toBe("−5.00 τ");
+    expect(fmtSignedTao(5)).toBe("+5.00τ");
+    expect(fmtSignedTao(-5)).toBe("−5.00τ");
     expect(fmtSignedTao(null)).toBe("—");
   });
 });
@@ -134,9 +134,9 @@ describe("counterpartyRail", () => {
 
   it("carries both directions and the net into the tooltip", () => {
     expect(counterpartyRail(parties)[0]?.detail).toEqual([
-      { key: "sent", label: "Sent", value: "1.0k τ" },
-      { key: "received", label: "Received", value: "1.0k τ" },
-      { key: "net", label: "Net", value: "0.0000 τ" },
+      { key: "sent", label: "Sent", value: "1.0kτ" },
+      { key: "received", label: "Received", value: "1.0kτ" },
+      { key: "net", label: "Net", value: "0.0000τ" },
       { key: "transfers", label: "Transfers", value: "8" },
     ]);
   });

--- a/apps/ui/src/components/metagraphed/account-detail/account-detail-logic.ts
+++ b/apps/ui/src/components/metagraphed/account-detail/account-detail-logic.ts
@@ -154,7 +154,7 @@ export interface CounterpartyRow {
 /**
  * Transfer partners ranked by how much moved, in either direction.
  *
- * By GROSS, not net: an address that sent 1,000 τ and received 1,000 τ back
+ * By GROSS, not net: an address that sent 1,000τ and received 1,000τ back
  * has a net of zero and is the account's most significant counterparty, and
  * ranking by net would put it last.
  */

--- a/apps/ui/src/components/metagraphed/account-detail/counterparties.tsx
+++ b/apps/ui/src/components/metagraphed/account-detail/counterparties.tsx
@@ -18,8 +18,8 @@ import { counterpartyRail, fmtCompactTao } from "./account-detail-logic";
  * section that answers a real question, and counterparties is the question
  * the transfer data can actually answer.
  *
- * Ranked by GROSS movement, not net: an address that sent 1,000 τ and got
- * 1,000 τ back nets to zero and is this account's most significant partner.
+ * Ranked by GROSS movement, not net: an address that sent 1,000τ and got
+ * 1,000τ back nets to zero and is this account's most significant partner.
  */
 export function CounterpartiesSection({ ss58 }: { ss58: string }) {
   const { ref, nearViewport } = useNearViewport("320px 0px");

--- a/apps/ui/src/components/metagraphed/accounts-index/accounts-index-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/accounts-index/accounts-index-logic.test.ts
@@ -40,9 +40,9 @@ describe("shortAddress / fmtTaoCompact", () => {
   });
 
   it("compacts at each magnitude and refuses a non-number", () => {
-    expect(fmtTaoCompact(1_914_956)).toBe("1.91M τ");
-    expect(fmtTaoCompact(1_500)).toBe("1.5k τ");
-    expect(fmtTaoCompact(1.5)).toBe("1.50 τ");
+    expect(fmtTaoCompact(1_914_956)).toBe("1.91Mτ");
+    expect(fmtTaoCompact(1_500)).toBe("1.5kτ");
+    expect(fmtTaoCompact(1.5)).toBe("1.50τ");
     expect(fmtTaoCompact(null)).toBe("—");
   });
 });
@@ -64,8 +64,8 @@ describe("holderCards", () => {
   ];
 
   it("shows the reading it was ranked by, not always stake", () => {
-    expect(holderCards(accounts, "stake")[0]?.value).toBe("100.00 τ");
-    expect(holderCards(accounts, "emission")[0]?.value).toBe("3.00 τ");
+    expect(holderCards(accounts, "stake")[0]?.value).toBe("100.00τ");
+    expect(holderCards(accounts, "emission")[0]?.value).toBe("3.00τ");
     expect(holderCards(accounts, "reach")[0]?.value).toBe("7 subnets");
     expect(holderCards(accounts, "reach")[1]?.value).toBe("2 subnets");
   });

--- a/apps/ui/src/components/metagraphed/chain-detail/chain-detail-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/chain-detail/chain-detail-logic.test.ts
@@ -188,7 +188,7 @@ describe("event links", () => {
   });
 });
 
-const fmt = { count: (n: number) => String(n), tao: (n: number) => `${n} τ` };
+const fmt = { count: (n: number) => String(n), tao: (n: number) => `${n}τ` };
 
 describe("blockFacts", () => {
   it("states the counts and the spec version", () => {
@@ -273,7 +273,7 @@ describe("extrinsicFacts", () => {
     ).toEqual([
       ["block", `#${8_713_384}`],
       ["result", "failed"],
-      ["fee", "0.0021 τ"],
+      ["fee", "0.0021τ"],
     ]);
   });
 
@@ -285,7 +285,7 @@ describe("extrinsicFacts", () => {
   it("shows a tip only when there is one", () => {
     expect(
       extrinsicFacts({ tip_tao: 0.5 } as Extrinsic, fmt).find((f) => f.key === "tip")?.value,
-    ).toBe("0.5 τ");
+    ).toBe("0.5τ");
     expect(extrinsicFacts({ tip_tao: 0 } as Extrinsic, fmt).some((f) => f.key === "tip")).toBe(
       false,
     );

--- a/apps/ui/src/components/metagraphed/chain-hub/chain-hub-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/chain-hub/chain-hub-logic.test.ts
@@ -27,7 +27,7 @@ describe("formatters", () => {
   it("compacts counts, formats TAO and shares, and refuses a non-number", () => {
     expect(fmtCount(1_020_430)).toBe("1.02M");
     expect(fmtCount(7_200)).toBe("7.2k");
-    expect(fmtTao(7.231114583, 4)).toBe("7.2311 τ");
+    expect(fmtTao(7.231114583, 4)).toBe("7.2311τ");
     expect(fmtShare(0.3464)).toBe("34.6%");
     expect(fmtCount(null)).toBe("—");
     expect(fmtTao(undefined)).toBe("—");

--- a/apps/ui/src/components/metagraphed/design/document-specimens.tsx
+++ b/apps/ui/src/components/metagraphed/design/document-specimens.tsx
@@ -98,8 +98,8 @@ export function HeroSection() {
             }
             cells={[
               { label: "Emission", value: "4.3%", delta: { text: "+0.2", tone: "good" } },
-              { label: "Alpha price", value: "0.0722 τ", delta: { text: "−1.4%", tone: "bad" } },
-              { label: "Total stake", value: "3.58M τ" },
+              { label: "Alpha price", value: "0.0722τ", delta: { text: "−1.4%", tone: "bad" } },
+              { label: "Total stake", value: "3.58Mτ" },
               { label: "UIDs", value: "247/256" },
             ]}
           />
@@ -130,8 +130,8 @@ export function FactsSection() {
           <FactStrip
             cells={[
               { label: "Emission", value: "4.3%", delta: { text: "+0.2", tone: "good" } },
-              { label: "Alpha price", value: "0.0722 τ", delta: { text: "−1.4%", tone: "bad" } },
-              { label: "Total stake", value: "3.58M τ" },
+              { label: "Alpha price", value: "0.0722τ", delta: { text: "−1.4%", tone: "bad" } },
+              { label: "Total stake", value: "3.58Mτ" },
               { label: "UIDs", value: "247/256" },
             ]}
           />
@@ -143,7 +143,7 @@ export function FactsSection() {
               { label: "Validators", value: "16" },
               { label: "Immunity", value: "5,000" },
               { label: "Tempo", value: "360" },
-              { label: "Burn", value: "1.42 τ" },
+              { label: "Burn", value: "1.42τ" },
             ]}
           />
         </div>

--- a/apps/ui/src/components/metagraphed/design/specimen-data.ts
+++ b/apps/ui/src/components/metagraphed/design/specimen-data.ts
@@ -16,5 +16,5 @@ export const LINE_SPECIMEN = lineSpecimen(120);
 export const STACKED_SPECIMEN = stackedSpecimen();
 
 export const formatTokens = (value: number) => `${value}T`;
-export const formatMillions = (value: number) => `${formatDecimal(value / 1_000_000, 2)}M τ`;
-export const formatThousands = (value: number) => `${formatDecimal(value / 1000, 0)}k τ`;
+export const formatMillions = (value: number) => `${formatDecimal(value / 1_000_000, 2)}Mτ`;
+export const formatThousands = (value: number) => `${formatDecimal(value / 1000, 0)}kτ`;

--- a/apps/ui/src/components/metagraphed/pre-sign-confirmation.tsx
+++ b/apps/ui/src/components/metagraphed/pre-sign-confirmation.tsx
@@ -65,7 +65,7 @@ export function PreSignConfirmation({
       <div>
         <div className="text-10 text-ink-muted mb-1">{copy.verb}</div>
         <div className="font-display text-16 font-medium text-ink-strong">
-          {amountTao} τ
+          {amountTao}τ
           {amountAlpha ? (
             <span className="ml-1.5 text-13 font-normal text-ink-muted">
               ({amountAlpha} α on subnet {netuid})
@@ -85,7 +85,7 @@ export function PreSignConfirmation({
       />
       <SummaryRow
         label="Network fee"
-        value={feeTao === null ? "Estimating…" : `${feeTao} τ`}
+        value={feeTao === null ? "Estimating…" : `${feeTao}τ`}
         loading={feeTao === null}
       />
       {expectedOut ? (

--- a/apps/ui/src/components/metagraphed/stake-amount-input.test.ts
+++ b/apps/ui/src/components/metagraphed/stake-amount-input.test.ts
@@ -109,6 +109,6 @@ describe("formatQuoteHint", () => {
   it("formats a 1:1 root-subnet note instead of a price-impact percentage", () => {
     expect(
       formatQuoteHint({ ...baseQuote, is_root: true, expected_out_unit: "tao", expected_out: 10 }),
-    ).toBe("≈ 10 τ · root subnet · 1:1");
+    ).toBe("≈ 10τ · root subnet · 1:1");
   });
 });

--- a/apps/ui/src/components/metagraphed/stake-amount-input.tsx
+++ b/apps/ui/src/components/metagraphed/stake-amount-input.tsx
@@ -1,7 +1,7 @@
 import { RangeControl } from "@jsonbored/ui-kit";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { SearchInput } from "@/components/metagraphed/table-controls";
-import { formatDecimal, formatNumber } from "@/lib/metagraphed/format";
+import { formatDecimal, formatNumber, joinAmountUnit } from "@/lib/metagraphed/format";
 import { raoToTao, type Rao } from "@/lib/metagraphed/units";
 import type { SubnetStakeQuote } from "@/lib/metagraphed/types";
 import type { StakeFlowAction, StakeFlowUnit } from "@/hooks/use-stake-flow";
@@ -68,7 +68,7 @@ export function formatQuoteHint(quote: SubnetStakeQuote | null): string | null {
   const impact = quote.is_root
     ? "root subnet · 1:1"
     : `${formatDecimal(quote.price_impact_pct, 2)}% price impact`;
-  return `≈ ${formatNumber(quote.expected_out)} ${outUnit} · ${impact}`;
+  return `≈ ${joinAmountUnit(formatNumber(quote.expected_out), outUnit)} · ${impact}`;
 }
 
 export interface StakeAmountInputProps {
@@ -158,7 +158,7 @@ export function StakeAmountInput({
             disabled={maxStakeRao == null}
             className="min-h-8 rounded border border-border bg-card px-3 py-1.5 text-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
           >
-            Max{maxStakeRao != null ? ` (${raoToTao(maxStakeRao)} τ)` : ""}
+            Max{maxStakeRao != null ? ` (${raoToTao(maxStakeRao)}τ)` : ""}
           </button>
         ) : (
           <button

--- a/apps/ui/src/components/metagraphed/subnet-detail/momentum.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-detail/momentum.tsx
@@ -89,7 +89,7 @@ export function MomentumSection({
     },
     {
       label: `Volume ${window}`,
-      value: volume != null ? `${taoCompact(volume)} τ` : "—",
+      value: volume != null ? `${taoCompact(volume)}τ` : "—",
       loading: ohlc.isPending,
     },
   ];

--- a/apps/ui/src/components/metagraphed/subnet-detail/validators.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-detail/validators.tsx
@@ -26,7 +26,7 @@ const COLUMNS: DataTableColumn<MetagraphNeuron>[] = [
     label: "Stake",
     kind: "number",
     value: (row) => row.stake_tao ?? null,
-    format: (v) => (typeof v === "number" ? `${taoCompact(v)} τ` : "—"),
+    format: (v) => (typeof v === "number" ? `${taoCompact(v)}τ` : "—"),
   },
   {
     key: "take",
@@ -111,7 +111,7 @@ export function ValidatorsSection({ netuid }: { netuid: number }) {
         showLoading ? (
           <RankedRails
             items={[]}
-            formatValue={(v) => `${taoCompact(v)} τ`}
+            formatValue={(v) => `${taoCompact(v)}τ`}
             scale="sqrt"
             columns={{ value: "Stake", name: "Validator", track: "Share of validator stake" }}
             ariaLabel={`Subnet ${netuid} validators by stake`}
@@ -128,7 +128,7 @@ export function ValidatorsSection({ netuid }: { netuid: number }) {
         ) : items.length > 0 ? (
           <RankedRails
             items={items}
-            formatValue={(v) => `${taoCompact(v)} τ`}
+            formatValue={(v) => `${taoCompact(v)}τ`}
             scale="sqrt"
             columns={{ value: "Stake", name: "Validator", track: "Share of validator stake" }}
             ariaLabel={`Subnet ${netuid} validators by stake`}

--- a/apps/ui/src/components/metagraphed/subnets-index/directory.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-index/directory.tsx
@@ -104,7 +104,7 @@ export function DirectorySection({
         kind: "number",
         sortable: true,
         value: (row) => row.alpha_price_tao ?? null,
-        format: (value) => (typeof value === "number" ? `${formatDecimal(value, 4)} τ` : "—"),
+        format: (value) => (typeof value === "number" ? `${formatDecimal(value, 4)}τ` : "—"),
       },
       {
         key: "priceChange",
@@ -131,7 +131,7 @@ export function DirectorySection({
         demote: true,
         sortable: true,
         value: (row) => row.subnet_volume_tao ?? null,
-        format: (value) => (typeof value === "number" ? `${fmtAlpha(value)} τ` : "—"),
+        format: (value) => (typeof value === "number" ? `${fmtAlpha(value)}τ` : "—"),
       },
       {
         key: "surfaces",

--- a/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.test.ts
@@ -117,7 +117,7 @@ describe("rankSubnets", () => {
     ];
     const ranked = rankSubnets("price", "7d", [], priced, name, noDomain);
     expect(ranked.map((r) => r.netuid)).toEqual([2, 1]);
-    expect(ranked[0]?.value).toBe("0.0010 τ");
+    expect(ranked[0]?.value).toBe("0.0010τ");
   });
 
   it("reads the 1-month field for the 30d window, as a fraction", () => {

--- a/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.ts
+++ b/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.ts
@@ -95,7 +95,7 @@ export const MOVERS_LIMIT = 100;
  * delta, which is the honest rendering of "we did not measure its change".
  *
  * Price is the exception and ranks by its change: an alpha price is a price
- * per subnet token, so one subnet's 0.5 τ is not comparable to another's, and
+ * per subnet token, so one subnet's 0.5τ is not comparable to another's, and
  * the level carries no ranking information at all.
  */
 export function rankSubnets(
@@ -136,7 +136,7 @@ export function rankSubnets(
       rows.push({
         netuid: row.netuid,
         sort: moved,
-        value: `${formatDecimal(price, 4)} τ`,
+        value: `${formatDecimal(price, 4)}τ`,
         delta: moved,
       });
       continue;

--- a/apps/ui/src/components/metagraphed/validator-detail/validator-detail-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/validator-detail/validator-detail-logic.test.ts
@@ -24,7 +24,7 @@ const membership = (over: Partial<ValidatorDetailSubnet>): ValidatorDetailSubnet
 
 describe("formatters", () => {
   it("compacts stake and alpha at each magnitude", () => {
-    expect(fmtStake(1_914_956)).toBe("1.91M τ");
+    expect(fmtStake(1_914_956)).toBe("1.91Mτ");
     expect(fmtAlpha(2_500)).toBe("2.5k α");
     expect(fmtAlpha(2.5)).toBe("2.50 α");
     expect(fmtStake(null)).toBe("—");
@@ -88,7 +88,7 @@ describe("historyPoints / apyPoints / changeOver", () => {
   });
 
   it("annualises the daily reward rate simply, not compounded", () => {
-    // The series is a reward per 1,000 τ per day; compounding it would state a
+    // The series is a reward per 1,000τ per day; compounding it would state a
     // return the validator did not produce.
     // Rounding here is the ASSERTION's, not the app's -- it compares floats
     // without pinning IEEE-754 noise, so it is arithmetic rather than display.
@@ -143,7 +143,7 @@ describe("nominatorRail", () => {
   it("drops a delegator who moved nothing, and keeps the direction in the tooltip", () => {
     const rows = nominatorRail(nominators);
     expect(rows.some((r) => r.key === "5CCCCCCCCCCCCCCC")).toBe(false);
-    expect(rows[0]?.detail.map((d) => d.value)).toEqual(["10.00 τ", "990.00 τ", "-980.00 τ", "9"]);
+    expect(rows[0]?.detail.map((d) => d.value)).toEqual(["10.00τ", "990.00τ", "-980.00τ", "9"]);
   });
 
   it("honours the limit", () => {

--- a/apps/ui/src/components/metagraphed/validator-detail/validator-detail-logic.ts
+++ b/apps/ui/src/components/metagraphed/validator-detail/validator-detail-logic.ts
@@ -93,7 +93,7 @@ export function historyPoints(
  * Annualised yield from the daily rewards-per-1000-TAO the history publishes.
  *
  * Simple annualisation, not compounded: the series is a daily reward rate
- * measured per 1,000 τ staked, and compounding it would state a return the
+ * measured per 1,000τ staked, and compounding it would state a return the
  * validator did not produce.
  */
 export function apyPoints(points: readonly ValidatorHistoryPoint[]): { t: number; v: number }[] {

--- a/apps/ui/src/components/metagraphed/validators-index/validators-index-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/validators-index/validators-index-logic.test.ts
@@ -259,7 +259,7 @@ describe("filterOperators", () => {
 
 describe("presentation helpers", () => {
   it("compacts stake and truncates only long keys", () => {
-    expect(fmtStake(1_914_956)).toBe("1.91M τ");
+    expect(fmtStake(1_914_956)).toBe("1.91Mτ");
     expect(fmtStake(null)).toBe("—");
     expect(shortKey("5GsbTgfvgCH4xdqSkiPb7EaBBFLHjWH5vfEALhJaewSFpZX9")).toBe("5GsbTg…pZX9");
     expect(shortKey("5Gsb")).toBe("5Gsb");

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -20,6 +20,7 @@ import {
   humaniseSeconds,
   isStaleFreshness,
   isUsableTimestamp,
+  normalizeTaoUnitSpacing,
   relativeFromDiff,
   subnetAgeDays,
 } from "./format";
@@ -181,35 +182,35 @@ describe("formatTao", () => {
   });
 
   it("keeps 4 decimals for zero and sub-unit amounts (< 1)", () => {
-    expect(formatTao(0)).toBe("0.0000 τ");
-    expect(formatTao(0.5)).toBe("0.5000 τ");
-    expect(formatTao(0.48213)).toBe("0.4821 τ");
+    expect(formatTao(0)).toBe("0.0000τ");
+    expect(formatTao(0.5)).toBe("0.5000τ");
+    expect(formatTao(0.48213)).toBe("0.4821τ");
   });
 
   it("uses 2 decimals for whole-unit amounts in [1, 1e3)", () => {
-    expect(formatTao(1)).toBe("1.00 τ"); // lower boundary — 2dp, not k-tier
-    expect(formatTao(256.5)).toBe("256.50 τ");
-    expect(formatTao(999.994)).toBe("999.99 τ");
+    expect(formatTao(1)).toBe("1.00τ"); // lower boundary — 2dp, not k-tier
+    expect(formatTao(256.5)).toBe("256.50τ");
+    expect(formatTao(999.994)).toBe("999.99τ");
   });
 
   it("switches to the k-tier at 1e3 and the M-tier at 1e6 (inclusive)", () => {
-    expect(formatTao(1_000)).toBe("1.0k τ"); // lower boundary of k-tier
-    expect(formatTao(12_345)).toBe("12.3k τ");
-    expect(formatTao(999_999)).toBe("1000.0k τ"); // still < 1e6 → k-tier
-    expect(formatTao(1_000_000)).toBe("1.00M τ"); // lower boundary of M-tier
-    expect(formatTao(2_500_000)).toBe("2.50M τ");
+    expect(formatTao(1_000)).toBe("1.0kτ"); // lower boundary of k-tier
+    expect(formatTao(12_345)).toBe("12.3kτ");
+    expect(formatTao(999_999)).toBe("1000.0kτ"); // still < 1e6 → k-tier
+    expect(formatTao(1_000_000)).toBe("1.00Mτ"); // lower boundary of M-tier
+    expect(formatTao(2_500_000)).toBe("2.50Mτ");
   });
 
   // #6019: tiering is by magnitude (|v|), not v itself, so a negative amount
   // gets the same tier a positive one of equal size would.
   it("tiers negative amounts by magnitude, preserving the sign", () => {
-    expect(formatTao(-0.48213)).toBe("-0.4821 τ"); // sub-unit
-    expect(formatTao(-256.5)).toBe("-256.50 τ"); // whole-unit, 2dp
-    expect(formatTao(-1_000)).toBe("-1.0k τ"); // lower boundary of k-tier
-    expect(formatTao(-12_345)).toBe("-12.3k τ");
-    expect(formatTao(-999_999)).toBe("-1000.0k τ"); // still < 1e6 → k-tier
-    expect(formatTao(-1_000_000)).toBe("-1.00M τ"); // lower boundary of M-tier
-    expect(formatTao(-2_500_000)).toBe("-2.50M τ");
+    expect(formatTao(-0.48213)).toBe("-0.4821τ"); // sub-unit
+    expect(formatTao(-256.5)).toBe("-256.50τ"); // whole-unit, 2dp
+    expect(formatTao(-1_000)).toBe("-1.0kτ"); // lower boundary of k-tier
+    expect(formatTao(-12_345)).toBe("-12.3kτ");
+    expect(formatTao(-999_999)).toBe("-1000.0kτ"); // still < 1e6 → k-tier
+    expect(formatTao(-1_000_000)).toBe("-1.00Mτ"); // lower boundary of M-tier
+    expect(formatTao(-2_500_000)).toBe("-2.50Mτ");
   });
 });
 
@@ -447,26 +448,35 @@ describe("formatAmount / formatAmountFixed / formatSignedAmount", () => {
   });
 
   it("formatAmountFixed keeps the caller's precision and unit", () => {
-    expect(formatAmountFixed(12.5, 2)).toBe("12.50 τ");
+    expect(formatAmountFixed(12.5, 2)).toBe("12.50τ");
     expect(formatAmountFixed(12.5, 0, "α")).toBe("13 α");
     expect(formatAmountFixed(null)).toBe("—");
   });
 
   it("formatSignedAmount marks direction with a typographic minus", () => {
-    expect(formatSignedAmount(1_000)).toBe("+1.0k τ");
-    expect(formatSignedAmount(-1_000)).toBe("−1.0k τ");
+    expect(formatSignedAmount(1_000)).toBe("+1.0kτ");
+    expect(formatSignedAmount(-1_000)).toBe("−1.0kτ");
     // U+2212, not the ASCII hyphen.
     expect(formatSignedAmount(-1_000)).toContain("−");
   });
 
   it("formatSignedAmount leaves an exact zero unsigned", () => {
-    expect(formatSignedAmount(0)).toBe("0.0000 τ");
-    expect(formatSignedAmount(-0)).toBe("0.0000 τ");
+    expect(formatSignedAmount(0)).toBe("0.0000τ");
+    expect(formatSignedAmount(-0)).toBe("0.0000τ");
   });
 
   it("falls back on nullish or non-finite input", () => {
     expect(formatAmount(null, "τ")).toBe("—");
     expect(formatSignedAmount(Number.NaN)).toBe("—");
+  });
+});
+
+describe("normalizeTaoUnitSpacing", () => {
+  it("attaches TAO in decoded prose without changing nonnumeric prose", () => {
+    expect(normalizeTaoUnitSpacing("Transferred 1.27 τ from Alice.")).toBe(
+      "Transferred 1.27τ from Alice.",
+    );
+    expect(normalizeTaoUnitSpacing("Enter a τ amount.")).toBe("Enter a τ amount.");
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -31,10 +31,10 @@ export function formatNumber(n: number | undefined | null, fallback = "—"): st
 /**
  * Format a TAO (τ) amount for compact display, tiering the precision by
  * magnitude so both dust and whole-subnet aggregates stay readable in a
- * single cell: ≥1e6 → "1.23M τ", ≥1e3 → "1.2k τ", ≥1 → "1.23 τ", and
- * sub-unit values keep 4 decimals ("0.5000 τ"). Tiering is by magnitude
+ * single cell: ≥1e6 → "1.23Mτ", ≥1e3 → "1.2kτ", ≥1 → "1.23τ", and
+ * sub-unit values keep 4 decimals ("0.5000τ"). Tiering is by magnitude
  * (|v|), not v itself, so a negative amount gets the same tier a positive
- * one of equal size would ("-2.00M τ", not "-2000000.0000 τ") -- the sign
+ * one of equal size would ("-2.00Mτ", not "-2000000.0000τ") -- the sign
  * is preserved by dividing the signed value, not the magnitude. Nullish /
  * non-finite input renders the em-dash fallback. Shared by the per-subnet
  * EconomicsPanel tiles and the /subnets table Registration column so the
@@ -56,10 +56,31 @@ export function formatTao(v?: number | null): string {
 export function formatAmount(v: number | null | undefined, unit: string): string {
   if (v == null || !Number.isFinite(v)) return "—";
   const magnitude = Math.abs(v);
-  if (magnitude >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M ${unit}`;
-  if (magnitude >= 1_000) return `${(v / 1_000).toFixed(1)}k ${unit}`;
-  if (magnitude >= 1) return `${v.toFixed(2)} ${unit}`;
-  return `${v.toFixed(4)} ${unit}`;
+  if (magnitude >= 1_000_000) return joinAmountUnit(`${(v / 1_000_000).toFixed(2)}M`, unit);
+  if (magnitude >= 1_000) return joinAmountUnit(`${(v / 1_000).toFixed(1)}k`, unit);
+  if (magnitude >= 1) return joinAmountUnit(v.toFixed(2), unit);
+  return joinAmountUnit(v.toFixed(4), unit);
+}
+
+/**
+ * Join an already-formatted numeric amount to its unit. TAO's currency glyph
+ * is a suffix and stays attached to the number; alpha and word units retain a
+ * separating space. Keeping that distinction here prevents narrow tables,
+ * charts and forms from inventing competing typography.
+ */
+export function joinAmountUnit(value: string, unit: string): string {
+  return unit === "τ" ? `${value}${unit}` : `${value} ${unit}`;
+}
+
+/**
+ * Normalize TAO amounts embedded in source-provided prose. Some decoded event
+ * summaries arrive as complete sentences rather than numeric fields, so they
+ * cannot pass through {@link formatAmount}. Limit the rewrite to a numeric
+ * token immediately followed by whitespace and the TAO glyph; ordinary prose
+ * such as "a τ amount" is intentionally unchanged.
+ */
+export function normalizeTaoUnitSpacing(value: string): string {
+  return value.replace(/(\d)\s+τ/g, "$1τ");
 }
 
 /**
@@ -98,23 +119,23 @@ export function formatCompactDelta(v: number | null | undefined): string {
   return `${sign}${scientific}`;
 }
 
-/** An amount at a fixed precision with its unit: `12.50 τ`. */
+/** An amount at a fixed precision with its unit: `12.50τ`. */
 export function formatAmountFixed(v: number | null | undefined, places = 2, unit = "τ"): string {
   if (v == null || !Number.isFinite(v)) return "—";
-  return `${v.toFixed(places)} ${unit}`;
+  return joinAmountUnit(v.toFixed(places), unit);
 }
 
 /**
  * A signed amount, with an explicit `+` on the positive side.
  *
- * A stake delta of `12 τ` and one of `-12 τ` are opposite events, and a column
+ * A stake delta of `12τ` and one of `-12τ` are opposite events, and a column
  * that renders the first without a sign makes the reader infer direction from
  * the absence of a character.
  */
 export function formatSignedAmount(v: number | null | undefined, unit = "τ"): string {
   if (v == null || !Number.isFinite(v)) return "—";
   const body = formatAmount(Math.abs(v), unit);
-  // A signed zero says nothing: "+0 τ" and "−0 τ" are the same event, and a
+  // A signed zero says nothing: "+0τ" and "−0τ" are the same event, and a
   // reader scanning a column for direction reads the sign, not the digits.
   if (v === 0) return body;
   // U+2212 MINUS, not the hyphen: it is the width of the plus it alternates

--- a/apps/ui/src/lib/metagraphed/visual-grammar-guardrails.test.ts
+++ b/apps/ui/src/lib/metagraphed/visual-grammar-guardrails.test.ts
@@ -31,6 +31,19 @@ const read = (p: string) => readFileSync(p, "utf8");
 const rel = (p: string) => p.slice(p.indexOf("/metagraphed/") + 13);
 
 describe("visual grammar guardrails (#8255)", () => {
+  it("keeps TAO's currency glyph attached to numeric values (#11794)", () => {
+    const spacedTao = /(?:\d|[kKM]|\})\s+τ/g;
+    const offenders: string[] = [];
+    for (const p of sources) {
+      const lines = read(p).split("\n");
+      lines.forEach((line, i) => {
+        if (spacedTao.test(line)) offenders.push(`${rel(p)}:${i + 1}`);
+        spacedTao.lastIndex = 0;
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
   it("keeps viewport scheduling details out of reader-facing copy (#11750)", () => {
     const implementationCopy =
       /(?:deferred below the fold|loads? as this section approaches|starts? only as this section approaches|loads? when this raw record is opened)/i;

--- a/apps/ui/src/lib/og-image.test.ts
+++ b/apps/ui/src/lib/og-image.test.ts
@@ -96,7 +96,7 @@ describe("readCardParams (#8489)", () => {
       stat1: "Netuid",
       stat1v: "SN64",
       stat2: "Price",
-      stat2v: "0.0832 τ",
+      stat2v: "0.0832τ",
       stat3: "Emission",
       stat3v: "3.41%",
       stat4: "Ignored",
@@ -110,7 +110,7 @@ describe("readCardParams (#8489)", () => {
       status: null,
       stats: [
         { label: "Netuid", value: "SN64" },
-        { label: "Price", value: "0.0832 τ" },
+        { label: "Price", value: "0.0832τ" },
         { label: "Emission", value: "3.41%" },
       ],
     });
@@ -271,7 +271,7 @@ describe("card font stack (#8489)", () => {
       title: "Chutes",
       subtitle: "x",
       eyebrow: null,
-      stats: [{ label: "Alpha price", value: "0.0832 τ" }],
+      stats: [{ label: "Alpha price", value: "0.0832τ" }],
     });
     expect(markup).toContain("font-family:'Space Grotesk','Inter'");
   });
@@ -328,7 +328,7 @@ describe("glyph subsetting (#8489) — every painted character must be subset", 
       title: "x",
       subtitle: "y",
       eyebrow: null,
-      stats: [{ label: "Alpha price", value: "0.0832 τ" }],
+      stats: [{ label: "Alpha price", value: "0.0832τ" }],
     });
     const painted = paintedChars(markup);
     for (const ch of "ALPHA PRICE".replace(/\s/g, "")) {
@@ -558,7 +558,7 @@ describe("three-stat rail (#8489)", () => {
       entity: true,
       stats: [
         { label: "Netuid", value: "SN64" },
-        { label: "Price", value: "0.0832 τ" },
+        { label: "Price", value: "0.0832τ" },
         { label: "Emission", value: "3.41%" },
       ],
     });
@@ -572,7 +572,7 @@ describe("three-stat rail (#8489)", () => {
       entity: true,
       stats: [
         { label: "Netuid", value: "SN64" },
-        { label: "Price", value: "0.0832 τ" },
+        { label: "Price", value: "0.0832τ" },
       ],
     });
     expect(two).toContain("font-size:42px");
@@ -624,7 +624,7 @@ describe("font subset request (#11204) — the bug that painted three tofu boxes
     entity: true,
     stats: [
       { label: "Netuid", value: "SN1" },
-      { label: "Price", value: "0.0080 τ" },
+      { label: "Price", value: "0.0080τ" },
       { label: "Emission", value: "0.61%" },
     ],
   };

--- a/apps/ui/src/lib/og-image.ts
+++ b/apps/ui/src/lib/og-image.ts
@@ -232,7 +232,7 @@ export function normalizeTitle(value: string | null): string {
 
 /**
  * The card's second line. Entity pages pass their own (#8257) -- "SN64 ·
- * 0.083 τ · healthy" says far more in a link unfurl than the same generic
+ * 0.083τ · healthy" says far more in a link unfurl than the same generic
  * tagline on every page did. Falls back to the tagline when absent, and is
  * bounded like the title so a long one can't overflow the card.
  */

--- a/apps/ui/src/routes/-compare-page.tsx
+++ b/apps/ui/src/routes/-compare-page.tsx
@@ -139,7 +139,7 @@ function SubnetLedger({ netuids }: { netuids: number[] }) {
           key: "price",
           label: "Alpha price",
           values: at((s) => s?.economics?.alpha_price_tao ?? null),
-          format: (v) => (typeof v === "number" ? `${formatDecimal(v, 4)} τ` : String(v)),
+          format: (v) => (typeof v === "number" ? `${formatDecimal(v, 4)}τ` : String(v)),
         },
         {
           key: "stake",

--- a/apps/ui/src/routes/-event-detail-page.test.ts
+++ b/apps/ui/src/routes/-event-detail-page.test.ts
@@ -42,6 +42,7 @@ describe("event detail route", () => {
     expect(page).toContain("eventArgRows(event?.args)");
     expect(page).toContain("defaultOpen");
     expect(page).toContain("Open extrinsic");
+    expect(page).toContain("normalizeTaoUnitSpacing(event.summary.trim())");
   });
 
   it("links every raw-event table to the canonical record", () => {

--- a/apps/ui/src/routes/-event-detail-page.tsx
+++ b/apps/ui/src/routes/-event-detail-page.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/metagraphed/chain-detail/chain-detail-logic";
 import { useRegisterApiSource } from "@/lib/metagraphed/api-source-context";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, normalizeTaoUnitSpacing } from "@/lib/metagraphed/format";
 import { blockChainEventsQuery } from "@/lib/metagraphed/queries";
 import type { ChainEvent } from "@/lib/metagraphed/types";
 import { Route } from "./events.$block.$index";
@@ -46,7 +46,9 @@ export function EventDetailPage() {
   const extrinsicHref = event ? eventExtrinsicHref(event) : null;
   const label = event ? eventLabel(event) : `Event #${formatNumber(Number(index))}`;
   const summary =
-    typeof event?.summary === "string" && event.summary.trim() ? event.summary.trim() : null;
+    typeof event?.summary === "string" && event.summary.trim()
+      ? normalizeTaoUnitSpacing(event.summary.trim())
+      : null;
   const cells: FactCells = [
     {
       label: "Block",

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -56,9 +56,9 @@ const API_PATHS = ["/api/v1/validators/operators", "/api/v1/validators/economics
 
 const MIN_STAKE_OPTIONS = [
   { value: 0, label: "Any stake" },
-  { value: 1_000, label: "1k τ and up" },
-  { value: 10_000, label: "10k τ and up" },
-  { value: 100_000, label: "100k τ and up" },
+  { value: 1_000, label: "1kτ and up" },
+  { value: 10_000, label: "10kτ and up" },
+  { value: 100_000, label: "100kτ and up" },
 ];
 
 function ApiSources() {

--- a/apps/ui/tests/e2e/block-detail.spec.ts
+++ b/apps/ui/tests/e2e/block-detail.spec.ts
@@ -15,7 +15,7 @@ test.describe("block detail progressive technical record", () => {
       await page.setViewportSize(viewport);
       await gotoThroughRestart(page, ROUTE);
       const ledger = page.getByRole("region", { name: "Value moved in this block." });
-      await expect(ledger).toContainText("3.75 τ");
+      await expect(ledger).toContainText("3.75τ");
       await expect(ledger).toContainText("$900");
       await expect(ledger.getByRole("link", { name: "SN19" })).toHaveAttribute(
         "href",

--- a/apps/ui/tests/e2e/event-detail.spec.ts
+++ b/apps/ui/tests/e2e/event-detail.spec.ts
@@ -13,7 +13,7 @@ test.describe("addressable event detail", () => {
       "href",
       "/extrinsics/8713384-11",
     );
-    await expect(page.getByText("Transferred 1.27 τ", { exact: false })).toBeVisible();
+    await expect(page.getByText("Transferred 1.27τ", { exact: false })).toBeVisible();
 
     const record = page.locator("[data-mg-raw][open]");
     await expect(record).toContainText("arg.from");

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -4013,7 +4013,7 @@ var LEADER_SPECIMEN = RAIL_SPECIMEN.map((r, i) => ({
   key: r.key,
   name: r.label,
   sub: i % 2 ? "Macrocosmos" : "Rayon Labs",
-  value: `${(r.value / 1e6).toFixed(2)}M \u03C4`,
+  value: `${(r.value / 1e6).toFixed(2)}M\u03C4`,
   delta: i === 3 ? "new" : i * 7 % 11 / 10 - 0.3,
   href: `/subnets/${i + 1}`
 }));

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3987,7 +3987,7 @@ var LEADER_SPECIMEN = RAIL_SPECIMEN.map((r, i) => ({
   key: r.key,
   name: r.label,
   sub: i % 2 ? "Macrocosmos" : "Rayon Labs",
-  value: `${(r.value / 1e6).toFixed(2)}M \u03C4`,
+  value: `${(r.value / 1e6).toFixed(2)}M\u03C4`,
   delta: i === 3 ? "new" : i * 7 % 11 / 10 - 0.3,
   href: `/subnets/${i + 1}`
 }));

--- a/packages/ui-kit/src/components/metagraphed/charts/rank-grid.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/rank-grid.tsx
@@ -12,7 +12,7 @@ import { markAriaLabel } from "./chart-aria";
 export interface RankGridItem {
   key: string;
   label: string;
-  /** Formatted value, e.g. "1.2M τ". */
+  /** Formatted value, e.g. "1.2Mτ". */
   value?: string;
   /** Formatted share, e.g. "42%". */
   share?: string;

--- a/packages/ui-kit/src/components/metagraphed/charts/rank-specimens.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/rank-specimens.ts
@@ -57,7 +57,7 @@ export const LEADER_SPECIMEN: LeaderCardItem[] = RAIL_SPECIMEN.map((r, i) => ({
   key: r.key,
   name: r.label,
   sub: i % 2 ? "Macrocosmos" : "Rayon Labs",
-  value: `${(r.value / 1_000_000).toFixed(2)}M τ`,
+  value: `${(r.value / 1_000_000).toFixed(2)}Mτ`,
   delta: i === 3 ? "new" : ((i * 7) % 11) / 10 - 0.3,
   href: `/subnets/${i + 1}`,
 }));

--- a/packages/ui-kit/src/components/metagraphed/charts/rank.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/rank.test.ts
@@ -230,7 +230,7 @@ describe("LeaderCards", () => {
     expect(html).toContain(
       '<span class="mg-leader-delta" data-state="new">New</span>',
     );
-    expect(html).toContain('aria-label="#1 Targon · 1.89M τ total"');
+    expect(html).toContain('aria-label="#1 Targon · 1.89Mτ total"');
   });
 
   it("preserves featured and compact reading geometry while a leaderboard loads", () => {

--- a/packages/ui-kit/src/components/metagraphed/compare-ledger.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/compare-ledger.test.ts
@@ -140,14 +140,14 @@ describe("CompareLedger markup", () => {
                 key: "r",
                 label: "Stake",
                 values: [1234, null],
-                format: (v: number | string) => `${v} τ`,
+                format: (v: number | string) => `${v}τ`,
               },
             ],
           },
         ],
       }),
     );
-    expect(html).toContain("1234 τ");
+    expect(html).toContain("1234τ");
     expect(html).toContain("—");
   });
 


### PR DESCRIPTION
## Summary

- centralize TAO suffix adjacency while preserving spacing for alpha and word units
- normalize source-provided event summaries and sweep remaining route-local TAO displays
- add a source guardrail so numeric TAO spacing cannot drift back across explorer routes
- rebuild the shared UI-kit outputs

## Validation

- `npm test --workspace=apps/ui` (2,392 passed)
- `npm test --workspace=packages/ui-kit`
- `npm run typecheck --workspace=apps/ui`
- `npm run typecheck --workspace=packages/ui-kit`
- `npm run lint --workspace=apps/ui`
- `npm run lint --workspace=packages/ui-kit`
- `npm run format:check --workspace=apps/ui`
- `npm run build:worker --workspace=apps/ui`
- `npm run build:worker:e2e --workspace=apps/ui`
- `npm run test:e2e --workspace=apps/ui` (598 passed)
- `npm run build`
- `npm run validate`
- `npm run validate:ui-route-coverage`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

Closes #11794