### PR TITLE
perf(api): keep directory response audits local

### DIFF
--- a/src/response-validation-tripwire.ts
+++ b/src/response-validation-tripwire.ts
@@ -35,6 +35,8 @@
 // parsed before it is sent, and a schema bug fails the route instead of
 // quietly shipping. That is the trade the flag exists to make.
 import { successEnvelopeSchema } from "../schemas-src/envelope.ts";
+import { AccountHolderDirectoryArtifactSchema } from "../schemas-src/routes/account-holder-directory.ts";
+import { ValidatorOperatorDirectoryArtifactSchema } from "../schemas-src/routes/validator-operator-directory.ts";
 import { isProjectedAway } from "./projection-signal.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import type { z } from "zod";
@@ -71,6 +73,21 @@ async function schemaForArtifact(artifactPath: string) {
   const cached = cache.get(artifactPath);
   if (cached) return cached;
   if (unresolved.has(artifactPath)) return null;
+  // These materialized directories already use their exact artifact schemas
+  // at the KV boundary. Enforcing the outgoing envelope needs the same schema,
+  // not initialization of every other component in the OpenAPI registry.
+  // Other routes still use the complete registry lookup below.
+  const directoryComponent =
+    artifactPath === "/metagraph/accounts/directory.json"
+      ? AccountHolderDirectoryArtifactSchema
+      : artifactPath === "/metagraph/validators/operators.json"
+        ? ValidatorOperatorDirectoryArtifactSchema
+        : null;
+  if (directoryComponent) {
+    const schema = successEnvelopeSchema(directoryComponent);
+    cache.set(artifactPath, schema);
+    return schema;
+  }
   const [{ schemaRefForArtifactPath }, { COMPONENT_SCHEMAS_BY_ID }] =
     await Promise.all([
       import("./contracts.ts"),

--- a/tests/directory-response-validation.test.ts
+++ b/tests/directory-response-validation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, vi } from "vitest";
+import { buildAccountHolderDirectory } from "../src/account-holder-directory.ts";
+import { buildValidatorOperatorDirectory } from "../src/validator-operator-directory.ts";
+import {
+  ResponseSchemaDriftError,
+  validateResponseTripwire,
+} from "../src/response-validation-tripwire.ts";
+
+const registry = vi.hoisted(() => ({ reads: vi.fn() }));
+vi.mock("../schemas-src/openapi-registry.ts", () => ({
+  get COMPONENT_SCHEMAS_BY_ID() {
+    registry.reads();
+    throw new Error("unrelated registry must stay unloaded for directories");
+  },
+}));
+
+describe("directory response validation without the full registry", () => {
+  for (const { id, path, data, count } of [
+    {
+      id: "account-holder-directory",
+      path: "/metagraph/accounts/directory.json",
+      data: buildAccountHolderDirectory([], { priceByNetuid: new Map() }),
+      count: "account_count",
+    },
+    {
+      id: "validator-operator-directory",
+      path: "/metagraph/validators/operators.json",
+      data: buildValidatorOperatorDirectory(null),
+      count: "operator_count",
+    },
+  ]) {
+    test(`${id} validates good responses and rejects drift on repeated reads`, async () => {
+      const envelope = {
+        ok: true,
+        schema_version: 1,
+        data,
+        meta: { contract_version: "test" },
+      };
+      await expect(
+        validateResponseTripwire(id, envelope, path),
+      ).resolves.toBeUndefined();
+      for (let attempt = 0; attempt < 2; attempt++) {
+        await expect(
+          validateResponseTripwire(
+            id,
+            { ...envelope, data: { ...data, [count]: -1 } },
+            path,
+          ),
+        ).rejects.toBeInstanceOf(ResponseSchemaDriftError);
+      }
+      expect(registry.reads).not.toHaveBeenCalled();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Enforced response validation loaded the complete OpenAPI component registry on the first account or validator directory request. Resolve these two materialized directories from their existing exact artifact schemas so validation does not initialize unrelated response schemas.

Refs #11760. The issue stays open until production latency is verified after deployment.

## What Changed

- Cache the same success-envelope validators for the two directory artifact paths; all other routes retain the registry lookup.
- Add regressions that reject malformed directory responses on first and repeated reads and fail if either route touches the full registry.
- Keep response enforcement, response shapes, freshness checks, and cache lifetime unchanged.

## Validation

- Full unsharded coverage: 22,507 tests passed across 983 files, 11 skipped.
- Patch coverage: 5/5 changed executable lines and 6/6 changed branches covered.
- All 75 pipeline validators, Worker dry-run build, full artifact build, typecheck, lint, formatting, and diff checks passed. No generated contract drift.

## Registry Safety

- [x] Linked issue is open.
- [x] No secrets, private endpoints, or registry data changes.
- [x] Build-generated artifacts have no semantic changes; deploy-owned outputs were not committed.
