### PR TITLE
perf(ui): preload homepage live blocks

### DIFF
--- a/apps/ui/src/routes/-index-page.test.ts
+++ b/apps/ui/src/routes/-index-page.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const homepage = readFileSync(fileURLToPath(new URL("./-index-page.tsx", import.meta.url)), "utf8");
+const homepageRoute = readFileSync(fileURLToPath(new URL("./index.tsx", import.meta.url)), "utf8");
 const styles = readFileSync(
   fileURLToPath(new URL("../../../../packages/ui-kit/src/styles.css", import.meta.url)),
   "utf8",
@@ -54,7 +55,12 @@ describe("homepage masthead", () => {
     );
     expect(homepage).toContain("blocksQuery({ limit: LIVE_BLOCK_LIMIT })");
     expect(homepage).toContain("enabled: heroBlockRailEnabled");
-    expect(homepage).toContain("useRefetchInterval(15_000, heroBlockRailEnabled)");
+    expect(homepage).toContain("const HERO_BLOCK_REFETCH_INTERVAL_MS = 12_000");
+    expect(homepageRoute).toContain('rel: "preload"');
+    expect(homepageRoute).toContain('as: "fetch"');
+    expect(homepageRoute).toContain('type: "application/json"');
+    expect(homepageRoute).toContain('media: "(min-width: 640px)"');
+    expect(homepageRoute).toContain("/api/v1/blocks?limit=12");
     expect(homepage).toContain(
       'value: typeof headBlock === "number" ? formatNumber(headBlock) : "—"',
     );

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -67,6 +67,7 @@ const EMISSION_WINDOWS = [
 ] as const;
 
 const HERO_BLOCK_RAIL_MEDIA_QUERY = "(min-width: 640px)";
+const HERO_BLOCK_REFETCH_INTERVAL_MS = 12_000;
 const MCP_INSTALL_COMMAND =
   "claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp/core";
 
@@ -130,7 +131,14 @@ export function OverviewPage() {
   const blocks = useQuery({ ...blocksSummaryQuery(), retry: 0 });
   // The block rail polls only while this tab is visible. It advances the
   // explorer reading without holding a permanent stream connection open.
-  const blockRefetchInterval = useRefetchInterval(15_000, heroBlockRailEnabled);
+  // Bittensor targets a roughly 12-second block cadence. The feed response's
+  // ten-second browser lifetime expires first, so each visible-tab tick can
+  // observe a newly indexed head rather than replaying a nominal refresh from
+  // the HTTP cache.
+  const blockRefetchInterval = useRefetchInterval(
+    HERO_BLOCK_REFETCH_INTERVAL_MS,
+    heroBlockRailEnabled,
+  );
   const blockFeed = useQuery({
     ...blocksQuery({ limit: LIVE_BLOCK_LIMIT }),
     enabled: heroBlockRailEnabled,

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -1,10 +1,30 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { OverviewPage } from "./-index-page";
 import { hubMeta } from "@/lib/metagraphed/hub-copy";
+import { API_DATA_ORIGIN } from "@/lib/metagraphed/identity";
+
+/**
+ * Start the optional desktop instrument while the document is still parsing.
+ * `type` aligns the preload's Accept header with apiFetch, so the hydrated
+ * React Query read reuses the same browser-cache entry. The media attribute is
+ * load-bearing: the compact phone hero does not render this rail and therefore
+ * must not pay for its feed.
+ */
+export const HOME_BLOCK_FEED_URL = `${API_DATA_ORIGIN}/api/v1/blocks?limit=12`;
 
 export const Route = createFileRoute("/")({
   head: () => ({
     meta: hubMeta("/"),
+    links: [
+      {
+        rel: "preload",
+        as: "fetch",
+        type: "application/json",
+        href: HOME_BLOCK_FEED_URL,
+        crossOrigin: "anonymous",
+        media: "(min-width: 640px)",
+      },
+    ],
   }),
   component: OverviewPage,
 });

--- a/apps/ui/tests/e2e/home-secondary-state.spec.ts
+++ b/apps/ui/tests/e2e/home-secondary-state.spec.ts
@@ -6,9 +6,22 @@ test.describe("homepage secondary analytics", () => {
     context,
     page,
   }) => {
+    let blockFeedRequests = 0;
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (url.pathname === "/api/v1/blocks" && url.searchParams.get("limit") === "12") {
+        blockFeedRequests += 1;
+      }
+    });
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     await page.setViewportSize({ width: 1280, height: 800 });
     await gotoThroughRestart(page, "/");
+
+    const preload = page.locator('link[rel="preload"][as="fetch"]');
+    await expect(preload).toHaveAttribute("media", "(min-width: 640px)");
+    await expect(preload).toHaveAttribute("type", "application/json");
+    await expect(page.locator("a.mg-live-block").first()).toBeVisible();
+    await expect.poll(() => blockFeedRequests).toBe(1);
 
     await expect(page.getByRole("combobox", { name: "Search the registry" })).toBeVisible();
     await expect(page.getByText("Bittensor in a box.", { exact: true })).toBeVisible();
@@ -29,6 +42,13 @@ test.describe("homepage secondary analytics", () => {
   test("keeps the three lower instruments structured during delayed mobile reads", async ({
     page,
   }) => {
+    let blockFeedRequests = 0;
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (url.pathname === "/api/v1/blocks" && url.searchParams.get("limit") === "12") {
+        blockFeedRequests += 1;
+      }
+    });
     let releaseReads: (() => void) | undefined;
     const readsReleased = new Promise<void>((resolve) => {
       releaseReads = resolve;
@@ -46,6 +66,7 @@ test.describe("homepage secondary analytics", () => {
 
     await page.setViewportSize({ width: 375, height: 812 });
     await gotoThroughRestart(page, "/");
+    expect(blockFeedRequests).toBe(0);
 
     const emission = page.getByRole("group", {
       name: "Subnet daily alpha gains over the 30d comparison",

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -4033,6 +4033,20 @@ describe("handleBlocks", () => {
     assert.equal(res.headers.get("vary"), "Accept, Accept-Encoding");
   });
 
+  test("expires the live JSON feed before the website's next head poll", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
+    const res = await handleBlocks(
+      req("/api/v1/blocks?limit=12"),
+      env as unknown as Env,
+      url("/api/v1/blocks?limit=12"),
+    );
+
+    assert.equal(
+      res.headers.get("cache-control"),
+      "public, max-age=10, must-revalidate",
+    );
+  });
+
   test("adds one fresh response-level TAO/USD conversion to complete mainnet blocks", async () => {
     const { env } = dbWith({
       blocksFeed: [

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -6755,6 +6755,8 @@ function readBlockTaoUsdCurrentKv(
     : Promise.resolve(null);
 }
 
+const LIVE_BLOCK_FEED_CACHE_CONTROL = "public, max-age=10, must-revalidate";
+
 export async function handleBlocks(
   request: Request,
   env: Env,
@@ -6826,7 +6828,7 @@ export async function handleBlocks(
       BLOCK_CSV_COLUMNS,
     );
   }
-  return envelopeResponse(
+  const response = await envelopeResponse(
     request,
     {
       data,
@@ -6839,6 +6841,13 @@ export async function handleBlocks(
     "short",
     { vary: "Accept, Accept-Encoding" },
   );
+  // The generic short profile is one minute, longer than both Bittensor's
+  // approximate block cadence and the website's visible-tab poll. A browser
+  // would otherwise answer several "refreshes" from its own cache. Ten seconds
+  // is still long enough for the homepage's document-head preload to bridge
+  // hydration, then expires before the next twelve-second live tick.
+  response.headers.set("cache-control", LIVE_BLOCK_FEED_CACHE_CONTROL);
+  return response;
 }
 
 // GET /api/v1/blocks/summary: block-production analytics over the most recent


### PR DESCRIPTION
## Summary

- start the desktop homepage block-feed read from a viewport-scoped document-head preload
- keep the compact phone hero from downloading the hidden feed
- shorten the feed browser lifetime to 10 seconds and align the visible-tab poll to the chain cadence
- preserve newest-left arrival motion, compact economic readings, reduced-motion behavior, and intent prefetch

## Evidence

- production baseline: the rail remained skeletal around 1.4s and rendered block links around 4s in the measured trace
- direct feed reads ranged from about 0.20s to 0.48s during diagnosis
- built-browser check: desktop emitted one exact latest-block request shared by preload and hydration; 375px emitted zero
- 22,438 backend tests passed with 95.75% branch coverage
- 2,393 UI unit tests passed
- focused desktop/mobile browser interaction suite passed
- root and UI typecheck, lint, format, validation, generated build, and Worker e2e build passed

Closes #11800
Related to #11731