### PR TITLE
fix(data): use event identities in scheduled projections

### DIFF
--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -81,13 +81,15 @@ import { CHAIN_SERVING_PROJECTION_KEY } from "./chain-serving-artifact.ts";
 import { CHAIN_PROMETHEUS_PROJECTION_KEY } from "./chain-prometheus-artifact.ts";
 import { CHAIN_WEIGHTS_PROJECTION_KEY } from "./chain-weights-artifact.ts";
 import {
+  CHAIN_PROMETHEUS_ROLLUP,
+  CHAIN_SERVING_ROLLUP,
   CHAIN_WEIGHTS_ROLLUP,
+  loadChainEventRollup,
   loadChainEventIdentityRollup,
   ROLLUP_POPULATION_CAP,
+  type ChainEventRollupSpec,
 } from "./chain-event-rollup-cold-tier.ts";
 import { CHAIN_WEIGHT_SETTERS_PROJECTION_KEY } from "./chain-weight-setters-artifact.ts";
-import { SERVING_EVENT_KIND } from "./subnet-serving.ts";
-import { PROMETHEUS_EVENT_KIND } from "./subnet-prometheus.ts";
 import {
   BLOCKS_SUMMARY_READ_COLUMNS,
   BLOCKS_SUMMARY_SCAN_CAP,
@@ -934,13 +936,7 @@ async function computeChainWeights(
   env: Env,
   network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
-  return computeAnalyticsDistinctLanes(
-    env,
-    network,
-    CHAIN_WEIGHTS_ROLLUP.eventKind,
-    CHAIN_WEIGHTS_ROLLUP.countField,
-    CHAIN_WEIGHTS_ROLLUP.distinctField,
-  );
+  return computeAnalyticsDistinctLanes(env, network, CHAIN_WEIGHTS_ROLLUP);
 }
 
 /**
@@ -1048,13 +1044,7 @@ async function computeChainServing(
   env: Env,
   network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
-  return computeAnalyticsDistinctLanes(
-    env,
-    network,
-    SERVING_EVENT_KIND,
-    "announcements",
-    "distinct_servers",
-  );
+  return computeAnalyticsDistinctLanes(env, network, CHAIN_SERVING_ROLLUP);
 }
 
 /**
@@ -1070,50 +1060,50 @@ async function computeChainPrometheus(
   env: Env,
   network: ChainNetworkId,
 ): Promise<Record<string, unknown> | null> {
-  return computeAnalyticsDistinctLanes(
-    env,
-    network,
-    PROMETHEUS_EVENT_KIND,
-    "announcements",
-    "distinct_exporters",
-  );
+  return computeAnalyticsDistinctLanes(env, network, CHAIN_PROMETHEUS_ROLLUP);
 }
 
 /**
  * Every ANALYTICS_WINDOW_DAYS window of one event kind, in the artifact shape
  * the readers expect.
  *
- * Shared because the two lanes above differ only in the event kind and the two
- * column aliases -- writing the window loop twice is how a lane gains a window
- * its twin does not have.
+ * Use the same identity contract as the live rollup reader: hotkeys for
+ * serving events, and (netuid, uid) pairs for weights. These events have no
+ * coldkey, so the stake-transfer helper would count every participant as zero.
  */
 async function computeAnalyticsDistinctLanes(
   env: Env,
   network: ChainNetworkId,
-  eventKind: string,
-  countAlias: string,
-  distinctAlias: string,
+  spec: ChainEventRollupSpec,
 ): Promise<Record<string, unknown> | null> {
   const generatedAt = Date.now();
   const windows: Record<string, unknown> = {};
   let rowCount = 0;
   for (const [label, days] of Object.entries(ANALYTICS_WINDOW_DAYS)) {
-    const window = await computeSubnetDistinctWindow(
-      env,
-      subnetDistinctWindowSql(
-        generatedAt - days * DAY_MS,
-        eventKind,
-        countAlias,
-        distinctAlias,
-        network,
-      ),
-    );
+    const outcome = await loadChainEventRollup(env, spec, {
+      windowDays: days,
+      now: generatedAt,
+      network,
+      query: (_env, sql) => laneQuery(env, sql),
+    });
+    if (outcome.kind === "empty") {
+      windows[label] = {
+        days,
+        network: { [spec.distinctField]: 0, newest_observed: null },
+        rows: [],
+      };
+      continue;
+    }
     // One failed window fails the LANE: a partial artifact would serve a real
     // 7d beside a stale 30d under one `generated_at`, and the runner's
     // write-only-on-non-null rule keeps the previous tick instead.
-    if (window === null) return null;
-    windows[label] = { days, network: window.network, rows: window.rows };
-    rowCount += window.rows.length;
+    if (outcome.kind !== "answer") return null;
+    const { rows, networkDistinct, subnetCount } = outcome.rollup;
+    // A stored directory must contain the full subnet population. The live
+    // reader's bounded page or inferred population is not a complete artifact.
+    if (subnetCount !== rows.length) return null;
+    windows[label] = { days, network: networkDistinct, rows };
+    rowCount += rows.length;
   }
   return {
     schema_version: 1,

--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3421,6 +3421,7 @@ describe("handleScheduled PROJECTION_LANES_CRON", () => {
     // exactly one row from a real engine, so an empty result there is a
     // DECLINE by design -- feeding them is what makes chain-weight-setters
     // exercise its store path here rather than its failure path.
+    if (sql.startsWith("SELECT netuid, sum(n) AS weight_sets")) return [];
     if (sql.includes("ORDER BY weight_sets DESC")) {
       // The identity rollup's GROUPED leg, matched on its ORDER BY rather than
       // its GROUP BY: the DISTINCT leg wraps the same `GROUP BY netuid, uid`

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -136,6 +136,10 @@ function lakeFetchWithBlocks(onFail?: (sql: string) => boolean) {
       sql.includes("AS newest_observed")
     ) {
       rows = [{ newest_observed: NOW - 1000 }];
+    } else if (sql.startsWith("SELECT netuid, sum(n) AS weight_sets")) {
+      // The per-subnet rollup is an empty window in this fixture. The
+      // identity leaderboard below is a separate query with its own row.
+      rows = [];
     } else if (sql.includes("ORDER BY weight_sets DESC")) {
       // The identity rollup's GROUPED leg, matched on its ORDER BY rather than
       // its GROUP BY: the DISTINCT leg wraps the same `GROUP BY netuid, uid`

--- a/tests/projection-participant-identity.test.ts
+++ b/tests/projection-participant-identity.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  LAKEHOUSE_NAMESPACES,
+  projectionKey,
+  type ChainNetworkId,
+} from "../src/chain-network.ts";
+import { loadChainServingFromArtifact } from "../src/chain-serving-artifact.ts";
+import { loadChainPrometheusFromArtifact } from "../src/chain-prometheus-artifact.ts";
+import { loadChainWeightsFromArtifact } from "../src/chain-weights-artifact.ts";
+import { ROLLUP_POPULATION_CAP } from "../src/chain-event-rollup-cold-tier.ts";
+import { resetModuleState } from "../src/module-state-registry.ts";
+import {
+  PROJECTION_LANES,
+  runProjectionLane,
+} from "../src/projection-lanes.ts";
+
+const NOW = Date.UTC(2026, 8, 2, 12);
+const OBSERVED = NOW - 60_000;
+const DAY_MS = 86_400_000;
+const realFetch = globalThis.fetch;
+let db: DatabaseSync;
+let failQuery: (sql: string) => boolean;
+
+beforeEach(() => {
+  resetModuleState();
+  vi.spyOn(Date, "now").mockReturnValue(NOW);
+  db = new DatabaseSync(":memory:");
+  for (const namespace of Object.values(LAKEHOUSE_NAMESPACES)) {
+    db.exec(`ATTACH DATABASE ':memory:' AS ${namespace}`);
+    db.exec(`CREATE TABLE ${namespace}.account_events (
+      netuid INTEGER, event_kind TEXT, observed_at INTEGER,
+      coldkey TEXT, hotkey TEXT, uid INTEGER
+    )`);
+  }
+  failQuery = () => false;
+  // Execute the actual projection SQL. Canned aggregate rows cannot detect
+  // counting a column that is NULL on every event of the selected kind.
+  globalThis.fetch = (async (_input, init) => {
+    const sql = String(JSON.parse(String(init?.body)).query);
+    if (failQuery(sql)) return new Response("unavailable", { status: 503 });
+    const rows = db.prepare(sql).all();
+    return Response.json({ success: true, result: { rows } });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+  resetModuleState();
+  db.close();
+});
+
+const CASES = [
+  {
+    lane: "chain-serving",
+    kind: "AxonServed",
+    count: "announcements",
+    distinct: "distinct_servers",
+    participants: 2,
+    events: 4,
+    rows: [
+      [19, "hotkey-a", null],
+      [19, "hotkey-a", null],
+      [50, "hotkey-a", null],
+      [50, "hotkey-b", null],
+    ],
+    read: loadChainServingFromArtifact,
+  },
+  {
+    lane: "chain-prometheus",
+    kind: "PrometheusServed",
+    count: "announcements",
+    distinct: "distinct_exporters",
+    participants: 1,
+    events: 3,
+    rows: [
+      [19, "hotkey-a", null],
+      [19, "hotkey-a", null],
+      [50, "hotkey-a", null],
+    ],
+    read: loadChainPrometheusFromArtifact,
+  },
+  {
+    lane: "chain-weights",
+    kind: "WeightsSet",
+    count: "weight_sets",
+    distinct: "distinct_setters",
+    participants: 3,
+    events: 4,
+    rows: [
+      [19, null, 0],
+      [19, null, 0],
+      [19, null, 1],
+      [50, null, 0],
+    ],
+    read: loadChainWeightsFromArtifact,
+  },
+] as const;
+
+function insertEvents(
+  scenario: (typeof CASES)[number],
+  network: ChainNetworkId,
+) {
+  const namespace = LAKEHOUSE_NAMESPACES[network];
+  const insert = db.prepare(`INSERT INTO ${namespace}.account_events
+    (netuid, event_kind, observed_at, hotkey, uid) VALUES (?, ?, ?, ?, ?)`);
+  for (const [netuid, hotkey, uid] of scenario.rows) {
+    insert.run(netuid, scenario.kind, OBSERVED, hotkey, uid);
+  }
+  insert.run(99, scenario.kind, NOW - 31 * DAY_MS, "old-hotkey", 99);
+  const other =
+    LAKEHOUSE_NAMESPACES[network === "mainnet" ? "testnet" : "mainnet"];
+  db.prepare(
+    `INSERT INTO ${other}.account_events
+    (netuid, event_kind, observed_at, hotkey, uid) VALUES (?, ?, ?, ?, ?)`,
+  ).run(88, scenario.kind, OBSERVED, "other-network", 88);
+}
+
+function storage() {
+  const objects = new Map<string, string>();
+  const writes: string[] = [];
+  const env = {
+    R2_SQL_TOKEN: "cfut_test",
+    METAGRAPH_ARCHIVE: {
+      async put(key: string, value: string) {
+        writes.push(key);
+        objects.set(key, value);
+      },
+      async get(key: string) {
+        const value = objects.get(key);
+        return value === undefined
+          ? null
+          : { json: async () => JSON.parse(value) };
+      },
+    },
+  } as unknown as Env;
+  return { env, objects, writes };
+}
+
+for (const scenario of CASES) {
+  describe(scenario.lane, () => {
+    const lane = PROJECTION_LANES.find(
+      (entry) => entry.name === scenario.lane,
+    )!;
+
+    for (const network of ["mainnet", "testnet"] as const) {
+      test(`${network} publishes and serves participants without coldkeys`, async () => {
+        insertEvents(scenario, network);
+        const { env, objects, writes } = storage();
+        const result = await runProjectionLane(env, lane, {}, network);
+        assert.equal(result.ok, true);
+        const key = projectionKey(lane.artifactKey, network);
+        assert.deepEqual(writes, [key]);
+        const artifact = JSON.parse(objects.get(key)!);
+        assert.equal(artifact.row_count, 4);
+        for (const window of ["7d", "30d"]) {
+          expect(artifact.windows[window].network).toMatchObject({
+            [scenario.distinct]: scenario.participants,
+            newest_observed: OBSERVED,
+          });
+          const card = await scenario.read(env, { window }, network);
+          expect(card).toMatchObject({
+            observed_at: new Date(OBSERVED).toISOString(),
+            subnet_count: 2,
+            network: {
+              [scenario.distinct]: scenario.participants,
+              [scenario.count]: scenario.events,
+            },
+          });
+          assert.equal(card?.subnets.length, 2);
+        }
+      });
+    }
+
+    test("an empty window publishes measured zeroes", async () => {
+      const { env, objects } = storage();
+      assert.equal((await runProjectionLane(env, lane)).ok, true);
+      const artifact = JSON.parse(objects.get(lane.artifactKey)!);
+      assert.equal(artifact.row_count, 0);
+      for (const window of ["7d", "30d"]) {
+        expect(artifact.windows[window]).toMatchObject({
+          rows: [],
+          network: { [scenario.distinct]: 0, newest_observed: null },
+        });
+        expect(await scenario.read(env, { window })).toMatchObject({
+          subnet_count: 0,
+          network: { [scenario.distinct]: 0, [scenario.count]: 0 },
+        });
+      }
+    });
+
+    test("a failed later window preserves the previous publication", async () => {
+      insertEvents(scenario, "mainnet");
+      const { env, objects, writes } = storage();
+      const previous = JSON.stringify({ previous: "verified artifact" });
+      objects.set(lane.artifactKey, previous);
+      failQuery = (sql) => sql.includes(String(NOW - 30 * DAY_MS));
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const result = await runProjectionLane(env, lane, {
+        recordException: async () => true,
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, "compute_declined");
+      assert.deepEqual(writes, []);
+      assert.equal(objects.get(lane.artifactKey), previous);
+    });
+
+    test.each(["unreadable", "capped"] as const)(
+      "an %s subnet population preserves the previous publication",
+      async (population) => {
+        if (population === "unreadable") {
+          insertEvents(scenario, "mainnet");
+          failQuery = (sql) =>
+            sql.startsWith("SELECT count(*) AS subnet_count");
+        } else {
+          const insert = db.prepare(`INSERT INTO chain.account_events
+            (netuid, event_kind, observed_at, hotkey, uid) VALUES (?, ?, ?, ?, ?)`);
+          const [, hotkey, uid] = scenario.rows[0];
+          for (let netuid = 0; netuid <= ROLLUP_POPULATION_CAP; netuid += 1) {
+            insert.run(netuid, scenario.kind, OBSERVED, hotkey, uid);
+          }
+        }
+        const { env, objects, writes } = storage();
+        const previous = JSON.stringify({ previous: "complete artifact" });
+        objects.set(lane.artifactKey, previous);
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        const result = await runProjectionLane(env, lane, {
+          recordException: async () => true,
+        });
+        assert.equal(result.ok, false);
+        assert.equal(result.reason, "compute_declined");
+        assert.deepEqual(writes, []);
+        assert.equal(objects.get(lane.artifactKey), previous);
+      },
+    );
+  });
+}


### PR DESCRIPTION
The scheduled serving, Prometheus, and weights projections counted coldkeys even though their events identify hotkeys or subnet/UID pairs. Production serving artifacts contained real announcement rows with zero distinct servers, so the API builder discarded every subnet and returned an empty card.

Use the shared event-rollup identity contracts for these projections: hotkeys for serving/Prometheus and subnet-scoped UIDs for weights. Preserve complete, exact populations by declining publication when a window fails or its verified subnet count differs from the returned rows. The existing coldkey-based stake projections retain their current query path.

Closes #11959.

Validation:

- SQL-backed regressions reproduced zero participants for all three producers on both networks before the fix. They now execute the projection SQL, persist its artifact, and verify the API reader's counts, including UID zero and identities shared across subnets.
- Empty windows remain measured zeroes. Failed later windows, unreadable population counts, and capped populations preserve the previous artifact.
- All 22,497 tests pass across 980 files, with 11 skipped, in the unsharded coverage run. Changed runtime coverage is 100%: 13/13 lines and 6/6 branches.
- The 107 focused projection/reader/network tests and 340 scheduler/API tests pass. Lint, formatting, TypeScript, repository validation, and `git diff --check` pass.

Read-only source verification: the recovered block batch 8,979,855–8,982,103 contains 5,459 serving events from 450 hotkeys and 10,690 weight updates from 1,064 subnet/UID pairs. These events have null coldkeys, confirming why the previous counters were zero.

Production verification after the first normal `11,41 * * * *` cycle on the deployed merge:

| Network | Card | Window | Subnets | Participants | Events |
| --- | --- | --- | ---: | ---: | ---: |
| mainnet | serving | 7d | 39 | 2,868 | 134,142 |
| mainnet | serving | 30d | 51 | 6,882 | 222,759 |
| mainnet | weights | 7d | 128 | 1,173 | 220,218 |
| mainnet | weights | 30d | 128 | 1,363 | 972,829 |
| testnet | serving | 7d | 21 | 65 | 90 |
| testnet | serving | 30d | 35 | 267 | 1,365 |
| testnet | weights | 7d | 40 | 50 | 8,515 |
| testnet | weights | 30d | 72 | 87 | 43,226 |

Every response was an explicit API cache miss and exactly matched the full stored artifact, including the network totals beyond the returned page of 20 rows. Mainnet artifacts published at 22:14 UTC and testnet artifacts at 22:18 UTC. The scheduled invocation completed with outcome `ok` on Worker version `f13c8b8a-4fee-48da-8409-24db7a1ac532`, from merge `b0442c681adabbb044dc96d526c20a4cd88da19d`.

Mainnet source observations remain `2026-09-02T21:17:36Z`; testnet serving observes `20:22:00Z` and weights `21:18:00Z`. These are the source event times, preserved separately from publication times. Prometheus artifacts also refreshed and retained the existing `prometheus_stream_not_curated` marker on their empty windows; no historical backfill is claimed.

The final public health reading at `2026-09-02T22:18:46.833Z` is `operational`, with all 75 active lanes healthy and zero stale lanes. All required PR checks, post-merge checks, and both public Cloudflare production builds passed.
