### PR TITLE
fix(ui): isolate degraded chain activity

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-hub/chain-hub-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/chain-hub/chain-hub-logic.test.ts
@@ -10,6 +10,7 @@ import type {
 import {
   callSegments,
   feePoints,
+  summarizeFeeWindow,
   pipelineRails,
   pipelineTally,
   flowRails,
@@ -70,6 +71,45 @@ describe("feePoints", () => {
 
   it("sorts into time order and drops a day with no reading", () => {
     expect(feePoints(days).map((p) => p.v)).toEqual([5, 7]);
+  });
+});
+
+describe("summarizeFeeWindow", () => {
+  it("weights the window average by signed extrinsics", () => {
+    const days = [
+      {
+        total_fee_tao: 100,
+        total_tip_tao: 2,
+        signed_extrinsic_count: 100,
+        avg_fee_tao: 1,
+      },
+      {
+        total_fee_tao: 9,
+        total_tip_tao: 1,
+        signed_extrinsic_count: 1,
+        avg_fee_tao: 9,
+      },
+    ] as unknown as ChainFeeDay[];
+
+    expect(summarizeFeeWindow(days)).toEqual({
+      totalFeeTao: 109,
+      totalTipTao: 3,
+      averageFeeTao: 109 / 101,
+      dayCount: 2,
+    });
+  });
+
+  it("does not turn an unavailable window or absent denominator into a zero average", () => {
+    expect(summarizeFeeWindow([])).toBeNull();
+    expect(
+      summarizeFeeWindow([
+        {
+          total_fee_tao: 0,
+          total_tip_tao: 0,
+          signed_extrinsic_count: 0,
+        } as unknown as ChainFeeDay,
+      ])?.averageFeeTao,
+    ).toBeNull();
   });
 });
 

--- a/apps/ui/src/components/metagraphed/chain-hub/chain-hub-logic.ts
+++ b/apps/ui/src/components/metagraphed/chain-hub/chain-hub-logic.ts
@@ -76,6 +76,37 @@ export function feePoints(days: readonly ChainFeeDay[]): { t: number; v: number 
     .sort((a, b) => a.t - b.t);
 }
 
+export interface FeeWindowSummary {
+  totalFeeTao: number;
+  totalTipTao: number;
+  averageFeeTao: number | null;
+  dayCount: number;
+}
+
+/**
+ * Summarize a fee window without averaging daily averages.
+ *
+ * Daily averages have different denominators. The truthful window average is
+ * the total fee divided by every signed extrinsic measured in the window.
+ */
+export function summarizeFeeWindow(days: readonly ChainFeeDay[]): FeeWindowSummary | null {
+  if (days.length === 0) return null;
+  const totals = days.reduce(
+    (current, day) => ({
+      fee: current.fee + (day.total_fee_tao ?? 0),
+      tip: current.tip + (day.total_tip_tao ?? 0),
+      signedExtrinsics: current.signedExtrinsics + (day.signed_extrinsic_count ?? 0),
+    }),
+    { fee: 0, tip: 0, signedExtrinsics: 0 },
+  );
+  return {
+    totalFeeTao: totals.fee,
+    totalTipTao: totals.tip,
+    averageFeeTao: totals.signedExtrinsics > 0 ? totals.fee / totals.signedExtrinsics : null,
+    dayCount: days.length,
+  };
+}
+
 export interface FlowRail {
   key: string;
   label: string;

--- a/apps/ui/src/components/metagraphed/states.test.tsx
+++ b/apps/ui/src/components/metagraphed/states.test.tsx
@@ -16,12 +16,14 @@ describe("ErrorState", () => {
             url: "https://api.example.test/api/v1/chain/activity",
           })
         }
+        onRetry={vi.fn()}
       />,
     );
 
     expect(html).toContain("Data source temporarily unavailable");
     expect(html).toContain("cannot verify its current source");
     expect(html).toContain("no zero or empty result is shown");
+    expect(html).toContain("Retry");
     expect(html).not.toContain("Deep-history tier not enabled");
     expect(html).not.toContain("Couldn't load complete-day chain activity");
   });

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -14,7 +14,13 @@ import { isUsableTimestamp } from "@/lib/metagraphed/format";
 import { NativeOnlyNotice } from "./native-only-notice";
 
 /** A truthful replacement for a response the API marked as unverified. */
-function DataTierUnavailableNotice({ context }: { context?: string }) {
+function DataTierUnavailableNotice({
+  context,
+  onRetry,
+}: {
+  context?: string;
+  onRetry?: () => void;
+}) {
   return (
     <div role="status" className="rounded border border-border bg-surface p-4">
       <div className="flex items-start gap-3">
@@ -27,6 +33,15 @@ function DataTierUnavailableNotice({ context }: { context?: string }) {
             {context ? `The ${context} view` : "This view"} cannot verify its current source, so no
             zero or empty result is shown. The rest of the page can continue updating.
           </p>
+          {onRetry ? (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-3 inline-flex min-h-9 items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-13 font-medium hover:border-ink/30"
+            >
+              <RefreshCw className="size-3" /> Retry
+            </button>
+          ) : null}
         </div>
       </div>
     </div>
@@ -205,7 +220,7 @@ export function ErrorState({
   // code. Neither is a measured empty answer, so keep the state informational
   // and explicit rather than rendering a zero or a generic red error card.
   if (isApi && error.code === "data_tier_unavailable") {
-    return <DataTierUnavailableNotice context={context} />;
+    return <DataTierUnavailableNotice context={context} onRetry={onRetry} />;
   }
   // A present block can sit momentarily between the live-follow and decoded
   // history windows. Keep its technical-detail state distinct from both a

--- a/apps/ui/src/lib/metagraphed/queries.chain-fees.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-fees.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { chainFeesQuery } from "./queries";
+import { runQuery } from "./run-query";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+describe("chainFeesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("retains the signed-extrinsic denominator used by window fee averages", async () => {
+    mockedApiFetch.mockResolvedValue({
+      data: {
+        observed_at: "2026-08-29T00:00:00Z",
+        day_count: 1,
+        daily: [
+          {
+            day: "2026-08-28",
+            extrinsic_count: 12,
+            signed_extrinsic_count: 10,
+            total_fee_tao: 2,
+            avg_fee_tao: 0.2,
+            total_tip_tao: 0.1,
+            avg_tip_tao: 0.01,
+          },
+        ],
+        top_fee_payers: [],
+      },
+      meta: {} as ApiResult<unknown>["meta"],
+      url: "/api/v1/chain/fees",
+    });
+
+    const result = await runQuery(chainFeesQuery("7d"));
+
+    expect(result.data.daily[0]).toMatchObject({
+      extrinsic_count: 12,
+      signed_extrinsic_count: 10,
+      total_fee_tao: 2,
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4085,6 +4085,7 @@ function normalizeChainFeeDay(raw: unknown): ChainFeeDay | null {
   return {
     day,
     extrinsic_count: extrinsicCount,
+    signed_extrinsic_count: coerceFiniteNumber(raw.signed_extrinsic_count) ?? null,
     total_fee_tao: totalFeeTao,
     avg_fee_tao: coerceFiniteNumber(raw.avg_fee_tao) ?? null,
     total_tip_tao: totalTipTao,

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -3742,6 +3742,7 @@ export interface ChainTransfers {
 export interface ChainFeeDay {
   day: string;
   extrinsic_count: number;
+  signed_extrinsic_count: number | null;
   total_fee_tao: number;
   avg_fee_tao: number | null;
   total_tip_tao: number;

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { metagraphedQueryInvalidationTarget } from "@/hooks/use-api-base";
 import {
   AnalyticsPage,
@@ -30,6 +30,7 @@ import {
   CHAIN_WINDOWS,
   callSegments,
   feePoints,
+  summarizeFeeWindow,
   flowRails,
   fmtCount,
   fmtShare,
@@ -100,7 +101,12 @@ export function ExplorerPage() {
   const { ref: emissionRef, nearViewport: emissionNearViewport } = useNearViewport("0px 0px");
   const { ref: governanceRef, nearViewport: governanceNearViewport } = useNearViewport("0px 0px");
 
-  const { data: activity } = useSuspenseQuery(chainActivityQuery(window));
+  // Daily activity is one independently fallible rollup, not the route's
+  // availability gate. If its projection declines, the blocks, calls, fees,
+  // stake, emission, and governance sources below can still answer. Keeping
+  // this as a normal query also avoids blocking the whole SSR stream on the
+  // slowest overview source.
+  const activity = useQuery({ ...chainActivityQuery(window), retry: 0 });
   const blocks = useQuery({ ...blocksSummaryQuery(), retry: 0 });
   const calls = useQuery({
     ...chainCallsQuery(window),
@@ -148,7 +154,7 @@ export function ExplorerPage() {
     return (netuid: number) => map.get(netuid) ?? `SN${netuid}`;
   }, [economics.data]);
 
-  const days = activity.data.days ?? [];
+  const days = activity.data?.data.days ?? [];
   const latest = lastCompleteDay(days);
   const segments = callSegments(calls.data?.data.calls ?? []);
   const points = feePoints(fees.data?.data.daily ?? []);
@@ -211,40 +217,37 @@ export function ExplorerPage() {
       loading: blocks.isPending,
     },
     // The last COMPLETE day, not the one in progress -- see lastCompleteDay.
-    { label: `Extrinsics ${latest?.day ?? ""}`.trim(), value: fmtCount(latest?.extrinsic_count) },
-    { label: "Events", value: fmtCount(latest?.event_count) },
-    { label: "Signers", value: fmtCount(latest?.unique_signers) },
+    {
+      label: `Extrinsics ${latest?.day ?? ""}`.trim(),
+      value: fmtCount(latest?.extrinsic_count),
+      loading: activity.isPending,
+    },
+    { label: "Events", value: fmtCount(latest?.event_count), loading: activity.isPending },
+    { label: "Signers", value: fmtCount(latest?.unique_signers), loading: activity.isPending },
   ];
+
+  const feeDays = fees.data?.data.daily ?? [];
+  const feeWindow = summarizeFeeWindow(feeDays);
 
   const feeCells: FactCells = [
     {
       label: `Fees ${window}`,
-      value: fmtTao(
-        (fees.data?.data.daily ?? []).reduce((acc, day) => acc + (day.total_fee_tao ?? 0), 0),
-        4,
-      ),
+      value: feeWindow ? fmtTao(feeWindow.totalFeeTao, 4) : "—",
       loading: fees.isPending,
     },
     {
       label: "Per extrinsic",
-      value: fmtTao(
-        (fees.data?.data.daily ?? []).reduce((acc, day) => acc + (day.avg_fee_tao ?? 0), 0) /
-          Math.max(1, (fees.data?.data.daily ?? []).length),
-        6,
-      ),
+      value: fmtTao(feeWindow?.averageFeeTao, 6),
       loading: fees.isPending,
     },
     {
       label: `Tips ${window}`,
-      value: fmtTao(
-        (fees.data?.data.daily ?? []).reduce((acc, day) => acc + (day.total_tip_tao ?? 0), 0),
-        4,
-      ),
+      value: feeWindow ? fmtTao(feeWindow.totalTipTao, 4) : "—",
       loading: fees.isPending,
     },
     {
       label: "Days measured",
-      value: formatNumber(fees.data?.data.day_count ?? 0),
+      value: feeWindow ? formatNumber(fees.data?.data.day_count ?? feeWindow.dayCount) : "—",
       loading: fees.isPending,
     },
   ];
@@ -307,7 +310,7 @@ export function ExplorerPage() {
             }
             cells={cells}
             live={{
-              updatedAt: activity.data.observed_at ?? null,
+              updatedAt: activity.data?.data.observed_at ?? null,
               source: "chain-direct",
               onRefresh: () =>
                 void queryClient.invalidateQueries(metagraphedQueryInvalidationTarget()),
@@ -330,26 +333,35 @@ export function ExplorerPage() {
             />
           }
           visual={
-            !throughputNearViewport || calls.isPending ? (
-              <CompositionBreakdown
-                formatValue={(value) => fmtCount(value)}
-                legendCols={3}
-                ariaLabel="Extrinsics by call module"
-                source="chain-call"
-                loading
-              />
-            ) : segments.length > 0 ? (
-              <CompositionBreakdown
-                segments={segments}
-                formatValue={(value) => fmtCount(value)}
-                // Throughput sits beside its reading lens on wide screens.
-                // Three columns retain the whole module name and measured
-                // value instead of turning the ranked legend into ellipses.
-                legendCols={3}
-                ariaLabel="Extrinsics by call module"
-                source="chain-call"
-              />
-            ) : null
+            <div className="grid gap-6">
+              {activity.isError ? (
+                <ErrorState
+                  error={activity.error}
+                  context="daily chain activity"
+                  onRetry={() => void activity.refetch()}
+                />
+              ) : null}
+              {!throughputNearViewport || calls.isPending ? (
+                <CompositionBreakdown
+                  formatValue={(value) => fmtCount(value)}
+                  legendCols={3}
+                  ariaLabel="Extrinsics by call module"
+                  source="chain-call"
+                  loading
+                />
+              ) : segments.length > 0 ? (
+                <CompositionBreakdown
+                  segments={segments}
+                  formatValue={(value) => fmtCount(value)}
+                  // Throughput sits beside its reading lens on wide screens.
+                  // Three columns retain the whole module name and measured
+                  // value instead of turning the ranked legend into ellipses.
+                  legendCols={3}
+                  ariaLabel="Extrinsics by call module"
+                  source="chain-call"
+                />
+              ) : null}
+            </div>
           }
           // Per-module totals for the window, not an hourly series:
           // /chain/calls publishes the former and nothing else.

--- a/apps/ui/tests/e2e/chain-overview-state.spec.ts
+++ b/apps/ui/tests/e2e/chain-overview-state.spec.ts
@@ -13,6 +13,69 @@ const DELAYED_READS = [
 ];
 
 test.describe("Chain overview secondary query states", () => {
+  // Browser routing must see the activity request; an installed service
+  // worker can otherwise satisfy it before Playwright can inject the degraded
+  // contract used by the first regression.
+  test.use({ serviceWorkers: "block" });
+
+  test("keeps independent chain sections available when daily activity is unverified", async ({
+    page,
+  }) => {
+    let activityUnavailable = true;
+    let activityRouteHits = 0;
+    await page.route("**/api/v1/chain/activity*", async (route) => {
+      activityRouteHits += 1;
+      if (!activityUnavailable) {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: {
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "x-metagraph-degraded",
+          "x-metagraph-degraded": "tier_unavailable",
+        },
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            schema_version: 1,
+            window: "7d",
+            observed_at: null,
+            day_count: 0,
+            days: [],
+          },
+        }),
+      });
+    });
+
+    await page.setViewportSize({ width: 375, height: 812 });
+    await gotoThroughRestart(page, "/chain");
+
+    await expect(page.getByRole("heading", { level: 1, name: "Chain" })).toBeVisible();
+    // The production Worker can stream a fresh dehydrated activity result
+    // before browser routing is installed. The hero refresh invalidates that
+    // cache and exercises the client-side degraded response deterministically.
+    await page.getByRole("button", { name: "refresh" }).click();
+    await expect.poll(() => activityRouteHits).toBeGreaterThan(0);
+    await expect(page.getByRole("status")).toContainText("Data source temporarily unavailable");
+    await expect(page.getByRole("status")).toContainText("no zero or empty result is shown");
+    await expect(page.locator("section#throughput")).toBeVisible();
+    await expect(page.getByRole("link", { name: "blocks", exact: true })).toBeVisible();
+    await expect(page.getByText(/0 extrinsics across 0 modules/)).toHaveCount(0);
+
+    activityUnavailable = false;
+    await page.getByRole("status").getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByRole("status")).toHaveCount(0);
+
+    const dimensions = await page.evaluate(() => ({
+      document: document.documentElement.scrollWidth,
+      viewport: window.innerWidth,
+    }));
+    expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
+  });
+
   test("starts only the opening throughput reading and keeps later analytics structured", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- keep the chain hub, its independent sections, and stream links available when daily activity rollups cannot be verified
- add a retryable, source-specific notice without presenting missing activity or fee history as measured zeroes
- retain the signed-extrinsic fee denominator and compute the window fee average from totals instead of averaging daily averages
- cover degraded mobile rendering, retry recovery, fee normalization, weighted aggregation, and overflow

## Validation
- `npm test --workspace=apps/ui -- src/components/metagraphed/chain-hub/chain-hub-logic.test.ts src/components/metagraphed/states.test.tsx src/lib/metagraphed/queries.chain-fees.test.ts` (32 passed)
- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm run build:worker --workspace=apps/ui`
- `npx playwright test tests/e2e/chain-overview-state.spec.ts --project=interaction --no-deps` (3 passed)
- rendered at 375px and 1280px in dark mode against the live degraded activity response: six sections remain available, no console errors, no horizontal overflow
- injected an unavailable fee response at 375px: all four fee facts render as unavailable rather than zero, with no overflow

Maintainer-directed screenshot and manual-review waiver applies to this task. Required code-quality and CI gates remain in force.

Closes #11815