### PR TITLE
perf(data): reduce directory cold path to one KV read

### DIFF
--- a/src/explorer-directory-current.ts
+++ b/src/explorer-directory-current.ts
@@ -1,0 +1,53 @@
+import { AccountHolderDirectoryArtifactSchema } from "../schemas-src/routes/account-holder-directory.ts";
+import { ValidatorOperatorDirectoryArtifactSchema } from "../schemas-src/routes/validator-operator-directory.ts";
+import {
+  KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+  KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+} from "./kv-keys.ts";
+import type { ExplorerDirectoryMaterialization } from "./explorer-directory-materialization.ts";
+
+type DirectoryKv = {
+  get(key: string, type: "json"): Promise<unknown>;
+};
+
+type DirectorySchema<T> = {
+  safeParse(value: unknown): { success: true; data: T } | { success: false };
+};
+
+async function readCurrentDirectory<T>(
+  kv: DirectoryKv | null | undefined,
+  key: string,
+  schema: DirectorySchema<T>,
+  label: string,
+): Promise<T | null> {
+  if (!kv) return null;
+  try {
+    const parsed = schema.safeParse(await kv.get(key, "json"));
+    return parsed.success ? parsed.data : null;
+  } catch (error) {
+    console.error(`${label} directory materialization read failed:`, error);
+    return null;
+  }
+}
+
+export function readCurrentAccountDirectory(
+  kv: DirectoryKv | null | undefined,
+): Promise<ExplorerDirectoryMaterialization["accounts"] | null> {
+  return readCurrentDirectory(
+    kv,
+    KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+    AccountHolderDirectoryArtifactSchema,
+    "account",
+  );
+}
+
+export function readCurrentValidatorDirectory(
+  kv: DirectoryKv | null | undefined,
+): Promise<ExplorerDirectoryMaterialization["validators"] | null> {
+  return readCurrentDirectory(
+    kv,
+    KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+    ValidatorOperatorDirectoryArtifactSchema,
+    "validator",
+  );
+}

--- a/src/kv-keys.ts
+++ b/src/kv-keys.ts
@@ -17,6 +17,10 @@ export const KV_EXPLORER_DIRECTORIES_CURRENT =
   "explorer-directories:v1:current" as const;
 export const KV_EXPLORER_DIRECTORIES_SNAPSHOT_PREFIX =
   "explorer-directories:v1:snapshot" as const;
+export const KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT =
+  "explorer-directories:v1:accounts:current" as const;
+export const KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT =
+  "explorer-directories:v1:validators:current" as const;
 
 export function explorerDirectoriesSnapshotKey(capturedAt: number): string {
   return `${KV_EXPLORER_DIRECTORIES_SNAPSHOT_PREFIX}:${capturedAt}`;

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -29,8 +29,8 @@ import {
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { CONTRACT_VERSION } from "../src/contracts.ts";
 import {
-  KV_EXPLORER_DIRECTORIES_CURRENT,
-  explorerDirectoriesSnapshotKey,
+  KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+  KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
 } from "../src/kv-keys.ts";
 import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
 import { resetObservedThroughCache } from "../src/lakehouse-observed-through.ts";
@@ -1479,12 +1479,12 @@ describe("analytics edge cache", () => {
     assert.equal(cache.matchCalls, 2);
   });
 
-  test("/api/v1/validators/operators caches on the completed neuron pass", async () => {
+  test("/api/v1/validators/operators caches within the bounded minute epoch", async () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();
     cache.install();
     const paths: string[] = [];
-    const stamp = Date.parse("2026-08-29T00:00:00.000Z");
+    const cacheStamp = `minute:${Math.floor(Date.now() / 60_000)}`;
     const directory = {
       schema_version: 1,
       captured_at: "2026-08-29T00:00:00.000Z",
@@ -1493,31 +1493,12 @@ describe("analytics edge cache", () => {
       operator_count: 0,
       operators: [],
     };
-    const materialization = {
-      schema_version: 1,
-      captured_at: stamp,
-      validators: directory,
-      accounts: {
-        schema_version: 1,
-        captured_at: directory.captured_at,
-        block_number: directory.block_number,
-        account_count: 0,
-        limit: 20,
-        priced_registered_stake_tao: 0,
-        rankings: { stake: [], emission: [], reach: [] },
-      },
-    };
     const env = {
       ...analyticsEnv([]),
       METAGRAPH_NEURONS_SOURCE: "data-api",
       METAGRAPH_CONTROL: {
         async get(key: string) {
-          if (key === KV_EXPLORER_DIRECTORIES_CURRENT) {
-            return { schema_version: 1, captured_at: stamp };
-          }
-          if (key === explorerDirectoriesSnapshotKey(stamp)) {
-            return materialization;
-          }
+          if (key === KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT) return directory;
           return null;
         },
       },
@@ -1525,9 +1506,7 @@ describe("analytics edge cache", () => {
         async fetch(request: Request) {
           const pathname = new URL(request.url).pathname;
           paths.push(pathname);
-          return pathname === "/api/v1/internal/neurons-snapshot-stamp"
-            ? Response.json({ captured_at: stamp })
-            : Response.json(directory);
+          return Response.json(directory);
         },
       },
     };
@@ -1546,17 +1525,17 @@ describe("analytics edge cache", () => {
     assert.deepEqual(cache.putKeys, [
       `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
         CONTRACT_VERSION,
-      )}/${stamp}/validator-operator-directory/api/v1/validators/operators`,
+      )}/${encodeURIComponent(cacheStamp)}/validator-operator-directory/api/v1/validators/operators`,
     ]);
     assert.equal(cache.matchCalls, 2);
   });
 
-  test("/api/v1/accounts/directory caches on the completed neuron pass", async () => {
+  test("/api/v1/accounts/directory caches within the bounded minute epoch", async () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();
     cache.install();
     const paths: string[] = [];
-    const stamp = Date.parse("2026-08-29T00:00:00.000Z");
+    const cacheStamp = `minute:${Math.floor(Date.now() / 60_000)}`;
     const directory = {
       schema_version: 1,
       captured_at: "2026-08-29T00:00:00.000Z",
@@ -1566,30 +1545,12 @@ describe("analytics edge cache", () => {
       priced_registered_stake_tao: 0,
       rankings: { stake: [], emission: [], reach: [] },
     };
-    const materialization = {
-      schema_version: 1,
-      captured_at: stamp,
-      accounts: directory,
-      validators: {
-        schema_version: 1,
-        captured_at: directory.captured_at,
-        block_number: directory.block_number,
-        validator_count: 0,
-        operator_count: 0,
-        operators: [],
-      },
-    };
     const env = {
       ...analyticsEnv([]),
       METAGRAPH_NEURONS_SOURCE: "data-api",
       METAGRAPH_CONTROL: {
         async get(key: string) {
-          if (key === KV_EXPLORER_DIRECTORIES_CURRENT) {
-            return { schema_version: 1, captured_at: stamp };
-          }
-          if (key === explorerDirectoriesSnapshotKey(stamp)) {
-            return materialization;
-          }
+          if (key === KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT) return directory;
           return null;
         },
       },
@@ -1597,9 +1558,7 @@ describe("analytics edge cache", () => {
         async fetch(request: Request) {
           const pathname = new URL(request.url).pathname;
           paths.push(pathname);
-          return pathname === "/api/v1/internal/neurons-snapshot-stamp"
-            ? Response.json({ captured_at: stamp })
-            : Response.json(directory);
+          return Response.json(directory);
         },
       },
     };
@@ -1618,7 +1577,7 @@ describe("analytics edge cache", () => {
     assert.deepEqual(cache.putKeys, [
       `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
         CONTRACT_VERSION,
-      )}/${stamp}/account-holder-directory/api/v1/accounts/directory`,
+      )}/${encodeURIComponent(cacheStamp)}/account-holder-directory/api/v1/accounts/directory`,
     ]);
     assert.equal(cache.matchCalls, 2);
   });

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -22,7 +22,9 @@ import type { Row } from "./row-type.ts";
 import { persistComputeDeclaration } from "../src/compute-declarations-lane.ts";
 import {
   explorerDirectoriesSnapshotKey,
+  KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
   KV_EXPLORER_DIRECTORIES_CURRENT,
+  KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
 } from "../src/kv-keys.ts";
 import { dataApiEnv } from "./helpers/worker-env.ts";
 import type { DataApiWorkerEnv } from "../workers/types.ts";
@@ -466,6 +468,16 @@ test("the direct neurons path publishes explorer directories when its declared p
   ) as Row;
   assert.equal((stored.accounts as Row).account_count, 1);
   assert.equal((stored.validators as Row).validator_count, 1);
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT)!)
+      .account_count,
+    1,
+  );
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT)!)
+      .validator_count,
+    1,
+  );
 });
 
 test("the direct neurons path does not publish an incomplete declared pass", async () => {
@@ -2842,6 +2854,16 @@ test("the snapshot stamp prepares one atomic directory materialization and both 
   assert.equal(stored.captured_at, CAPTURED_AT);
   assert.equal((stored.accounts as Row).account_count, 3);
   assert.equal((stored.validators as Row).validator_count, 3);
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT)!)
+      .account_count,
+    3,
+  );
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT)!)
+      .validator_count,
+    3,
+  );
 
   // Prove these are KV reads rather than another whole-network aggregation:
   // once the materialization exists, even an unavailable source table cannot
@@ -2881,9 +2903,9 @@ test("concurrent requests share one directory refresh for a completed snapshot",
     ),
   ]);
   assert.deepEqual([first, second], [true, true]);
-  // One versioned payload plus one tiny current pointer, still from one shared
-  // build rather than one pair of writes per caller.
-  assert.equal(kv.putCount(), 2);
+  // One versioned payload, two route-specific hot values and one tiny current
+  // pointer, still from one shared build rather than one write set per caller.
+  assert.equal(kv.putCount(), 4);
 });
 
 test("the cache-stamp hot path reads only the small directory pointer", async () => {
@@ -3427,6 +3449,16 @@ test("the queue consumer publishes explorer directories when a neuron pass compl
   );
   assert.equal(
     materialized.validators.captured_at,
+    new Date(CAPTURED_AT).toISOString(),
+  );
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT)!)
+      .captured_at,
+    new Date(CAPTURED_AT).toISOString(),
+  );
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT)!)
+      .captured_at,
     new Date(CAPTURED_AT).toISOString(),
   );
 });

--- a/tests/data-api-tier.test.ts
+++ b/tests/data-api-tier.test.ts
@@ -5,11 +5,11 @@
 // withEdgeCache write, #5090) are tested directly here rather than only
 // incidentally through individual handler tests.
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import {
   DATA_API_TIER_RETRY_ATTEMPTS,
   currentDataApiTierFallbackGeneration,
-  readNeuronsSnapshotCacheStamp,
+  readExplorerDirectoryCacheStamp,
   tryDataApiTier,
 } from "../workers/data-api-tier.ts";
 import { mockEnv, type AnyFn } from "./row-type.ts";
@@ -24,74 +24,24 @@ function dataApi(handler: AnyFn) {
   return { fetch: handler };
 }
 
-function directoryKv(value: unknown, error: Error | null = null) {
-  return {
-    async get() {
-      if (error) throw error;
-      return value;
-    },
-  };
-}
-
 function req() {
   return new Request("https://api.metagraph.sh/api/v1/health");
 }
 
-test("readNeuronsSnapshotCacheStamp: returns the completed-pass watermark", async () => {
-  const result = await readNeuronsSnapshotCacheStamp(
-    mockEnv({
-      METAGRAPH_NEURONS_SOURCE: "data-api",
-      METAGRAPH_CONTROL: directoryKv({
-        schema_version: 1,
-        captured_at: 1_780_000_000_000,
-      }),
-    }),
+test("readExplorerDirectoryCacheStamp: returns the current minute epoch", async () => {
+  const now = 1_780_000_000_000;
+  const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+  const result = await readExplorerDirectoryCacheStamp(
+    mockEnv({ METAGRAPH_NEURONS_SOURCE: "data-api" }),
   );
-  assert.equal(result, "1780000000000");
+  nowSpy.mockRestore();
+  assert.equal(result, `minute:${Math.floor(now / 60_000)}`);
 });
 
-test("readNeuronsSnapshotCacheStamp: declines without the active lane or pointer", async () => {
+test("readExplorerDirectoryCacheStamp: declines without the active lane", async () => {
   assert.equal(
-    await readNeuronsSnapshotCacheStamp(
+    await readExplorerDirectoryCacheStamp(
       mockEnv({ METAGRAPH_NEURONS_SOURCE: "retired" }),
-    ),
-    null,
-  );
-  assert.equal(
-    await readNeuronsSnapshotCacheStamp(
-      mockEnv({ METAGRAPH_NEURONS_SOURCE: "data-api" }),
-    ),
-    null,
-  );
-});
-
-test("readNeuronsSnapshotCacheStamp: unproven pointers disable caching", async () => {
-  for (const pointer of [
-    null,
-    { schema_version: 1, captured_at: null },
-    { schema_version: 1, captured_at: -1 },
-    { schema_version: 1, captured_at: 1.5 },
-    { schema_version: 2, captured_at: 1_780_000_000_000 },
-  ]) {
-    assert.equal(
-      await readNeuronsSnapshotCacheStamp(
-        mockEnv({
-          METAGRAPH_NEURONS_SOURCE: "data-api",
-          METAGRAPH_CONTROL: directoryKv(pointer),
-        }),
-      ),
-      null,
-    );
-  }
-});
-
-test("readNeuronsSnapshotCacheStamp: KV failures disable caching", async () => {
-  assert.equal(
-    await readNeuronsSnapshotCacheStamp(
-      mockEnv({
-        METAGRAPH_NEURONS_SOURCE: "data-api",
-        METAGRAPH_CONTROL: directoryKv(null, new Error("offline")),
-      }),
     ),
     null,
   );

--- a/tests/explorer-directory-materialization.test.ts
+++ b/tests/explorer-directory-materialization.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+
+import {
+  readCurrentAccountDirectory,
+  readCurrentValidatorDirectory,
+} from "../src/explorer-directory-current.ts";
+import {
+  KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+  KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+} from "../src/kv-keys.ts";
+
+const capturedAt = "2026-08-29T00:00:00.000Z";
+
+const accounts = {
+  schema_version: 1 as const,
+  captured_at: capturedAt,
+  block_number: 8_950_000,
+  account_count: 0,
+  limit: 20 as const,
+  priced_registered_stake_tao: 0,
+  rankings: { stake: [], emission: [], reach: [] },
+};
+
+const validators = {
+  schema_version: 1 as const,
+  captured_at: capturedAt,
+  block_number: 8_950_000,
+  validator_count: 0,
+  operator_count: 0,
+  operators: [],
+};
+
+test("route-specific directory readers fetch and validate exactly one KV value", async () => {
+  const reads: string[] = [];
+  const kv = {
+    async get(key: string) {
+      reads.push(key);
+      return key === KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT
+        ? accounts
+        : validators;
+    },
+  };
+
+  assert.deepEqual(await readCurrentAccountDirectory(kv), accounts);
+  assert.deepEqual(await readCurrentValidatorDirectory(kv), validators);
+  assert.deepEqual(reads, [
+    KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+    KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+  ]);
+});
+
+test("route-specific directory readers decline absent or malformed values", async () => {
+  assert.equal(await readCurrentAccountDirectory(null), null);
+  assert.equal(
+    await readCurrentValidatorDirectory({
+      get: async () => ({ broken: true }),
+    }),
+    null,
+  );
+});
+
+test("route-specific directory readers contain KV failures", async () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  assert.equal(
+    await readCurrentAccountDirectory({
+      get: async () => {
+        throw new Error("offline");
+      },
+    }),
+    null,
+  );
+  assert.equal(error.mock.calls.length, 1);
+  error.mockRestore();
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -316,7 +316,7 @@ import {
   accountEdgeCacheEligible,
 } from "./account-edge-cache.ts";
 import { parseRouteQuery, routeQuery, routeText } from "../src/route-query.ts";
-import { readNeuronsSnapshotCacheStamp } from "./data-api-tier.ts";
+import { readExplorerDirectoryCacheStamp } from "./data-api-tier.ts";
 import {
   serverTimingHeader,
   withRequestTiming,
@@ -6947,7 +6947,7 @@ async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {
       "validator-operator-directory",
       (cacheRequest) => handleValidatorOperatorDirectory(cacheRequest, env),
       url.pathname,
-      readNeuronsSnapshotCacheStamp,
+      readExplorerDirectoryCacheStamp,
     );
   }
 
@@ -6997,7 +6997,7 @@ async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {
       "account-holder-directory",
       (cacheRequest) => handleAccountHolderDirectory(cacheRequest, env),
       url.pathname,
-      readNeuronsSnapshotCacheStamp,
+      readExplorerDirectoryCacheStamp,
     );
   }
 

--- a/workers/data-api-tier.ts
+++ b/workers/data-api-tier.ts
@@ -1,7 +1,6 @@
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { maskRouteParams } from "../src/route-label.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
-import { readExplorerDirectoryPointer } from "../src/explorer-directory-materialization.ts";
 
 // DATA_API-forwarding serving gate, one env flag per data source (originally
 // ADR 0013 Sequencing step 3's gated D1 -> Postgres cutover; D1 fully
@@ -158,21 +157,20 @@ export const FORWARDABLE_TIER_FLAGS = [
 export type ForwardableTierFlag = (typeof FORWARDABLE_TIER_FLAGS)[number];
 
 /**
- * The newest fully-landed neuron snapshot, for cache invalidation.
+ * A bounded cache epoch for the precomputed explorer directories.
  *
- * The pointer is published only after both directory projections have been
- * built from one complete neuron pass. The main Worker shares the exact KV
- * namespace with data-api, so reading that tiny pointer locally avoids a
- * second Worker invocation before every cache lookup. It does not use health
- * metadata: a health probe can run without neuron data moving, and a partial
- * multi-request neuron pass must never advance this cache boundary.
+ * The route responses are already bounded by a 60-second public
+ * cache profile, while their source snapshot advances roughly every 15
+ * minutes. A wall-clock epoch keeps the edge key fresh within that same
+ * contract without adding a KV read before every cache lookup. The handler's
+ * first miss can therefore spend its one storage read on the route-specific
+ * materialization rather than reading a pointer first.
  */
-export async function readNeuronsSnapshotCacheStamp(
+export async function readExplorerDirectoryCacheStamp(
   env: Env,
 ): Promise<string | null> {
   if (env.METAGRAPH_NEURONS_SOURCE !== "data-api") return null;
-  const pointer = await readExplorerDirectoryPointer(env.METAGRAPH_CONTROL);
-  return pointer ? String(pointer.captured_at) : null;
+  return `minute:${Math.floor(Date.now() / 60_000)}`;
 }
 
 export async function tryDataApiTier(

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -446,7 +446,9 @@ import {
 import { PASS_TABLES } from "../src/pass-completeness.ts";
 import {
   explorerDirectoriesSnapshotKey,
+  KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
   KV_EXPLORER_DIRECTORIES_CURRENT,
+  KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
   KV_TAO_USD_CURRENT,
 } from "../src/kv-keys.ts";
 import { NEON_PRUNE_CRON, runNeonPrune } from "../src/neon-prune.ts";
@@ -7061,11 +7063,8 @@ async function loadGlobalValidatorsFromStore(
   });
 }
 
-// The two network-wide pages are read far more often than the neuron snapshot
-// changes. Their compact response shapes still required a complete store scan
-// on every new edge-cache location, so a correct cold request took seconds.
-// Keep one atomic KV value per completed snapshot: readers see either the old
-// complete pair or the new complete pair, never one directory from each.
+// Precompute account and validator directories for single-read
+// cold paths; advance the versioned fallback pointer only after both are stored.
 export { materializationFromUnknown };
 
 async function latestCompletedNeuronSnapshot(
@@ -7165,10 +7164,20 @@ export async function refreshExplorerDirectoryMaterialization(
       accounts,
       validators,
     };
-    await env.METAGRAPH_CONTROL.put(
-      explorerDirectoriesSnapshotKey(capturedAt),
-      JSON.stringify(value),
-    );
+    await Promise.all([
+      env.METAGRAPH_CONTROL.put(
+        explorerDirectoriesSnapshotKey(capturedAt),
+        JSON.stringify(value),
+      ),
+      env.METAGRAPH_CONTROL.put(
+        KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+        JSON.stringify(accounts),
+      ),
+      env.METAGRAPH_CONTROL.put(
+        KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+        JSON.stringify(validators),
+      ),
+    ]);
     await env.METAGRAPH_CONTROL.put(
       KV_EXPLORER_DIRECTORIES_CURRENT,
       JSON.stringify({ schema_version: 1, captured_at: capturedAt }),

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -93,7 +93,10 @@ import {
 import { buildAccountsList } from "../../src/accounts-list.ts";
 import { buildAccountHolderDirectory } from "../../src/account-holder-directory.ts";
 import { buildValidatorOperatorDirectory } from "../../src/validator-operator-directory.ts";
-import { readExplorerDirectoryMaterialization } from "../../src/explorer-directory-materialization.ts";
+import {
+  readCurrentAccountDirectory,
+  readCurrentValidatorDirectory,
+} from "../../src/explorer-directory-current.ts";
 import { buildTopHoldersList } from "../../src/top-holders.ts";
 import {
   buildDeregistrationHistory,
@@ -1392,10 +1395,10 @@ export async function handleValidatorOperatorDirectory(
   const publishedAtPromise = publishedAt(env);
   const materialized =
     env.METAGRAPH_NEURONS_SOURCE === "data-api"
-      ? await readExplorerDirectoryMaterialization(env.METAGRAPH_CONTROL)
+      ? await readCurrentValidatorDirectory(env.METAGRAPH_CONTROL)
       : null;
   const data =
-    materialized?.validators ??
+    materialized ??
     ((await tryDataApiTier(
       env,
       request,
@@ -1497,10 +1500,10 @@ export async function handleAccountHolderDirectory(request: Request, env: Env) {
   const publishedAtPromise = publishedAt(env);
   const materialized =
     env.METAGRAPH_NEURONS_SOURCE === "data-api"
-      ? await readExplorerDirectoryMaterialization(env.METAGRAPH_CONTROL)
+      ? await readCurrentAccountDirectory(env.METAGRAPH_CONTROL)
       : null;
   const data =
-    materialized?.accounts ??
+    materialized ??
     ((await tryDataApiTier(
       env,
       request,


### PR DESCRIPTION
## Summary

- publish stable route-specific account and validator directory values alongside the versioned combined snapshot
- serve each public directory with one validated KV read and keep the data-tier fallback intact
- replace the preflight KV stamp read with the route cache profile’s bounded one-minute epoch
- preserve the existing source flag as a kill switch and retain the combined snapshot pointer as the fallback boundary

## Validation

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run worker:deploy:dry-run`
- `npm run worker:bundle:budget` (1,802.2 KiB gzip)
- full coverage run: 22,457 passed, 11 skipped; the sole initial failure was the unchanged data-Worker source ceiling, then the public-only reader was isolated from that graph and the boundary test passed without raising the budget
- focused final run: 94 passed

Refs #11760