### PR TITLE
fix(data): refresh explorer directories after buffered writes

### DIFF
--- a/src/explorer-directory-current.ts
+++ b/src/explorer-directory-current.ts
@@ -5,6 +5,11 @@ import {
   KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
 } from "./kv-keys.ts";
 import type { ExplorerDirectoryMaterialization } from "./explorer-directory-materialization.ts";
+import { missedTicksMs } from "./producer-cadence.ts";
+
+// A valid KV value can outlive its producer. After eight metagraph passes,
+// use the source route, which can repair publication from a completed pass.
+export const EXPLORER_DIRECTORY_MAX_AGE_MS = missedTicksMs("metagraph", 8);
 
 type DirectoryKv = {
   get(key: string, type: "json"): Promise<unknown>;
@@ -14,7 +19,7 @@ type DirectorySchema<T> = {
   safeParse(value: unknown): { success: true; data: T } | { success: false };
 };
 
-async function readCurrentDirectory<T>(
+async function readCurrentDirectory<T extends { captured_at: string | null }>(
   kv: DirectoryKv | null | undefined,
   key: string,
   schema: DirectorySchema<T>,
@@ -23,7 +28,14 @@ async function readCurrentDirectory<T>(
   if (!kv) return null;
   try {
     const parsed = schema.safeParse(await kv.get(key, "json"));
-    return parsed.success ? parsed.data : null;
+    if (!parsed.success) return null;
+    const capturedAt = Date.parse(parsed.data.captured_at ?? "");
+    const age = Date.now() - capturedAt;
+    return Number.isFinite(capturedAt) &&
+      age >= 0 &&
+      age <= EXPLORER_DIRECTORY_MAX_AGE_MS
+      ? parsed.data
+      : null;
   } catch (error) {
     console.error(`${label} directory materialization read failed:`, error);
     return null;

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -1487,7 +1487,7 @@ describe("analytics edge cache", () => {
     const cacheStamp = `minute:${Math.floor(Date.now() / 60_000)}`;
     const directory = {
       schema_version: 1,
-      captured_at: "2026-08-29T00:00:00.000Z",
+      captured_at: new Date().toISOString(),
       block_number: 8_950_000,
       validator_count: 0,
       operator_count: 0,
@@ -1538,7 +1538,7 @@ describe("analytics edge cache", () => {
     const cacheStamp = `minute:${Math.floor(Date.now() / 60_000)}`;
     const directory = {
       schema_version: 1,
-      captured_at: "2026-08-29T00:00:00.000Z",
+      captured_at: new Date().toISOString(),
       block_number: 8_950_000,
       account_count: 0,
       limit: 20,

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -2881,6 +2881,87 @@ test("the snapshot stamp prepares one atomic directory materialization and both 
   assert.equal(((await validators.json()) as Row).validator_count, 3);
 });
 
+test.each(["/api/v1/accounts/directory", "/api/v1/validators/operators"])(
+  "%s repairs an older materialization from the newest completed pass",
+  async (route) => {
+    await insertNeuron({ uid: 0, hotkey: "5Old", stake_tao: 100 });
+    await seed(
+      "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+      [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+    );
+    const kv = memoryKv();
+    const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+    await refreshExplorerDirectoryMaterialization(
+      materializedEnv as DataApiEnv,
+      ctx,
+      CAPTURED_AT,
+    );
+
+    const newer = CAPTURED_AT + 900_000;
+    await seed("UPDATE neurons SET captured_at = ?, stake_tao = ?", [
+      newer,
+      200,
+    ]);
+    await seed(
+      "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+      [newer, 1, 1, newer + 1],
+    );
+    const collected = collectingCtx();
+    const response = await worker.fetch(
+      req(route),
+      materializedEnv,
+      collected.ctx,
+    );
+    assert.equal(response.status, 200);
+    await Promise.all(collected.pending);
+    assert.equal(
+      JSON.parse(kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT)!).captured_at,
+      newer,
+    );
+    assert.equal(
+      JSON.parse(kv.values.get(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT)!)
+        .captured_at,
+      new Date(newer).toISOString(),
+    );
+  },
+);
+
+test.each(["/api/v1/accounts/directory", "/api/v1/validators/operators"])(
+  "%s retains the last verified directory when completed-pass metadata is unavailable",
+  async (route) => {
+    await insertNeuron({ uid: 0, hotkey: "5Verified", stake_tao: 100 });
+    await seed(
+      "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+      [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+    );
+    const kv = memoryKv();
+    const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+    await refreshExplorerDirectoryMaterialization(
+      materializedEnv as DataApiEnv,
+      ctx,
+      CAPTURED_AT,
+    );
+    const previousPointer = kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT);
+    await db.exec("TRUNCATE neurons_passes");
+    const collected = collectingCtx();
+    const response = await worker.fetch(
+      req(route),
+      materializedEnv,
+      collected.ctx,
+    );
+    assert.equal(response.status, 200);
+    await Promise.all(collected.pending);
+    assert.equal(
+      kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT),
+      previousPointer,
+    );
+    assert.equal(
+      ((await response.json()) as Row).captured_at,
+      new Date(CAPTURED_AT).toISOString(),
+    );
+  },
+);
+
 test("concurrent requests share one directory refresh for a completed snapshot", async () => {
   await insertNeuron({ uid: 0, hotkey: "5Only", stake_tao: 100 });
   await seed(
@@ -3032,7 +3113,9 @@ test("a legacy combined directory restores both hot values without folding parti
   assert.equal(((await response.json()) as Row).account_count, 1);
   await Promise.all(collected.pending);
 
-  assert.equal(pg.control.queries.length, queriesBeforeFallback);
+  const fallbackQueries = pg.control.queries.slice(queriesBeforeFallback);
+  assert.equal(fallbackQueries.length, 1);
+  assert.match(fallbackQueries[0].text, /FROM neurons_passes/);
   assert.equal(
     JSON.parse(kv.values.get(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT)!)
       .account_count,

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -2962,6 +2962,42 @@ test.each(["/api/v1/accounts/directory", "/api/v1/validators/operators"])(
   },
 );
 
+test.each(["/api/v1/accounts/directory", "/api/v1/validators/operators"])(
+  "%s still serves the verified directory when the freshness lookup fails",
+  async (route) => {
+    await insertNeuron({ uid: 0, hotkey: "5Verified", stake_tao: 100 });
+    await seed(
+      "INSERT INTO neurons_passes (captured_at, expected_rows, received_rows, completed_at) VALUES (?, ?, ?, ?)",
+      [CAPTURED_AT, 1, 1, CAPTURED_AT + 1],
+    );
+    const kv = memoryKv();
+    const materializedEnv = env({ METAGRAPH_CONTROL: kv });
+    await refreshExplorerDirectoryMaterialization(
+      materializedEnv as DataApiEnv,
+      ctx,
+      CAPTURED_AT,
+    );
+    const previousPointer = kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT);
+    pg.control.failNext = new Error("Neon temporarily unavailable");
+    const collected = collectingCtx();
+    const response = await worker.fetch(
+      req(route),
+      materializedEnv,
+      collected.ctx,
+    );
+    assert.equal(response.status, 200);
+    await Promise.all(collected.pending);
+    assert.equal(
+      kv.values.get(KV_EXPLORER_DIRECTORIES_CURRENT),
+      previousPointer,
+    );
+    assert.equal(
+      ((await response.json()) as Row).captured_at,
+      new Date(CAPTURED_AT).toISOString(),
+    );
+  },
+);
+
 test("concurrent requests share one directory refresh for a completed snapshot", async () => {
   await insertNeuron({ uid: 0, hotkey: "5Only", stake_tao: 100 });
   await seed(

--- a/tests/explorer-directory-materialization.test.ts
+++ b/tests/explorer-directory-materialization.test.ts
@@ -10,7 +10,7 @@ import {
   KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
 } from "../src/kv-keys.ts";
 
-const capturedAt = "2026-08-29T00:00:00.000Z";
+const capturedAt = new Date().toISOString();
 
 const accounts = {
   schema_version: 1 as const,
@@ -72,4 +72,25 @@ test("route-specific directory readers contain KV failures", async () => {
   );
   assert.equal(error.mock.calls.length, 1);
   error.mockRestore();
+});
+
+test("old or future directory snapshots fall through to the source repair path", async () => {
+  for (const captured_at of [
+    new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    null,
+  ]) {
+    assert.equal(
+      await readCurrentAccountDirectory({
+        get: async () => ({ ...accounts, captured_at }),
+      }),
+      null,
+    );
+    assert.equal(
+      await readCurrentValidatorDirectory({
+        get: async () => ({ ...validators, captured_at }),
+      }),
+      null,
+    );
+  }
 });

--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -141,6 +141,105 @@ describe("enqueueStatement", () => {
 });
 
 describe("flushBuffer", () => {
+  test("refreshes explorer directories after buffered neuron statements reach Neon", async () => {
+    const storage = fakeStorage();
+    for (const text of ["neuron rows", "completed pass"])
+      await enqueueStatement(storage, stmt("neurons", text), NOW);
+    const seen: string[] = [];
+    const pending: Promise<unknown>[] = [];
+    const out = await flushBuffer(
+      storage,
+      {
+        DATA_API: {
+          async fetch(request: Request) {
+            assert.equal(
+              new URL(request.url).pathname,
+              "/api/v1/internal/neurons-snapshot-stamp",
+            );
+            seen.push("refresh");
+            return Response.json({ captured_at: NOW });
+          },
+        },
+      },
+      { waitUntil: (p) => pending.push(p) },
+      {
+        laneHealthDb: laneSpy().db,
+        sql: {
+          unsafe: async (text) => {
+            seen.push(text);
+          },
+        },
+      },
+    );
+    await Promise.all(pending);
+    assert.equal(out.ok, true);
+    assert.deepEqual(seen, ["neuron rows", "completed pass", "refresh"]);
+    assert.equal(await countPending(storage), 0);
+  });
+
+  test("a directory refresh failure does not replay committed neuron writes", async () => {
+    for (const failure of ["http", "network"]) {
+      const storage = fakeStorage();
+      await enqueueStatement(storage, stmt("neurons", "rows"), NOW);
+      const pending: Promise<unknown>[] = [];
+      const captured: string[] = [];
+      const out = await flushBuffer(
+        storage,
+        {
+          DATA_API: {
+            async fetch() {
+              if (failure === "network") throw new Error("unavailable");
+              return new Response(null, { status: 503 });
+            },
+          },
+        },
+        { waitUntil: (p) => pending.push(p) },
+        {
+          laneHealthDb: laneSpy().db,
+          sql: { unsafe: async () => [] },
+          captureException: async (_env, event) => {
+            captured.push(event.errorCode!);
+            return true;
+          },
+        },
+      );
+      await Promise.all(pending);
+      assert.equal(out.ok, true);
+      assert.equal(await countPending(storage), 0);
+      assert.deepEqual(captured, ["directory_refresh_failed"]);
+    }
+  });
+
+  test("unrelated and failed flushes do not request a directory refresh", async () => {
+    for (const lane of ["account-balances", "neurons"]) {
+      const storage = fakeStorage();
+      await enqueueStatement(storage, stmt(lane, "rows"), NOW);
+      let requests = 0;
+      await flushBuffer(
+        storage,
+        {
+          DATA_API: {
+            fetch: async () => {
+              requests++;
+              return Response.json({});
+            },
+          },
+        },
+        CTX,
+        {
+          laneHealthDb: laneSpy().db,
+          sql: {
+            unsafe: async () => {
+              if (lane === "neurons") throw new Error("offline");
+            },
+          },
+          captureException: async () => true,
+        },
+      );
+      assert.equal(requests, 0);
+    }
+  });
+
   test("an empty buffer is a clean no-op", async () => {
     const out = await flushBuffer(fakeStorage(), {}, CTX, { sql: null });
     assert.deepEqual(out, {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7549,7 +7549,12 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         env.METAGRAPH_CONTROL,
       );
       if (materialized) {
-        scheduleExplorerDirectoryRefresh(env, ctx, materialized.captured_at);
+        const latest = await latestCompletedNeuronSnapshot(sql);
+        scheduleExplorerDirectoryRefresh(
+          env,
+          ctx,
+          latest ?? materialized.captured_at,
+        );
         return json(materialized.validators);
       }
       return json(
@@ -8383,7 +8388,12 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         env.METAGRAPH_CONTROL,
       );
       if (materialized) {
-        scheduleExplorerDirectoryRefresh(env, ctx, materialized.captured_at);
+        const latest = await latestCompletedNeuronSnapshot(sql);
+        scheduleExplorerDirectoryRefresh(
+          env,
+          ctx,
+          latest ?? materialized.captured_at,
+        );
         return json(materialized.accounts);
       }
       const [rows, priceByNetuid] = await Promise.all([

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7229,14 +7229,14 @@ export async function refreshExplorerDirectoryMaterialization(
 function scheduleExplorerDirectoryRefresh(
   env: DataApiEnv,
   ctx: ExecutionContext,
-  capturedAt: number,
+  capturedAt: number | Promise<number>,
 ) {
   ctx.waitUntil(
-    refreshExplorerDirectoryMaterialization(env, ctx, capturedAt).catch(
-      (error) => {
+    Promise.resolve(capturedAt)
+      .then((stamp) => refreshExplorerDirectoryMaterialization(env, ctx, stamp))
+      .catch((error) => {
         console.error("explorer directory publication failed:", error);
-      },
-    ),
+      }),
   );
 }
 
@@ -7549,11 +7549,13 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         env.METAGRAPH_CONTROL,
       );
       if (materialized) {
-        const latest = await latestCompletedNeuronSnapshot(sql);
+        // Keep the verified response available if the freshness read fails.
         scheduleExplorerDirectoryRefresh(
           env,
           ctx,
-          latest ?? materialized.captured_at,
+          latestCompletedNeuronSnapshot(sql).then(
+            (latest) => latest ?? materialized.captured_at,
+          ),
         );
         return json(materialized.validators);
       }
@@ -8388,11 +8390,13 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         env.METAGRAPH_CONTROL,
       );
       if (materialized) {
-        const latest = await latestCompletedNeuronSnapshot(sql);
+        // Keep the verified response available if the freshness read fails.
         scheduleExplorerDirectoryRefresh(
           env,
           ctx,
-          latest ?? materialized.captured_at,
+          latestCompletedNeuronSnapshot(sql).then(
+            (latest) => latest ?? materialized.captured_at,
+          ),
         );
         return json(materialized.accounts);
       }

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -214,6 +214,7 @@ export interface BufferStorage {
 /** What the hub needs from its environment, so the flush can be driven alone. */
 export interface BufferEnv extends TelemetryEnv {
   HYPERDRIVE?: HyperdriveLike;
+  DATA_API?: { fetch(request: Request): Promise<Response> };
   [key: string]: unknown;
 }
 
@@ -505,6 +506,33 @@ export async function flushBuffer(
     }`,
     checked_at: now(),
   });
+  // Enqueue-time publication cannot see the completed pass in Neon. Ask again
+  // after the ordered flush, when both the rows and their tally are committed.
+  // The source route still declines partial passes and folds each stamp once.
+  if (perLane.get("neurons")?.ok && env.DATA_API) {
+    const dataApi = env.DATA_API;
+    ctx.waitUntil(
+      (async () => {
+        const response = await dataApi.fetch(
+          new Request(
+            "https://data-api/api/v1/internal/neurons-snapshot-stamp",
+          ),
+        );
+        if (!response.ok) {
+          throw new Error(
+            `explorer directory refresh returned HTTP ${response.status}`,
+          );
+        }
+        await response.text();
+      })().catch((error) =>
+        capture(env, {
+          error,
+          route: BUFFER_ROUTE,
+          errorCode: "directory_refresh_failed",
+        }),
+      ),
+    );
+  }
   return { drained, undecodable, ok: true, remaining: truncated };
 }
 


### PR DESCRIPTION
## Summary

The account and validator directories stayed at the August 30 snapshot while complete neuron passes continued arriving every 15 minutes. Buffered sync returns after enqueue, so the existing publication hook ran before the rows and pass tally became visible in Neon. No hook retried publication after the buffer committed them.

Closes #11953. Related operational verification remains tracked in #11760.

## What Changed

- Request the existing completed-pass materialization after an ordered neuron buffer flush. Publication failures are reported without replaying committed writes. This follows the existing neuron sync callbacks in `workers/data-api.ts` and the buffered write contract in `src/neurons-neon-write.ts:399`.
- Bound route-specific directory KV values to eight metagraph passes. An old, missing, or invalid observation timestamp reaches the existing source repair path.
- Repair a legacy combined materialization from the newest completed pass while continuing to serve the last verified snapshot, including when the background freshness lookup fails. The existing completion and final boundary checks in `workers/data-api.ts:7084` still reject partial or mixed passes.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #11953`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented: response contracts are unchanged.

## Validation

- [ ] `npm run check`: the composite pipeline was stopped after its live native-snapshot dry run; lint, format, typecheck, and all 75 code/static pipeline gates were run separately and passed.
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage -- --maxWorkers=4`: 979 test files passed; 22,478 tests passed and 11 skipped. Changed runtime lines and branches are both 100% covered (18/18 lines, 19/19 branches), measured from the unsharded LCOV report.
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

`npm run build`, `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm run worker:deploy:dry-run` also passed. GitHub Validate run 33676297033 also passed on head `4ea5e388c75696936ab6a879bf69a326d25d57b8`: validation, all five test shards, and combined coverage are green. All three Cloudflare preview builds passed. Production rollout is verified: both Workers serve merge `b1f040bf1177dce6b0674e4e09ad6266a01b5084`, and the pointer advanced automatically from the 20:15 to the 20:31 UTC snapshot after a successful buffer drain. Both public routes then returned block 8,982,016. Post-merge CI also passed. Remaining cold-response latency measurements are recorded in #11760.
