### PR TITLE
fix(ui): surface unverified API fallbacks

### DIFF
--- a/apps/ui/src/components/metagraphed/states.test.tsx
+++ b/apps/ui/src/components/metagraphed/states.test.tsx
@@ -5,6 +5,43 @@ import { ApiError } from "@/lib/metagraphed/client";
 import { BlockDetailCatchupStatus, ErrorState } from "./states";
 
 describe("ErrorState", () => {
+  it("does not present an unavailable data tier as a measured empty result", () => {
+    const html = renderToStaticMarkup(
+      <ErrorState
+        context="complete-day chain activity"
+        error={
+          new ApiError("unverified fallback", {
+            status: 200,
+            code: "data_tier_unavailable",
+            url: "https://api.example.test/api/v1/chain/activity",
+          })
+        }
+      />,
+    );
+
+    expect(html).toContain("Data source temporarily unavailable");
+    expect(html).toContain("cannot verify its current source");
+    expect(html).toContain("no zero or empty result is shown");
+    expect(html).not.toContain("Deep-history tier not enabled");
+    expect(html).not.toContain("Couldn't load complete-day chain activity");
+  });
+
+  it("uses neutral copy when the unavailable response has no route context", () => {
+    const html = renderToStaticMarkup(
+      <ErrorState
+        error={
+          new ApiError("unverified fallback", {
+            status: 200,
+            code: "data_tier_unavailable",
+            url: "https://api.example.test/api/v1/data",
+          })
+        }
+      />,
+    );
+
+    expect(html).toContain("This view cannot verify its current source");
+  });
+
   it("keeps a block-detail coverage gap distinct from an empty or generic error", () => {
     const html = renderToStaticMarkup(
       <ErrorState

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -13,13 +13,7 @@ import { getNetworkPrefix } from "@/lib/metagraphed/config";
 import { isUsableTimestamp } from "@/lib/metagraphed/format";
 import { NativeOnlyNotice } from "./native-only-notice";
 
-/**
- * Shown when a `/chain-events*` request 503s with `data_tier_unavailable` —
- * the deep-history lakehouse tier can't answer in this deployment (its R2 SQL
- * credentials aren't bound). Expected on a preview/fork/from-scratch
- * environment, not a fault in the feed itself, so an informational notice
- * reads better than a red error card (mirrors `NativeOnlyNotice`'s reasoning).
- */
+/** A truthful replacement for a response the API marked as unverified. */
 function DataTierUnavailableNotice({ context }: { context?: string }) {
   return (
     <div role="status" className="rounded border border-border bg-surface p-4">
@@ -27,11 +21,11 @@ function DataTierUnavailableNotice({ context }: { context?: string }) {
         <Database className="size-4 shrink-0 text-ink-muted" />
         <div className="min-w-0 flex-1">
           <div className="mb-1 font-display text-13 font-medium text-ink-strong">
-            Deep-history tier not enabled
+            Data source temporarily unavailable
           </div>
           <p className="text-13 leading-relaxed text-ink-muted">
-            {context ? `The ${context} view` : "This view"} reads the deep-history all-events tier,
-            which isn't available in this deployment. It's unrelated to the rest of this page.
+            {context ? `The ${context} view` : "This view"} cannot verify its current source, so no
+            zero or empty result is shown. The rest of the page can continue updating.
           </p>
         </div>
       </div>
@@ -207,11 +201,9 @@ export function ErrorState({
   ) {
     return <NativeOnlyNotice context={context} />;
   }
-  // #2564: the chain-events deep-history tier (workers/api.ts's handleChainEventsFamily)
-  // 503s with this exact code when nothing can answer the route in a deployment (e.g. a
-  // preview/fork environment without lakehouse credentials). That's an expected,
-  // documented condition, not a fault in this feed — an informational notice reads better
-  // than a red error card for every call site that reads /chain-events*.
+  // Both explicit 503s and header-marked schema-stable 200 fallbacks use this
+  // code. Neither is a measured empty answer, so keep the state informational
+  // and explicit rather than rendering a zero or a generic red error card.
   if (isApi && error.code === "data_tier_unavailable") {
     return <DataTierUnavailableNotice context={context} />;
   }

--- a/apps/ui/src/lib/metagraphed/client.test.ts
+++ b/apps/ui/src/lib/metagraphed/client.test.ts
@@ -158,6 +158,71 @@ describe("apiFetch", () => {
     });
   });
 
+  it("rejects a header-marked empty fallback instead of treating it as measured data", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { ok: true, data: { day_count: 0, days: [] }, meta: {} },
+          { headers: { "x-metagraph-degraded": "tier_unavailable" } },
+        ),
+      ),
+    );
+
+    await expect(apiFetch("/api/v1/chain/activity")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 200,
+      code: "data_tier_unavailable",
+      url: "https://api.metagraph.sh/api/v1/chain/activity",
+    } satisfies Partial<ApiError>);
+  });
+
+  it("keeps an explicit error envelope more specific than the degraded header", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { ok: false, error: { message: "bad window", code: "bad_window" } },
+          { headers: { "x-metagraph-degraded": "tier_unavailable" } },
+        ),
+      ),
+    );
+
+    await expect(apiFetch("/api/v1/chain/activity")).rejects.toMatchObject({
+      message: "bad window",
+      status: 200,
+      code: "bad_window",
+    } satisfies Partial<ApiError>);
+  });
+
+  it("rejects an unverified plain JSON fallback too", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { day_count: 0, days: [] },
+          { headers: { "x-metagraph-degraded": "tier_unavailable" } },
+        ),
+      ),
+    );
+
+    await expect(apiFetch("/api/v1/chain/activity")).rejects.toMatchObject({
+      code: "data_tier_unavailable",
+      status: 200,
+    } satisfies Partial<ApiError>);
+  });
+
+  it("keeps an ordinary measured empty response usable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ ok: true, data: { day_count: 0, days: [] }, meta: {} })),
+    );
+
+    await expect(apiFetch("/api/v1/chain/activity")).resolves.toMatchObject({
+      data: { day_count: 0, days: [] },
+    });
+  });
+
   it("wraps network failures as ApiError with status 0", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/ui/src/lib/metagraphed/client.ts
+++ b/apps/ui/src/lib/metagraphed/client.ts
@@ -144,7 +144,27 @@ export async function apiFetch<T>(
         network: env.meta?.network,
       });
     }
+    // Some collection routes deliberately return a schema-stable empty 200
+    // when their backing tier cannot answer. The response header is the contract
+    // that separates that fallback from a measured empty result. Promote it to
+    // the same typed error the UI already uses for unavailable data tiers so a
+    // zero-row fallback can never be presented as real network activity.
+    if (res.headers.get("x-metagraph-degraded") === "tier_unavailable") {
+      throw new ApiError("The data tier could not verify this response", {
+        status: res.status,
+        code: "data_tier_unavailable",
+        url: redactUrlForError(url),
+      });
+    }
     return { data: env.data, meta: env.meta ?? {}, url };
+  }
+
+  if (res.headers.get("x-metagraph-degraded") === "tier_unavailable") {
+    throw new ApiError("The data tier could not verify this response", {
+      status: res.status,
+      code: "data_tier_unavailable",
+      url: redactUrlForError(url),
+    });
   }
   return { data: body as T, meta: {}, url };
 }


### PR DESCRIPTION
## Summary

- promote header-marked unverified HTTP 200 fallbacks to the existing typed unavailable-data state
- preserve explicit API error envelopes and ordinary measured-empty responses
- replace the deep-history-specific notice with truthful route-agnostic copy
- cover enveloped, plain JSON, explicit-error, measured-empty, and contextual notice behavior

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` — 2,399 tests passed
- `npm run build:worker --workspace=apps/ui`
- `npm run validate:ui-route-coverage` — all 219 published routes referenced

Closes #11807
