### PR TITLE
fix(ui): eliminate hydration mismatches

### DIFF
--- a/apps/ui/src/lib/theme.test.ts
+++ b/apps/ui/src/lib/theme.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   THEME_BOOTSTRAP_SCRIPT,
@@ -6,7 +8,12 @@ import {
   bootstrapTheme,
   normalizeThemeChoice,
   resolveTheme,
+  useTheme,
 } from "./theme";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("normalizeThemeChoice", () => {
   it.each([
@@ -72,5 +79,17 @@ describe("THEME_BOOTSTRAP_SCRIPT", () => {
     expect(THEME_BOOTSTRAP_SCRIPT).toContain('r.classList.remove("dark")');
     expect(THEME_BOOTSTRAP_SCRIPT).toContain('r.dataset.theme = dark ? "dark" : "light"');
     expect(THEME_BOOTSTRAP_SCRIPT).toContain('matchMedia("(prefers-color-scheme: dark)")');
+  });
+});
+
+describe("useTheme hydration contract", () => {
+  it("keeps the first client choice equal to SSR when storage contains an explicit theme", () => {
+    const Probe = () => createElement("span", null, useTheme().choice);
+
+    expect(renderToStaticMarkup(createElement(Probe))).toBe("<span>system</span>");
+    vi.stubGlobal("window", {
+      localStorage: { getItem: () => "dark" },
+    });
+    expect(renderToStaticMarkup(createElement(Probe))).toBe("<span>system</span>");
   });
 });

--- a/apps/ui/src/lib/theme.ts
+++ b/apps/ui/src/lib/theme.ts
@@ -66,7 +66,11 @@ export const THEME_BOOTSTRAP_SCRIPT = `(() => {
 })();`;
 
 export function useTheme() {
-  const [choice, setChoiceState] = useState<ThemeChoice>(() => readChoice());
+  // The server cannot read localStorage, so both SSR and the first client
+  // render must use the same choice. The bootstrap script has already applied
+  // the stored choice to <html> before paint; the first effect adopts that
+  // choice for visible labels and controls after hydration.
+  const [choice, setChoiceState] = useState<ThemeChoice>("system");
   // Initialize to a fixed "light" so the server render and the first client
   // render agree — the effect below syncs `resolved` to the real theme right
   // after mount, and the pre-hydration THEME_BOOTSTRAP_SCRIPT has already set
@@ -75,16 +79,25 @@ export function useTheme() {
   // "light" and trips a hydration mismatch on every theme-param'd value — e.g.
   // BrandIcon's `?theme=light|dark` icon-proxy URL.
   const [resolved, setResolved] = useState<ResolvedTheme>("light");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const initial = readChoice();
+    setChoiceState(initial);
+    setResolved(apply(initial));
+    setMounted(true);
+  }, []);
 
   // Apply choice + listen to system changes while in `system` mode.
   useEffect(() => {
+    if (!mounted) return;
     setResolved(apply(choice));
     if (choice !== "system" || typeof window === "undefined") return;
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const onChange = () => setResolved(apply("system"));
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
-  }, [choice]);
+  }, [choice, mounted]);
 
   const setChoice = useCallback((next: ThemeChoice) => {
     if (typeof document !== "undefined") {

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -466,16 +466,24 @@ function apply(choice) {
   return resolved;
 }
 function useTheme() {
-  const [choice, setChoiceState] = React2.useState(() => readChoice());
+  const [choice, setChoiceState] = React2.useState("system");
   const [resolved, setResolved] = React2.useState("light");
+  const [mounted2, setMounted] = React2.useState(false);
   React2.useEffect(() => {
+    const initial = readChoice();
+    setChoiceState(initial);
+    setResolved(apply(initial));
+    setMounted(true);
+  }, []);
+  React2.useEffect(() => {
+    if (!mounted2) return;
     setResolved(apply(choice));
     if (choice !== "system" || typeof window === "undefined") return;
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const onChange = () => setResolved(apply("system"));
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
-  }, [choice]);
+  }, [choice, mounted2]);
   const setChoice = React2.useCallback((next) => {
     if (typeof document !== "undefined") {
       document.documentElement.classList.add("theme-transition");
@@ -4652,6 +4660,7 @@ function Cell({
   const align = column.align ?? (column.kind === "number" || column.kind === "delta" || column.kind === "tint" ? "right" : void 0);
   const tint = column.kind === "tint" ? column.tint?.(row) ?? null : null;
   let body;
+  let bodyIsLink = false;
   if (column.render) body = column.render(row);
   else if (column.kind === "identifier" && typeof raw === "string" && raw)
     body = /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "mg-dt-id", title: raw, children: [
@@ -4677,6 +4686,7 @@ function Cell({
   else if (column.kind === "link") {
     const to = column.href?.(row);
     const LinkCmp = link ?? DefaultLink2;
+    bodyIsLink = Boolean(to);
     body = to ? /* @__PURE__ */ jsxRuntime.jsx(LinkCmp, { href: to, className: "mg-dt-link", children: text }) : text;
   } else body = text;
   const RowLink = link ?? DefaultLink2;
@@ -4694,10 +4704,10 @@ function Cell({
       }
     }
   );
-  const linked = href !== void 0 ? /* @__PURE__ */ jsxRuntime.jsx(RowLink, { href, className: "mg-dt-rowlink", children: body }) : null;
+  const linked = href !== void 0 && !bodyIsLink ? /* @__PURE__ */ jsxRuntime.jsx(RowLink, { href, className: "mg-dt-rowlink", children: body }) : null;
   const content = disclosure !== void 0 ? /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "mg-dt-rowlead", children: [
     toggle,
-    linked ?? /* @__PURE__ */ jsxRuntime.jsx(
+    linked ?? (bodyIsLink ? body : /* @__PURE__ */ jsxRuntime.jsx(
       "button",
       {
         type: "button",
@@ -4710,8 +4720,8 @@ function Cell({
         },
         children: body
       }
-    )
-  ] }) : linked !== null ? linked : onActivate ? /* @__PURE__ */ jsxRuntime.jsx("button", { type: "button", className: "mg-dt-rowbutton", onClick: onActivate, children: body }) : body;
+    ))
+  ] }) : linked !== null ? linked : bodyIsLink ? body : onActivate ? /* @__PURE__ */ jsxRuntime.jsx("button", { type: "button", className: "mg-dt-rowbutton", onClick: onActivate, children: body }) : body;
   return /* @__PURE__ */ jsxRuntime.jsx(
     "td",
     {

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -440,16 +440,24 @@ function apply(choice) {
   return resolved;
 }
 function useTheme() {
-  const [choice, setChoiceState] = useState(() => readChoice());
+  const [choice, setChoiceState] = useState("system");
   const [resolved, setResolved] = useState("light");
+  const [mounted2, setMounted] = useState(false);
   useEffect(() => {
+    const initial = readChoice();
+    setChoiceState(initial);
+    setResolved(apply(initial));
+    setMounted(true);
+  }, []);
+  useEffect(() => {
+    if (!mounted2) return;
     setResolved(apply(choice));
     if (choice !== "system" || typeof window === "undefined") return;
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const onChange = () => setResolved(apply("system"));
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
-  }, [choice]);
+  }, [choice, mounted2]);
   const setChoice = useCallback((next) => {
     if (typeof document !== "undefined") {
       document.documentElement.classList.add("theme-transition");
@@ -4626,6 +4634,7 @@ function Cell({
   const align = column.align ?? (column.kind === "number" || column.kind === "delta" || column.kind === "tint" ? "right" : void 0);
   const tint = column.kind === "tint" ? column.tint?.(row) ?? null : null;
   let body;
+  let bodyIsLink = false;
   if (column.render) body = column.render(row);
   else if (column.kind === "identifier" && typeof raw === "string" && raw)
     body = /* @__PURE__ */ jsxs("span", { className: "mg-dt-id", title: raw, children: [
@@ -4651,6 +4660,7 @@ function Cell({
   else if (column.kind === "link") {
     const to = column.href?.(row);
     const LinkCmp = link ?? DefaultLink2;
+    bodyIsLink = Boolean(to);
     body = to ? /* @__PURE__ */ jsx(LinkCmp, { href: to, className: "mg-dt-link", children: text }) : text;
   } else body = text;
   const RowLink = link ?? DefaultLink2;
@@ -4668,10 +4678,10 @@ function Cell({
       }
     }
   );
-  const linked = href !== void 0 ? /* @__PURE__ */ jsx(RowLink, { href, className: "mg-dt-rowlink", children: body }) : null;
+  const linked = href !== void 0 && !bodyIsLink ? /* @__PURE__ */ jsx(RowLink, { href, className: "mg-dt-rowlink", children: body }) : null;
   const content = disclosure !== void 0 ? /* @__PURE__ */ jsxs("span", { className: "mg-dt-rowlead", children: [
     toggle,
-    linked ?? /* @__PURE__ */ jsx(
+    linked ?? (bodyIsLink ? body : /* @__PURE__ */ jsx(
       "button",
       {
         type: "button",
@@ -4684,8 +4694,8 @@ function Cell({
         },
         children: body
       }
-    )
-  ] }) : linked !== null ? linked : onActivate ? /* @__PURE__ */ jsx("button", { type: "button", className: "mg-dt-rowbutton", onClick: onActivate, children: body }) : body;
+    ))
+  ] }) : linked !== null ? linked : bodyIsLink ? body : onActivate ? /* @__PURE__ */ jsx("button", { type: "button", className: "mg-dt-rowbutton", onClick: onActivate, children: body }) : body;
   return /* @__PURE__ */ jsx(
     "td",
     {

--- a/packages/ui-kit/src/components/metagraphed/data-table/data-table.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/data-table/data-table.test.ts
@@ -180,6 +180,26 @@ describe("DataTable markup", () => {
     );
   });
 
+  it("does not nest a row link around a nominated link column", () => {
+    const html = render({
+      rowHref: (r: Row) => `/subnets/${r.id}`,
+      columns: [
+        {
+          key: "name",
+          label: "Subnet",
+          kind: "link",
+          lead: true,
+          value: (r: Row) => r.name,
+          href: (r: Row) => `/subnets/${r.id}`,
+        },
+      ],
+    });
+
+    expect((html.match(/<a\b/g) ?? []).length).toBe(3);
+    expect((html.match(/class="mg-dt-link"/g) ?? []).length).toBe(3);
+    expect(html).not.toMatch(/<a\b[^>]*>\s*<a\b/);
+  });
+
   it("routes every link through the caller's Link, not a bare anchor", () => {
     // The row link and a `kind: "link"` cell both have to reach the router;
     // a bare <a> would navigate with a full page load and drop the router's

--- a/packages/ui-kit/src/components/metagraphed/data-table/data-table.tsx
+++ b/packages/ui-kit/src/components/metagraphed/data-table/data-table.tsx
@@ -828,6 +828,7 @@ function Cell<Row_>({
   const tint = column.kind === "tint" ? (column.tint?.(row) ?? null) : null;
 
   let body: ReactNode;
+  let bodyIsLink = false;
   if (column.render) body = column.render(row);
   else if (column.kind === "identifier" && typeof raw === "string" && raw)
     body = (
@@ -857,6 +858,7 @@ function Cell<Row_>({
   else if (column.kind === "link") {
     const to = column.href?.(row);
     const LinkCmp = link ?? DefaultLink;
+    bodyIsLink = Boolean(to);
     body = to ? (
       <LinkCmp href={to} className="mg-dt-link">
         {text}
@@ -891,8 +893,14 @@ function Cell<Row_>({
       ></button>
     );
 
+  // A nominated row-link cell can itself be a `kind: "link"` column. Wrapping
+  // that cell's anchor in the generic row anchor creates invalid `<a><a>`
+  // markup; browsers repair the server HTML before React sees it, which turns
+  // every affected table into a hydration mismatch. The column link already
+  // carries the same crawlable, keyboard-accessible identity, so keep exactly
+  // that one anchor in this case.
   const linked =
-    href !== undefined ? (
+    href !== undefined && !bodyIsLink ? (
       <RowLink href={href} className="mg-dt-rowlink">
         {body}
       </RowLink>
@@ -902,25 +910,30 @@ function Cell<Row_>({
     disclosure !== undefined ? (
       <span className="mg-dt-rowlead">
         {toggle}
-        {linked ?? (
-          <button
-            type="button"
-            className="mg-dt-rowbutton"
-            aria-expanded={disclosure.expanded}
-            aria-controls={
-              disclosure.expanded ? disclosure.controls : undefined
-            }
-            onClick={(event) => {
-              event.stopPropagation();
-              disclosure.onToggle();
-            }}
-          >
-            {body}
-          </button>
-        )}
+        {linked ??
+          (bodyIsLink ? (
+            body
+          ) : (
+            <button
+              type="button"
+              className="mg-dt-rowbutton"
+              aria-expanded={disclosure.expanded}
+              aria-controls={
+                disclosure.expanded ? disclosure.controls : undefined
+              }
+              onClick={(event) => {
+                event.stopPropagation();
+                disclosure.onToggle();
+              }}
+            >
+              {body}
+            </button>
+          ))}
       </span>
     ) : linked !== null ? (
       linked
+    ) : bodyIsLink ? (
+      body
     ) : onActivate ? (
       <button type="button" className="mg-dt-rowbutton" onClick={onActivate}>
         {body}

--- a/packages/ui-kit/src/lib/theme.ts
+++ b/packages/ui-kit/src/lib/theme.ts
@@ -53,21 +53,33 @@ function apply(choice: ThemeChoice): ResolvedTheme {
 }
 
 export function useTheme() {
-  const [choice, setChoiceState] = useState<ThemeChoice>(() => readChoice());
+  // SSR cannot read localStorage. Keep the first client render identical to
+  // the server, then adopt the already bootstrapped document choice after
+  // hydration so theme-aware icons and visible controls stay deterministic.
+  const [choice, setChoiceState] = useState<ThemeChoice>("system");
   // Initialize to a fixed "light" so the server render and the first client
   // render agree -- the effect below syncs `resolved` to the real theme right
   // after mount, and the app's THEME_BOOTSTRAP_SCRIPT has already set the
   // document class for a flash-free first paint.
   const [resolved, setResolved] = useState<ResolvedTheme>("light");
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    const initial = readChoice();
+    setChoiceState(initial);
+    setResolved(apply(initial));
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
     setResolved(apply(choice));
     if (choice !== "system" || typeof window === "undefined") return;
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const onChange = () => setResolved(apply("system"));
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
-  }, [choice]);
+  }, [choice, mounted]);
 
   const setChoice = useCallback((next: ThemeChoice) => {
     if (typeof document !== "undefined") {


### PR DESCRIPTION
## Summary

- keep exactly one valid router anchor when a data-table row route and link column share the nominated cell
- defer stored theme-choice state until after hydration while preserving the pre-paint theme bootstrap
- add regressions for deterministic first-render theme state and non-nested table links

Closes #11813

## Validation

- `npm test --workspace=packages/ui-kit -- src/components/metagraphed/data-table/data-table.test.ts`
- `npm test --workspace=apps/ui -- src/lib/theme.test.ts`
- `npm run typecheck --workspace=packages/ui-kit`
- `npm run typecheck --workspace=apps/ui`
- `npm run lint --workspace=packages/ui-kit`
- `npm run lint --workspace=apps/ui`
- `npm run build:worker --workspace=apps/ui`
- production Worker build: settings, validator detail, blocks, extrinsics, and contribute all hydrate without recoverable console errors