### PR TITLE
perf(data): materialize explorer directories

### DIFF
--- a/src/kv-keys.ts
+++ b/src/kv-keys.ts
@@ -8,6 +8,20 @@ export const KV_HEALTH_RPC_POOL = "health:rpc-pool" as const;
 export const KV_HEALTH_META = "health:meta" as const;
 export const KV_ECONOMICS_CURRENT = "economics:current" as const;
 /**
+ * The small pointer to the account-holder and validator-operator directories
+ * derived from the newest materialized neuron snapshot. The payload itself is
+ * versioned by captured_at so an eventually-consistent pointer can never make
+ * a reader mistake the previous snapshot for the new one.
+ */
+export const KV_EXPLORER_DIRECTORIES_CURRENT =
+  "explorer-directories:v1:current" as const;
+export const KV_EXPLORER_DIRECTORIES_SNAPSHOT_PREFIX =
+  "explorer-directories:v1:snapshot" as const;
+
+export function explorerDirectoriesSnapshotKey(capturedAt: number): string {
+  return `${KV_EXPLORER_DIRECTORIES_SNAPSHOT_PREFIX}:${capturedAt}`;
+}
+/**
  * The newest TAO/USD reading, so a consumer can price alpha without a DB read.
  *
  * WHY KV AND NOT A NEON READ (#10381). `tao_usd_index` is the durable series

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -20,6 +20,10 @@ import { beforeAll, beforeEach, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 import type { Row } from "./row-type.ts";
 import { persistComputeDeclaration } from "../src/compute-declarations-lane.ts";
+import {
+  explorerDirectoriesSnapshotKey,
+  KV_EXPLORER_DIRECTORIES_CURRENT,
+} from "../src/kv-keys.ts";
 import { dataApiEnv } from "./helpers/worker-env.ts";
 import type { DataApiWorkerEnv } from "../workers/types.ts";
 
@@ -34,7 +38,11 @@ const { pg } = await vi.hoisted(async () => ({
 }));
 vi.mock("pg", () => pg.module);
 
-const { default: worker } = await import("../workers/data-api.ts");
+const {
+  default: worker,
+  materializationFromUnknown,
+  refreshExplorerDirectoryMaterialization,
+} = await import("../workers/data-api.ts");
 
 /**
  * The REAL Neon DDL for every table this route family touches (#10328).
@@ -146,6 +154,38 @@ function env(overrides: Record<string, unknown> = {}): DataApiWorkerEnv {
     NEURON_DAILY_BACKFILL_SECRET: BACKFILL_SECRET,
     ...overrides,
   });
+}
+
+function memoryKv() {
+  const values = new Map<string, string>();
+  let puts = 0;
+  return {
+    values,
+    putCount: () => puts,
+    get: async (key: string, type?: string) => {
+      const value = values.get(key) ?? null;
+      return type === "json" && value !== null ? JSON.parse(value) : value;
+    },
+    put: async (key: string, value: string) => {
+      puts += 1;
+      values.set(key, value);
+    },
+    delete: async (key: string) => {
+      values.delete(key);
+    },
+  };
+}
+
+function collectingCtx() {
+  const pending: Promise<unknown>[] = [];
+  return {
+    pending,
+    ctx: {
+      waitUntil(value: Promise<unknown>) {
+        pending.push(Promise.resolve(value));
+      },
+    } as unknown as ExecutionContext,
+  };
 }
 
 /** A ctx with a real `waitUntil`. createPgSql hands the client back through it
@@ -2726,6 +2766,502 @@ test("the neuron snapshot stamp stays null until a pass completes", async () => 
   const res = await call(req("/api/v1/internal/neurons-snapshot-stamp"));
   assert.equal(res.status, 200);
   assert.deepEqual(await res.json(), { captured_at: null });
+});
+
+test("the snapshot stamp prepares one atomic directory materialization and both routes reuse it", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Stake", stake_tao: 100 });
+  await insertNeuron({ uid: 1, hotkey: "5Emission", emission_tao: 20 });
+  await insertNeuron({ uid: 2, hotkey: "5Reach", stake_tao: 5 });
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 3, 3, CAPTURED_AT + 1],
+  );
+  const kv = memoryKv();
+  const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+  const collected = collectingCtx();
+
+  const stamp = await worker.fetch(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    materializedEnv,
+    collected.ctx,
+  );
+  assert.deepEqual(await stamp.json(), { captured_at: CAPTURED_AT });
+  await Promise.all(collected.pending);
+
+  const pointer = JSON.parse(
+    kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!,
+  ) as Row;
+  assert.equal(pointer.captured_at, CAPTURED_AT);
+  const stored = JSON.parse(
+    kv.values.get(explorerDirectoriesSnapshotKey(CAPTURED_AT))!,
+  ) as Row;
+  assert.equal(stored.captured_at, CAPTURED_AT);
+  assert.equal((stored.accounts as Row).account_count, 3);
+  assert.equal((stored.validators as Row).validator_count, 3);
+
+  // Prove these are KV reads rather than another whole-network aggregation:
+  // once the materialization exists, even an unavailable source table cannot
+  // turn the two compact website routes into an error or an empty directory.
+  await db.exec("TRUNCATE neurons");
+  const accounts = await call(
+    req("/api/v1/accounts/directory"),
+    materializedEnv,
+  );
+  const validators = await call(
+    req("/api/v1/validators/operators"),
+    materializedEnv,
+  );
+  assert.equal(((await accounts.json()) as Row).account_count, 3);
+  assert.equal(((await validators.json()) as Row).validator_count, 3);
+});
+
+test("concurrent requests share one directory refresh for a completed snapshot", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Only", stake_tao: 100 });
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+  );
+  const kv = memoryKv();
+  const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+  const collected = collectingCtx();
+  const [first, second] = await Promise.all([
+    refreshExplorerDirectoryMaterialization(
+      materializedEnv as DataApiEnv,
+      collected.ctx,
+      CAPTURED_AT,
+    ),
+    refreshExplorerDirectoryMaterialization(
+      materializedEnv as DataApiEnv,
+      collected.ctx,
+      CAPTURED_AT,
+    ),
+  ]);
+  assert.deepEqual([first, second], [true, true]);
+  // One versioned payload plus one tiny current pointer, still from one shared
+  // build rather than one pair of writes per caller.
+  assert.equal(kv.putCount(), 2);
+});
+
+test("the cache-stamp hot path reads only the small directory pointer", async () => {
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+  );
+  const reads: string[] = [];
+  const pointerKv = {
+    get: async (key: string, type?: string) => {
+      reads.push(key);
+      const value =
+        key === KV_EXPLORER_DIRECTORIES_CURRENT
+          ? JSON.stringify({ schema_version: 1, captured_at: CAPTURED_AT })
+          : null;
+      return type === "json" && value !== null ? JSON.parse(value) : value;
+    },
+  };
+  const stamp = await call(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    env({ METAGRAPH_CONTROL: pointerKv }),
+  );
+  assert.deepEqual(await stamp.json(), { captured_at: CAPTURED_AT });
+  assert.deepEqual(reads, [KV_EXPLORER_DIRECTORIES_CURRENT]);
+});
+
+test("a refresh already represented by the current pointer does no database work", async () => {
+  const kv = memoryKv();
+  kv.values.set(
+    KV_EXPLORER_DIRECTORIES_CURRENT,
+    JSON.stringify({ schema_version: 1, captured_at: CAPTURED_AT }),
+  );
+  assert.equal(
+    await refreshExplorerDirectoryMaterialization(
+      env({ METAGRAPH_CONTROL: kv }) as DataApiEnv,
+      ctx,
+      CAPTURED_AT,
+    ),
+    true,
+  );
+  assert.equal(kv.putCount(), 0);
+  assert.equal(pg.control.queries.length, 0);
+});
+
+test("a directory refresh declines cleanly when its store runner is unavailable", async () => {
+  const kv = memoryKv();
+  assert.equal(
+    await refreshExplorerDirectoryMaterialization(
+      dataApiEnv({ METAGRAPH_CONTROL: kv }) as DataApiEnv,
+      ctx,
+      CAPTURED_AT,
+    ),
+    false,
+  );
+});
+
+test("a failed background materialization leaves the current stamp readable", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Only", stake_tao: 100 });
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+  );
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const brokenKv = {
+    get: async () => null,
+    put: async () => {
+      throw new Error("KV write unavailable");
+    },
+  };
+  const collected = collectingCtx();
+  const stamp = await worker.fetch(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    env({ METAGRAPH_CONTROL: brokenKv }),
+    collected.ctx,
+  );
+  assert.deepEqual(await stamp.json(), { captured_at: CAPTURED_AT });
+  await Promise.all(collected.pending);
+  assert.ok(
+    error.mock.calls.some((call) =>
+      String(call[0]).includes("explorer directory materialization failed"),
+    ),
+  );
+  error.mockRestore();
+});
+
+test("directory materializations reject malformed and mixed-snapshot values", () => {
+  const capturedAt = CAPTURED_AT;
+  const capturedAtIso = new Date(capturedAt).toISOString();
+  const valid = {
+    schema_version: 1,
+    captured_at: capturedAt,
+    accounts: {
+      schema_version: 1,
+      captured_at: capturedAtIso,
+      block_number: 8_600_000,
+      account_count: 0,
+      limit: 20,
+      priced_registered_stake_tao: 0,
+      rankings: { stake: [], emission: [], reach: [] },
+    },
+    validators: {
+      schema_version: 1,
+      captured_at: capturedAtIso,
+      block_number: 8_600_000,
+      validator_count: 0,
+      operator_count: 0,
+      operators: [],
+    },
+  };
+  assert.deepEqual(materializationFromUnknown(valid), valid);
+  assert.equal(materializationFromUnknown(null), null);
+  assert.equal(
+    materializationFromUnknown({
+      ...valid,
+      validators: {
+        ...valid.validators,
+        captured_at: new Date(capturedAt + 1).toISOString(),
+      },
+    }),
+    null,
+  );
+});
+
+test("a directory KV read failure falls back to the truthful live projection", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Live", stake_tao: 100 });
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const failingKv = {
+    get: async () => {
+      throw new Error("KV unavailable");
+    },
+  };
+  const accounts = await call(
+    req("/api/v1/accounts/directory"),
+    env({ METAGRAPH_CONTROL: failingKv }),
+  );
+  assert.equal(accounts.status, 200);
+  const body = (await accounts.json()) as Row;
+  assert.equal(body.account_count, 1);
+  assert.equal(((body.rankings as Row).stake as Row[])[0]!.hotkey, "5Live");
+  assert.equal(error.mock.calls.length, 1);
+  error.mockRestore();
+});
+
+test("a versioned directory payload read failure also falls back to live data", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Live", stake_tao: 100 });
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const failingPayloadKv = {
+    get: async (key: string, type?: string) => {
+      if (key !== KV_EXPLORER_DIRECTORIES_CURRENT) {
+        throw new Error("KV payload unavailable");
+      }
+      const pointer = { schema_version: 1, captured_at: CAPTURED_AT };
+      return type === "json" ? pointer : JSON.stringify(pointer);
+    },
+  };
+  const accounts = await call(
+    req("/api/v1/accounts/directory"),
+    env({ METAGRAPH_CONTROL: failingPayloadKv }),
+  );
+  assert.equal(
+    ((((await accounts.json()) as Row).rankings as Row).stake as Row[])[0]!
+      .hotkey,
+    "5Live",
+  );
+  assert.ok(
+    error.mock.calls.some((call) =>
+      String(call[0]).includes("materialization read failed"),
+    ),
+  );
+  error.mockRestore();
+});
+
+test("a pointer whose versioned payload has another stamp falls back to live data", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Live", stake_tao: 100 });
+  const kv = memoryKv();
+  const otherCapturedAt = CAPTURED_AT + 60_000;
+  kv.values.set(
+    KV_EXPLORER_DIRECTORIES_CURRENT,
+    JSON.stringify({ schema_version: 1, captured_at: CAPTURED_AT }),
+  );
+  kv.values.set(
+    explorerDirectoriesSnapshotKey(CAPTURED_AT),
+    JSON.stringify({
+      schema_version: 1,
+      captured_at: otherCapturedAt,
+      accounts: {
+        schema_version: 1,
+        captured_at: new Date(otherCapturedAt).toISOString(),
+        block_number: 8_600_000,
+        account_count: 0,
+        limit: 20,
+        priced_registered_stake_tao: 0,
+        rankings: { stake: [], emission: [], reach: [] },
+      },
+      validators: {
+        schema_version: 1,
+        captured_at: new Date(otherCapturedAt).toISOString(),
+        block_number: 8_600_000,
+        validator_count: 0,
+        operator_count: 0,
+        operators: [],
+      },
+    }),
+  );
+  const accounts = await call(
+    req("/api/v1/accounts/directory"),
+    env({ METAGRAPH_CONTROL: kv }),
+  );
+  assert.equal(
+    ((((await accounts.json()) as Row).rankings as Row).stake as Row[])[0]!
+      .hotkey,
+    "5Live",
+  );
+});
+
+test("a newer complete snapshot keeps the previous directory live while its replacement builds", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Old", stake_tao: 100 });
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+  );
+  const kv = memoryKv();
+  const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+  const first = collectingCtx();
+  await worker.fetch(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    materializedEnv,
+    first.ctx,
+  );
+  await Promise.all(first.pending);
+
+  const nextCapturedAt = CAPTURED_AT + 60_000;
+  await seed("UPDATE neurons SET captured_at = ?, hotkey = ? WHERE uid = ?", [
+    nextCapturedAt,
+    "5New",
+    0,
+  ]);
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [nextCapturedAt, 1, 1, nextCapturedAt + 1],
+  );
+  const next = collectingCtx();
+  const duringRefresh = await worker.fetch(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    materializedEnv,
+    next.ctx,
+  );
+  assert.deepEqual(await duringRefresh.json(), { captured_at: CAPTURED_AT });
+  await Promise.all(next.pending);
+
+  const ready = await call(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    materializedEnv,
+  );
+  assert.deepEqual(await ready.json(), { captured_at: nextCapturedAt });
+  assert.equal(
+    kv.values.has(explorerDirectoriesSnapshotKey(CAPTURED_AT)),
+    false,
+  );
+  assert.equal(
+    kv.values.has(explorerDirectoriesSnapshotKey(nextCapturedAt)),
+    true,
+  );
+  const accounts = await call(
+    req("/api/v1/accounts/directory"),
+    materializedEnv,
+  );
+  assert.equal(
+    ((((await accounts.json()) as Row).rankings as Row).stake as Row[])[0]!
+      .hotkey,
+    "5New",
+  );
+});
+
+test("an obsolete-payload cleanup failure cannot undo a published directory", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Old", stake_tao: 100 });
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+  );
+  const kv = memoryKv();
+  const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+  assert.equal(
+    await refreshExplorerDirectoryMaterialization(
+      materializedEnv as DataApiEnv,
+      ctx,
+      CAPTURED_AT,
+    ),
+    true,
+  );
+
+  const nextCapturedAt = CAPTURED_AT + 60_000;
+  await seed("UPDATE neurons SET captured_at = ?, hotkey = ? WHERE uid = ?", [
+    nextCapturedAt,
+    "5New",
+    0,
+  ]);
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [nextCapturedAt, 1, 1, nextCapturedAt + 1],
+  );
+  kv.delete = async () => {
+    throw new Error("KV cleanup unavailable");
+  };
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  assert.equal(
+    await refreshExplorerDirectoryMaterialization(
+      materializedEnv as DataApiEnv,
+      ctx,
+      nextCapturedAt,
+    ),
+    true,
+  );
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!).captured_at,
+    nextCapturedAt,
+  );
+  assert.ok(
+    error.mock.calls.some((call) =>
+      String(call[0]).includes("materialization cleanup failed"),
+    ),
+  );
+  error.mockRestore();
+});
+
+test("a partial newer neuron write cannot replace the last complete directory", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Stable", stake_tao: 100 });
+  const nextCapturedAt = CAPTURED_AT + 60_000;
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?), (?, ?, ?, ?)",
+    [
+      CAPTURED_AT,
+      1,
+      1,
+      CAPTURED_AT + 1,
+      nextCapturedAt,
+      1,
+      1,
+      nextCapturedAt + 1,
+    ],
+  );
+  const kv = memoryKv();
+  const previous = {
+    schema_version: 1,
+    captured_at: CAPTURED_AT,
+    accounts: {
+      schema_version: 1,
+      captured_at: new Date(CAPTURED_AT).toISOString(),
+      block_number: 8_600_000,
+      account_count: 1,
+      limit: 20,
+      priced_registered_stake_tao: 100,
+      rankings: { stake: [], emission: [], reach: [] },
+    },
+    validators: {
+      schema_version: 1,
+      captured_at: new Date(CAPTURED_AT).toISOString(),
+      block_number: 8_600_000,
+      validator_count: 1,
+      operator_count: 1,
+      operators: [],
+    },
+  };
+  kv.values.set(
+    KV_EXPLORER_DIRECTORIES_CURRENT,
+    JSON.stringify({ schema_version: 1, captured_at: CAPTURED_AT }),
+  );
+  kv.values.set(
+    explorerDirectoriesSnapshotKey(CAPTURED_AT),
+    JSON.stringify(previous),
+  );
+  // A third pass has started mutating the in-place table but is not complete.
+  await seed("UPDATE neurons SET captured_at = ? WHERE uid = ?", [
+    nextCapturedAt + 60_000,
+    0,
+  ]);
+  const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+  const collected = collectingCtx();
+  const stamp = await worker.fetch(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    materializedEnv,
+    collected.ctx,
+  );
+  assert.deepEqual(await stamp.json(), { captured_at: CAPTURED_AT });
+  await Promise.all(collected.pending);
+  const stored = JSON.parse(
+    kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!,
+  ) as Row;
+  assert.equal(stored.captured_at, CAPTURED_AT);
+});
+
+test("a neuron pass that starts during a directory fold is rejected by the final boundary check", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Stable", stake_tao: 100 });
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+  );
+  const kv = memoryKv();
+  const runQuery = pg.control.postgres!;
+  let mutated = false;
+  pg.control.postgres = async (text, values) => {
+    const rows = await runQuery(text, values);
+    if (!mutated && text.includes("ORDER BY hotkey ASC, stake_tao DESC")) {
+      mutated = true;
+      await db.query("UPDATE neurons SET captured_at = $1 WHERE uid = $2", [
+        CAPTURED_AT + 60_000,
+        0,
+      ]);
+    }
+    return rows;
+  };
+
+  assert.equal(
+    await refreshExplorerDirectoryMaterialization(
+      env({ METAGRAPH_CONTROL: kv }) as DataApiEnv,
+      ctx,
+      CAPTURED_AT,
+    ),
+    false,
+  );
+  assert.equal(mutated, true);
+  assert.equal(kv.putCount(), 0);
 });
 
 test("a pass_total smaller than the rows sent is refused", async () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -143,6 +143,9 @@ import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
 } from "../src/accounts-list.ts";
 import { buildAccountHolderDirectory } from "../src/account-holder-directory.ts";
+import { AccountHolderDirectoryArtifactSchema } from "../schemas-src/routes/account-holder-directory.ts";
+import { ValidatorOperatorDirectoryArtifactSchema } from "../schemas-src/routes/validator-operator-directory.ts";
+import { z } from "zod";
 import { resolveClientIp } from "./config.ts";
 import {
   SUBNET_HYPERPARAMS_INSERT_COLUMNS,
@@ -209,6 +212,13 @@ const SCHEMA_DRIFT_SQLSTATES = new Set(["42P01", "42703"]);
 // route, is a different key and captures again).
 const capturedSchemaDrift = new Set<string>();
 
+// One projection build per completed neuron snapshot, shared by every request
+// that reaches this isolate while the KV value is being replaced. KV is the
+// cross-isolate authority; these promises only prevent a burst of identical
+// service-binding requests from doing the same expensive fold concurrently
+// before that write becomes visible.
+const explorerDirectoryRefreshes = new Map<number, Promise<boolean>>();
+
 // Required by src/module-state-registry.ts's contract: under `isolate: false`
 // every test file in a worker shares one module registry, so a Set that
 // remembers "already captured" across files would make one file's drift
@@ -222,6 +232,7 @@ const capturedSchemaDrift = new Set<string>();
 // demanded it.
 registerModuleStateReset("workers/data-api.ts", () => {
   capturedSchemaDrift.clear();
+  explorerDirectoryRefreshes.clear();
 });
 
 /** The stable SQLSTATE of a postgres.js error, when it has one. */
@@ -430,7 +441,11 @@ import {
   neuronSnapshotWrite,
 } from "../src/neurons-neon-write.ts";
 import { PASS_TABLES } from "../src/pass-completeness.ts";
-import { KV_TAO_USD_CURRENT } from "../src/kv-keys.ts";
+import {
+  explorerDirectoriesSnapshotKey,
+  KV_EXPLORER_DIRECTORIES_CURRENT,
+  KV_TAO_USD_CURRENT,
+} from "../src/kv-keys.ts";
 import { NEON_PRUNE_CRON, runNeonPrune } from "../src/neon-prune.ts";
 import { runTableFreshnessWatchdog } from "../src/table-freshness-watchdog.ts";
 import { runTaoUsdIndexWatchdog } from "../src/tao-usd-index-watchdog.ts";
@@ -6521,6 +6536,7 @@ async function handleAccountKeysRoute(
 type NeuronsStoreRouteHandler = (
   sql: PgSql,
   env: DataApiEnv,
+  ctx: ExecutionContext,
 ) => Promise<Response>;
 
 // The D1 twin of loadAlphaPricesByNetuid (#9051): netuid -> latest
@@ -7038,18 +7054,270 @@ async function loadGlobalValidatorsFromStore(
   });
 }
 
+// The two network-wide pages are read far more often than the neuron snapshot
+// changes. Their compact response shapes still required a complete store scan
+// on every new edge-cache location, so a correct cold request took seconds.
+// Keep one atomic KV value per completed snapshot: readers see either the old
+// complete pair or the new complete pair, never one directory from each.
+type ExplorerDirectoryMaterialization = {
+  schema_version: 1;
+  captured_at: number;
+  accounts: ReturnType<typeof buildAccountHolderDirectory>;
+  validators: ReturnType<typeof buildValidatorOperatorDirectory>;
+};
+
+type ExplorerDirectoryPointer = {
+  schema_version: 1;
+  captured_at: number;
+};
+
+const ExplorerDirectoryPointerSchema = z
+  .object({
+    schema_version: z.literal(1),
+    captured_at: z.number().int().positive().max(8_640_000_000_000_000),
+  })
+  .strict();
+
+const ExplorerDirectoryMaterializationSchema = z
+  .object({
+    schema_version: z.literal(1),
+    captured_at: z.number().int().positive().max(8_640_000_000_000_000),
+    accounts: AccountHolderDirectoryArtifactSchema,
+    validators: ValidatorOperatorDirectoryArtifactSchema,
+  })
+  .strict()
+  .superRefine((value, refinement) => {
+    const capturedAt = new Date(value.captured_at).toISOString();
+    if (
+      value.accounts.captured_at !== capturedAt ||
+      value.validators.captured_at !== capturedAt
+    ) {
+      refinement.addIssue({
+        code: "custom",
+        message: "directory snapshots do not match the materialization stamp",
+      });
+    }
+  });
+
+export function materializationFromUnknown(
+  value: unknown,
+): ExplorerDirectoryMaterialization | null {
+  const parsed = ExplorerDirectoryMaterializationSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function pointerFromUnknown(value: unknown): ExplorerDirectoryPointer | null {
+  const parsed = ExplorerDirectoryPointerSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+async function readExplorerDirectoryPointer(
+  env: DataApiEnv,
+): Promise<ExplorerDirectoryPointer | null> {
+  if (!env.METAGRAPH_CONTROL) return null;
+  try {
+    return pointerFromUnknown(
+      await env.METAGRAPH_CONTROL.get(KV_EXPLORER_DIRECTORIES_CURRENT, "json"),
+    );
+  } catch (error) {
+    console.error(
+      "explorer directory materialization pointer read failed:",
+      error,
+    );
+    return null;
+  }
+}
+
+async function readExplorerDirectoryMaterialization(
+  env: DataApiEnv,
+): Promise<ExplorerDirectoryMaterialization | null> {
+  if (!env.METAGRAPH_CONTROL) return null;
+  try {
+    const pointer = await readExplorerDirectoryPointer(env);
+    if (!pointer) return null;
+    const raw = await env.METAGRAPH_CONTROL.get(
+      explorerDirectoriesSnapshotKey(pointer.captured_at),
+      "json",
+    );
+    const materialization = materializationFromUnknown(raw);
+    return materialization?.captured_at === pointer.captured_at
+      ? materialization
+      : null;
+  } catch (error) {
+    // KV is an optimization tier. A read failure must fall through to the
+    // existing store-backed answer rather than turn a valid directory into a
+    // 5xx or a measured zero.
+    console.error("explorer directory materialization read failed:", error);
+    return null;
+  }
+}
+
+async function latestCompletedNeuronSnapshot(
+  sql: PgSql,
+): Promise<number | null> {
+  const rows = await sql<{ captured_at: number | string | null }>`
+    SELECT captured_at FROM neurons_passes
+    WHERE completed_at IS NOT NULL
+    ORDER BY completed_at DESC
+    LIMIT 1`;
+  const capturedAt = Number(rows[0]?.captured_at);
+  return Number.isSafeInteger(capturedAt) && capturedAt > 0 ? capturedAt : null;
+}
+
+/**
+ * Build the browser-sized account and validator directories once for one
+ * completed neuron snapshot.
+ *
+ * The completeness recheck is deliberate. `neurons` is updated in chunks; if
+ * a newer partial pass has started, filtering it out would drop rows because
+ * the table keeps only the newest value per key. In that state we retain the
+ * previous complete materialization and let the next request retry after the
+ * pass completes.
+ */
+export async function refreshExplorerDirectoryMaterialization(
+  env: DataApiEnv,
+  ctx: ExecutionContext,
+  capturedAt: number,
+): Promise<boolean> {
+  if (!env.METAGRAPH_CONTROL) return false;
+  const existing = explorerDirectoryRefreshes.get(capturedAt);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    const sql = routeRunner(env, ctx);
+    if (!sql) return false;
+    const previousPointer = await readExplorerDirectoryPointer(env);
+    if (previousPointer?.captured_at === capturedAt) return true;
+    const latest = await latestCompletedNeuronSnapshot(sql);
+    const newestRows = await sql<{ captured_at: number | string | null }>`
+      SELECT MAX(captured_at) AS captured_at FROM neurons`;
+    const newestCapturedAt = Number(newestRows[0]?.captured_at);
+    if (
+      latest !== capturedAt ||
+      !Number.isSafeInteger(newestCapturedAt) ||
+      newestCapturedAt !== capturedAt
+    ) {
+      return false;
+    }
+
+    const [accountRows, priceByNetuid, globalValidators] = await Promise.all([
+      sql<{
+        netuid: Neurons["netuid"];
+        uid: Neurons["uid"];
+        hotkey: Neurons["hotkey"];
+        coldkey: Neurons["coldkey"];
+        validator_permit: Neurons["validator_permit"];
+        emission_tao: Neurons["emission_tao"];
+        stake_tao: Neurons["stake_tao"];
+        block_number: Neurons["block_number"];
+        captured_at: Neurons["captured_at"];
+      }>`
+        SELECT netuid, uid, hotkey, coldkey, validator_permit, emission_tao, stake_tao, block_number, captured_at
+        FROM neurons WHERE hotkey IS NOT NULL
+        ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
+      loadStoreAlphaPricesByNetuid(sql, env),
+      loadGlobalValidatorsFromStore(
+        sql,
+        env,
+        "total_stake",
+        GLOBAL_VALIDATOR_LIMIT_MAX,
+        true,
+      ),
+    ]);
+    const accounts = buildAccountHolderDirectory(accountRows, {
+      priceByNetuid,
+    });
+    const validators = buildValidatorOperatorDirectory(globalValidators);
+
+    // The table is updated in-place and the fold above is intentionally not a
+    // long-running transaction. Recheck both boundaries after the scans so a
+    // newer pass that started while they ran cannot be published under the
+    // previous snapshot's stamp.
+    const finalLatest = await latestCompletedNeuronSnapshot(sql);
+    const finalRows = await sql<{ captured_at: number | string | null }>`
+      SELECT MAX(captured_at) AS captured_at FROM neurons`;
+    const finalCapturedAt = Number(finalRows[0]?.captured_at);
+    if (finalLatest !== capturedAt || finalCapturedAt !== capturedAt) {
+      return false;
+    }
+
+    const value: ExplorerDirectoryMaterialization = {
+      schema_version: 1,
+      captured_at: capturedAt,
+      accounts,
+      validators,
+    };
+    await env.METAGRAPH_CONTROL.put(
+      explorerDirectoriesSnapshotKey(capturedAt),
+      JSON.stringify(value),
+    );
+    await env.METAGRAPH_CONTROL.put(
+      KV_EXPLORER_DIRECTORIES_CURRENT,
+      JSON.stringify({ schema_version: 1, captured_at: capturedAt }),
+    );
+    if (
+      previousPointer &&
+      previousPointer.captured_at !== capturedAt &&
+      typeof env.METAGRAPH_CONTROL.delete === "function"
+    ) {
+      try {
+        await env.METAGRAPH_CONTROL.delete(
+          explorerDirectoriesSnapshotKey(previousPointer.captured_at),
+        );
+      } catch (error) {
+        // Cleanup is bounded-storage hygiene, not part of publication. The new
+        // pointer and payload are already complete and must stay readable.
+        console.error(
+          "explorer directory materialization cleanup failed:",
+          error,
+        );
+      }
+    }
+    return true;
+  })().finally(() => {
+    explorerDirectoryRefreshes.delete(capturedAt);
+  });
+  explorerDirectoryRefreshes.set(capturedAt, promise);
+  return promise;
+}
+
 function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
   // Internal-only freshness stamp used by the public API Worker's edge cache.
   // The completed pass is the snapshot boundary: MAX(neurons.captured_at) can
   // advance after only one chunk and would make a partial capture look whole.
   if (url.pathname === "/api/v1/internal/neurons-snapshot-stamp") {
-    return async (sql) => {
-      const rows = await sql<{ captured_at: number | null }>`
-        SELECT captured_at FROM neurons_passes
-        WHERE completed_at IS NOT NULL
-        ORDER BY completed_at DESC
-        LIMIT 1`;
-      return json({ captured_at: rows[0]?.captured_at ?? null });
+    return async (sql, env, ctx) => {
+      const capturedAt = await latestCompletedNeuronSnapshot(sql);
+      if (capturedAt === null) return json({ captured_at: null });
+
+      // This hot path intentionally reads only the tiny pointer. Fetching and
+      // validating the ~300 KiB directory payload before every edge-cache hit
+      // would move the whole cold-miss cost into the freshness check.
+      const pointer = await readExplorerDirectoryPointer(env);
+      if (pointer?.captured_at === capturedAt) {
+        return json({ captured_at: capturedAt });
+      }
+
+      // Do not make a reader wait for a whole-network fold. While the new
+      // snapshot is prepared, keep advertising the previous complete stamp so
+      // the main Worker's snapshot-keyed cache continues serving its matching
+      // complete response. With no prior materialization (the one-time rollout
+      // bootstrap), the existing live handler remains the safe fallback.
+      ctx.waitUntil(
+        refreshExplorerDirectoryMaterialization(env, ctx, capturedAt).catch(
+          (error) => {
+            console.error("explorer directory materialization failed:", error);
+            return false;
+          },
+        ),
+      );
+      const servedStamp = pointer?.captured_at;
+      return json({
+        captured_at:
+          typeof servedStamp === "number" && servedStamp < capturedAt
+            ? servedStamp
+            : capturedAt,
+      });
     };
   }
 
@@ -7325,8 +7593,10 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
   // GET /api/v1/validators/operators: the website's grouped directory shape.
   // The rich per-hotkey route above remains unchanged for REST/MCP consumers.
   if (url.pathname === "/api/v1/validators/operators") {
-    return async (sql, env) =>
-      json(
+    return async (sql, env) => {
+      const materialized = await readExplorerDirectoryMaterialization(env);
+      if (materialized) return json(materialized.validators);
+      return json(
         buildValidatorOperatorDirectory(
           await loadGlobalValidatorsFromStore(
             sql,
@@ -7337,6 +7607,7 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
           ),
         ),
       );
+    };
   }
 
   // GET /api/v1/validators/:hotkey
@@ -8154,6 +8425,8 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
   // The rich sortable route above remains unchanged for REST/MCP consumers.
   if (url.pathname === "/api/v1/accounts/directory") {
     return async (sql, env) => {
+      const materialized = await readExplorerDirectoryMaterialization(env);
+      if (materialized) return json(materialized.accounts);
       const [rows, priceByNetuid] = await Promise.all([
         sql<{
           netuid: Neurons["netuid"];
@@ -8927,7 +9200,7 @@ async function dispatchDataApiRequest(
         return json({ error: "no store bound for this route" }, 503);
       }
       try {
-        return await neuronsStoreHandler(store, env);
+        return await neuronsStoreHandler(store, env, ctx);
       } catch (err) {
         console.error("data-api neurons query failed:", err);
         await captureDataApiError(err, maskRouteParams(url.pathname), env);
@@ -8946,7 +9219,7 @@ async function dispatchDataApiRequest(
           return json({ error: "no store bound for this route" }, 503);
         }
         try {
-          return await healthStatusStoreHandler(store, env);
+          return await healthStatusStoreHandler(store, env, ctx);
         } catch (err) {
           console.error("data-api health-status store query failed:", err);
           await captureDataApiError(err, maskRouteParams(url.pathname), env);
@@ -8969,7 +9242,7 @@ async function dispatchDataApiRequest(
           return json({ error: "no store bound for this route" }, 503);
         }
         try {
-          return await hyperparamsIdentityStoreHandler(store, env);
+          return await hyperparamsIdentityStoreHandler(store, env, ctx);
         } catch (err) {
           console.error(
             "data-api hyperparams/identity store query failed:",


### PR DESCRIPTION
## Summary

- build the compact account and validator website directories once per completed neuron snapshot
- publish each atomic directory pair behind a small versioned pointer so edge freshness checks remain cheap
- retain the prior complete snapshot during refresh and fall back to the live store on KV, validation, or snapshot-boundary failures

## Why

Production cold misses were recomputing whole-network folds while warm cached responses were already fast. This moves that work to snapshot publication without changing the rich public REST or MCP response contracts.

## Validation

- `npm run validate`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage` — 978 files, 22,452 tests passed
- focused data/edge regression suite — 543 tests passed
- `npm run worker:deploy:dry-run`
- `npm run worker:bundle:budget`
- changed source diff — all changed lines and branches covered
- Data Worker bundle delta — approximately 1.34 KiB gzip

Closes #11760