### PR TITLE
perf(data): bootstrap route directory values

### DIFF
--- a/src/explorer-directory-materialization.ts
+++ b/src/explorer-directory-materialization.ts
@@ -19,6 +19,7 @@ export type ExplorerDirectoryMaterialization = {
 export type ExplorerDirectoryPointer = {
   schema_version: 1;
   captured_at: number;
+  route_values_ready?: true;
 };
 
 type ExplorerDirectoryKv = Pick<KVNamespace, "get">;
@@ -27,6 +28,7 @@ const ExplorerDirectoryPointerSchema = z
   .object({
     schema_version: z.literal(1),
     captured_at: z.number().int().positive().max(8_640_000_000_000_000),
+    route_values_ready: z.literal(true).optional(),
   })
   .strict();
 

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -2919,7 +2919,11 @@ test("the cache-stamp hot path reads only the small directory pointer", async ()
       reads.push(key);
       const value =
         key === KV_EXPLORER_DIRECTORIES_CURRENT
-          ? JSON.stringify({ schema_version: 1, captured_at: CAPTURED_AT })
+          ? JSON.stringify({
+              schema_version: 1,
+              captured_at: CAPTURED_AT,
+              route_values_ready: true,
+            })
           : null;
       return type === "json" && value !== null ? JSON.parse(value) : value;
     },
@@ -2936,7 +2940,11 @@ test("a refresh already represented by the current pointer does no database work
   const kv = memoryKv();
   kv.values.set(
     KV_EXPLORER_DIRECTORIES_CURRENT,
-    JSON.stringify({ schema_version: 1, captured_at: CAPTURED_AT }),
+    JSON.stringify({
+      schema_version: 1,
+      captured_at: CAPTURED_AT,
+      route_values_ready: true,
+    }),
   );
   assert.equal(
     await refreshExplorerDirectoryMaterialization(
@@ -2948,6 +2956,46 @@ test("a refresh already represented by the current pointer does no database work
   );
   assert.equal(kv.putCount(), 0);
   assert.equal(pg.control.queries.length, 0);
+});
+
+test("a matching legacy pointer backfills route-specific directory values once", async () => {
+  await insertNeuron({ uid: 0, hotkey: "5Legacy", stake_tao: 100 });
+  await seed(
+    "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+    [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+  );
+  const kv = memoryKv();
+  kv.values.set(
+    KV_EXPLORER_DIRECTORIES_CURRENT,
+    JSON.stringify({ schema_version: 1, captured_at: CAPTURED_AT }),
+  );
+  const collected = collectingCtx();
+  const stamp = await worker.fetch(
+    req("/api/v1/internal/neurons-snapshot-stamp"),
+    env({ METAGRAPH_CONTROL: kv }),
+    collected.ctx,
+  );
+
+  assert.deepEqual(await stamp.json(), { captured_at: CAPTURED_AT });
+  await Promise.all(collected.pending);
+  assert.deepEqual(
+    JSON.parse(kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!),
+    {
+      schema_version: 1,
+      captured_at: CAPTURED_AT,
+      route_values_ready: true,
+    },
+  );
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT)!)
+      .account_count,
+    1,
+  );
+  assert.equal(
+    JSON.parse(kv.values.get(KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT)!)
+      .validator_count,
+    1,
+  );
 });
 
 test("a directory refresh declines cleanly when its store runner is unavailable", async () => {
@@ -3438,7 +3486,11 @@ test("the queue consumer publishes explorer directories when a neuron pass compl
   assert.deepEqual(acked, ["ack"]);
   assert.deepEqual(
     JSON.parse(kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!),
-    { schema_version: 1, captured_at: CAPTURED_AT },
+    {
+      schema_version: 1,
+      captured_at: CAPTURED_AT,
+      route_values_ready: true,
+    },
   );
   const materialized = JSON.parse(
     kv.values.get(explorerDirectoriesSnapshotKey(CAPTURED_AT))!,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7104,7 +7104,12 @@ export async function refreshExplorerDirectoryMaterialization(
     const previousPointer = await readExplorerDirectoryPointer(
       env.METAGRAPH_CONTROL,
     );
-    if (previousPointer?.captured_at === capturedAt) return true;
+    if (
+      previousPointer?.captured_at === capturedAt &&
+      previousPointer.route_values_ready
+    ) {
+      return true;
+    }
     const latest = await latestCompletedNeuronSnapshot(sql);
     const newestRows = await sql<{ captured_at: number | string | null }>`
       SELECT MAX(captured_at) AS captured_at FROM neurons`;
@@ -7180,7 +7185,11 @@ export async function refreshExplorerDirectoryMaterialization(
     ]);
     await env.METAGRAPH_CONTROL.put(
       KV_EXPLORER_DIRECTORIES_CURRENT,
-      JSON.stringify({ schema_version: 1, captured_at: capturedAt }),
+      JSON.stringify({
+        schema_version: 1,
+        captured_at: capturedAt,
+        route_values_ready: true,
+      }),
     );
     if (
       previousPointer &&
@@ -7235,15 +7244,12 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
       // validating the ~300 KiB directory payload before every edge-cache hit
       // would move the whole cold-miss cost into the freshness check.
       const pointer = await readExplorerDirectoryPointer(env.METAGRAPH_CONTROL);
-      if (pointer?.captured_at === capturedAt) {
+      if (pointer?.captured_at === capturedAt && pointer.route_values_ready) {
         return json({ captured_at: capturedAt });
       }
 
-      // Do not make a reader wait for a whole-network fold. While the new
-      // snapshot is prepared, keep advertising the previous complete stamp so
-      // the main Worker's snapshot-keyed cache continues serving its matching
-      // complete response. With no prior materialization (the one-time rollout
-      // bootstrap), the existing live handler remains the safe fallback.
+      // Keep serving the last complete stamp while this background fold runs.
+      // Legacy pointers reach this once to backfill the route-specific values.
       ctx.waitUntil(
         refreshExplorerDirectoryMaterialization(env, ctx, capturedAt).catch(
           (error) => {


### PR DESCRIPTION
## Summary

- mark directory pointers only after both route-specific values are published
- rebuild once when a matching legacy pointer predates those values
- preserve the one-pointer-read, zero-database-work steady-state freshness path

## Validation

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run validate`
- `npm run worker:deploy:dry-run`
- `npm test -- --run tests/data-api-neurons.test.ts` (118 passed)
- `npm test -- --run tests/data-api-bundle-boundary.test.ts tests/data-api-neurons.test.ts` (125 passed)
- full `npm run test:coverage`: 22,458 tests passed; its sole first run failure was the source-budget assertion, then the exact failed test and full changed family passed after trimming the implementation below the unchanged budget

Closes #11809
Refs #11760