### PR TITLE
perf(data): publish directories from direct neuron sync

### DIFF
--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -442,6 +442,50 @@ test("neurons-sync writes neurons, neuron_daily, and account_position_daily from
   assert.equal(position.stake_tao, 100);
 });
 
+test("the direct neurons path publishes explorer directories when its declared pass completes", async () => {
+  const kv = memoryKv();
+  const collected = collectingCtx();
+  const response = await worker.fetch(
+    req("/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: { "x-neurons-sync-token": SYNC_SECRET },
+      body: { rows: [syncRow()], pass_total: 1 },
+    }),
+    env({ METAGRAPH_CONTROL: kv }),
+    collected.ctx,
+  );
+
+  assert.equal(response.status, 200);
+  await Promise.all(collected.pending);
+  const pointer = JSON.parse(
+    kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!,
+  ) as Row;
+  assert.equal(pointer.captured_at, CAPTURED_AT);
+  const stored = JSON.parse(
+    kv.values.get(explorerDirectoriesSnapshotKey(CAPTURED_AT))!,
+  ) as Row;
+  assert.equal((stored.accounts as Row).account_count, 1);
+  assert.equal((stored.validators as Row).validator_count, 1);
+});
+
+test("the direct neurons path does not publish an incomplete declared pass", async () => {
+  const kv = memoryKv();
+  const collected = collectingCtx();
+  const response = await worker.fetch(
+    req("/api/v1/internal/neurons-sync", {
+      method: "POST",
+      headers: { "x-neurons-sync-token": SYNC_SECRET },
+      body: { rows: [syncRow()], pass_total: 2 },
+    }),
+    env({ METAGRAPH_CONTROL: kv }),
+    collected.ctx,
+  );
+
+  assert.equal(response.status, 200);
+  await Promise.all(collected.pending);
+  assert.equal(kv.putCount(), 0);
+});
+
 test("neurons-sync upsert: a newer capture replaces the row, an older one is discarded by the captured_at guard", async () => {
   insertNeuron({ stake_tao: 100, captured_at: CAPTURED_AT });
   // Older capture for the same (netuid, uid): the ON CONFLICT ... WHERE
@@ -3452,7 +3496,7 @@ test("a queue publication failure cannot retry a neuron snapshot that already la
   assert.deepEqual(acked, ["ack"]);
   assert.ok(
     error.mock.calls.some((call) =>
-      String(call[0]).includes("explorer directory queue publication failed"),
+      String(call[0]).includes("explorer directory publication failed"),
     ),
   );
   error.mockRestore();

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -729,7 +729,7 @@ function stripClientSnapshotDate(row: Row) {
 async function handleNeuronsSync(
   request: Request,
   env: DataApiEnv,
-  ctx?: ExecutionContext,
+  ctx: ExecutionContext,
 ) {
   if (!env.NEURONS_SYNC_SECRET) {
     return writeJson(
@@ -920,6 +920,10 @@ async function handleNeuronsSync(
       env,
     );
     return writeJson({ error: "neon write failed" }, 502);
+  }
+
+  if (pass) {
+    scheduleExplorerDirectoryRefresh(env, ctx, pass.capturedAt);
   }
 
   // `stores` stays REPORTED rather than inferred, so a reader can see which
@@ -7281,6 +7285,20 @@ export async function refreshExplorerDirectoryMaterialization(
   return promise;
 }
 
+function scheduleExplorerDirectoryRefresh(
+  env: DataApiEnv,
+  ctx: ExecutionContext,
+  capturedAt: number,
+) {
+  ctx.waitUntil(
+    refreshExplorerDirectoryMaterialization(env, ctx, capturedAt).catch(
+      (error) => {
+        console.error("explorer directory publication failed:", error);
+      },
+    ),
+  );
+}
+
 function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
   // Internal-only freshness stamp used by the public API Worker's edge cache.
   // The completed pass is the snapshot boundary: MAX(neurons.captured_at) can
@@ -9908,29 +9926,8 @@ export default {
       }
       try {
         await writeSyncBatch(body, writers, Date.now(), familyWriters);
-        // Build the website-sized account/validator pair at the only point
-        // that reliably observes a neuron pass becoming complete: directly
-        // after a queue chunk and its pass tally have landed. A request-side
-        // refresh remains as repair, but it can repeatedly arrive while the
-        // next pass is partial and correctly decline the mixed snapshot.
-        //
-        // This is best-effort and must not change queue acknowledgement. The
-        // neuron rows are the durable fact; a failed derived publication is
-        // retried by the next completed chunk or directory freshness read.
         if (body.lane === "neurons" && body.pass_total !== undefined) {
-          ctx.waitUntil(
-            refreshExplorerDirectoryMaterialization(
-              env,
-              ctx,
-              body.captured_at,
-            ).catch((error) => {
-              console.error(
-                "explorer directory queue publication failed:",
-                error,
-              );
-              return false;
-            }),
-          );
+          scheduleExplorerDirectoryRefresh(env, ctx, body.captured_at);
         }
         message.ack();
       } catch (err) {


### PR DESCRIPTION
Closes #11760

## Summary
- publish the compact account and validator directory pair after a successful direct neuron-sync chunk closes its declared pass
- share one best-effort publication scheduler between direct and queued ingestion
- retain completeness guards, live fallback, and non-fatal derived-cache behavior
- cover completed and incomplete direct passes and preserve the queue failure acknowledgement contract

## Verification
- npm run build
- npm run format:check
- npm run lint
- npm run typecheck
- npm run validate
- npm run worker:deploy:dry-run
- npm run worker:bundle:budget
- npm run test:coverage (978 files; 22,456 passed, 11 skipped)
- npx vitest run tests/data-api-bundle-boundary.test.ts tests/data-api-neurons.test.ts (124 passed)
- data-api first-party source boundary: 4,599,465 bytes (< 4,600,000)