### PR TITLE
perf(api): cache settled priced block detail

### DIFF
--- a/tests/chain-detail-edge-cache.test.ts
+++ b/tests/chain-detail-edge-cache.test.ts
@@ -14,6 +14,10 @@ import {
   handleRequest,
   withChainDetailEdgeCache,
 } from "../workers/api.ts";
+import {
+  METAGRAPH_SETTLED_SHORT_CACHE,
+  type SettledShortCacheResponse,
+} from "../workers/http.ts";
 import type { Row } from "./row-type.ts";
 
 const globalWithCaches = globalThis as unknown as { caches?: unknown };
@@ -56,8 +60,12 @@ const get = (headers: Record<string, string> = {}) =>
   new Request(url.toString(), { headers });
 
 /** A handler response carrying `profile`, shaped like envelopeResponse's. */
-function answer(profile: "static" | "short", body = '{"ok":true}') {
-  return new Response(body, {
+function answer(
+  profile: "static" | "short",
+  body = '{"ok":true}',
+  settledShort = false,
+) {
+  const response = new Response(body, {
     status: 200,
     headers: {
       "content-type": "application/json",
@@ -65,6 +73,11 @@ function answer(profile: "static" | "short", body = '{"ok":true}') {
       etag: 'W/"abc"',
     },
   });
+  if (settledShort) {
+    (response as SettledShortCacheResponse)[METAGRAPH_SETTLED_SHORT_CACHE] =
+      true;
+  }
+  return response;
 }
 
 /** Counts how many times the underlying handler actually ran. */
@@ -203,6 +216,39 @@ describe("chain-detail edge cache (#11001)", () => {
     );
     await Promise.all(waits);
     assert.equal(cache.putKeys.length, 0);
+  });
+
+  test("stores an explicitly settled short answer for only its short freshness window", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const waits: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+    const handler = producer(() => answer("short", '{"ok":true}', true));
+
+    const miss = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      ctx,
+      handler.produce,
+    );
+    assert.equal(miss.headers.get("x-metagraph-cache"), "miss");
+    await Promise.all(waits);
+
+    const stored = [...cache.store.values()][0];
+    assert.equal(stored.headers.get("cache-control"), "public, s-maxage=60");
+
+    const hit = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      ctx,
+      handler.produce,
+    );
+    assert.equal(hit.headers.get("x-metagraph-cache"), "hit");
+    assert.equal(handler.calls, 1);
   });
 
   test("does NOT store a gap (503) — it is transient by definition", async () => {

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -13,6 +13,10 @@ import {
 import { handleRequest } from "../workers/api.ts";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import {
+  METAGRAPH_SETTLED_SHORT_CACHE,
+  type SettledShortCacheResponse,
+} from "../workers/http.ts";
 
 // Every hot-tier read in these handlers goes through readStore -> `new
 // Client({ connectionString })` (#10179), and a handler is entered as
@@ -4247,6 +4251,10 @@ describe("handleBlock", () => {
       assert.equal(body.data.block.economic_activity_usd, 250);
       assert.equal(body.data.block.usd_per_tao, 200);
       assert.equal(response.headers.get("x-metagraph-cache-profile"), "short");
+      assert.equal(
+        (response as SettledShortCacheResponse)[METAGRAPH_SETTLED_SHORT_CACHE],
+        true,
+      );
     } finally {
       cold.restore();
     }

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -243,11 +243,13 @@ import {
   exposeCustomResponseHeaders,
   ifNoneMatchSatisfied,
   isPathUnder,
+  METAGRAPH_SETTLED_SHORT_CACHE,
   weakEtag,
   withCacheStatus,
   X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER,
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   type CacheProfile,
+  type SettledShortCacheResponse,
   readBoundedRequestText,
 } from "./http.ts";
 import {
@@ -4392,6 +4394,7 @@ function cacheWrite(ctx: Ctx | undefined, write: () => Promise<unknown>): void {
  * different questions and were never the same number.
  */
 const CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS = 3600;
+const CHAIN_DETAIL_SETTLED_SHORT_CACHE_TTL_SECONDS = 60;
 
 /**
  * Cache namespace for the serialized chain-detail response shape.
@@ -4478,10 +4481,18 @@ export async function withChainDetailEdgeCache(
   }
 
   const response = await produce();
-  if (
-    response.status === 200 &&
-    response.headers.get("x-metagraph-cache-profile") === "static"
-  ) {
+  const profile = response.headers.get("x-metagraph-cache-profile");
+  const settledShort =
+    profile === "short" &&
+    (response as SettledShortCacheResponse)[METAGRAPH_SETTLED_SHORT_CACHE] ===
+      true;
+  const cacheTtl =
+    profile === "static"
+      ? CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS
+      : settledShort
+        ? CHAIN_DETAIL_SETTLED_SHORT_CACHE_TTL_SECONDS
+        : null;
+  if (response.status === 200 && cacheTtl !== null) {
     // Stored with OUR ttl, not the client-facing one. Built explicitly rather
     // than by passing the Response as an init so the headers are copied into a
     // fresh Headers and mutating them cannot reach the response we return.
@@ -4490,10 +4501,7 @@ export async function withChainDetailEdgeCache(
       statusText: response.statusText,
       headers: response.headers,
     });
-    stored.headers.set(
-      "cache-control",
-      `public, s-maxage=${CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS}`,
-    );
+    stored.headers.set("cache-control", `public, s-maxage=${cacheTtl}`);
     cacheWrite(ctx, () => cacheable.store.put(cacheable.key, stored));
   }
   // Stamped on the returned response only -- `stored` above is the cache's own

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -43,6 +43,22 @@ export const X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER =
  */
 export const X_METAGRAPH_CACHE_HEADER = "x-metagraph-cache";
 
+/**
+ * In-memory hand-off from a chain-detail handler to its edge-cache wrapper.
+ *
+ * A `short` response is normally deliberately unsettled and must not be
+ * stored. One exception is a settled chain record with a live market overlay:
+ * the record is immutable, but the composed response may be reused only for
+ * its short public freshness window. A symbol property carries that exception
+ * without adding internal coordination metadata to the HTTP response.
+ */
+export const METAGRAPH_SETTLED_SHORT_CACHE = Symbol(
+  "metagraph.settledShortCache",
+);
+export type SettledShortCacheResponse = Response & {
+  [METAGRAPH_SETTLED_SHORT_CACHE]?: true;
+};
+
 /** Statuses the Response constructor forbids a body on (null body only). */
 const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -37,8 +37,10 @@ import { resolveClientIp } from "../config.ts";
 
 import {
   errorResponse,
+  METAGRAPH_SETTLED_SHORT_CACHE,
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   type CacheProfile,
+  type SettledShortCacheResponse,
 } from "../http.ts";
 import {
   contractVersion,
@@ -6923,7 +6925,7 @@ export async function handleBlock(
     data.block.usd_per_tao === null
       ? "static"
       : "short";
-  return envelopeResponse(
+  const response = await envelopeResponse(
     request,
     {
       data,
@@ -6935,6 +6937,15 @@ export async function handleBlock(
     },
     cacheProfile,
   );
+  // The chain-native record is settled, but its current-price conversion is
+  // intentionally short-lived. Let the chain-detail wrapper reuse the whole
+  // composed response for that same 60-second window instead of re-reading the
+  // immutable block on every request. Pending/unknown blocks never set this.
+  if (data.block?.decode_status === "complete") {
+    (response as SettledShortCacheResponse)[METAGRAPH_SETTLED_SHORT_CACHE] =
+      true;
+  }
+  return response;
 }
 
 /**


### PR DESCRIPTION
Closes #11798

## Summary

- opt decoded complete block detail into the chain-detail edge cache without changing its public short freshness profile
- retain the existing 60-second TAO/USD freshness window for priced block responses while preserving the one-hour internal TTL for fully static history
- keep unknown, pending, gap, and ordinary short-profile responses uncached
- carry the handler-to-cache signal in memory rather than in an HTTP header

## Evidence

- fresh production baseline for a decoded complete block: three consecutive requests at roughly 176–198 ms TTFB, each an edge miss with one database call
- focused tests: 354 passed
- full unsharded coverage: 978 files, 22,437 passed, 11 skipped; 95.75% branch coverage
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run validate`

## Review note

This is a non-visual API performance change. No screenshot workflow applies.