### PR TITLE
fix(ui): preserve nominated row links

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -4687,7 +4687,14 @@ function Cell({
     const to = column.href?.(row);
     const LinkCmp = link ?? DefaultLink2;
     bodyIsLink = Boolean(to);
-    body = to ? /* @__PURE__ */ jsxRuntime.jsx(LinkCmp, { href: to, className: "mg-dt-link", children: text }) : text;
+    body = to ? /* @__PURE__ */ jsxRuntime.jsx(
+      LinkCmp,
+      {
+        href: to,
+        className: classNames("mg-dt-link", href && "mg-dt-rowlink"),
+        children: text
+      }
+    ) : text;
   } else body = text;
   const RowLink = link ?? DefaultLink2;
   const toggle = disclosure === void 0 ? null : /* @__PURE__ */ jsxRuntime.jsx(

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -4661,7 +4661,14 @@ function Cell({
     const to = column.href?.(row);
     const LinkCmp = link ?? DefaultLink2;
     bodyIsLink = Boolean(to);
-    body = to ? /* @__PURE__ */ jsx(LinkCmp, { href: to, className: "mg-dt-link", children: text }) : text;
+    body = to ? /* @__PURE__ */ jsx(
+      LinkCmp,
+      {
+        href: to,
+        className: classNames("mg-dt-link", href && "mg-dt-rowlink"),
+        children: text
+      }
+    ) : text;
   } else body = text;
   const RowLink = link ?? DefaultLink2;
   const toggle = disclosure === void 0 ? null : /* @__PURE__ */ jsx(

--- a/packages/ui-kit/src/components/metagraphed/data-table/data-table.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/data-table/data-table.test.ts
@@ -196,7 +196,28 @@ describe("DataTable markup", () => {
     });
 
     expect((html.match(/<a\b/g) ?? []).length).toBe(3);
-    expect((html.match(/class="mg-dt-link"/g) ?? []).length).toBe(3);
+    expect((html.match(/class="mg-dt-link mg-dt-rowlink"/g) ?? []).length).toBe(
+      3,
+    );
+    expect(html).not.toMatch(/<a\b[^>]*>\s*<a\b/);
+  });
+
+  it("keeps the nominated column discoverable as the row link", () => {
+    const html = render({
+      rowHref: (r: Row) => `/blocks/${r.id}`,
+      columns: [
+        {
+          key: "name",
+          label: "Block",
+          kind: "link",
+          lead: true,
+          value: (r: Row) => r.name,
+          href: (r: Row) => `/blocks/${r.id}`,
+        },
+      ],
+    });
+
+    expect((html.match(/mg-dt-rowlink/g) ?? []).length).toBe(3);
     expect(html).not.toMatch(/<a\b[^>]*>\s*<a\b/);
   });
 

--- a/packages/ui-kit/src/components/metagraphed/data-table/data-table.tsx
+++ b/packages/ui-kit/src/components/metagraphed/data-table/data-table.tsx
@@ -860,7 +860,10 @@ function Cell<Row_>({
     const LinkCmp = link ?? DefaultLink;
     bodyIsLink = Boolean(to);
     body = to ? (
-      <LinkCmp href={to} className="mg-dt-link">
+      <LinkCmp
+        href={to}
+        className={classNames("mg-dt-link", href && "mg-dt-rowlink")}
+      >
         {text}
       </LinkCmp>
     ) : (


### PR DESCRIPTION
## Summary
- keep nominated link columns as the single valid anchor while preserving the row-link interaction contract
- retain client-side navigation, block intent prefetch, and mobile row targeting without nested anchors
- add focused server-markup coverage and regenerate the UI kit bundle

## Validation
- `npm test --workspace=@jsonbored/ui-kit -- src/components/metagraphed/data-table/data-table.test.ts`
- `npm run lint --workspace=@jsonbored/ui-kit`
- `npm run build --workspace=@jsonbored/ui-kit`
- `npm run build:worker:e2e --workspace=apps/ui`
- `npx playwright test tests/e2e/block-detail.spec.ts tests/e2e/block-stream-prefetch.spec.ts --project=interaction --no-deps` (6 passed)

Maintainer-directed screenshot and manual-review waiver applies to this task. Required code-quality and CI gates remain in force.

Closes #11813