### PR TITLE
perf(api): preserve deferred Worker modules at deployment

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -37,6 +37,8 @@ export default tseslint.config(
   {
     ignores: [
       "node_modules/**",
+      // Compiled Worker modules and staged deploy output, not source files.
+      "dist/**",
       "packages/*/node_modules/**",
       "packages/*/dist/**",
       "packages/*/src/metagraphed-*.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "5.20260730.1",
         "@electric-sql/pglite": "^0.5.4",
         "@eslint/js": "^10.0.1",
         "@graphql-codegen/cli": "^7.2.0",
@@ -44,8 +45,10 @@
         "@vitest/coverage-v8": "^4.1.10",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
+        "esbuild": "^0.28.2",
         "eslint": "^10.7.0",
         "knip": "^6.32.1",
+        "miniflare": "5.20260730.0-alpha",
         "openapi-typescript": "^7.13.0",
         "prettier": "^3.9.6",
         "sharp": "^0.35.2",
@@ -797,6 +800,13 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.3.tgz",
       "integrity": "sha512-5dIeQlJTDKAQvy3GcrtWBhPvTb9lHeRp/m8MoostTkcrbrGImH8zKSdJhogQ5YSTFUCg+b7FBg38b7KCM/x3VQ==",
       "license": "MIT"
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260730.1.tgz",
+      "integrity": "sha512-3e1cBXcPTwXBk2ur0CfxZKQKL6X7vUZlOn1R7VYU0zZVJcSKFcq1AoOZM+ps0LuL0uTAxdcLg+qwXrBXVu+UuQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "5.20260730.1",
     "@electric-sql/pglite": "^0.5.4",
     "@eslint/js": "^10.0.1",
     "@graphql-codegen/cli": "^7.2.0",
@@ -232,8 +233,10 @@
     "@vitest/coverage-v8": "^4.1.10",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
+    "esbuild": "^0.28.2",
     "eslint": "^10.7.0",
     "knip": "^6.32.1",
+    "miniflare": "5.20260730.0-alpha",
     "openapi-typescript": "^7.13.0",
     "prettier": "^3.9.6",
     "sharp": "^0.35.2",

--- a/scripts/build-api-worker.ts
+++ b/scripts/build-api-worker.ts
@@ -1,0 +1,76 @@
+// Preserve dynamic imports as native Worker modules. Wrangler's single bundle
+// otherwise makes every request parse the MCP, GraphQL and image dependencies
+// before entering the handler, including a cached directory read (#11760).
+import { build } from "esbuild";
+import { rm } from "node:fs/promises";
+import { isBuiltin } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { repoRoot } from "./lib.ts";
+
+export async function buildApiWorker(
+  outdir = path.join(repoRoot, "dist/api-modules"),
+) {
+  await rm(outdir, { recursive: true, force: true });
+  return build({
+    absWorkingDir: repoRoot,
+    entryPoints: ["workers/api.entry.ts"],
+    outdir,
+    // Keep exactly one top-level JS entry for the sourcemap deploy wrapper.
+    // It injects/uploads this directory recursively before shipping it intact.
+    chunkNames: "chunks/[name]-[hash]",
+    bundle: true,
+    splitting: true,
+    format: "esm",
+    platform: "browser",
+    target: "es2024",
+    minify: true,
+    sourcemap: true,
+    metafile: true,
+    conditions: ["workerd", "worker", "browser"],
+    loader: { ".wasm": "copy" },
+    external: ["cloudflare:*"],
+    plugins: [
+      {
+        name: "native-node-requires",
+        setup(builder) {
+          // CommonJS dependencies such as pg require Node builtins. A bare
+          // external require survives esbuild and throws inside an ESM Worker.
+          // Import workerd's nodejs_compat implementation and expose that same
+          // value to the CJS module; do not substitute browser polyfills.
+          builder.onResolve({ filter: /.*/ }, (args) => {
+            if (!isBuiltin(args.path)) return;
+            if (args.kind === "require-call") {
+              return {
+                path: args.path.replace(/^node:/, ""),
+                namespace: "native-node-require",
+              };
+            }
+            return {
+              path: args.path.startsWith("node:")
+                ? args.path
+                : `node:${args.path}`,
+              external: true,
+            };
+          });
+          builder.onLoad(
+            { filter: /.*/, namespace: "native-node-require" },
+            (args) => ({
+              contents: `import native from 'node:${args.path}'; module.exports = native;`,
+              loader: "js",
+            }),
+          );
+        },
+      },
+    ],
+    define: {
+      "process.env.NODE_ENV": '"production"',
+      "global.process.env.NODE_ENV": '"production"',
+      "globalThis.process.env.NODE_ENV": '"production"',
+    },
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await buildApiWorker();
+}

--- a/scripts/cloudflare-verify.ts
+++ b/scripts/cloudflare-verify.ts
@@ -35,16 +35,15 @@ const requireKvBinding =
   Boolean(process.env.METAGRAPH_KV_NAMESPACE_ID);
 
 check(config.name === "metagraphed", "wrangler name must be metagraphed");
-// workers/api.entry.ts is the real deployed entry point (metagraphed#7151,
-// #7766) -- a thin composition layer that imports workers/api.ts's own
-// handler + Durable Object classes and layers the GitHub OAuth provider on
-// top (see that file's own header for why it's a separate file, not an
-// inline wrap). Either value is a legitimate, verified-working entry point;
-// this check's real intent is "the main Worker's own handler, wrapped or
-// not," not a literal string pin to one exact filename.
+// Matches worker-deploy-dry-run.ts: compile the OAuth composition entry and
+// retain its dynamic imports as separate modules through the final upload.
 check(
-  config.main === "workers/api.ts" || config.main === "workers/api.entry.ts",
-  "wrangler main must point to workers/api.ts or its deploy-entry wrapper, workers/api.entry.ts",
+  config.main === "dist/api-modules/api.entry.js" &&
+    (config.build as Row | undefined)?.command ===
+      "node scripts/build-api-worker.ts" &&
+    config.no_bundle === true &&
+    config.find_additional_modules === true,
+  "wrangler must deploy all modules from the API entry's custom build without rebundling",
 );
 check(Boolean(config.compatibility_date), "compatibility_date is required");
 check(

--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -40,12 +40,9 @@
 # `posthog-cli sourcemap inject` embeds the marker into that build output,
 # (3) `wrangler deploy --no-bundle` ships THAT EXACT injected file,
 # skipping wrangler's own esbuild step (which would otherwise silently
-# rebuild from source and discard the marker just injected). Verified
-# locally: the dry-run build + inject steps (single flat `<entry>.js`/
-# `.js.map` per Worker, no code-splitting -- confirmed via `wrangler
-# deploy --dry-run --outdir` against wrangler.jsonc). The `--no-bundle`
-# deploy step (3) could not be safely tested against a live Worker from a
-# dev sandbox -- watch the first real deploy after this lands closely.
+# rebuild from source and discard the marker just injected). The API Worker
+# uses native ESM chunks below its entry; both PostHog phases traverse them,
+# and Wrangler collects them unchanged through find_additional_modules.
 #
 # --message passed on the wrangler call itself (metagraphed#7224): the
 # deployed commit SHA needs to land in the deployment's own real
@@ -170,6 +167,15 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
     --message "$COMMIT_SHA" \
     --dry-run
 
+  # Wrangler --no-bundle copies JS/WASM to --outdir but leaves external maps
+  # in the custom build directory. Stage that complete build before PostHog
+  # injects it, or none of the API Worker's 25 module maps would be uploaded.
+  # Keep this separate from dist/api-modules: the final Wrangler invocation
+  # runs the custom build again and must not overwrite the injected files.
+  if [[ "$BASENAME" == "wrangler" ]]; then
+    cp -R dist/api-modules/. "$OUTDIR/"
+  fi
+
   # Phase 2: inject PostHog's chunk-ID marker into the just-built bundle,
   # BEFORE it ever ships.
   # --release-name/--release-version passed HERE as well as on the upload in
@@ -194,16 +200,15 @@ if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # Phases 3-4 below: upload the sourcemap, then ship the EXACT injected
   # file -- --no-bundle skips wrangler's
   # own esbuild step (which would otherwise rebuild from source and discard
-  # the marker just injected above). ENTRY_JS is the single flat bundle
-  # wrangler's own build produces for these Workers (no code-splitting for
-  # a single-entry Worker, confirmed locally) -- resolved by globbing
-  # rather than hardcoded per-Worker, since each of the 3 configs' `main`
-  # basename differs.
+  # the marker just injected above). ENTRY_JS is the single top-level entry;
+  # the API Worker's deferred modules live under chunks/ and are collected by
+  # find_additional_modules. Injection and upload both traverse the directory.
+  # Resolve the entry by globbing since each config's main basename differs.
   ENTRY_JS=$(find "$OUTDIR" -maxdepth 1 -name '*.js')
 
-  # Assert the "single flat bundle" the comment above asserts. Phase 0 makes
+  # Assert the single top-level entry. Phase 0 makes
   # a stale leftover impossible, so this covers the other half: wrangler
-  # emitting more than one chunk (code-splitting, a future entry shape), or
+  # emitting more than one top-level entry (a future entry shape), or
   # none at all because the build silently produced nothing. Unguarded,
   # ENTRY_JS would become an empty or newline-joined string and get passed
   # straight to `wrangler deploy` in phase 4 -- which is the point where a

--- a/scripts/worker-bundle-budget.ts
+++ b/scripts/worker-bundle-budget.ts
@@ -65,7 +65,9 @@ try {
   // The deployable Worker bundle is the produced JS entry plus any bound wasm
   // modules. Source maps (.map) and asset metadata (README.md) are not uploaded
   // to the Worker, so they're excluded from the measurement.
-  const entries = await fs.readdir(outDir);
+  // Native ESM chunks live below chunks/. Count those too: otherwise splitting
+  // a bundle would hide most deployed bytes from this gate.
+  const entries = await fs.readdir(outDir, { recursive: true });
   const moduleFiles = entries
     .filter((name) => name.endsWith(".js") || name.endsWith(".wasm"))
     .sort();

--- a/scripts/worker-deploy-dry-run.ts
+++ b/scripts/worker-deploy-dry-run.ts
@@ -10,19 +10,16 @@ const assetsIgnore = await fs.readFile(assetsIgnorePath, "utf8");
 const errors: string[] = [];
 
 check(config.name === "metagraphed", "wrangler name must be metagraphed");
-// workers/api.entry.ts is the real deployed entry point (metagraphed#7151,
-// #7766) -- a thin composition layer that imports workers/api.ts's own
-// handler + Durable Object classes and layers the GitHub OAuth provider on
-// top (see that file's own header for why it's a separate file, not an
-// inline wrap). Either value is a legitimate, verified-working entry point;
-// this check's real intent is "the main Worker's own handler, wrapped or
-// not," not a literal string pin to one exact filename. Mirrors the same
-// check in cloudflare-verify.ts.
+// The custom build compiles the OAuth composition entry and preserves its
+// dynamic imports. Rebundling the output defeats that startup boundary.
 check(
-  config.main === "workers/api.ts" || config.main === "workers/api.entry.ts",
-  "wrangler main must point to workers/api.ts or its deploy-entry wrapper, workers/api.entry.ts",
+  config.main === "dist/api-modules/api.entry.js" &&
+    config.build?.command === "node scripts/build-api-worker.ts" &&
+    config.no_bundle === true &&
+    config.find_additional_modules === true,
+  "wrangler must deploy all modules from the API entry's custom build without rebundling",
 );
-const workerPath = path.join(repoRoot, config.main);
+const workerPath = path.join(repoRoot, "workers/api.entry.ts");
 check(
   config.compatibility_date === "2026-06-06",
   "compatibility_date must be locked to 2026-06-06",

--- a/tests/api-worker-modules.test.ts
+++ b/tests/api-worker-modules.test.ts
@@ -1,0 +1,163 @@
+// Exercise the compiled deploy entry in workerd, where native Node imports,
+// cloudflare:workers, WASM and deferred ESM chunks must all resolve together.
+// Source-only handler tests cannot catch a broken deployed module graph.
+import { Miniflare } from "miniflare";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import { buildApiWorker } from "../scripts/build-api-worker.ts";
+import { repoRoot } from "../scripts/lib.ts";
+import {
+  KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+  KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+} from "../src/kv-keys.ts";
+
+let outdir: string;
+let runtime: Miniflare;
+let eagerBytes: number;
+let totalBytes: number;
+
+beforeAll(async () => {
+  outdir = await mkdtemp(path.join(tmpdir(), "api-worker-modules-"));
+  const { metafile } = await buildApiWorker(outdir);
+  const visited = new Set<string>();
+  const visit = (name: string): number => {
+    if (visited.has(name)) return 0;
+    visited.add(name);
+    const output = metafile.outputs[name];
+    return (
+      output.bytes +
+      output.imports
+        .filter((item) => !item.external && item.kind === "import-statement")
+        .reduce((bytes, item) => bytes + visit(item.path), 0)
+    );
+  };
+  eagerBytes = visit(
+    path.relative(repoRoot, path.join(outdir, "api.entry.js")),
+  );
+  totalBytes = Object.entries(metafile.outputs)
+    .filter(([name]) => name.endsWith(".js"))
+    .reduce((bytes, [, output]) => bytes + output.bytes, 0);
+
+  const names = (await readdir(outdir, { recursive: true }))
+    .filter((name) => name.endsWith(".js") || name.endsWith(".wasm"))
+    .sort((a, b) =>
+      a === "api.entry.js" ? -1 : b === "api.entry.js" ? 1 : a.localeCompare(b),
+    );
+  runtime = new Miniflare({
+    modules: names.map((name) => ({
+      type: name.endsWith(".wasm") ? "CompiledWasm" : "ESModule",
+      path: path.join(outdir, name),
+    })),
+    modulesRoot: outdir,
+    compatibilityDate: "2026-06-06",
+    compatibilityFlags: ["nodejs_compat", "global_fetch_strictly_public"],
+    kvNamespaces: ["METAGRAPH_CONTROL", "OAUTH_KV"],
+    bindings: {
+      METAGRAPH_NEURONS_SOURCE: "data-api",
+      METAGRAPH_AUDIT_RESPONSES: "enforce",
+    },
+  });
+  const kv = await runtime.getKVNamespace("METAGRAPH_CONTROL");
+  const stamp = {
+    schema_version: 1,
+    captured_at: new Date().toISOString(),
+    block_number: 8_950_000,
+  };
+  await kv.put(
+    KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+    JSON.stringify({
+      ...stamp,
+      account_count: 0,
+      limit: 20,
+      priced_registered_stake_tao: 0,
+      rankings: { stake: [], emission: [], reach: [] },
+    }),
+  );
+  await kv.put(
+    KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+    JSON.stringify({
+      ...stamp,
+      validator_count: 0,
+      operator_count: 0,
+      operators: [],
+    }),
+  );
+}, 60_000);
+
+afterAll(async () => {
+  await runtime?.dispose();
+  if (outdir) await rm(outdir, { recursive: true, force: true });
+});
+
+test("directory startup excludes at least a third of the JavaScript", () => {
+  expect(eagerBytes).toBeLessThan(totalBytes * (2 / 3));
+});
+
+test("the composed entry serves both validated directory projections", async () => {
+  for (const [route, count] of [
+    ["accounts/directory", "account_count"],
+    ["validators/operators", "operator_count"],
+  ]) {
+    const response = await runtime.dispatchFetch(
+      `https://api.metagraph.sh/api/v1/${route}`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      data: { [count]: 0 },
+    });
+  }
+});
+
+test("query validation still rejects invalid requests", async () => {
+  const response = await runtime.dispatchFetch(
+    "https://api.metagraph.sh/api/v1/accounts/directory?network=invalid",
+  );
+  expect(response.status).toBe(400);
+});
+
+test("the GraphQL chunk loads and executes in workerd", async () => {
+  const response = await runtime.dispatchFetch(
+    "https://api.metagraph.sh/api/v1/graphql",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "{ __typename }" }),
+    },
+  );
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ data: { __typename: "Query" } });
+});
+
+test("the MCP chunk loads and anonymous initialization remains available", async () => {
+  const response = await runtime.dispatchFetch("https://api.metagraph.sh/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "module-runtime-test", version: "1" },
+      },
+    }),
+  });
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    jsonrpc: "2.0",
+    id: 1,
+    result: { protocolVersion: "2025-11-25" },
+  });
+});
+
+test("the OAuth provider still owns bearer-token authentication", async () => {
+  const response = await runtime.dispatchFetch("https://api.metagraph.sh/mcp", {
+    method: "POST",
+    headers: { authorization: "Bearer invalid" },
+  });
+  expect(response.status).toBe(401);
+});

--- a/tests/deploy-worker-sourcemaps.test.ts
+++ b/tests/deploy-worker-sourcemaps.test.ts
@@ -47,6 +47,7 @@ function sandbox({
   failInject = false,
   failUpload = false,
   emitBundles = 1,
+  customModules = false,
 } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "deploy-sourcemaps-"));
   const bin = join(dir, "bin");
@@ -60,7 +61,9 @@ echo "npx $*" >> ${JSON.stringify(log)}
 args="$*"
 case "$args" in
   *"--no-install @posthog/cli --version"*) exit 0 ;;
-  *"sourcemap inject"*) exit ${failInject ? 1 : 0} ;;
+  *"sourcemap inject"*)
+    ${customModules ? "[ -f dist/worker-wrangler/chunks/lazy.js.map ] || exit 1" : ":"}
+    exit ${failInject ? 1 : 0} ;;
   *"sourcemap upload"*) exit ${failUpload ? 1 : 0} ;;
   *"--dry-run"*)
     # wrangler's build phase: write the bundle(s) the script then globs for.
@@ -72,6 +75,15 @@ case "$args" in
     done
     mkdir -p "$outdir"
     for i in $(seq 1 ${emitBundles}); do echo "// bundle" > "$outdir/entry$i.js"; done
+    ${
+      customModules
+        ? `mkdir -p dist/api-modules/chunks
+    cp "$outdir/entry1.js" dist/api-modules/entry1.js
+    echo '{}' > dist/api-modules/entry1.js.map
+    echo '// deferred module' > dist/api-modules/chunks/lazy.js
+    echo '{}' > dist/api-modules/chunks/lazy.js.map`
+        : ":"
+    }
     exit 0 ;;
   *) exit 0 ;;
 esac
@@ -96,7 +108,10 @@ function run(
   opts: Parameters<typeof sandbox>[0] & { preview?: boolean } = {},
 ): { calls: string[]; failed: boolean } {
   const { dir, bin, log } = sandbox(opts);
-  const args = ["fake.jsonc", ...(opts.preview ? ["--preview"] : [])];
+  const args = [
+    opts.customModules ? "wrangler.jsonc" : "fake.jsonc",
+    ...(opts.preview ? ["--preview"] : []),
+  ];
   let failed = false;
   try {
     execFileSync("bash", [SCRIPT, ...args], {
@@ -152,6 +167,19 @@ describe("the deploy survives PostHog being unreachable (#11421)", () => {
     assert.ok(
       !calls.some((c) => c.includes("--no-bundle")),
       "the fallback rebuilds from source rather than shipping a half-injected file",
+    );
+  });
+
+  test("the API stages external chunk maps and ships one unambiguous entry", () => {
+    const { calls, failed } = run({ customModules: true });
+    assert.equal(failed, false);
+    assert.ok(calls.some((c) => c.includes("sourcemap upload")));
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.includes("dist/worker-wrangler/entry1.js") &&
+          c.includes("--no-bundle"),
+      ),
     );
   });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,7 +5,23 @@
   // handler -- see workers/api.entry.ts's own header for why this can't be
   // composed inline (breaks its ~90 existing tests, which import
   // workers/api.ts directly and are unaffected by this).
-  "main": "workers/api.entry.ts",
+  // Keep the entry's dynamic imports deferred in production (#11760). The
+  // custom build still starts at workers/api.entry.ts, including its OAuth,
+  // scheduled/queue handlers and Durable Object exports.
+  "main": "dist/api-modules/api.entry.js",
+  "no_bundle": true,
+  "find_additional_modules": true,
+  "build": {
+    "command": "node scripts/build-api-worker.ts",
+    "watch_dir": [
+      "workers",
+      "src",
+      "schemas-src",
+      "generated",
+      "scripts/build-api-worker.ts",
+    ],
+  },
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js"], "fallthrough": true }],
   "compatibility_date": "2026-06-06",
   // `global_fetch_strictly_public` (#11569): required before the OAuth provider
   // will advertise Client ID Metadata Document support, and required for a
@@ -16,7 +32,6 @@
   // internal call goes over the DATA_API service binding, which the flag does
   // not touch.
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
-  "minify": true,
   // Cloudflare's own per-deploy version UUID (metagraphed#7766: no longer
   // read for Sentry release tagging -- Sentry fully removed -- but still
   // useful as a stable deploy identifier). upload_source_maps makes Wrangler


### PR DESCRIPTION
Cached directory requests still spend about half a second starting a new Worker instance before entering the handler. Preserve the existing dynamic imports as native ESM modules, reducing eager JavaScript from 4.46 MB to 2.46 MB (45% deferred). The build starts at the existing OAuth composition entry and preserves its scheduled, queue, and Durable Object exports.

Use workerd's native Node modules for CommonJS dependencies, keep deferred chunks below one entry, and stage their external source maps before PostHog injection/upload. The final upload preserves the injected modules; the bundle budget now counts nested chunks.

Validation: 22,523 tests passed across 984 files in unsharded coverage; all 75 repository checks, typecheck, lint, formatting, and Worker bundle budget passed. Real workerd tests exercise both directories, invalid queries, GraphQL, anonymous MCP initialization, and bearer-token rejection. A two-stage Wrangler dry run preserved all 27 JS/WASM modules byte for byte with all 25 source maps staged. The full deployed bundle is 1,736 KiB gzipped.

Refs #11760. Keep the issue open until production cold-response measurements confirm the latency target.
