### PR TITLE
perf(data): serve explorer directories from shared KV

### DIFF
--- a/src/explorer-directory-materialization.ts
+++ b/src/explorer-directory-materialization.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+import { AccountHolderDirectoryArtifactSchema } from "../schemas-src/routes/account-holder-directory.ts";
+import { ValidatorOperatorDirectoryArtifactSchema } from "../schemas-src/routes/validator-operator-directory.ts";
+import {
+  KV_EXPLORER_DIRECTORIES_CURRENT,
+  explorerDirectoriesSnapshotKey,
+} from "./kv-keys.ts";
+import type { buildAccountHolderDirectory } from "./account-holder-directory.ts";
+import type { buildValidatorOperatorDirectory } from "./validator-operator-directory.ts";
+
+export type ExplorerDirectoryMaterialization = {
+  schema_version: 1;
+  captured_at: number;
+  accounts: ReturnType<typeof buildAccountHolderDirectory>;
+  validators: ReturnType<typeof buildValidatorOperatorDirectory>;
+};
+
+export type ExplorerDirectoryPointer = {
+  schema_version: 1;
+  captured_at: number;
+};
+
+type ExplorerDirectoryKv = Pick<KVNamespace, "get">;
+
+const ExplorerDirectoryPointerSchema = z
+  .object({
+    schema_version: z.literal(1),
+    captured_at: z.number().int().positive().max(8_640_000_000_000_000),
+  })
+  .strict();
+
+const ExplorerDirectoryMaterializationSchema = z
+  .object({
+    schema_version: z.literal(1),
+    captured_at: z.number().int().positive().max(8_640_000_000_000_000),
+    accounts: AccountHolderDirectoryArtifactSchema,
+    validators: ValidatorOperatorDirectoryArtifactSchema,
+  })
+  .strict()
+  .superRefine((value, refinement) => {
+    const capturedAt = new Date(value.captured_at).toISOString();
+    if (
+      value.accounts.captured_at !== capturedAt ||
+      value.validators.captured_at !== capturedAt
+    ) {
+      refinement.addIssue({
+        code: "custom",
+        message: "directory snapshots do not match the materialization stamp",
+      });
+    }
+  });
+
+export function materializationFromUnknown(
+  value: unknown,
+): ExplorerDirectoryMaterialization | null {
+  const parsed = ExplorerDirectoryMaterializationSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function pointerFromUnknown(
+  value: unknown,
+): ExplorerDirectoryPointer | null {
+  const parsed = ExplorerDirectoryPointerSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function readExplorerDirectoryPointer(
+  kv: ExplorerDirectoryKv | null | undefined,
+): Promise<ExplorerDirectoryPointer | null> {
+  if (!kv) return null;
+  try {
+    return pointerFromUnknown(
+      await kv.get(KV_EXPLORER_DIRECTORIES_CURRENT, "json"),
+    );
+  } catch (error) {
+    console.error(
+      "explorer directory materialization pointer read failed:",
+      error,
+    );
+    return null;
+  }
+}
+
+export async function readExplorerDirectoryMaterialization(
+  kv: ExplorerDirectoryKv | null | undefined,
+): Promise<ExplorerDirectoryMaterialization | null> {
+  if (!kv) return null;
+  try {
+    const pointer = await readExplorerDirectoryPointer(kv);
+    if (!pointer) return null;
+    const raw = await kv.get(
+      explorerDirectoriesSnapshotKey(pointer.captured_at),
+      "json",
+    );
+    const materialization = materializationFromUnknown(raw);
+    return materialization?.captured_at === pointer.captured_at
+      ? materialization
+      : null;
+  } catch (error) {
+    console.error("explorer directory materialization read failed:", error);
+    return null;
+  }
+}

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -28,6 +28,10 @@ import {
 } from "../workers/request-handlers/entities.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
+import {
+  KV_EXPLORER_DIRECTORIES_CURRENT,
+  explorerDirectoriesSnapshotKey,
+} from "../src/kv-keys.ts";
 import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
 import { resetObservedThroughCache } from "../src/lakehouse-observed-through.ts";
 import { resetSurfacesMemo } from "../src/revenue-load.ts";
@@ -1480,7 +1484,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const paths: string[] = [];
-    const stamp = 1_780_000_000_000;
+    const stamp = Date.parse("2026-08-29T00:00:00.000Z");
     const directory = {
       schema_version: 1,
       captured_at: "2026-08-29T00:00:00.000Z",
@@ -1489,9 +1493,34 @@ describe("analytics edge cache", () => {
       operator_count: 0,
       operators: [],
     };
+    const materialization = {
+      schema_version: 1,
+      captured_at: stamp,
+      validators: directory,
+      accounts: {
+        schema_version: 1,
+        captured_at: directory.captured_at,
+        block_number: directory.block_number,
+        account_count: 0,
+        limit: 20,
+        priced_registered_stake_tao: 0,
+        rankings: { stake: [], emission: [], reach: [] },
+      },
+    };
     const env = {
       ...analyticsEnv([]),
       METAGRAPH_NEURONS_SOURCE: "data-api",
+      METAGRAPH_CONTROL: {
+        async get(key: string) {
+          if (key === KV_EXPLORER_DIRECTORIES_CURRENT) {
+            return { schema_version: 1, captured_at: stamp };
+          }
+          if (key === explorerDirectoriesSnapshotKey(stamp)) {
+            return materialization;
+          }
+          return null;
+        },
+      },
       DATA_API: {
         async fetch(request: Request) {
           const pathname = new URL(request.url).pathname;
@@ -1513,11 +1542,7 @@ describe("analytics edge cache", () => {
     assert.equal(second.status, 200);
     assert.deepEqual((await first.json()).data, directory);
     assert.deepEqual((await second.json()).data, directory);
-    assert.deepEqual(paths, [
-      "/api/v1/internal/neurons-snapshot-stamp",
-      "/api/v1/validators/operators",
-      "/api/v1/internal/neurons-snapshot-stamp",
-    ]);
+    assert.deepEqual(paths, []);
     assert.deepEqual(cache.putKeys, [
       `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
         CONTRACT_VERSION,
@@ -1531,7 +1556,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const paths: string[] = [];
-    const stamp = 1_780_000_000_000;
+    const stamp = Date.parse("2026-08-29T00:00:00.000Z");
     const directory = {
       schema_version: 1,
       captured_at: "2026-08-29T00:00:00.000Z",
@@ -1541,9 +1566,33 @@ describe("analytics edge cache", () => {
       priced_registered_stake_tao: 0,
       rankings: { stake: [], emission: [], reach: [] },
     };
+    const materialization = {
+      schema_version: 1,
+      captured_at: stamp,
+      accounts: directory,
+      validators: {
+        schema_version: 1,
+        captured_at: directory.captured_at,
+        block_number: directory.block_number,
+        validator_count: 0,
+        operator_count: 0,
+        operators: [],
+      },
+    };
     const env = {
       ...analyticsEnv([]),
       METAGRAPH_NEURONS_SOURCE: "data-api",
+      METAGRAPH_CONTROL: {
+        async get(key: string) {
+          if (key === KV_EXPLORER_DIRECTORIES_CURRENT) {
+            return { schema_version: 1, captured_at: stamp };
+          }
+          if (key === explorerDirectoriesSnapshotKey(stamp)) {
+            return materialization;
+          }
+          return null;
+        },
+      },
       DATA_API: {
         async fetch(request: Request) {
           const pathname = new URL(request.url).pathname;
@@ -1565,11 +1614,7 @@ describe("analytics edge cache", () => {
     assert.equal(second.status, 200);
     assert.deepEqual((await first.json()).data, directory);
     assert.deepEqual((await second.json()).data, directory);
-    assert.deepEqual(paths, [
-      "/api/v1/internal/neurons-snapshot-stamp",
-      "/api/v1/accounts/directory",
-      "/api/v1/internal/neurons-snapshot-stamp",
-    ]);
+    assert.deepEqual(paths, []);
     assert.deepEqual(cache.putKeys, [
       `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
         CONTRACT_VERSION,

--- a/tests/data-api-tier.test.ts
+++ b/tests/data-api-tier.test.ts
@@ -24,29 +24,33 @@ function dataApi(handler: AnyFn) {
   return { fetch: handler };
 }
 
+function directoryKv(value: unknown, error: Error | null = null) {
+  return {
+    async get() {
+      if (error) throw error;
+      return value;
+    },
+  };
+}
+
 function req() {
   return new Request("https://api.metagraph.sh/api/v1/health");
 }
 
 test("readNeuronsSnapshotCacheStamp: returns the completed-pass watermark", async () => {
-  let requested: Request | null = null;
   const result = await readNeuronsSnapshotCacheStamp(
     mockEnv({
       METAGRAPH_NEURONS_SOURCE: "data-api",
-      DATA_API: dataApi(async (request: Request) => {
-        requested = request;
-        return Response.json({ captured_at: 1_780_000_000_000 });
+      METAGRAPH_CONTROL: directoryKv({
+        schema_version: 1,
+        captured_at: 1_780_000_000_000,
       }),
     }),
   );
   assert.equal(result, "1780000000000");
-  assert.equal(
-    new URL(requested!.url).pathname,
-    "/api/v1/internal/neurons-snapshot-stamp",
-  );
 });
 
-test("readNeuronsSnapshotCacheStamp: declines without the active lane or binding", async () => {
+test("readNeuronsSnapshotCacheStamp: declines without the active lane or pointer", async () => {
   assert.equal(
     await readNeuronsSnapshotCacheStamp(
       mockEnv({ METAGRAPH_NEURONS_SOURCE: "retired" }),
@@ -61,18 +65,19 @@ test("readNeuronsSnapshotCacheStamp: declines without the active lane or binding
   );
 });
 
-test("readNeuronsSnapshotCacheStamp: unproven responses disable caching", async () => {
-  for (const response of [
-    new Response("no", { status: 503 }),
-    Response.json({ captured_at: null }),
-    Response.json({ captured_at: -1 }),
-    Response.json({ captured_at: 1.5 }),
+test("readNeuronsSnapshotCacheStamp: unproven pointers disable caching", async () => {
+  for (const pointer of [
+    null,
+    { schema_version: 1, captured_at: null },
+    { schema_version: 1, captured_at: -1 },
+    { schema_version: 1, captured_at: 1.5 },
+    { schema_version: 2, captured_at: 1_780_000_000_000 },
   ]) {
     assert.equal(
       await readNeuronsSnapshotCacheStamp(
         mockEnv({
           METAGRAPH_NEURONS_SOURCE: "data-api",
-          DATA_API: dataApi(async () => response.clone()),
+          METAGRAPH_CONTROL: directoryKv(pointer),
         }),
       ),
       null,
@@ -80,23 +85,16 @@ test("readNeuronsSnapshotCacheStamp: unproven responses disable caching", async 
   }
 });
 
-test("readNeuronsSnapshotCacheStamp: transport and malformed JSON failures disable caching", async () => {
-  for (const fetch of [
-    async () => {
-      throw new Error("offline");
-    },
-    async () => new Response("not-json", { status: 200 }),
-  ]) {
-    assert.equal(
-      await readNeuronsSnapshotCacheStamp(
-        mockEnv({
-          METAGRAPH_NEURONS_SOURCE: "data-api",
-          DATA_API: dataApi(fetch),
-        }),
-      ),
-      null,
-    );
-  }
+test("readNeuronsSnapshotCacheStamp: KV failures disable caching", async () => {
+  assert.equal(
+    await readNeuronsSnapshotCacheStamp(
+      mockEnv({
+        METAGRAPH_NEURONS_SOURCE: "data-api",
+        METAGRAPH_CONTROL: directoryKv(null, new Error("offline")),
+      }),
+    ),
+    null,
+  );
 });
 
 test("an unforwardable flag no longer COMPILES -- membership moved into the type (#10190)", () => {

--- a/workers/data-api-tier.ts
+++ b/workers/data-api-tier.ts
@@ -1,6 +1,7 @@
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { maskRouteParams } from "../src/route-label.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import { readExplorerDirectoryPointer } from "../src/explorer-directory-materialization.ts";
 
 // DATA_API-forwarding serving gate, one env flag per data source (originally
 // ADR 0013 Sequencing step 3's gated D1 -> Postgres cutover; D1 fully
@@ -159,31 +160,19 @@ export type ForwardableTierFlag = (typeof FORWARDABLE_TIER_FLAGS)[number];
 /**
  * The newest fully-landed neuron snapshot, for cache invalidation.
  *
- * This asks the data Worker for one indexed row from `neurons_passes`. It does
- * not use health metadata: a health probe can run without neuron data moving,
- * and a partial multi-request neuron pass can move MAX(captured_at) before the
- * network-wide directory is complete. Returning null disables the edge cache
- * for that request rather than reusing a stamp we could not prove.
+ * The pointer is published only after both directory projections have been
+ * built from one complete neuron pass. The main Worker shares the exact KV
+ * namespace with data-api, so reading that tiny pointer locally avoids a
+ * second Worker invocation before every cache lookup. It does not use health
+ * metadata: a health probe can run without neuron data moving, and a partial
+ * multi-request neuron pass must never advance this cache boundary.
  */
 export async function readNeuronsSnapshotCacheStamp(
   env: Env,
 ): Promise<string | null> {
-  if (env.METAGRAPH_NEURONS_SOURCE !== "data-api" || !env.DATA_API) return null;
-  try {
-    const response = await env.DATA_API.fetch(
-      new Request(
-        "https://data-api.internal/api/v1/internal/neurons-snapshot-stamp",
-      ),
-    );
-    if (!response.ok) return null;
-    const body = (await response.json()) as { captured_at?: unknown };
-    const capturedAt = Number(body?.captured_at);
-    return Number.isSafeInteger(capturedAt) && capturedAt > 0
-      ? String(capturedAt)
-      : null;
-  } catch {
-    return null;
-  }
+  if (env.METAGRAPH_NEURONS_SOURCE !== "data-api") return null;
+  const pointer = await readExplorerDirectoryPointer(env.METAGRAPH_CONTROL);
+  return pointer ? String(pointer.captured_at) : null;
 }
 
 export async function tryDataApiTier(

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -143,9 +143,12 @@ import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
 } from "../src/accounts-list.ts";
 import { buildAccountHolderDirectory } from "../src/account-holder-directory.ts";
-import { AccountHolderDirectoryArtifactSchema } from "../schemas-src/routes/account-holder-directory.ts";
-import { ValidatorOperatorDirectoryArtifactSchema } from "../schemas-src/routes/validator-operator-directory.ts";
-import { z } from "zod";
+import {
+  materializationFromUnknown,
+  readExplorerDirectoryMaterialization,
+  readExplorerDirectoryPointer,
+  type ExplorerDirectoryMaterialization,
+} from "../src/explorer-directory-materialization.ts";
 import { resolveClientIp } from "./config.ts";
 import {
   SUBNET_HYPERPARAMS_INSERT_COLUMNS,
@@ -7063,98 +7066,7 @@ async function loadGlobalValidatorsFromStore(
 // on every new edge-cache location, so a correct cold request took seconds.
 // Keep one atomic KV value per completed snapshot: readers see either the old
 // complete pair or the new complete pair, never one directory from each.
-type ExplorerDirectoryMaterialization = {
-  schema_version: 1;
-  captured_at: number;
-  accounts: ReturnType<typeof buildAccountHolderDirectory>;
-  validators: ReturnType<typeof buildValidatorOperatorDirectory>;
-};
-
-type ExplorerDirectoryPointer = {
-  schema_version: 1;
-  captured_at: number;
-};
-
-const ExplorerDirectoryPointerSchema = z
-  .object({
-    schema_version: z.literal(1),
-    captured_at: z.number().int().positive().max(8_640_000_000_000_000),
-  })
-  .strict();
-
-const ExplorerDirectoryMaterializationSchema = z
-  .object({
-    schema_version: z.literal(1),
-    captured_at: z.number().int().positive().max(8_640_000_000_000_000),
-    accounts: AccountHolderDirectoryArtifactSchema,
-    validators: ValidatorOperatorDirectoryArtifactSchema,
-  })
-  .strict()
-  .superRefine((value, refinement) => {
-    const capturedAt = new Date(value.captured_at).toISOString();
-    if (
-      value.accounts.captured_at !== capturedAt ||
-      value.validators.captured_at !== capturedAt
-    ) {
-      refinement.addIssue({
-        code: "custom",
-        message: "directory snapshots do not match the materialization stamp",
-      });
-    }
-  });
-
-export function materializationFromUnknown(
-  value: unknown,
-): ExplorerDirectoryMaterialization | null {
-  const parsed = ExplorerDirectoryMaterializationSchema.safeParse(value);
-  return parsed.success ? parsed.data : null;
-}
-
-function pointerFromUnknown(value: unknown): ExplorerDirectoryPointer | null {
-  const parsed = ExplorerDirectoryPointerSchema.safeParse(value);
-  return parsed.success ? parsed.data : null;
-}
-
-async function readExplorerDirectoryPointer(
-  env: DataApiEnv,
-): Promise<ExplorerDirectoryPointer | null> {
-  if (!env.METAGRAPH_CONTROL) return null;
-  try {
-    return pointerFromUnknown(
-      await env.METAGRAPH_CONTROL.get(KV_EXPLORER_DIRECTORIES_CURRENT, "json"),
-    );
-  } catch (error) {
-    console.error(
-      "explorer directory materialization pointer read failed:",
-      error,
-    );
-    return null;
-  }
-}
-
-async function readExplorerDirectoryMaterialization(
-  env: DataApiEnv,
-): Promise<ExplorerDirectoryMaterialization | null> {
-  if (!env.METAGRAPH_CONTROL) return null;
-  try {
-    const pointer = await readExplorerDirectoryPointer(env);
-    if (!pointer) return null;
-    const raw = await env.METAGRAPH_CONTROL.get(
-      explorerDirectoriesSnapshotKey(pointer.captured_at),
-      "json",
-    );
-    const materialization = materializationFromUnknown(raw);
-    return materialization?.captured_at === pointer.captured_at
-      ? materialization
-      : null;
-  } catch (error) {
-    // KV is an optimization tier. A read failure must fall through to the
-    // existing store-backed answer rather than turn a valid directory into a
-    // 5xx or a measured zero.
-    console.error("explorer directory materialization read failed:", error);
-    return null;
-  }
-}
+export { materializationFromUnknown };
 
 async function latestCompletedNeuronSnapshot(
   sql: PgSql,
@@ -7190,7 +7102,9 @@ export async function refreshExplorerDirectoryMaterialization(
   const promise = (async () => {
     const sql = routeRunner(env, ctx);
     if (!sql) return false;
-    const previousPointer = await readExplorerDirectoryPointer(env);
+    const previousPointer = await readExplorerDirectoryPointer(
+      env.METAGRAPH_CONTROL,
+    );
     if (previousPointer?.captured_at === capturedAt) return true;
     const latest = await latestCompletedNeuronSnapshot(sql);
     const newestRows = await sql<{ captured_at: number | string | null }>`
@@ -7311,7 +7225,7 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
       // This hot path intentionally reads only the tiny pointer. Fetching and
       // validating the ~300 KiB directory payload before every edge-cache hit
       // would move the whole cold-miss cost into the freshness check.
-      const pointer = await readExplorerDirectoryPointer(env);
+      const pointer = await readExplorerDirectoryPointer(env.METAGRAPH_CONTROL);
       if (pointer?.captured_at === capturedAt) {
         return json({ captured_at: capturedAt });
       }
@@ -7612,7 +7526,9 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
   // The rich per-hotkey route above remains unchanged for REST/MCP consumers.
   if (url.pathname === "/api/v1/validators/operators") {
     return async (sql, env) => {
-      const materialized = await readExplorerDirectoryMaterialization(env);
+      const materialized = await readExplorerDirectoryMaterialization(
+        env.METAGRAPH_CONTROL,
+      );
       if (materialized) return json(materialized.validators);
       return json(
         buildValidatorOperatorDirectory(
@@ -8443,7 +8359,9 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
   // The rich sortable route above remains unchanged for REST/MCP consumers.
   if (url.pathname === "/api/v1/accounts/directory") {
     return async (sql, env) => {
-      const materialized = await readExplorerDirectoryMaterialization(env);
+      const materialized = await readExplorerDirectoryMaterialization(
+        env.METAGRAPH_CONTROL,
+      );
       if (materialized) return json(materialized.accounts);
       const [rows, priceByNetuid] = await Promise.all([
         sql<{

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -93,6 +93,7 @@ import {
 import { buildAccountsList } from "../../src/accounts-list.ts";
 import { buildAccountHolderDirectory } from "../../src/account-holder-directory.ts";
 import { buildValidatorOperatorDirectory } from "../../src/validator-operator-directory.ts";
+import { readExplorerDirectoryMaterialization } from "../../src/explorer-directory-materialization.ts";
 import { buildTopHoldersList } from "../../src/top-holders.ts";
 import {
   buildDeregistrationHistory,
@@ -938,13 +939,14 @@ async function metagraphMeta(
   env: Env,
   artifactPath: string,
   generatedAt: unknown,
+  publishedAtPromise: Promise<string | null> | null = null,
 ) {
   return {
     artifact_path: artifactPath,
     cache: "short",
     contract_version: contractVersion(env),
     generated_at: generatedAt,
-    published_at: await publishedAt(env),
+    published_at: await (publishedAtPromise ?? publishedAt(env)),
     source: "metagraph-snapshot",
   };
 }
@@ -1387,7 +1389,13 @@ export async function handleValidatorOperatorDirectory(
   request: Request,
   env: Env,
 ) {
+  const publishedAtPromise = publishedAt(env);
+  const materialized =
+    env.METAGRAPH_NEURONS_SOURCE === "data-api"
+      ? await readExplorerDirectoryMaterialization(env.METAGRAPH_CONTROL)
+      : null;
   const data =
+    materialized?.validators ??
     ((await tryDataApiTier(
       env,
       request,
@@ -1402,6 +1410,7 @@ export async function handleValidatorOperatorDirectory(
         env,
         "/metagraph/validators/operators.json",
         data.captured_at,
+        publishedAtPromise,
       ),
     },
     "short",
@@ -1485,7 +1494,13 @@ export async function handleAccountsList(request: Request, env: Env, url: URL) {
 }
 
 export async function handleAccountHolderDirectory(request: Request, env: Env) {
+  const publishedAtPromise = publishedAt(env);
+  const materialized =
+    env.METAGRAPH_NEURONS_SOURCE === "data-api"
+      ? await readExplorerDirectoryMaterialization(env.METAGRAPH_CONTROL)
+      : null;
   const data =
+    materialized?.accounts ??
     ((await tryDataApiTier(
       env,
       request,
@@ -1500,6 +1515,7 @@ export async function handleAccountHolderDirectory(request: Request, env: Env) {
         env,
         "/metagraph/accounts/directory.json",
         data.captured_at,
+        publishedAtPromise,
       ),
     },
     "short",


### PR DESCRIPTION
Closes #11760

## Summary
- read the completed explorer-directory pointer directly from the shared control KV for cache invalidation
- serve account and validator directory materializations directly in the public Worker, retaining the data-tier live projection as fallback
- overlap publication metadata lookup with the directory read
- keep strict snapshot/schema validation in one shared reader

## Validation
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run worker:deploy:dry-run`
- `npm run worker:bundle:budget`
- `npm run test:coverage` (978 files; 22,457 passed; 11 skipped)
- targeted directory/cache/handler suite (541 passed)