### PR TITLE
fix(health): respect account-summary refresh cadence

### DIFF
--- a/schemas-src/artifacts/container-lane-status.ts
+++ b/schemas-src/artifacts/container-lane-status.ts
@@ -46,6 +46,7 @@ import { z } from "zod";
 export const ContainerLaneStatusSchema = z.object({
   checked_at: z.string().nullable().optional().catch(null),
   updated_at: z.string().nullable().optional().catch(null),
+  started_at: z.string().nullable().optional().catch(null),
   ok: z.boolean().nullable().optional().catch(null),
   status: z.string().nullable().optional().catch(null),
   detail: z.string().nullable().optional().catch(null),

--- a/src/container-lane-watchdog.ts
+++ b/src/container-lane-watchdog.ts
@@ -5,7 +5,8 @@
 // Five lanes run inside metagraphed-infra's decode container, one after another
 // in a single hourly pass: decode, the daily rollup, the state mirror, the
 // account-events rollup, and the account-summary projection. Every one of them
-// already publishes a status object to R2. NOTHING READ ANY OF THEM.
+// publishes a status object to R2. The account summary skips refreshes for
+// twenty hours once its history is complete; the other lanes report hourly.
 //
 // `projection-staleness` cannot: it iterates PROJECTION_LANES, the thirteen
 // lanes this Worker computes, so anything container-written is structurally
@@ -57,6 +58,8 @@ export interface ContainerLane {
   lane: string;
   /** The R2 key of its status object. */
   key: string;
+  /** Minimum refresh interval after success, in addition to the stall grace. */
+  successIntervalMs?: number;
 }
 
 /**
@@ -88,6 +91,10 @@ export const CONTAINER_LANES: readonly ContainerLane[] = [
   {
     lane: "container:account-summary",
     key: "metagraph/lakehouse/account-summary-status.json",
+    // account_summary_r2.py's min_interval_ms() defaults to twenty hours.
+    // The deployed decoder has no override. Failures and active scans do not
+    // get this allowance: only a producer that explicitly completed succeeds.
+    successIntervalMs: 20 * 60 * 60_000,
   },
 ];
 
@@ -135,6 +142,7 @@ export interface ContainerLaneVerdict {
 /** One lane's status as this watchdog reads it. */
 export interface ContainerLaneStatus {
   lane: string;
+  successIntervalMs?: number;
   /** The parsed body, or null when absent/unreadable. */
   body: {
     checked_at?: string | null;
@@ -224,7 +232,8 @@ export function evaluateContainerLanes(input: {
   thresholdMs: number;
 }): ContainerLaneVerdict {
   const { statuses, nowMs, thresholdMs } = input;
-  const entries = statuses.map(({ lane, body }): ContainerLaneEntry => {
+  const entries = statuses.map((status): ContainerLaneEntry => {
+    const { lane, body, successIntervalMs } = status;
     if (body === null) {
       return {
         lane,
@@ -287,13 +296,13 @@ export function evaluateContainerLanes(input: {
       };
     }
 
-    if (age > thresholdMs) {
+    const laneThresholdMs =
+      thresholdMs + (body.ok === true ? (successIntervalMs ?? 0) : 0);
+    if (age > laneThresholdMs) {
       return {
         lane,
         verdict: "stale",
-        detail:
-          `${hours(age)}h since the last pass (threshold ${hours(thresholdMs)}h, ` +
-          `${CONTAINER_MISSED_PASSES} missed passes)`,
+        detail: `${hours(age)}h since the last pass (threshold ${hours(laneThresholdMs)}h)`,
         age_ms: age,
       };
     }
@@ -332,7 +341,7 @@ export async function runContainerLaneWatchdog(
   const thresholdMs = deps.thresholdMs ?? CONTAINER_LANE_THRESHOLD_MS;
 
   const statuses: ContainerLaneStatus[] = [];
-  for (const { lane, key } of CONTAINER_LANES) {
+  for (const { lane, key, successIntervalMs } of CONTAINER_LANES) {
     // Declared without an initialiser: both arms below assign it, so a `= null`
     // here is a value nothing reads (`no-useless-assignment`).
     let body: ContainerLaneStatus["body"];
@@ -348,7 +357,7 @@ export async function runContainerLaneWatchdog(
       // lanes worth worrying about.
       body = null;
     }
-    statuses.push({ lane, body });
+    statuses.push({ lane, body, successIntervalMs });
   }
 
   const verdict = evaluateContainerLanes({

--- a/tests/container-lane-watchdog.test.ts
+++ b/tests/container-lane-watchdog.test.ts
@@ -289,6 +289,98 @@ describe("runContainerLaneWatchdog", () => {
     };
   }
 
+  for (const { name, lane, body, expected } of [
+    {
+      name: "a completed summary between scheduled refreshes is healthy",
+      lane: "container:account-summary",
+      body: {
+        checked_at: new Date(NOW - 6.4 * 3_600_000).toISOString(),
+        ok: true,
+        phase: "complete",
+      },
+      expected: "ok",
+    },
+    {
+      name: "the summary refresh interval includes six hours of grace",
+      lane: "container:account-summary",
+      body: {
+        checked_at: new Date(NOW - 26 * 3_600_000).toISOString(),
+        ok: true,
+        phase: "current",
+      },
+      expected: "ok",
+    },
+    {
+      name: "a successful summary overdue for its next refresh is stale",
+      lane: "container:account-summary",
+      body: {
+        checked_at: new Date(NOW - 26 * 3_600_000 - 1).toISOString(),
+        ok: true,
+        phase: "complete",
+      },
+      expected: "stale",
+    },
+    {
+      name: "a fresh summary scan preserves its start time through R2 parsing",
+      lane: "container:account-summary",
+      body: { started_at: FRESH, ok: null, phase: "scanning" },
+      expected: "ok",
+    },
+    {
+      name: "an active summary scan gets no daily refresh allowance",
+      lane: "container:account-summary",
+      body: {
+        started_at: new Date(NOW - 7 * 3_600_000).toISOString(),
+        ok: null,
+        phase: "scanning",
+      },
+      expected: "stale",
+    },
+    {
+      name: "a failed summary is stale immediately",
+      lane: "container:account-summary",
+      body: { checked_at: FRESH, ok: false, phase: "complete" },
+      expected: "stale",
+    },
+    {
+      name: "an unreadable summary start time remains unknown",
+      lane: "container:account-summary",
+      body: { started_at: 123, ok: null, phase: "scanning" },
+      expected: "unknown",
+    },
+    {
+      name: "an invalid summary start date remains unknown",
+      lane: "container:account-summary",
+      body: { started_at: "invalid", ok: null, phase: "scanning" },
+      expected: "unknown",
+    },
+    {
+      name: "an hourly lane keeps the six-hour limit after success",
+      lane: "container:daily-rollup",
+      body: {
+        checked_at: new Date(NOW - 7 * 3_600_000).toISOString(),
+        ok: true,
+      },
+      expected: "stale",
+    },
+  ]) {
+    test(name, async () => {
+      const bodies = Object.fromEntries(
+        CONTAINER_LANES.map(({ key, lane: candidate }) => [
+          key,
+          candidate === lane ? body : { checked_at: FRESH, ok: true },
+        ]),
+      );
+      const spy = laneSpy();
+      await runContainerLaneWatchdog(bucketWith(bodies), {
+        now: () => NOW,
+        recordException: (async () => true) as never,
+        laneHealthDb: spy.db,
+      });
+      assert.equal(spy.rows.find((row) => row[0] === lane)?.[1], expected);
+    });
+  }
+
   test("writes a DURABLE verdict for every lane, every tick", async () => {
     // #9330/#9340: PostHog drops `$exception` once the free-tier quota is
     // exhausted, and a dropped notification is indistinguishable from a fleet


### PR DESCRIPTION
## Summary

The account-summary producer intentionally waits at least 20 hours between successful refreshes after completing its historical walk, but the watchdog called it stale after six hours. The current production generation covers history through 2020-01-01 and its last complete UTC day, yet this mismatch raises a daily false alarm.

Closes #11969.

## What Changed

- Give a successful account-summary status its 20-hour refresh interval plus the existing six-hour grace. Hourly lanes retain their existing limit.
- Keep declared failures immediately stale and in-progress scans on the six-hour limit.
- Preserve started_at through the R2 status schema so scanning passes can be evaluated using their actual start time.
- Add nine regressions through the complete R2-reader/watchdog path, including the deadline boundary, overdue refresh, active scan, failed pass, malformed timestamp, and hourly lane.

## Validation

- 22,514 tests passed across 982 files in the unsharded coverage run, 11 skipped.
- Patch coverage: 6/6 changed executable lines and 6/6 changed branches covered.
- All 75 repository validators, full build, typecheck, lint, formatting, Worker dry-run, and diff checks passed.
- Production API inspection confirmed the 20-hour default has no deployment override and the summary history walk is complete. No data or producer timestamp was modified.

## Registry Safety

- [x] Linked issue is open.
- [x] No secrets, private endpoints, or registry data changes.
- [x] Generated contracts were verified through the build; there is no public response-shape change.
