### PR TITLE
perf(api): cache settled historical blocks

### DIFF
--- a/src/block-economics.ts
+++ b/src/block-economics.ts
@@ -124,6 +124,26 @@ export function blockEconomicsUsd(
   reading: TaoUsdReading | null | undefined,
   nowMs: number,
 ): BlockEconomicsUsd {
+  const tao =
+    typeof economicActivityTao === "string" && DECIMAL.test(economicActivityTao)
+      ? Number(economicActivityTao)
+      : typeof economicActivityTao === "number" &&
+          Number.isFinite(economicActivityTao)
+        ? economicActivityTao
+        : null;
+  // A price reading is not applicable until the block has a measured native
+  // total. Omitting it here also keeps settled, undecodable block records
+  // independent from a live index that changes after the block was produced.
+  if (tao === null) {
+    return {
+      economic_activity_usd: null,
+      usd_per_tao: null,
+      tao_usd_block: null,
+      tao_usd_observed_at: null,
+      tao_usd_basis: null,
+    };
+  }
+
   const usable = taoUsdUsable(reading, nowMs);
   if (!usable.ok) {
     return {
@@ -137,14 +157,7 @@ export function blockEconomicsUsd(
   }
 
   const rate = reading!.usd_per_tao as number;
-  const tao =
-    typeof economicActivityTao === "string" && DECIMAL.test(economicActivityTao)
-      ? Number(economicActivityTao)
-      : typeof economicActivityTao === "number" &&
-          Number.isFinite(economicActivityTao)
-        ? economicActivityTao
-        : null;
-  const usd = tao === null ? null : tao * rate;
+  const usd = tao * rate;
   return {
     economic_activity_usd:
       usd !== null && Number.isFinite(usd) ? Number(usd.toFixed(6)) : null,

--- a/tests/block-economics.test.ts
+++ b/tests/block-economics.test.ts
@@ -208,13 +208,19 @@ describe("summarizeBlockEconomics", () => {
         .tao_usd_unavailable,
       "index_stale",
     );
-    assert.equal(
+    assert.deepEqual(
       blockEconomicsUsd(
         null,
         { ...reading, observed_at: "2026-08-29T04:59:00.000Z" },
         Date.parse("2026-08-29T05:00:00.000Z"),
-      ).economic_activity_usd,
-      null,
+      ),
+      {
+        economic_activity_usd: null,
+        usd_per_tao: null,
+        tao_usd_block: null,
+        tao_usd_observed_at: null,
+        tao_usd_basis: null,
+      },
     );
   });
 

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -4236,17 +4236,56 @@ describe("handleBlock", () => {
       }),
     ]);
     try {
-      const body = await json(
-        await handleBlock(
-          req(`/api/v1/blocks/${BLOCK_NUM}`),
-          env as unknown as Env,
-          String(BLOCK_NUM),
-        ),
+      const response = await handleBlock(
+        req(`/api/v1/blocks/${BLOCK_NUM}`),
+        env as unknown as Env,
+        String(BLOCK_NUM),
       );
+      const body = await json(response);
 
       assert.equal(body.data.block.economic_activity_tao, 1.25);
       assert.equal(body.data.block.economic_activity_usd, 250);
       assert.equal(body.data.block.usd_per_tao, 200);
+      assert.equal(response.headers.get("x-metagraph-cache-profile"), "short");
+    } finally {
+      cold.restore();
+    }
+  });
+
+  test("caches a settled unpriced historical block without live price metadata", async () => {
+    const { env } = dbWith({ blockDetail: blockRow() });
+    Object.assign(env, LAKEHOUSE_ENV);
+    env.METAGRAPH_CONTROL = {
+      get: async () => ({
+        usd_per_tao: 200,
+        observed_at: new Date().toISOString(),
+        block_number: 9_000_000,
+        price_basis: "tao-usd-index",
+      }),
+    };
+
+    const cold = lakehouse([
+      blockRow({
+        decode_status: "unavailable",
+        economic_activity_tao: null,
+        economics_complete: false,
+      }),
+    ]);
+    try {
+      const response = await handleBlock(
+        req(`/api/v1/blocks/${BLOCK_NUM}`),
+        env as unknown as Env,
+        String(BLOCK_NUM),
+      );
+      const body = await json(response);
+
+      assert.equal(body.data.block.decode_status, "unavailable");
+      assert.equal(body.data.block.economic_activity_tao, null);
+      assert.equal(body.data.block.economic_activity_usd, null);
+      assert.equal(body.data.block.usd_per_tao, null);
+      assert.equal(body.data.block.tao_usd_observed_at, null);
+      assert.equal(response.headers.get("x-metagraph-cache-profile"), "static");
+      assert.match(response.headers.get("cache-control") || "", /max-age=600/);
     } finally {
       cold.restore();
     }

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -6912,10 +6912,17 @@ export async function handleBlock(
         },
       }
     : rawData;
-  // The chain record is immutable, but its explicit current-price conversion
-  // is not. Keep the response on the short profile so USD never freezes at the
-  // first rate a CDN happened to cache for this block.
-  const cacheProfile = "short";
+  // Complete block totals carry a current-price conversion, so keep those on
+  // the short profile rather than freezing one index reading at the edge. A
+  // settled block that could not be decoded has no native total or applicable
+  // conversion; its response is immutable and can use the static edge profile.
+  // Unknown and still-pending records remain short-lived so recovery is visible.
+  const cacheProfile =
+    data.block?.decode_status === "unavailable" &&
+    data.block.economic_activity_tao === null &&
+    data.block.usd_per_tao === null
+      ? "static"
+      : "short";
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary
- omit TAO/USD index metadata when a block has no decoded economic total
- classify settled unavailable block detail as static so the existing chain-detail edge cache can reuse it
- keep unknown, pending, and complete price-bearing block responses on the short profile

## Validation
- `npm run build`
- `npm run validate`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage` (22,436 passed; 11 skipped)
- focused block economics, block handler, and chain-detail edge-cache tests (363 passed)

The local pipeline reached its supported live native-snapshot refresh but the external SDK/RPC process has no timeout; required CI remains the merge gate.

Closes #11796