### PR TITLE
perf(data): publish explorer directories after neuron passes

### DIFF
--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -3343,6 +3343,121 @@ test("the queue consumer writes a neurons message and acks it", async () => {
   assert.equal((await count("neuron_daily")) > 0, true);
 });
 
+test("the queue consumer publishes explorer directories when a neuron pass completes", async () => {
+  const kv = memoryKv();
+  const pending = collectingCtx();
+  const acked: string[] = [];
+
+  await worker.queue(
+    {
+      messages: [
+        {
+          body: {
+            lane: "neurons",
+            captured_at: CAPTURED_AT,
+            pass_total: 1,
+            key_complete: true,
+            rows: [syncRow()],
+          },
+          ack: () => acked.push("ack"),
+          retry: () => acked.push("retry"),
+        },
+      ],
+    } as never,
+    env({ METAGRAPH_CONTROL: kv }),
+    pending.ctx,
+  );
+  await Promise.all(pending.pending);
+
+  assert.deepEqual(acked, ["ack"]);
+  assert.deepEqual(
+    JSON.parse(kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!),
+    { schema_version: 1, captured_at: CAPTURED_AT },
+  );
+  const materialized = JSON.parse(
+    kv.values.get(explorerDirectoriesSnapshotKey(CAPTURED_AT))!,
+  );
+  assert.equal(
+    materialized.accounts.captured_at,
+    new Date(CAPTURED_AT).toISOString(),
+  );
+  assert.equal(
+    materialized.validators.captured_at,
+    new Date(CAPTURED_AT).toISOString(),
+  );
+});
+
+test("an incomplete neuron queue pass is acknowledged without publishing a mixed directory", async () => {
+  const kv = memoryKv();
+  const pending = collectingCtx();
+  const acked: string[] = [];
+
+  await worker.queue(
+    {
+      messages: [
+        {
+          body: {
+            lane: "neurons",
+            captured_at: CAPTURED_AT,
+            pass_total: 2,
+            key_complete: true,
+            rows: [syncRow()],
+          },
+          ack: () => acked.push("ack"),
+          retry: () => acked.push("retry"),
+        },
+      ],
+    } as never,
+    env({ METAGRAPH_CONTROL: kv }),
+    pending.ctx,
+  );
+  await Promise.all(pending.pending);
+
+  assert.deepEqual(acked, ["ack"]);
+  assert.equal(kv.putCount(), 0);
+  assert.equal(kv.values.has(KV_EXPLORER_DIRECTORIES_CURRENT), false);
+});
+
+test("a queue publication failure cannot retry a neuron snapshot that already landed", async () => {
+  const pending = collectingCtx();
+  const acked: string[] = [];
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  await worker.queue(
+    {
+      messages: [
+        {
+          body: {
+            lane: "neurons",
+            captured_at: CAPTURED_AT,
+            pass_total: 1,
+            key_complete: true,
+            rows: [syncRow()],
+          },
+          ack: () => acked.push("ack"),
+          retry: () => acked.push("retry"),
+        },
+      ],
+    } as never,
+    env({
+      METAGRAPH_CONTROL: {
+        get: async () => null,
+        put: async () => Promise.reject(new Error("KV unavailable")),
+      },
+    }),
+    pending.ctx,
+  );
+  await Promise.all(pending.pending);
+
+  assert.deepEqual(acked, ["ack"]);
+  assert.ok(
+    error.mock.calls.some((call) =>
+      String(call[0]).includes("explorer directory queue publication failed"),
+    ),
+  );
+  error.mockRestore();
+});
+
 test("the consumer refuses a neurons message that does not claim key-completeness", async () => {
   // Refused, not written. The claim was introduced because the D1 write PRUNED
   // -- applying a partial message would have deleted rows it never carried --

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -9908,6 +9908,30 @@ export default {
       }
       try {
         await writeSyncBatch(body, writers, Date.now(), familyWriters);
+        // Build the website-sized account/validator pair at the only point
+        // that reliably observes a neuron pass becoming complete: directly
+        // after a queue chunk and its pass tally have landed. A request-side
+        // refresh remains as repair, but it can repeatedly arrive while the
+        // next pass is partial and correctly decline the mixed snapshot.
+        //
+        // This is best-effort and must not change queue acknowledgement. The
+        // neuron rows are the durable fact; a failed derived publication is
+        // retried by the next completed chunk or directory freshness read.
+        if (body.lane === "neurons" && body.pass_total !== undefined) {
+          ctx.waitUntil(
+            refreshExplorerDirectoryMaterialization(
+              env,
+              ctx,
+              body.captured_at,
+            ).catch((error) => {
+              console.error(
+                "explorer directory queue publication failed:",
+                error,
+              );
+              return false;
+            }),
+          );
+        }
         message.ack();
       } catch (err) {
         console.error("sync-batches: write failed:", err);


### PR DESCRIPTION
## Summary

- trigger the guarded account/validator directory publication immediately after successful neuron queue writes with declared pass totals
- keep incomplete passes from publishing a mixed snapshot
- preserve queue acknowledgement when the derived KV publication fails, leaving the existing read-side path as repair

## Why

Post-deploy verification of #11802 confirmed the production Worker version but found no materialization pointer and cold edge reads remained about 1.2–2.2 seconds. A request-triggered refresh can correctly collide with an in-progress neuron pass and decline; publishing after the pass-closing queue write makes the stable snapshot boundary the primary trigger.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run validate`
- `npm run worker:deploy:dry-run`
- `npm run worker:bundle:budget`
- focused data/queue/edge regression suite — 604 tests passed
- `npm run test:coverage` — 978 files, 22,455 tests passed, 11 skipped
- changed production diff — all 24 changed lines and all changed branches covered

Closes #11760