### PR TITLE
fix(data): distinguish quiet Prometheus windows from unavailable sources

### DIFF
--- a/schemas-src/routes/chain-network-rollups.ts
+++ b/schemas-src/routes/chain-network-rollups.ts
@@ -227,8 +227,7 @@ export const ChainPrometheusArtifactSchema = z
           "One subnet's Prometheus telemetry-serving activity in the window, ranked by announcements.",
         ),
     ),
-    // #9307: the chain emits PrometheusServed and our account_events curation
-    // drops it, so the empty answer is not a measurement.
+    // Distinguishes an unavailable source from a measured quiet window.
     degraded: EventStreamDegradedSchema.nullable().optional(),
   })
   .strict();

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -586,7 +586,10 @@ export async function loadAccountPrometheusColdTier(
   );
   if (rows === null) return null;
   return {
-    data: buildAccountPrometheus(rows, ss58, { window: label }),
+    data: buildAccountPrometheus(rows, ss58, {
+      window: label,
+      sourceAvailable: true,
+    }),
     generatedAt: latestObservedIso(rows),
   };
 }

--- a/src/account-prometheus.ts
+++ b/src/account-prometheus.ts
@@ -16,7 +16,7 @@
 
 import { roundBelowOne } from "./lib/stats.ts";
 import {
-  PROMETHEUS_DEGRADED_NOT_CURATED,
+  DEGRADED_UNAVAILABLE,
   type EventStreamDegraded,
 } from "./uncurated-event-streams.ts";
 
@@ -97,7 +97,10 @@ export interface AccountPrometheusResult {
 export function buildAccountPrometheus(
   rows: Array<Record<string, unknown>> | null | undefined,
   address: string,
-  { window }: { window?: string | null } = {},
+  {
+    window,
+    sourceAvailable = false,
+  }: { window?: string | null; sourceAvailable?: boolean } = {},
 ): AccountPrometheusResult {
   const list = Array.isArray(rows) ? rows : [];
   // Merge by netuid so a malformed direct caller passing duplicate rows for a subnet sums rather
@@ -170,11 +173,9 @@ export function buildAccountPrometheus(
     dominant_netuid: dominantNetuid,
     subnets,
   };
-  // An empty footprint here has never been a measurement of this account: the
-  // chain emitted 18,041 PrometheusServed events and the account_events
-  // projection this reads carries 0 of them.
-  if (totalAnnouncements === 0) {
-    card.degraded = { reason: PROMETHEUS_DEGRADED_NOT_CURATED };
+  // Empty reads are measurements; a fallback without a source is unavailable.
+  if (totalAnnouncements === 0 && !sourceAvailable) {
+    card.degraded = { reason: DEGRADED_UNAVAILABLE };
   }
   return card;
 }
@@ -215,7 +216,10 @@ export async function loadAccountPrometheus(
     }
   }
   return {
-    data: buildAccountPrometheus(rows, address, { window: windowLabel }),
+    data: buildAccountPrometheus(rows, address, {
+      window: windowLabel,
+      sourceAvailable: true,
+    }),
     generatedAt: toIso(latestObserved),
   };
 }

--- a/src/chain-prometheus-artifact.ts
+++ b/src/chain-prometheus-artifact.ts
@@ -23,11 +23,8 @@
 // under a request at all. A cron pays the variance once per interval; a caller
 // then pays one R2 GET.
 //
-// This route ALSO carries `PROMETHEUS_DEGRADED_NOT_CURATED` permanently: the
-// chain emits `PrometheusServed` and our `account_events` curation drops it, so
-// the card is empty whatever tier answers. Serving an empty from a cron instead
-// of from a 15-second timeout does not make it less empty -- it makes it
-// honest about WHY, which is the marker's job and not this lane's.
+// A validated projection can prove a quiet window. Missing, invalid, or stale
+// artifacts decline so callers retain the unavailable-source behavior.
 //
 // The RESPONSE SHAPE is unchanged: the lane stores the same network DISTINCT
 // row and per-subnet aggregate the cold tier computes, and this reader hands
@@ -79,5 +76,6 @@ export async function loadChainPrometheusFromArtifact(
     window: read.label,
     limit: query.limit ?? CHAIN_PROMETHEUS_LIMIT_DEFAULT,
     networkDistinct: read.cell.network ?? undefined,
+    sourceAvailable: true,
   });
 }

--- a/src/chain-prometheus-loader.ts
+++ b/src/chain-prometheus-loader.ts
@@ -60,16 +60,20 @@ export async function loadChainPrometheusColdTier(
     windowDays: ANALYTICS_WINDOW_DAYS[label],
     query,
   });
-  // A configured lakehouse that could not answer. `empty` and `miss` both keep
-  // the caller's zeros -- one is a measured quiet window, the other a
-  // deployment with no lakehouse -- and only this branch is a claim nobody
-  // measured. See ChainEventRollupOutcome.
+  // Preserve the distinction between a quiet window and a source that did not answer.
   if (rollup.kind === "gap") return declineChainEventCard(label);
-  if (rollup.kind !== "answer") return null;
+  if (rollup.kind === "miss") return null;
+  if (rollup.kind === "empty") {
+    return buildChainPrometheus([], {
+      window: label,
+      sourceAvailable: true,
+    });
+  }
   return buildChainPrometheus(rollup.rollup.rows, {
     window: label,
     limit: rowLimit,
     networkDistinct: rollup.rollup.networkDistinct,
     subnetCount: rollup.rollup.subnetCount,
+    sourceAvailable: true,
   });
 }

--- a/src/chain-prometheus.ts
+++ b/src/chain-prometheus.ts
@@ -10,7 +10,7 @@
 import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import {
-  PROMETHEUS_DEGRADED_NOT_CURATED,
+  DEGRADED_UNAVAILABLE,
   type EventStreamDegraded,
 } from "./uncurated-event-streams.ts";
 
@@ -152,9 +152,12 @@ export function buildChainPrometheus(
     limit = CHAIN_PROMETHEUS_LIMIT_DEFAULT,
     networkDistinct,
     subnetCount,
+    sourceAvailable = false,
   }: {
     window?: string | null;
     limit?: number;
+    /** True only after a successful source read, including a measured empty window. */
+    sourceAvailable?: boolean;
     /**
      * How many subnets the WINDOW covers, from the loader's own count.
      *
@@ -186,12 +189,7 @@ export function buildChainPrometheus(
     network: { ...EMPTY_NETWORK },
     intensity_distribution: null,
     subnets: [],
-    // The empty answer is the ONLY answer this route can produce today, and
-    // it is not a measurement: the chain emitted 18,041 PrometheusServed
-    // events and our account_events curation carries 0 of them. Marking it
-    // here rather than at each caller means REST, MCP and the GraphQL
-    // resolver all inherit it from the one builder they share.
-    degraded: { reason: PROMETHEUS_DEGRADED_NOT_CURATED },
+    ...(!sourceAvailable && { degraded: { reason: DEGRADED_UNAVAILABLE } }),
   };
   if (list.length === 0) return empty;
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3984,8 +3984,7 @@ const rootValue = {
       distinct_exporters: data.distinct_exporters ?? 0,
       announcements: data.announcements ?? 0,
       announcements_per_exporter: data.announcements_per_exporter ?? null,
-      // #9307: the account_events projection this reads carries 0 of the
-      // 18,041 PrometheusServed events the chain emitted.
+      // Preserve the shared loader's source-availability verdict.
       degraded: data.degraded ?? null,
     };
   },
@@ -6436,8 +6435,7 @@ const rootValue = {
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
       subnets: data.subnets || [],
-      // #9307: the account_events projection this reads carries 0 of the
-      // 18,041 PrometheusServed events the chain emitted.
+      // Preserve the shared loader's source-availability verdict.
       degraded: data.degraded ?? null,
     };
   },
@@ -8313,8 +8311,7 @@ const rootValue = {
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],
-      // #9307: the chain emits PrometheusServed and our account_events
-      // curation drops it, so an empty answer here is not a measurement.
+      // Preserve the shared loader's source-availability verdict.
       degraded: data.degraded ?? null,
     };
   },

--- a/src/projection-lanes.ts
+++ b/src/projection-lanes.ts
@@ -172,15 +172,12 @@ export interface ProjectionLane {
    * PROJECTION_LANES_CRON tick, so none sets this yet. */
   intervalCron?: string;
   /**
-   * A lane whose EMPTY answer is correct and permanent, so zero rows is not a
-   * fault for it.
+   * A lane whose empty answer can be a valid measurement.
    *
    * `projection-staleness` treats zero rows as broken because on mainnet a
    * block every 12s means an empty window cannot be real. That claim is right
-   * for every lane but this kind: `chain-prometheus` reads `PrometheusServed`
-   * from `account_events`, and our curation drops that variant, so the card is
-   * empty whatever tier answers -- which the route already states permanently
-   * via PROMETHEUS_DEGRADED_NOT_CURATED.
+   * for continuously active streams. Prometheus announcements can be absent
+   * throughout a 7d/30d window even when the complete event source is current.
    *
    * Set only with the reason written down. The watchdog's own comment asks for
    * exactly this -- exemption by NAME rather than weakening the rule into one
@@ -1051,10 +1048,8 @@ async function computeChainServing(
  * GET /api/v1/chain/prometheus, every supported window (#11419).
  *
  * AxonServed's twin -- the pallet emits both as (netuid, hotkey) from the same
- * serving.rs -- so it projects identically. Its card stays empty for the
- * separate reason `PROMETHEUS_DEGRADED_NOT_CURATED` records (the curation drops
- * `PrometheusServed`), and the lane does not change that: it stops the empty
- * costing a 15-second timeout to produce.
+ * serving.rs -- so it projects identically. A quiet window is a valid empty
+ * measurement, and the scheduled projection keeps that answer off request-time SQL.
  */
 async function computeChainPrometheus(
   env: Env,
@@ -1593,11 +1588,8 @@ export const PROJECTION_LANES: ProjectionLane[] = [
     name: "chain-prometheus",
     artifactKey: CHAIN_PROMETHEUS_PROJECTION_KEY,
     compute: computeChainPrometheus,
-    // The chain emits PrometheusServed and `account_events` curation drops it,
-    // so this card is empty whatever tier answers -- stated permanently on the
-    // route as PROMETHEUS_DEGRADED_NOT_CURATED. Alarming on it every tick made
-    // the projection-staleness lane permanent noise (#11484) without ever
-    // describing a condition anyone could act on.
+    // Prometheus announcements are sporadic; a current, successfully queried
+    // 7d/30d window can contain none. Freshness and query-failure checks still apply.
     emptyIsExpected: true,
   },
   {

--- a/src/subnet-event-card-loader.ts
+++ b/src/subnet-event-card-loader.ts
@@ -15,10 +15,8 @@
 // declines unconditionally and the card is all that is left. A 200, no degraded marker,
 // and a number that reads as "this subnet has no activity of this kind".
 //
-// Deliberately NOT extended to `/prometheus` and `/axon-removals`: those report 0
-// per-subnet AND 0 chain-wide, because `PrometheusServed` and `AxonInfoRemoved` do not
-// occur in the window at all. Their zero is the right answer, and wiring a loader there
-// would have been a fix for a bug that is not there.
+// Prometheus also uses this loader. A successful quiet window is a measurement;
+// an unavailable source must remain distinguishable from it.
 import { loadChainEventIdentityRollup } from "./chain-event-rollup-cold-tier.ts";
 import {
   DEGRADED_UNAVAILABLE,
@@ -45,7 +43,11 @@ export async function loadSubnetEventCardColdTier<T extends object>(
   env: Parameters<R2SqlReader>[0],
   spec: ChainEventRollupSpec,
   netuid: number,
-  build: (row: Row | null, netuid: unknown, options: { window?: unknown }) => T,
+  build: (
+    row: Row | null,
+    netuid: unknown,
+    options: { window?: unknown; sourceAvailable?: boolean },
+  ) => T,
   {
     windowLabel,
     windowDays,
@@ -69,10 +71,7 @@ export async function loadSubnetEventCardColdTier<T extends object>(
   // the zeroed card, which the header above calls "the whole defect this
   // closes". It was closed at this frame and reopened at the next one.
   //
-  // Only a configured lakehouse that could not answer is marked. An `empty`
-  // window is a MEASUREMENT and a `miss` is a deployment with no lakehouse;
-  // both keep the caller's zeros, unmarked, because in both cases the zeros are
-  // the right answer.
+  // An empty window is a measurement. A miss leaves the fallback to the caller.
   //
   // The card is still built, from a null row, so the marked payload has exactly
   // the key set the measured one has -- a consumer branches on `degraded`, never
@@ -83,6 +82,9 @@ export async function loadSubnetEventCardColdTier<T extends object>(
       degraded: { reason: DEGRADED_UNAVAILABLE },
     };
   }
-  if (rollup.kind !== "answer") return null;
-  return build(rollup.rollup.totals, netuid, { window: windowLabel });
+  if (rollup.kind === "miss") return null;
+  return build(rollup.kind === "answer" ? rollup.rollup.totals : null, netuid, {
+    window: windowLabel,
+    sourceAvailable: true,
+  });
 }

--- a/src/subnet-prometheus.ts
+++ b/src/subnet-prometheus.ts
@@ -8,7 +8,7 @@
 // shaping (buildSubnetPrometheus) + a thin store loader (loadSubnetPrometheus); the Worker adds the
 // envelope. Null-safe: a cold store or a subnet with no PrometheusServed events yields the zeroed card.
 
-import { PROMETHEUS_DEGRADED_NOT_CURATED } from "./uncurated-event-streams.ts";
+import { DEGRADED_UNAVAILABLE } from "./uncurated-event-streams.ts";
 import { roundDp } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
@@ -64,7 +64,10 @@ function announcementsPerExporter(
 export function buildSubnetPrometheus(
   row: Row | null | undefined,
   netuid: unknown,
-  { window }: { window?: unknown } = {},
+  {
+    window,
+    sourceAvailable = false,
+  }: { window?: unknown; sourceAvailable?: boolean } = {},
 ): Row {
   const distinctExporters = toCount(row?.distinct_exporters);
   const announcements = toCount(row?.announcements);
@@ -80,13 +83,9 @@ export function buildSubnetPrometheus(
       distinctExporters,
     ),
   };
-  // The zeroed card is the only card this route can produce: the chain emitted
-  // 18,041 PrometheusServed events and the account_events projection this
-  // reads carries 0 of them, so its zero is "we could not look", not "this
-  // subnet announced nothing". Conditional rather than unconditional so the
-  // marker disappears on its own the day the curation gap is closed upstream.
-  if (announcements === 0) {
-    card.degraded = { reason: PROMETHEUS_DEGRADED_NOT_CURATED };
+  // Successful empty reads are quiet windows, not missing event curation.
+  if (announcements === 0 && !sourceAvailable) {
+    card.degraded = { reason: DEGRADED_UNAVAILABLE };
   }
   return card;
 }
@@ -111,5 +110,6 @@ export async function loadSubnetPrometheus(
   );
   return buildSubnetPrometheus(rows?.[0] ?? null, netuid, {
     window: windowLabel,
+    sourceAvailable: true,
   });
 }

--- a/src/uncurated-event-streams.ts
+++ b/src/uncurated-event-streams.ts
@@ -64,22 +64,6 @@ export interface EventStreamDegraded {
 export const DEGRADED_UNAVAILABLE = "unavailable";
 
 /**
- * The chain emits `PrometheusServed` and our `account_events` curation drops
- * it: 18,041 events in the complete stream, 0 in the projection every
- * prometheus route reads. A CURATION gap, not a chain fact -- the fix is
- * upstream in the indexer's extract() match arm (metagraphed-infra #242) plus
- * a backfill, neither of which lives in this repo.
- *
- * Worth stating precisely, because "deploy #242 and the route lights up" is
- * only half true: the newest `PrometheusServed` in the complete stream is
- * 2026-07-19 and exactly ONE lands inside the widest window these routes
- * offer (30d). Curating it makes the routes correct; it does not make them
- * busy. The 18,041 are historical and reach back to 2023-03-20, so the
- * backfill is what makes them visible at all.
- */
-export const PROMETHEUS_DEGRADED_NOT_CURATED = "prometheus_stream_not_curated";
-
-/**
  * `AxonInfoRemoved` has ZERO occurrences in the complete pallet-level stream,
  * ever. The routes were modelled on an event the Subtensor runtime does not
  * emit, so no indexer work can populate them.

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -1030,6 +1030,7 @@ describe("loadAccountPrometheusColdTier", () => {
     const res = await loadAccountPrometheusColdTier(TOKEN as never, ADDR);
     assert.equal(res!.data.total_announcements, 0);
     assert.equal(res!.generatedAt, null);
+    assert.equal(res!.data.degraded, undefined);
   });
 
   test("declines an unusable address rather than scanning every account", async () => {

--- a/tests/account-prometheus.test.ts
+++ b/tests/account-prometheus.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { PROMETHEUS_DEGRADED_NOT_CURATED } from "../src/uncurated-event-streams.ts";
+import { DEGRADED_UNAVAILABLE } from "../src/uncurated-event-streams.ts";
 import { describe, test } from "vitest";
 import {
   buildAccountPrometheus,
@@ -157,7 +157,7 @@ describe("buildAccountPrometheus", () => {
 describe("buildAccountPrometheus honesty marker (#9307)", () => {
   test("an empty footprint says its zero is not a measurement", () => {
     const d = buildAccountPrometheus([], "5A", { window: "30d" });
-    assert.deepEqual(d.degraded, { reason: PROMETHEUS_DEGRADED_NOT_CURATED });
+    assert.deepEqual(d.degraded, { reason: DEGRADED_UNAVAILABLE });
   });
 
   test("a footprint with announcements carries NO marker", () => {

--- a/tests/chain-prometheus.test.ts
+++ b/tests/chain-prometheus.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
-import { PROMETHEUS_DEGRADED_NOT_CURATED } from "../src/uncurated-event-streams.ts";
+import { DEGRADED_UNAVAILABLE } from "../src/uncurated-event-streams.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainPrometheus,
@@ -240,7 +240,7 @@ describe("buildChainPrometheus honesty marker (#9307)", () => {
     // GraphQL resolver all inherit it from the one function they share.
     for (const rows of [null, [], [{ netuid: 1, distinct_exporters: 0 }]]) {
       const d = buildChainPrometheus(rows, { window: "7d" });
-      assert.deepEqual(d.degraded, { reason: PROMETHEUS_DEGRADED_NOT_CURATED });
+      assert.deepEqual(d.degraded, { reason: DEGRADED_UNAVAILABLE });
     }
   });
 

--- a/tests/chain-serving-prometheus-artifact.test.ts
+++ b/tests/chain-serving-prometheus-artifact.test.ts
@@ -141,6 +141,11 @@ for (const { name, key, distinctField, load } of CASES) {
       const card = await load(env, { window: "30d" });
       assert.ok(card, "an empty stored window is not a decline");
       assert.deepEqual(card.subnets, []);
+      assert.equal(
+        card.degraded,
+        undefined,
+        "a validated empty window is measured",
+      );
     });
 
     test("defaults to the route's own window when none is asked for", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -79,7 +79,7 @@ import {
 import {
   AXON_REMOVALS_DEGRADED_NEVER_EMITTED,
   DEREGISTRATIONS_DEGRADED_NOT_DERIVED,
-  PROMETHEUS_DEGRADED_NOT_CURATED,
+  DEGRADED_UNAVAILABLE,
 } from "../src/uncurated-event-streams.ts";
 import type { AnyFn, Row } from "./row-type.ts";
 
@@ -24295,17 +24295,17 @@ describe("graphql — event-stream honesty (#9307)", () => {
     [
       "chain_prometheus",
       "{ chain_prometheus { degraded { reason } } }",
-      PROMETHEUS_DEGRADED_NOT_CURATED,
+      DEGRADED_UNAVAILABLE,
     ],
     [
       "subnet_prometheus",
       "{ subnet_prometheus(netuid: 3) { degraded { reason } } }",
-      PROMETHEUS_DEGRADED_NOT_CURATED,
+      DEGRADED_UNAVAILABLE,
     ],
     [
       "account_prometheus",
       `{ account_prometheus(ss58: "${SS58_ADDR}") { degraded { reason } } }`,
-      PROMETHEUS_DEGRADED_NOT_CURATED,
+      DEGRADED_UNAVAILABLE,
     ],
     [
       "chain_axon_removals",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -100,7 +100,7 @@ import {
 import {
   AXON_REMOVALS_DEGRADED_NEVER_EMITTED,
   DEREGISTRATIONS_DEGRADED_NOT_DERIVED,
-  PROMETHEUS_DEGRADED_NOT_CURATED,
+  DEGRADED_UNAVAILABLE,
 } from "../src/uncurated-event-streams.ts";
 import type { Row } from "./row-type.ts";
 import { assertValid } from "./helpers/assert-valid.ts";
@@ -25620,13 +25620,9 @@ describe("MCP event-stream honesty (#9307)", () => {
       { ss58: HONEST_SS58 },
       DEREGISTRATIONS_DEGRADED_NOT_DERIVED,
     ],
-    ["get_chain_prometheus", {}, PROMETHEUS_DEGRADED_NOT_CURATED],
-    ["get_subnet_prometheus", { netuid: 3 }, PROMETHEUS_DEGRADED_NOT_CURATED],
-    [
-      "get_account_prometheus",
-      { ss58: HONEST_SS58 },
-      PROMETHEUS_DEGRADED_NOT_CURATED,
-    ],
+    ["get_chain_prometheus", {}, DEGRADED_UNAVAILABLE],
+    ["get_subnet_prometheus", { netuid: 3 }, DEGRADED_UNAVAILABLE],
+    ["get_account_prometheus", { ss58: HONEST_SS58 }, DEGRADED_UNAVAILABLE],
     ["get_chain_axon_removals", {}, AXON_REMOVALS_DEGRADED_NEVER_EMITTED],
     [
       "get_subnet_axon_removals",

--- a/tests/prometheus-source-availability.test.ts
+++ b/tests/prometheus-source-availability.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import { buildChainPrometheus } from "../src/chain-prometheus.ts";
+import {
+  buildAccountPrometheus,
+  loadAccountPrometheus,
+} from "../src/account-prometheus.ts";
+import {
+  buildSubnetPrometheus,
+  loadSubnetPrometheus,
+} from "../src/subnet-prometheus.ts";
+import { loadChainPrometheusColdTier } from "../src/chain-prometheus-loader.ts";
+import { loadSubnetEventCardColdTier } from "../src/subnet-event-card-loader.ts";
+import { CHAIN_PROMETHEUS_ROLLUP } from "../src/chain-event-rollup-cold-tier.ts";
+
+describe.each(["7d", "30d"])(
+  "Prometheus source availability for %s",
+  (window) => {
+    test("shared builders distinguish measured zeros from unavailable fallbacks", () => {
+      for (const sourceAvailable of [false, true]) {
+        const options = { window, sourceAvailable };
+        const cards = [
+          buildChainPrometheus([], options),
+          buildAccountPrometheus([], "account", options),
+          buildSubnetPrometheus(null, 112, options),
+        ];
+        for (const card of cards) {
+          expect(card.degraded).toEqual(
+            sourceAvailable ? undefined : { reason: "unavailable" },
+          );
+        }
+      }
+    });
+
+    test("a successful empty chain or subnet query remains a measured answer", async () => {
+      const query = async (_env: unknown, sql: string) =>
+        sql.includes("ORDER BY")
+          ? []
+          : [
+              {
+                announcements: 0,
+                distinct_exporters: 0,
+                newest_observed: null,
+              },
+            ];
+      const chain = await loadChainPrometheusColdTier({}, { window, query });
+      const subnet = await loadSubnetEventCardColdTier(
+        {},
+        CHAIN_PROMETHEUS_ROLLUP,
+        112,
+        buildSubnetPrometheus,
+        { windowLabel: window, windowDays: Number.parseInt(window, 10), query },
+      );
+      expect(chain?.network?.announcements).toBe(0);
+      expect(subnet?.announcements).toBe(0);
+      expect(chain?.degraded).toBeUndefined();
+      expect(subnet?.degraded).toBeUndefined();
+    });
+
+    test("store loaders pass through an empty measurement", async () => {
+      const account = await loadAccountPrometheus(async () => [], "account", {
+        windowLabel: window,
+      });
+      const subnet = await loadSubnetPrometheus(async () => [], 112, {
+        windowLabel: window,
+        windowDays: Number.parseInt(window, 10),
+      });
+      expect(account.data.total_announcements).toBe(0);
+      expect(account.data.degraded).toBeUndefined();
+      expect(subnet.announcements).toBe(0);
+      expect(subnet.degraded).toBeUndefined();
+    });
+  },
+);

--- a/tests/subnet-prometheus.test.ts
+++ b/tests/subnet-prometheus.test.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_SUBNET_PROMETHEUS_WINDOW,
 } from "../src/subnet-prometheus.ts";
 import type { Row } from "./row-type.ts";
-import { PROMETHEUS_DEGRADED_NOT_CURATED } from "../src/uncurated-event-streams.ts";
+import { DEGRADED_UNAVAILABLE } from "../src/uncurated-event-streams.ts";
 
 describe("buildSubnetPrometheus", () => {
   test("cold / null row yields a zeroed, schema-stable card", () => {
@@ -91,7 +91,7 @@ describe("buildSubnetPrometheus honesty marker (#9307)", () => {
     // projection this route reads carries 0 of them. Without the marker the
     // card is indistinguishable from "this subnet announced nothing".
     const d = buildSubnetPrometheus(null, 7, { window: "7d" });
-    assert.deepEqual(d.degraded, { reason: PROMETHEUS_DEGRADED_NOT_CURATED });
+    assert.deepEqual(d.degraded, { reason: DEGRADED_UNAVAILABLE });
   });
 
   test("a card with announcements carries NO marker", () => {


### PR DESCRIPTION
Prometheus cards labeled every zero result `prometheus_stream_not_curated`, including valid quiet windows read from current projections or the lakehouse. That historical diagnosis remained after forward curation was enabled.

Shared chain, subnet, and account builders now distinguish a successful empty read from an unavailable-source fallback. Validated projections and successful queries return measured zeros without degradation; missing or failed reads retain an `unavailable` marker. REST, MCP, and GraphQL share the same behavior, and all response fields and nonzero totals remain compatible.

Closes #11964.

Validation:
- Unsharded coverage: 982 test files and 22,505 tests passed; 100% of changed executable lines and branches covered (9 lines, 23 branches).
- 75 contribution validators, lint, formatting, typecheck, full build, and contract drift passed.
- Regression coverage includes both windows, stored empty projections, account/subnet/chain source reads, missing-source fallbacks, and shared MCP/GraphQL behavior.
