### PR TITLE
perf(api): serve default directories from a small Worker entry

### DIFF
--- a/src/contract-constants.ts
+++ b/src/contract-constants.ts
@@ -1,0 +1,15 @@
+// Shared protocol constants, independent of the route and schema catalogue.
+export const CONTRACT_VERSION = "2026-07-03.2";
+
+// The API + artifacts are served from the api subdomain; the bare apex
+// (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
+// server URL and the consumer metadata in contracts.json / api-index.json.
+export const PRIMARY_DOMAIN = "api.metagraph.sh";
+
+export const ARTIFACT_BASE_PATH = "/metagraph";
+
+export const CACHE_SECONDS = {
+  short: 60,
+  standard: 300,
+  static: 600,
+};

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,4 +1,14 @@
 import {
+  CONTRACT_VERSION,
+  ARTIFACT_BASE_PATH,
+  PRIMARY_DOMAIN,
+} from "./contract-constants.ts";
+export {
+  CONTRACT_VERSION,
+  CACHE_SECONDS,
+  PRIMARY_DOMAIN,
+} from "./contract-constants.ts";
+import {
   DECLARATIONS_REQUIRING_A_GPU,
   MIN_COMPUTE_SURFACES_REGISTERED,
   SUBNETS_IN_REGISTRY,
@@ -151,13 +161,7 @@ interface RetirementInfo {
   http_status: number;
   message: string;
 }
-
-export const CONTRACT_VERSION = "2026-07-03.2";
 export const SCHEMA_VERSION = 1;
-// The API + artifacts are served from the api subdomain; the bare apex
-// (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
-// server URL and the consumer metadata in contracts.json / api-index.json.
-export const PRIMARY_DOMAIN = "api.metagraph.sh";
 
 /**
  * The human-facing origin — the block explorer, not the API.
@@ -192,14 +196,7 @@ export function subnetPageUrl(netuid: number | null | undefined): string {
  */
 export const REPOSITORY_URL = "https://github.com/JSONbored/metagraphed";
 export const API_BASE_PATH = "/api/v1";
-export const ARTIFACT_BASE_PATH = "/metagraph";
 export const TYPE_DEFINITIONS_PATH = "/metagraph/types.d.ts";
-
-export const CACHE_SECONDS = {
-  short: 60,
-  standard: 300,
-  static: 600,
-};
 
 // The published query-parameter schemas, derived from the ONE vocabulary in
 // schemas-src/query-params.ts (#10073).

--- a/tests/api-worker-modules.test.ts
+++ b/tests/api-worker-modules.test.ts
@@ -17,6 +17,7 @@ let outdir: string;
 let runtime: Miniflare;
 let eagerBytes: number;
 let totalBytes: number;
+let eagerInputs: Set<string>;
 
 beforeAll(async () => {
   outdir = await mkdtemp(path.join(tmpdir(), "api-worker-modules-"));
@@ -35,6 +36,9 @@ beforeAll(async () => {
   };
   eagerBytes = visit(
     path.relative(repoRoot, path.join(outdir, "api.entry.js")),
+  );
+  eagerInputs = new Set(
+    [...visited].flatMap((name) => Object.keys(metafile.outputs[name].inputs)),
   );
   totalBytes = Object.entries(metafile.outputs)
     .filter(([name]) => name.endsWith(".js"))
@@ -91,8 +95,10 @@ afterAll(async () => {
   if (outdir) await rm(outdir, { recursive: true, force: true });
 });
 
-test("directory startup excludes at least a third of the JavaScript", () => {
-  expect(eagerBytes).toBeLessThan(totalBytes * (2 / 3));
+test("directory startup excludes the full router and at least three quarters of the JavaScript", () => {
+  expect(eagerBytes).toBeLessThan(totalBytes / 4);
+  expect(eagerInputs.has("workers/api.ts")).toBe(false);
+  expect(eagerInputs.has("src/contracts.ts")).toBe(false);
 });
 
 test("the composed entry serves both validated directory projections", async () => {

--- a/tests/explorer-directory-entry.test.ts
+++ b/tests/explorer-directory-entry.test.ts
@@ -109,12 +109,23 @@ describe("default directory entry", () => {
     { path: `${ACCOUNT_PATH}?network=invalid` },
     { path: "/finney/api/v1/accounts/directory" },
     { path: "/api/v1/validators" },
-    ...["authorization", "x-payment", "payment-signature", "upgrade"].map(
-      (name) => ({
-        path: ACCOUNT_PATH,
-        init: { headers: { [name]: "present" } },
-      }),
-    ),
+    ...[
+      "authorization",
+      "x-api-key",
+      "x-payment",
+      "payment-signature",
+      "upgrade",
+    ].map((name) => ({
+      path: ACCOUNT_PATH,
+      init: {
+        headers: {
+          [name]:
+            name === "authorization"
+              ? "Bearer mg_test_directory_key"
+              : "mg_test_directory_key",
+        },
+      },
+    })),
   ])(
     "delegates unsupported variants without reading or caching data: %j",
     async ({ path, init }) => {

--- a/tests/explorer-directory-entry.test.ts
+++ b/tests/explorer-directory-entry.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import api, {
+  flushUsageRollup,
+  markRequestErrorCode,
+  usageRollupBufferSize,
+} from "../workers/api.ts";
+import {
+  EXPLORER_DIRECTORY_ENTRIES,
+  handleDefaultExplorerDirectory,
+} from "../workers/explorer-directory-entry.ts";
+import { API_ROUTES } from "../src/contracts.ts";
+import { buildAccountHolderDirectory } from "../src/account-holder-directory.ts";
+import { buildValidatorOperatorDirectory } from "../src/validator-operator-directory.ts";
+import {
+  KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+  KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT,
+} from "../src/kv-keys.ts";
+import * as telemetry from "../src/usage-telemetry.ts";
+import { mockEnv } from "./row-type.ts";
+
+const NOW = Date.parse("2026-09-03T01:30:00Z");
+const ACCOUNT_PATH = "/api/v1/accounts/directory";
+const request = (path = ACCOUNT_PATH, init?: RequestInit) =>
+  new Request(`https://api.metagraph.sh${path}`, init);
+
+function fixture() {
+  const stamp = {
+    captured_at: new Date(NOW - 60_000).toISOString(),
+    block_number: 8_983_000,
+  };
+  const accounts = {
+    ...buildAccountHolderDirectory([], { priceByNetuid: new Map() }),
+    ...stamp,
+  };
+  const validators = { ...buildValidatorOperatorDirectory(null), ...stamp };
+  const values = new Map<string, unknown>([
+    [KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT, accounts],
+    [KV_EXPLORER_VALIDATOR_DIRECTORY_CURRENT, validators],
+    [
+      "metagraph:latest",
+      { published_at: new Date(NOW - 60_000).toISOString() },
+    ],
+  ]);
+  const get = vi.fn(async (key: string) => values.get(key) ?? null);
+  const pending: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil: (work: Promise<unknown>) => {
+      pending.push(work);
+    },
+  };
+  const env = mockEnv({
+    METAGRAPH_NEURONS_SOURCE: "data-api",
+    METAGRAPH_AUDIT_RESPONSES: "enforce",
+    METAGRAPH_CONTROL: { get },
+  });
+  return { values, accounts, validators, get, ctx, pending, env };
+}
+
+function cacheFixture() {
+  const values = new Map<string, Response>();
+  const match = vi.fn(async (key: Request) => values.get(key.url)?.clone());
+  const put = vi.fn(async (key: Request, response: Response) => {
+    values.set(key.url, response.clone());
+  });
+  vi.stubGlobal("caches", { default: { match, put } });
+  return { values, match, put };
+}
+
+beforeEach(() => {
+  vi.spyOn(Date, "now").mockReturnValue(NOW);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("default directory entry", () => {
+  test("route descriptors stay tied to the published contract", () => {
+    for (const entry of EXPLORER_DIRECTORY_ENTRIES) {
+      const route = API_ROUTES.find((row) => row.path === entry.path);
+      expect(route).toMatchObject({
+        id: entry.id,
+        artifact_path: entry.artifactTemplate,
+      });
+    }
+  });
+
+  test.each(EXPLORER_DIRECTORY_ENTRIES)(
+    "$id returns the same envelope and headers as the complete router",
+    async (entry) => {
+      const f = fixture();
+      const expected = await api.fetch(request(entry.path), f.env, f.ctx);
+      const actual = await handleDefaultExplorerDirectory(
+        request(entry.path),
+        f.env,
+        f.ctx,
+      );
+      expect(actual).not.toBeNull();
+      expect(actual!.status).toBe(200);
+      expect(await actual!.json()).toEqual(await expected.json());
+      expect(Object.fromEntries(actual!.headers)).toEqual(
+        Object.fromEntries(expected.headers),
+      );
+    },
+  );
+
+  test.each([
+    { path: ACCOUNT_PATH, init: { method: "POST" } },
+    { path: `${ACCOUNT_PATH}?network=invalid` },
+    { path: "/finney/api/v1/accounts/directory" },
+    { path: "/api/v1/validators" },
+    ...["authorization", "x-payment", "payment-signature", "upgrade"].map(
+      (name) => ({
+        path: ACCOUNT_PATH,
+        init: { headers: { [name]: "present" } },
+      }),
+    ),
+  ])(
+    "delegates unsupported variants without reading or caching data: %j",
+    async ({ path, init }) => {
+      const f = fixture();
+      const cache = cacheFixture();
+      expect(
+        await handleDefaultExplorerDirectory(request(path, init), f.env, f.ctx),
+      ).toBeNull();
+      expect(f.get).not.toHaveBeenCalled();
+      expect(cache.match).not.toHaveBeenCalled();
+    },
+  );
+
+  test("respects the source kill switch", async () => {
+    const f = fixture();
+    expect(
+      await handleDefaultExplorerDirectory(request(), mockEnv(), f.ctx),
+    ).toBeNull();
+    expect(f.get).not.toHaveBeenCalled();
+  });
+
+  test("shares the original cache key and advances to the next snapshot within the existing minute bound", async () => {
+    const f = fixture();
+    const cache = cacheFixture();
+    const first = await handleDefaultExplorerDirectory(request(), f.env, f.ctx);
+    expect(first!.headers.get("x-metagraph-cache")).toBe("miss");
+    await Promise.all(f.pending);
+    const general = await api.fetch(request(), f.env, f.ctx);
+    expect(general.headers.get("x-metagraph-cache")).toBe("hit");
+    expect(
+      f.get.mock.calls.filter(
+        ([key]) => key === KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT,
+      ),
+    ).toHaveLength(1);
+    const advanced = {
+      ...f.accounts,
+      captured_at: new Date(NOW + 60_000).toISOString(),
+      block_number: 8_983_010,
+    };
+    f.values.set(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT, advanced);
+    vi.mocked(Date.now).mockReturnValue(NOW + 61_000);
+    const next = await handleDefaultExplorerDirectory(request(), f.env, f.ctx);
+    expect(next!.headers.get("x-metagraph-cache")).toBe("miss");
+    expect(await next!.json()).toMatchObject({ data: advanced });
+    expect(cache.match.mock.calls[0][0].url).not.toBe(
+      cache.match.mock.calls[2][0].url,
+    );
+  });
+
+  test("a cold HEAD retains the GET body in cache and conditional requests still return 304", async () => {
+    const f = fixture();
+    cacheFixture();
+    const head = await handleDefaultExplorerDirectory(
+      request(ACCOUNT_PATH, { method: "HEAD" }),
+      f.env,
+      f.ctx,
+    );
+    expect(head!.status).toBe(200);
+    expect(await head!.text()).toBe("");
+    await Promise.all(f.pending);
+    const get = await handleDefaultExplorerDirectory(request(), f.env, f.ctx);
+    expect(get!.headers.get("x-metagraph-cache")).toBe("hit");
+    expect(await get!.json()).toMatchObject({ data: f.accounts });
+    const conditional = await handleDefaultExplorerDirectory(
+      request(ACCOUNT_PATH, {
+        headers: { "if-none-match": head!.headers.get("etag")! },
+      }),
+      f.env,
+      f.ctx,
+    );
+    expect(conditional!.status).toBe(304);
+    expect(await conditional!.text()).toBe("");
+  });
+
+  test("an absent materialization uses the existing source-backed fallback", async () => {
+    const f = fixture();
+    f.values.delete(KV_EXPLORER_ACCOUNT_DIRECTORY_CURRENT);
+    const fetch = vi.fn(async () => Response.json(f.accounts));
+    const response = await handleDefaultExplorerDirectory(
+      request(),
+      mockEnv({ ...f.env, DATA_API: { fetch } }),
+      f.ctx,
+    );
+    expect(response!.status).toBe(200);
+    expect(await response!.json()).toMatchObject({ data: f.accounts });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("a cached response without an ETag still returns its complete body", async () => {
+    const f = fixture();
+    const cache = cacheFixture();
+    await handleDefaultExplorerDirectory(request(), f.env, f.ctx);
+    await Promise.all(f.pending);
+    for (const cached of cache.values.values()) cached.headers.delete("etag");
+    const response = await handleDefaultExplorerDirectory(
+      request(ACCOUNT_PATH, { headers: { "if-none-match": 'W/"older"' } }),
+      f.env,
+      f.ctx,
+    );
+    expect(response!.status).toBe(200);
+    expect(response!.headers.get("x-metagraph-cache")).toBe("hit");
+    expect(await response!.json()).toMatchObject({ data: f.accounts });
+  });
+
+  test("invalid request error markers cannot label successful usage as a failure", async () => {
+    const f = fixture();
+    const record = vi
+      .spyOn(telemetry, "recordUsageEvent")
+      .mockResolvedValue(true);
+    for (const code of [undefined, "", 500]) {
+      const req = request();
+      markRequestErrorCode(req, code);
+      const response = await handleDefaultExplorerDirectory(
+        req,
+        mockEnv({ ...f.env, POSTHOG_PROJECT_TOKEN: "phc_test" }),
+        f.ctx,
+      );
+      expect(response!.status).toBe(200);
+    }
+    await Promise.all(f.pending);
+    expect(record).toHaveBeenCalledTimes(3);
+    for (const [, event] of record.mock.calls) {
+      expect(event.ok).toBe(true);
+      expect(event.errorCode).toBeUndefined();
+    }
+  });
+
+  test("records one usage event and shares the same cost-rollup buffer with the general router", async () => {
+    const f = fixture();
+    const record = vi
+      .spyOn(telemetry, "recordUsageEvent")
+      .mockResolvedValue(true);
+    const fetch = vi.fn(async (_request: Request) =>
+      Response.json({ ok: true }),
+    );
+    const env = mockEnv({
+      ...f.env,
+      POSTHOG_PROJECT_TOKEN: "phc_test",
+      DATA_API: { fetch },
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-only",
+    });
+    const size = usageRollupBufferSize();
+    await handleDefaultExplorerDirectory(request(), env, f.ctx);
+    await Promise.all(f.pending);
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(record.mock.calls[0][1]).toMatchObject({
+      route: "account-holder-directory",
+      ok: true,
+      method: "GET",
+    });
+    await api.fetch(request("/api/v1/validators/operators"), env, f.ctx);
+    await Promise.all(f.pending);
+    expect(usageRollupBufferSize()).toBe(size + 2);
+    flushUsageRollup(mockEnv(), f.ctx);
+    flushUsageRollup(mockEnv({ DATA_API: { fetch } }), f.ctx);
+    expect(usageRollupBufferSize()).toBe(size + 2);
+    expect(fetch).not.toHaveBeenCalled();
+    flushUsageRollup(env, f.ctx);
+    await Promise.all(f.pending);
+    const sent = await (fetch.mock.calls[0][0] as Request).json();
+    expect(sent).toMatchObject({
+      buckets: expect.arrayContaining([
+        expect.objectContaining({ family: ACCOUNT_PATH }),
+        expect.objectContaining({ family: "/api/v1/validators/operators" }),
+      ]),
+    });
+  });
+});

--- a/workers/api.entry.ts
+++ b/workers/api.entry.ts
@@ -1,112 +1,61 @@
-// Deploy entry point for workers/api.ts -- composes the GitHub OAuth
-// provider on top of the raw handler (metagraphed#7151). Kept SEPARATE from
-// the actual handler (not composed inline in that file) purely so
-// wrangler.jsonc's "main" can point at a thin composition layer while
-// ~90 existing tests for this Worker keep importing api.ts's own
-// handleRequest/handleScheduled/default export directly, unaffected by
-// whatever this entry adds on top.
-//
-// metagraphed#7766: previously also wrapped everything with
-// @sentry/cloudflare's withSentry() (Sentry fully removed here -- PostHog
-// $exception capture already covers every route, and PostHog distributed
-// tracing (src/tracing.ts, #7768) replaces the automatic HTTP
-// instrumentation withSentry() provided). This file is now pure OAuth
-// composition, no error-tracking wrap of its own.
-//
-// wrangler.jsonc's "main" points HERE instead of at the raw handler file,
-// so only the actual deployed Worker -- running in the real workerd
-// runtime, never a test -- ever executes the wrapped path. This file
-// itself is excluded from coverage tracking (vitest.config.ts); it's a
-// thin, mechanical composition with no logic of its own worth testing here
-// (isNonOAuthMcpRequest/buildOAuthProviderOptions have their own coverage
-// in tests/github-oauth.test.ts).
-import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
-import handler from "./api.ts";
-import {
-  buildOAuthProviderOptions,
-  isNonOAuthMcpRequest,
-} from "../src/github-oauth.ts";
-// wrangler.jsonc's "main" points at THIS file, so wrangler looks for every
-// Durable Object binding's class as a named export from here, not from
-// api.ts -- confirmed by a real `wrangler deploy --dry-run` failure ("Your
-// Worker depends on the following Durable Objects, which are not exported
-// in your entrypoint file") before this re-export was added.
-export {
-  ChainFirehoseHub,
-  McpSessionHub,
-  AlerterHub,
-  SubnetStatusHub,
-  NeonWriteBufferHub,
-} from "./api.ts";
+// Compose public directory reads, the full API and GitHub OAuth at deployment.
+// Keep the module graph for the default directories independent of the general
+// router: deferred ESM files alone do not help if the entry imports that router.
+import { handleDefaultExplorerDirectory } from "./explorer-directory-entry.ts";
 
-// GitHub OAuth (metagraphed#7151): OAuthProvider owns top-level fetch
-// dispatch (its own /oauth/token + /oauth/register endpoints, plus routing
-// /mcp to apiHandler with ctx.props populated when a valid Bearer token is
-// present). A BARE /mcp request with no Bearer token is routed to the real,
-// unmodified `handler` directly, bypassing oauthProvider.fetch() entirely --
-// isNonOAuthMcpRequest below, NOT anything inside OAuthProvider's own
-// apiRoute/apiHandler machinery, is what keeps anonymous/IP-rate-limited
-// access to /mcp working. This was a real production regression (silently
-// 401ing every anonymous MCP client since #7151) until this explicit bypass
-// was added: @cloudflare/workers-oauth-provider's apiRoute/apiHandler
-// mechanism unconditionally requires a valid Bearer token and 401s BEFORE
-// apiHandler is ever reached -- there is no library-level "authenticate if
-// present, else fall through to defaultHandler" option (confirmed against
-// node_modules/@cloudflare/workers-oauth-provider/dist/oauth-provider.js
-// directly, not just its .d.ts); see src/github-oauth.ts's
-// buildOAuthProviderOptions/isNonOAuthMcpRequest comments for the full
-// story. Every other path -- /authorize, /oauth/token, /oauth/register,
-// OAuthProvider's own discovery endpoints, and /mcp WITH a Bearer token --
-// still needs the real oauthProvider.fetch() dispatch, so this bypass stays
-// scoped to exactly the one route/no-token combination.
-//
-// OAuthProvider instances expose ONLY .fetch(), not .scheduled() -- this
-// Worker has four live cron triggers (wrangler.jsonc "triggers.crons": the
-// 15-min health probe, two hourly rollups, the daily embedding sync) that
-// dispatch to handler.scheduled (handleScheduled in api.ts). Swapping the
-// top-level export for a bare OAuthProvider instance would silently drop
-// every one of those -- Cloudflare would just never find a .scheduled to
-// call. This composed object keeps .scheduled pointed at the ORIGINAL,
-// untouched handler so cron behavior is byte-for-byte unaffected by this
-// change; only .fetch is rerouted through OAuthProvider.
-const oauthProvider = new OAuthProvider(buildOAuthProviderOptions(handler));
+// Durable Object names must remain exports on the deploy entry. Re-export the
+// original classes directly so their identity and persisted state stay intact.
+export { ChainFirehoseHub } from "./chain-firehose-hub.ts";
+export { McpSessionHub } from "./mcp-session-hub.ts";
+export { AlerterHub } from "./alerter-hub.ts";
+export { SubnetStatusHub } from "./subnet-status-hub.ts";
+export { NeonWriteBufferHub } from "./neon-write-buffer-hub.ts";
+
+const handler = {
+  fetch: async (request: Request, env: Env, ctx: ExecutionContext) =>
+    (await import("./api.ts")).default.fetch(request, env, ctx),
+};
+
+// Memoize the composition after its first use, without loading either the
+// provider or the general router for the two default directory requests.
+async function loadOAuth() {
+  const [
+    { OAuthProvider },
+    { buildOAuthProviderOptions, isNonOAuthMcpRequest },
+  ] = await Promise.all([
+    import("@cloudflare/workers-oauth-provider"),
+    import("../src/github-oauth.ts"),
+  ]);
+  return {
+    provider: new OAuthProvider(buildOAuthProviderOptions(handler)),
+    isNonOAuthMcpRequest,
+  };
+}
+let oauth: ReturnType<typeof loadOAuth> | undefined;
 
 export default {
-  fetch: (request: Request, env: Env, ctx: ExecutionContext) =>
-    isNonOAuthMcpRequest(request)
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const directory = await handleDefaultExplorerDirectory(request, env, ctx);
+    if (directory) return directory;
+    const { provider, isNonOAuthMcpRequest } = await (oauth ??= loadOAuth());
+    // Bare MCP retains its anonymous path. Bearer tokens and all OAuth
+    // discovery/token/registration routes remain owned by the provider.
+    return isNonOAuthMcpRequest(request)
       ? handler.fetch(request, env, ctx)
-      : oauthProvider.fetch(request, env, ctx),
-  // Discards handleScheduled's (api.ts) return value --
-  // it returns diagnostic objects for its own test suite's benefit; the real
-  // Workers runtime ignores scheduled()'s return value, and ExportedHandler's
-  // type expects `void | Promise<void>`.
-  scheduled: async (
+      : provider.fetch(request, env, ctx);
+  },
+  async scheduled(
     controller: ScheduledController,
     env: Env,
     ctx: ExecutionContext,
-  ): Promise<void> => {
-    await handler.scheduled(controller, env, ctx);
+  ): Promise<void> {
+    await (await import("./api.ts")).default.scheduled(controller, env, ctx);
   },
-  // #9847: this MUST be here, for exactly the reason the
-  // .scheduled note above gives.
-  //
-  // A queue consumer is registered at deploy time only if the deployed Worker
-  // actually exports a `queue` handler -- and "deployed Worker" means THIS
-  // file, not api.ts. #9655 added queue() to api.ts and wired both consumers
-  // in wrangler.jsonc, but the composed object here was never extended, so
-  // Cloudflare saw a Worker with no queue handler and registered neither:
-  //
-  //   webhook-deliveries      producers 1 (worker:metagraphed)  consumers 0
-  //   webhook-deliveries-dlq  producers 0                       consumers 0
-  //
-  // The PRODUCER registered from the same config block, because a producer is
-  // just a binding and needs no handler -- which is what made this look like a
-  // Cloudflare-side inconsistency rather than a missing export. metagraphed-
-  // data-api's queues work because its wrangler "main" points straight at the
-  // raw handler, so its queue() is on the deployed entry by construction.
-  queue: (
+  async queue(
     batch: MessageBatch<unknown>,
     env: Env,
     ctx: ExecutionContext,
-  ): Promise<void> => handler.queue(batch, env, ctx),
+  ): Promise<void> {
+    await (await import("./api.ts")).default.queue(batch, env, ctx);
+  },
 };

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1,3 +1,17 @@
+import { recordMatchedUsageRollup } from "./usage-rollup.ts";
+export { flushUsageRollup, usageRollupBufferSize } from "./usage-rollup.ts";
+import { scheduleExceptionEvent } from "./request-lifecycle.ts";
+import { withResponseTiming } from "./request-lifecycle.ts";
+import {
+  withRequestUsageTelemetry,
+  auditRouteResponse,
+  markRequestAuthTier,
+  markRequestErrorCode,
+} from "./request-lifecycle.ts";
+export {
+  markRequestAuthTier,
+  markRequestErrorCode,
+} from "./request-lifecycle.ts";
 import {
   X402_RESPONSE_HEADER,
   x402Manifest,
@@ -160,23 +174,10 @@ function cacheableWith(key: Request): { store: Cache; key: Request } | null {
   return store ? { store, key } : null;
 }
 import {
-  isUsageTelemetryConfigured,
   recordExceptionEvent,
   recordUsageEvent,
-  parseUserAgentClient,
-  statusClassOf,
-  anonymousUsageDistinctId,
-  sanitizeUsageLabel,
-  USAGE_ACCOUNT_NAMESPACE,
-  USAGE_WORKER_NAMESPACE,
-  type UsageEvent,
 } from "../src/usage-telemetry.ts";
-import {
-  newSpanId,
-  newTraceId,
-  recordTraceSpan,
-  shouldRecordTraceSpan,
-} from "../src/tracing.ts";
+
 import {
   loadLatestLaneHealth,
   recordLaneVerdict,
@@ -317,10 +318,7 @@ import {
 } from "./account-edge-cache.ts";
 import { parseRouteQuery, routeQuery, routeText } from "../src/route-query.ts";
 import { readExplorerDirectoryCacheStamp } from "./data-api-tier.ts";
-import {
-  serverTimingHeader,
-  withRequestTiming,
-} from "../src/request-timing.ts";
+
 import {
   handleSubnetMetagraph,
   handleNeuron,
@@ -606,11 +604,7 @@ import {
   degradedChainEventsPayload,
   hotTierBlockChainEvents,
 } from "../src/chain-events-degraded.ts";
-import {
-  degradedSnapshot,
-  labelDegradedResponse,
-  markDataApiTierFallbackResponse,
-} from "./request-handlers/analytics.ts";
+import { markDataApiTierFallbackResponse } from "./request-handlers/analytics.ts";
 import { loadGlobalOperationalHealth } from "../src/global-operational-health.ts";
 import {
   CHAIN_FIREHOSE_CAP_HEADER,
@@ -663,7 +657,7 @@ import {
   ResponseSchemaDriftError,
   validateResponseTripwire,
 } from "../src/response-validation-tripwire.ts";
-import { urlProjects } from "../src/projection-signal.ts";
+
 import {
   handleAuthorizeConsent,
   handleAuthorizeRequest,
@@ -768,7 +762,6 @@ import {
   MAX_WEBHOOK_BODY_BYTES,
   PERCENTILES_PATH_PATTERN,
   RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN,
-  ANONYMOUS_CLIENT_KEY,
   resolveClientIp,
   RUNTIME_VERSIONS_PATH_PATTERN,
   SUBNET_BURN_HISTORY_PATH_PATTERN,
@@ -864,8 +857,7 @@ import {
 } from "./tiered-rate-limit.ts";
 import { buildTierPolicies } from "../src/api-tiers.ts";
 import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
-import { foldObservations, observeRequest } from "../src/usage-rollup.ts";
-import type { UsageObservation } from "../src/usage-rollup.ts";
+
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
 import { withAlphaUsdEconomics } from "../src/alpha-usd-overlay.ts";
 import { readTaoUsdCurrentKv } from "./tao-usd-current.ts";
@@ -966,96 +958,6 @@ const USAGE_ROLLUP_MATCHERS = API_ROUTES.map((entry) => ({
   path: entry.path,
   pattern: compileRoutePattern(entry.path),
 }));
-
-// Fire-and-forget ALL-TRAFFIC usage rollup (#8597) -- keyed and keyless alike.
-//
-// Distinct from recordApiKeyUsage below, which it does not replace: that one is
-// per-account and only fires for requests presenting a key, powering the tenant
-// dashboard. This one has no account dimension and fires for EVERY API request,
-// because keyless traffic is the majority by design and is the entire subject
-// of the "does the free tier cost too much" question ADR 0022 defers.
-//
-// Same posture as recordApiKeyUsage: ctx.waitUntil so it adds no latency, and
-// it swallows its own failure -- a rollup miss must never surface as an error
-// on the actual API call.
-// #8823: observations are BUFFERED in the isolate and flushed in batches.
-//
-// Until this landed, foldObservations was handed a single-element array on
-// every request, so N requests meant N DATA_API subrequests, N postgres()
-// clients (withAccountsSql builds a fresh one per invocation), and N upserts
-// -- and a flood of `/api/v1/<random>` 404s all collapse to the single
-// (day, "unmatched", "edge") row, so those N upserts serialised on one row
-// lock against a self-hosted database whose capacity is ours. Nothing
-// throttles that path: /api/* is run_worker_first and the generic 404 is
-// reached without passing any of the per-surface limiters.
-//
-// The flush triggers are count-OR-age, evaluated synchronously as each
-// observation arrives (Workers has no timer that runs outside a request, so
-// the age check can only fire when a LATER request arrives -- which is
-// exactly when a flush is affordable). Both bounds are deliberately small:
-// they cap what an isolate can lose on eviction, which is the one accuracy
-// cost of buffering.
-const USAGE_ROLLUP_FLUSH_COUNT = 64;
-const USAGE_ROLLUP_FLUSH_AGE_MS = 10_000;
-let usageRollupBuffer: UsageObservation[] = [];
-let usageRollupBufferedAtMs = 0;
-
-// Exported for the tests that assert the batching property; not part of any
-// route's behaviour.
-export function usageRollupBufferSize(): number {
-  return usageRollupBuffer.length;
-}
-
-// Drain the buffer into ONE subrequest carrying every folded bucket. Drains
-// before the fetch so a concurrent request in the same isolate cannot send
-// the same observations twice. A failed POST loses that batch, the same
-// best-effort posture the single-observation write already had -- a rollup
-// miss must never surface on the API call that triggered it.
-export function flushUsageRollup(env: Env, ctx: Ctx | undefined): void {
-  if (usageRollupBuffer.length === 0) return;
-  if (!env.DATA_API?.fetch || !env.API_KEY_LOOKUP_INTERNAL_TOKEN) return;
-  const buckets = foldObservations(usageRollupBuffer);
-  usageRollupBuffer = [];
-  usageRollupBufferedAtMs = 0;
-  const pending = env.DATA_API.fetch(
-    new Request("https://api.metagraph.sh/api/v1/internal/usage-rollup", {
-      method: "POST",
-      headers: {
-        [API_KEY_LOOKUP_TOKEN_HEADER]: env.API_KEY_LOOKUP_INTERNAL_TOKEN,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ buckets }),
-    }),
-  ).catch(() => {});
-  if (typeof ctx?.waitUntil === "function") {
-    ctx.waitUntil(pending);
-  }
-}
-
-export function recordUsageRollup(
-  env: Env,
-  ctx: Ctx | undefined,
-  pathname: string,
-  keyed: boolean,
-): void {
-  if (!env.DATA_API?.fetch || !env.API_KEY_LOOKUP_INTERNAL_TOKEN) return;
-  const observation = observeRequest(pathname, USAGE_ROLLUP_MATCHERS, {
-    keyed,
-  });
-  const nowMs = Date.now();
-  if (usageRollupBuffer.length === 0) usageRollupBufferedAtMs = nowMs;
-  usageRollupBuffer.push(observation);
-  // A buffer spanning midnight needs no special case: each observation
-  // carries its own `day` and foldObservations groups on it, so the batch
-  // simply emits two buckets.
-  if (
-    usageRollupBuffer.length < USAGE_ROLLUP_FLUSH_COUNT &&
-    nowMs - usageRollupBufferedAtMs < USAGE_ROLLUP_FLUSH_AGE_MS
-  ) {
-    return;
-  }
-  flushUsageRollup(env, ctx);
-}
 
 // Fire-and-forget usage-counter increment for the self-serve dashboard
 // (#8386) -- via ctx.waitUntil so it never adds latency to the response that
@@ -1692,519 +1594,6 @@ export function usageRouteLabel(url: URL) {
  */
 function maskUsageRouteParams(pathname: string) {
   return maskRouteParams(pathname);
-}
-
-// #9446: the caller's tier, for the usage_event `auth_tier` dimension.
-//
-// `authTier` has been declared on UsageEvent since #8993 and populated ONLY on
-// the MCP path, so on REST -- the surface with 99% of the traffic -- the
-// question the tier system exists to answer ("what share of usage is
-// authenticated, and on which tier") had no data behind it at all.
-//
-// A WeakMap keyed on the Request, rather than a new parameter threaded from
-// four gate sites up through handleRequest to this wrapper. The gate already
-// resolves the tier (applyTieredRateLimit returns it and every caller
-// discarded it); this carries that answer back out without reshaping the
-// signature of every function in between, which is the same reasoning the MCP
-// side used when it put authTier on its ctx rather than passing it down.
-//
-// WeakMap and not a Map: the key is the request object itself, so an entry
-// becomes collectable the moment the request is done. There is nothing to
-// evict, nothing to size, and no way for one request's tier to be read by
-// another -- the failure mode a keyed cache would have.
-const requestAuthTier = new WeakMap<Request, string>();
-
-/**
- * The account a request authenticated as, for its usage-event distinct_id.
- *
- * A SECOND WeakMap rather than widening the one above to an object: the tier
- * is set by every gate and the account only by a key-verified one, so a single
- * entry would have to encode "tier known, account not" as a partial object at
- * every call site. Two maps say that by which one has an entry, and both stay
- * collectable with the request for the reasons the tier map already documents.
- */
-const requestAccountId = new WeakMap<Request, string>();
-
-/**
- * An error code resolved somewhere the RESPONSE cannot carry it.
- *
- * `withUsageTelemetry` reads `error_code` off the response header, which works
- * for every route that answers through `errorResponse`. It cannot work for a
- * refusal whose whole design is that the response says nothing distinguishing
- * -- the chain-firehose caps (#10606), where telling the caller which limit it
- * hit tells a scraper whether to rotate addresses. Same WeakMap-on-the-Request
- * shape as the tier above, and the same collectability argument.
- */
-const requestErrorCode = new WeakMap<Request, string>();
-
-/** Record an error code the response is deliberately not allowed to carry. */
-export function markRequestErrorCode(request: Request, code: unknown): void {
-  if (typeof code === "string" && code) requestErrorCode.set(request, code);
-}
-
-/**
- * Record the tier a request authenticated on, for its usage event.
- *
- * Called from the tiered-rate-limit gates, which are the only places that
- * verify a key. Exported for tests.
- *
- * `accountId` is optional so the pre-#10606 two-argument form still compiles
- * and still means what it did -- a gate that resolves no account passes
- * nothing, and the caller stays anonymous rather than being attributed to an
- * account it never presented.
- */
-export function markRequestAuthTier(
-  request: Request,
-  tier: unknown,
-  accountId?: unknown,
-): void {
-  if (typeof tier === "string" && tier) requestAuthTier.set(request, tier);
-  if (typeof accountId === "string" && accountId) {
-    requestAccountId.set(request, accountId);
-  }
-}
-
-/**
- * Who to count this request under, for the usage event's distinct_id.
- *
- * ## WHY REST HAD NO ANSWER TO THIS
- *
- * Every REST usage event carried the same literal id, so `uniq(distinct_id)`
- * was 1 across 142 routes and the surface with ~99% of this project's traffic
- * could not say how many callers it had. See USAGE_EVENT_DISTINCT_ID's own
- * header for the measurement and for how it surfaced.
- *
- * ## THE TWO NAMESPACES, AND WHY THEY ARE DIFFERENT KINDS OF THING
- *
- * An `account:` id is an identity the caller PRESENTED -- it authenticated
- * with a key belonging to that account. An `ip:` id is an observation we made
- * about the connection. Naming them apart keeps that distinction queryable,
- * and it is what `assignUsagePersonProcessing` reads to decide which callers
- * become person profiles (only the first: see its header for why that is a
- * cost gate and not a label).
- *
- * ## THE HASH IS SALTED, AND UNSALTED IS NOT AN OPTION
- *
- * IPv4 is 2^32 addresses -- small enough that an unsalted digest is a
- * reversible encoding of the address rather than a pseudonym, and it would put
- * a recoverable client IP in a third party's event store. So a missing salt
- * degrades to the old shared id instead of hashing without one: no salt, no
- * anonymous identity, and the count stays as uninformative as it was rather
- * than becoming informative and leaky.
- *
- * Resolved through `resolveClientIp` -- the same cf-connecting-ip-only path
- * the rate limiters use, not a second IP-extraction scheme that could disagree
- * with the thing enforcing the per-IP quotas this was written to diagnose.
- */
-async function resolveUsageDistinctId(
-  request: Request,
-  env: Env,
-): Promise<string | undefined> {
-  const accountId = requestAccountId.get(request);
-  if (accountId) return `${USAGE_ACCOUNT_NAMESPACE}${accountId}`;
-  // Read off the declared field rather than by index, so the access is typed
-  // against Env. The name is documented once as USAGE_DISTINCT_ID_SALT_ENV in
-  // src/usage-telemetry.ts, for the ops side that has to set it.
-  const salt: string | undefined = env.USAGE_DISTINCT_ID_SALT;
-  if (!salt) return undefined;
-  const ip = resolveClientIp(request);
-  // `resolveClientIp` NEVER returns falsy -- absent `cf-connecting-ip` collapses
-  // to ANONYMOUS_CLIENT_KEY, one fixed bucket, which is the right failure mode
-  // for a rate limiter and the wrong one here. Hashing it would mint a single
-  // confident-looking `ip:` id shared by every caller we could not resolve, and
-  // a count built on that reads as "one caller" exactly the way the shared
-  // fallback already did -- except now it looks specific. So an unresolved
-  // address falls back to the shared id, which at least says so.
-  if (ip !== ANONYMOUS_CLIENT_KEY) {
-    return anonymousUsageDistinctId(salt, ip);
-  }
-  // #10606: a Worker-to-Worker subrequest has no client address and IS a
-  // caller. `cf-worker` is set by Cloudflare, not by the sender, so it is
-  // trustworthy and low-cardinality -- one value per calling Worker -- and
-  // `resolveUsageClient` above already trusts it for the `client` dimension
-  // for exactly that reason.
-  //
-  // RANKED BELOW THE ADDRESS, matching `resolveUsageClient`'s own precedence:
-  // a Worker proxying a browser forwards the end user's `cf-connecting-ip`,
-  // and the person behind the proxy is the more interesting caller than the
-  // proxy. Only when there is no address at all does the calling Worker
-  // become the best available answer.
-  //
-  // Worth having rather than collapsing to the shared id: #9004 found ONE
-  // Worker (`zeronode.workers.dev`) was 82% of `block-detail`, which was in
-  // turn the largest route in the project -- a caller that dominated the
-  // traffic and could not be counted.
-  // Guarded on the SANITISED value, not the raw header: the id is what has to
-  // be non-empty, and checking the input instead would let a header that
-  // sanitises away become the bare namespace -- `worker:`, a caller whose name
-  // is the empty string, which reads as an identity and is not one.
-  const callingWorker = sanitizeUsageLabel(request.headers.get("cf-worker"));
-  if (callingWorker) {
-    return `${USAGE_WORKER_NAMESPACE}${callingWorker}`;
-  }
-  return undefined;
-}
-
-/**
- * Who made this request, for the usage_event `client` dimension.
- *
- * #9004: a Cloudflare Worker subrequest sends NO User-Agent, so all of it
- * landed in the "no client" bucket. That is not a rounding error here -- it was
- * ~93% of `block-detail`, the single largest route in the project at 758,995
- * events/day, and identifying it required a live `wrangler tail` because the
- * telemetry could not answer it. One Worker (`zeronode.workers.dev`) turned out
- * to be 82% of that route: ~380K requests/day, each one a Worker invocation, a
- * Hyperdrive round-trip AND a PostHog event.
- *
- * Cloudflare sets `cf-worker` on Worker-to-Worker subrequests, so it is
- * trustworthy (not caller-supplied) and low-cardinality (one value per calling
- * Worker). Prefixed `worker:` so provenance rides with the value and a
- * UA-derived name can never be confused with a subrequest origin -- the same
- * discipline $mcp_client_name_source applies on the MCP side.
- *
- * User-Agent wins when both are present: a real client behind a Worker proxy is
- * more interesting than the proxy.
- */
-function resolveUsageClient(request: Request): string | undefined {
-  const fromUserAgent = parseUserAgentClient(
-    request.headers.get("user-agent"),
-  ).clientName;
-  if (fromUserAgent) return fromUserAgent;
-  const cfWorker = request.headers.get("cf-worker");
-  return cfWorker ? `worker:${cfWorker}` : undefined;
-}
-
-/**
- * Run the request pipeline and record exactly one usage event for it. Returns
- * the handler's response untouched, and never converts a telemetry failure into
- * a request failure: an unconfigured deployment skips the work entirely, and a
- * recorder that rejects, throws, or a waitUntil that throws is swallowed.
- *
- * @param {Request} request
- * @param {object} env
- * @param {object} ctx ExecutionContext (may be a bare object in tests).
- * @param {() => Promise<Response>} handle
- * @param {{recordUsageEvent?: typeof recordUsageEvent}} [deps]
- * @returns {Promise<Response>}
- */
-export async function withUsageTelemetry(
-  request: Request,
-  env: Env,
-  ctx: Ctx,
-  handle: () => Promise<Response>,
-  deps: {
-    recordUsageEvent?: typeof recordUsageEvent;
-    recordExceptionEvent?: typeof recordExceptionEvent;
-  } = {},
-) {
-  const record = deps.recordUsageEvent ?? recordUsageEvent;
-  const recordException = deps.recordExceptionEvent ?? recordExceptionEvent;
-  if (!isUsageTelemetryConfigured(env)) {
-    return handle();
-  }
-
-  // A subscription upgrade (GraphQL subscriptions reuse the /api/v1/graphql
-  // path over a WebSocket) opens a long-lived socket rather than serving a
-  // request/response pair, so its latency would be meaningless. Recognized the
-  // same way handleRequest itself dispatches it.
-  if (request.headers.get("upgrade") === "websocket") {
-    return handle();
-  }
-
-  const route = usageRouteLabel(new URL(request.url));
-  if (route === null) {
-    return handle();
-  }
-
-  const startedAt = Date.now();
-  // #8963: request dimensions resolved once, up front, so they are recorded
-  // even when the handler throws (the finally block below still fires).
-  const method = request.method;
-  const client = resolveUsageClient(request);
-  let statusClass;
-  let ok = false;
-  // metagraphed#7733: errorResponse() (workers/http.ts) already sets this on
-  // every REST error -- the same established code (invalid_query,
-  // method_not_allowed, ai_error, ...) every route handler already uses, not
-  // a new taxonomy. Undefined for a success response or one that predates
-  // this convention, same "omitted, not just falsy" contract as MCP's
-  // errorCode (#7726).
-  let errorCode;
-  try {
-    const response = await handle();
-    // 4xx is a route correctly rejecting a bad request, not a broken route;
-    // only 5xx (and a thrown handler, which leaves ok false) is a failure.
-    ok = response.status < 500;
-    // Recorded alongside `ok`, not instead of it: `ok` folds every 4xx in with
-    // the successes (a route correctly rejecting a bad request is not a
-    // failure), which makes "are callers sending us garbage" unanswerable.
-    statusClass = statusClassOf(response.status);
-    errorCode =
-      response.headers.get("x-metagraph-error-code") ??
-      // #10606: a refusal whose response is deliberately uniform records its
-      // code out of band. Second, never first -- a real header is the response
-      // this request actually served, and must win.
-      requestErrorCode.get(request) ??
-      undefined;
-    // metagraphed#7734: GraphQL execution errors are a spec-mandated 200
-    // with a populated `errors` array (src/graphql.ts) -- status alone
-    // can't distinguish that from a real success, so this one code (set
-    // only when execute() surfaced a genuine resolver fault, never a
-    // deliberate/expected GraphQLError -- see graphql.ts's own
-    // genuineFaults comment) is a narrow, explicit exception to the
-    // status-based rule above. Every other route/code keeps the existing
-    // status<500 semantics untouched.
-    if (errorCode === "graphql_execution_error") {
-      ok = false;
-    }
-    return response;
-  } catch (error) {
-    // #9430: until now this wrapper was try/finally with NO catch, and
-    // workers/api.entry.ts dropped Sentry's withSentry() wrap without
-    // replacing it (#7766) -- so an uncaught throw anywhere in the REST
-    // pipeline produced a usage_event with ok:false and NOTHING ELSE. No
-    // stack, no PostHog Issue, no message: the single most severe class of
-    // failure this Worker can have was also the least diagnosable, and
-    // src/usage-telemetry.ts's own header documented the hole rather than
-    // closing it ("a truly uncaught throw has no dedicated $exception capture
-    // of its own ... just without a stack trace").
-    //
-    // Rethrown unchanged: this observes the failure, it does not handle it.
-    // The runtime still produces its own 1101/500 exactly as before, and the
-    // finally block below still records the same ok:false usage event -- so
-    // the only behavioral difference is that the stack now reaches PostHog.
-    //
-    // `route` is already resolved and low-cardinality, giving the capture the
-    // same fingerprint grouping (`<route>:<type>`) every hand-placed REST
-    // capture site already gets.
-    scheduleExceptionEvent(env, ctx, recordException, {
-      error,
-      route,
-      errorCode: "internal_error",
-    });
-    throw error;
-  } finally {
-    const endedAt = Date.now();
-    // Read AFTER the handler, since the gate that resolves it runs inside.
-    // Absent for a route with no tiered gate, which is the honest answer --
-    // those routes did not check a key, so "anonymous" would be a claim the
-    // request never actually made. Same omitted-not-defaulted contract every
-    // other optional dimension here follows.
-    const authTier = requestAuthTier.get(request);
-    scheduleUsageEvent(
-      env,
-      ctx,
-      record,
-      {
-        route,
-        ok,
-        durationMs: endedAt - startedAt,
-        method,
-        ...(statusClass ? { statusClass } : {}),
-        ...(client ? { client } : {}),
-        ...(errorCode ? { errorCode } : {}),
-        ...(authTier ? { authTier } : {}),
-      },
-      () => resolveUsageDistinctId(request, env),
-    );
-    // metagraphed#7768: PostHog distributed tracing (alpha), one root span
-    // per request -- replaces @sentry/cloudflare's automatic withSentry() HTTP
-    // instrumentation. Off by default (POSTHOG_TRACES_SAMPLE_RATE unset --
-    // see src/tracing.ts's own header for why); set it as a deployed var to
-    // match Sentry's old 0.05. Reuses this chokepoint's own route/ok/duration
-    // -- see src/tracing.ts's header for why this is an independent span (no
-    // parent) rather than nested under anything.
-    // Outcome-aware since the AI-Observability tier measurement: this Worker's
-    // REST rate is 0 (see src/tracing.ts's header for why its ~1.1M req/day
-    // stays dark), which previously meant a 5xx here produced no span EVER.
-    // Failures now always reach the recorder, bounded there by the storm
-    // guard, so "REST is dark" costs throughput visibility without also
-    // costing incident visibility.
-    if (shouldRecordTraceSpan(env, { name: route, ok })) {
-      scheduleTraceSpan(env, ctx, {
-        traceId: newTraceId(),
-        spanId: newSpanId(),
-        name: route,
-        startTimeMs: startedAt,
-        endTimeMs: endedAt,
-        ok,
-        serviceName: "metagraphed-api",
-        attributes: { route, error_code: errorCode },
-      });
-    }
-  }
-}
-
-/**
- * Hand an exception to the recorder without ever blocking or failing the
- * response. Mirrors scheduleUsageEvent/scheduleTraceSpan exactly -- telemetry
- * must never surface into the request path, least of all on a path that is
- * already failing.
- */
-function scheduleExceptionEvent(
-  env: Env,
-  ctx: Ctx,
-  record: typeof recordExceptionEvent,
-  event: Parameters<typeof recordExceptionEvent>[1],
-) {
-  try {
-    const pending = Promise.resolve(record(env, event)).catch(() => false);
-    if (typeof ctx?.waitUntil === "function") {
-      ctx.waitUntil(pending);
-    }
-  } catch {
-    // Telemetry must never surface into the request path.
-  }
-}
-
-function scheduleTraceSpan(
-  env: Env,
-  ctx: Ctx,
-  span: Parameters<typeof recordTraceSpan>[1],
-) {
-  try {
-    const pending = Promise.resolve(recordTraceSpan(env, span)).catch(
-      () => false,
-    );
-    if (typeof ctx?.waitUntil === "function") {
-      ctx.waitUntil(pending);
-    }
-  } catch {
-    // Telemetry must never surface into the request path.
-  }
-}
-
-/**
- * Hand the event to the recorder without ever blocking or failing the response.
- *
- * @param {object} env
- * @param {object} ctx
- * @param {typeof recordUsageEvent} record
- * @param {object} event
- */
-function scheduleUsageEvent(
-  env: Env,
-  ctx: Ctx,
-  record: typeof recordUsageEvent,
-  event: UsageEvent,
-  /**
-   * Resolves the caller's distinct_id, INSIDE the scheduled work.
-   *
-   * A thunk rather than a resolved string because resolving it hashes, and
-   * `withUsageTelemetry` awaits its telemetry in a `finally` -- an await there
-   * happens before the function returns, so computing this eagerly would put a
-   * SubtleCrypto digest in front of every response on a Worker serving ~1.1M
-   * requests a day. Deferring it into the waitUntil keeps the request path
-   * exactly as long as it was.
-   */
-  resolveDistinctId?: () => Promise<string | undefined>,
-) {
-  try {
-    const pending = Promise.resolve(
-      resolveDistinctId
-        ? resolveDistinctId().then((distinctId) =>
-            record(env, event, distinctId ? { distinctId } : {}),
-          )
-        : record(env, event),
-    ).catch(() => false);
-    if (typeof ctx?.waitUntil === "function") {
-      ctx.waitUntil(pending);
-    }
-  } catch {
-    // Telemetry must never surface into the request path.
-  }
-}
-
-/**
- * Staged response audit for the routes the in-path tripwire cannot reach
- * (#10984). The entity handlers (per-UID metagraph, accounts, blocks,
- * extrinsics, chain-*) assemble their envelopes outside handleApiRequest's
- * generic seam, so METAGRAPH_VALIDATE_RESPONSES never sees them -- and
- * turning enforcement on for bodies never validated anywhere is how #10897
- * spent 26 hours serving 500s. This is the warn-first path the issue
- * prescribes:
- *
- *   METAGRAPH_AUDIT_RESPONSES unset  -- off (the flag check is the only cost)
- *   "warn"                           -- validate a CLONE under waitUntil and
- *                                       log each drift fingerprint; the body
- *                                       the caller gets is untouched
- *   "enforce"                        -- validate in-path and substitute the
- *                                       same refusal the generic seam serves
- *
- * Promotion is a flag flip, not a deploy of new logic: enforce reuses exactly
- * the code warn exercised. The route's TEMPLATE comes from matchRoute (the
- * #10985 lookup), so the resolver never sees a concrete path. A response the
- * generic seam already validated gets re-parsed here only while the audit
- * flag is set -- the staging cost, paid on purpose and only during staging.
- *
- * `projected` is passed when the request carried a fields/sections parameter:
- * the handler-level projections (metagraph-neurons, emission-pipeline) never
- * set meta.projection, so the URL is the only honest signal at this seam.
- */
-// EXPORTED for its own tests: the drift arm needs a body no local route
-// serves (the entity stores are empty locally, and empty arrays validate), so
-// the suite hands it crafted responses directly.
-export async function auditResponse(
-  request: Request,
-  env: Env,
-  ctx: Ctx,
-  response: Response,
-): Promise<Response> {
-  const mode = env.METAGRAPH_AUDIT_RESPONSES as string | undefined;
-  if (mode !== "warn" && mode !== "enforce") return response;
-  if (response.status !== 200) return response;
-  if (!response.headers.get("content-type")?.includes("json")) return response;
-  const url = new URL(request.url);
-  const matched = matchRoute(url.pathname);
-  if (!matched?.artifactTemplate) return response;
-  // The three levers are declared once, in src/projection-signal.ts, because
-  // the MCP dispatch answers the same question about the same contract and was
-  // answering it differently -- which is to say not at all (#11142).
-  const projected = urlProjects(url.searchParams);
-  const run = async (body: unknown) => {
-    await validateResponseTripwire(
-      matched.id,
-      body,
-      matched.artifactTemplate,
-      projected,
-    );
-  };
-  if (mode === "warn") {
-    const clone = response.clone();
-    ctx.waitUntil?.(
-      (async () => {
-        try {
-          await run(await clone.json());
-        } catch (err) {
-          if (err instanceof ResponseSchemaDriftError) {
-            console.warn(
-              `[METAGRAPH_AUDIT_RESPONSES] ${matched.id} DRIFTED (warn):`,
-              JSON.stringify(err.detail).slice(0, 2000),
-            );
-          }
-        }
-      })(),
-    );
-    return response;
-  }
-  try {
-    await run(await response.clone().json());
-    return response;
-  } catch (err) {
-    if (err instanceof ResponseSchemaDriftError) {
-      console.error(
-        `[METAGRAPH_AUDIT_RESPONSES] ${matched.id} refused:`,
-        err.detail,
-      );
-      return errorResponse(
-        "response_schema_drift",
-        `The ${matched.id} response did not match its published schema and was refused rather than served.`,
-        500,
-        { artifact_path: matched.artifactPath },
-      );
-    }
-    return response;
-  }
 }
 
 /**
@@ -6121,31 +5510,7 @@ async function handleChainFirehoseIngest(request: Request, env: Env) {
  * unforgettable rather than 40 more places to remember.
  */
 export async function handleRequest(request: Request, env: Env, ctx: Ctx = {}) {
-  return withRequestTiming(async () => {
-    const before = degradedSnapshot();
-    const response = await dispatchCached(request, env, ctx);
-    labelDegradedResponse(response, before);
-    // WHERE THE MILLISECONDS WENT, as the standard header a browser's devtools
-    // panel already renders. Set here for the same reason the degraded label is
-    // -- one point every route passes -- and built from marks collected at the
-    // three storage boundaries rather than by instrumenting handlers, so a
-    // route written next year is covered without its author doing anything.
-    //
-    // IN PLACE, swallowing an immutable-headers throw, exactly as
-    // `labelDegradedResponse` documents. The one response class with immutable
-    // headers is a body read back out of the edge cache, whose timings belong
-    // to the request that STORED it -- losing the header there is correct,
-    // because this request spent none of that time.
-    const timing = serverTimingHeader();
-    if (timing !== null) {
-      try {
-        response.headers.set("server-timing", timing);
-      } catch {
-        // A cached body; see above.
-      }
-    }
-    return response;
-  });
+  return withResponseTiming(() => dispatchCached(request, env, ctx));
 }
 
 /**
@@ -9890,11 +9255,6 @@ configureAnalyticsRoutes({ readHealthMetaKv, readEconomicsCurrentKv });
 // handler module has dropped back to its unwired placeholders — leaving the
 // process in exactly the state a fresh import would produce.
 registerModuleStateReset("workers/api.ts", () => {
-  // #8823: the usage-rollup buffer is module-scoped isolate state, so it
-  // must reset between test files exactly like the memos below -- a leftover
-  // observation would otherwise shift the next file's flush boundary.
-  usageRollupBuffer = [];
-  usageRollupBufferedAtMs = 0;
   healthMetaKvMemo = { env: null, value: null, expiresAt: 0 };
   economicsCurrentKvMemo = { env: null, value: null, expiresAt: 0 };
   chainEventsDbMemo = { env: null, value: null, expiresAt: 0 };
@@ -11556,4 +10916,41 @@ function corsPreflight(request: Request) {
   );
   headers.set("access-control-max-age", "86400");
   return new Response(null, { status: 204, headers });
+}
+
+export function withUsageTelemetry(
+  request: Request,
+  env: Env,
+  ctx: Ctx,
+  handle: () => Promise<Response>,
+  deps: {
+    recordUsageEvent?: typeof recordUsageEvent;
+    recordExceptionEvent?: typeof recordExceptionEvent;
+  } = {},
+) {
+  return withRequestUsageTelemetry(
+    request,
+    env,
+    ctx,
+    handle,
+    usageRouteLabel,
+    deps,
+  );
+}
+export function auditResponse(
+  request: Request,
+  env: Env,
+  ctx: Ctx,
+  response: Response,
+): Promise<Response> {
+  return auditRouteResponse(request, env, ctx, response, matchRoute);
+}
+
+export function recordUsageRollup(
+  env: Env,
+  ctx: Ctx | undefined,
+  pathname: string,
+  keyed: boolean,
+): void {
+  recordMatchedUsageRollup(env, ctx, pathname, keyed, USAGE_ROLLUP_MATCHERS);
 }

--- a/workers/edge-cache.ts
+++ b/workers/edge-cache.ts
@@ -1,0 +1,408 @@
+// Shared edge-cache and degradation handling, without analytics route startup.
+import {
+  type ChainNetworkId,
+  DEFAULT_CHAIN_NETWORK,
+} from "../src/chain-network.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import { ifNoneMatchSatisfied, withCacheStatus } from "./http.ts";
+import { contractVersion } from "./responses.ts";
+import { currentDataApiTierFallbackGeneration } from "./data-api-tier.ts";
+import { currentR2SqlFailureGeneration } from "../src/r2-sql.ts";
+import { currentOffsetCapDeclineGeneration } from "../src/r2-sql-blocks.ts";
+const DATA_API_TIER_FALLBACK_RESPONSES = new WeakSet<Response>();
+
+/**
+ * The header a degraded response carries (#9110).
+ *
+ * A tier miss used to be invisible to the caller: the empty payload came back
+ * `ok: true` with the same headers as a real one, so `total_extrinsics: 0` from
+ * a missed tier read exactly like a measured zero. Observed live —
+ * /api/v1/chain/calls?window=30d returned 0 in the same minute ?window=7d
+ * returned 1,347,135, and 5,118,674 on the next attempt. That is worse than an
+ * error: a client retries a 503 and publishes a zero.
+ *
+ * A HEADER and not a body field, deliberately. Writing `meta.degraded` into the
+ * envelope means re-serialising it, which invalidates the ETag
+ * `envelopeResponse` already computed — and recomputing it breaks conditional
+ * requests, because the retry recomputes the ETag from the UNLABELLED body and
+ * no longer matches. That is not hypothetical; it broke
+ * "a warm cache honours conditional requests with a 304" when this was tried
+ * body-first. The header carries the same information, costs no
+ * re-serialisation, and works for the CSV variants too.
+ */
+export const DEGRADED_HEADER = "x-metagraph-degraded";
+
+export const DEGRADED_TIER_UNAVAILABLE = "tier_unavailable";
+
+/**
+ * An UNMEASURED answer is not the same thing as a DEGRADED one, and #10189
+ * turns on keeping them apart.
+ *
+ * #9110 gave withEdgeCache one signal for both: tryDataApiTier's counter set
+ * the `x-metagraph-degraded` header AND suppressed caching, which was right
+ * while the two always coincided -- a tier that just failed will probably
+ * succeed next minute, so caching the failure prolongs it.
+ *
+ * A projection decline is different. `loadChainFeesFromArtifact` and its
+ * siblings return null on an absent artifact, an unknown window, or a scope
+ * they never precompute -- states that are stable for the whole cache TTL, not
+ * transient failures. Those answers SHOULD carry the header (a caller must not
+ * read zeros as measured) and SHOULD still be cacheable, which is what the
+ * suite already asserts in a dozen places ("chain-signers ... is
+ * edge-cacheable", "a healthy CSV response is edge-cached").
+ *
+ * So this counter labels without suppressing, and tryDataApiTier's keeps
+ * doing both. Wrapping the final `?? build…()` operand is what makes it exact:
+ * `??` short-circuits, so it runs on precisely the requests that get an empty
+ * body and never on one carrying data.
+ *
+ * Measured 2026-08-08, driving each route with no flag forced -- the
+ * configuration production actually runs -- 9 of 12 answered `ok: true` with
+ * zeros and no header at all.
+ */
+let unmeasuredGeneration = 0;
+
+registerModuleStateReset("workers/edge-cache.ts:unmeasured", () => {
+  unmeasuredGeneration = 0;
+});
+
+export function unmeasured<T>(stub: T): T {
+  unmeasuredGeneration += 1;
+  return stub;
+}
+
+/**
+ * Set the degraded header, returning the SAME object where possible.
+ *
+ * Identity matters: `withEdgeCache` reads a WeakSet on the object it gets
+ * back, and handlers pass this response straight on, so returning a copy would
+ * break that invariant. A response read back out of the edge cache has
+ * immutable headers -- that path does not reach here today, and copying is the
+ * right fallback if it ever does, rather than throwing on a degraded response.
+ */
+function withDegradedHeader(response: Response): Response {
+  try {
+    response.headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+/**
+ * Tag a response as having used the empty-fallback path, and say so to the
+ * caller.
+ *
+ * Adds the never-cache WeakSet membership on top of the header (the #1760 bug
+ * class it exists for): a tier that just failed will likely succeed on the next
+ * request, so persisting the failure would prolong it. An UNMEASURED answer
+ * takes the header alone -- see `unmeasured`.
+ */
+export function markDataApiTierFallbackResponse(response: Response): Response {
+  const marked = withDegradedHeader(response);
+  DATA_API_TIER_FALLBACK_RESPONSES.add(marked);
+  return marked;
+}
+
+/**
+ * Every "this answer was not measured" counter, read as one value (#10270).
+ *
+ * There are three of them and they lived in three modules, so each place that
+ * wanted to know whether an answer was real had to remember the full list.
+ * `withEdgeCache` remembered two; the r2-sql one it never knew about at all,
+ * even though `src/r2-sql.ts` declares its counter with "same contract as the
+ * Postgres tier's fallback generation: a caller can snapshot this before a
+ * read and compare after". Nothing outside its own test file ever did --
+ * measured repo-wide, `currentR2SqlFailureGeneration` had zero production
+ * readers -- which is why `/accounts/{ss58}/counterparties` could answer
+ * `counterparty_count: 0, transfers_scanned: 0` with `ok: true` and no header
+ * while the lakehouse was rate-limited. That route's Postgres rung is
+ * `"retired"` in wrangler.jsonc, so the r2-sql read IS the tier; a signal
+ * nobody reads is the same as no signal.
+ */
+export interface DegradedSnapshot {
+  postgresTier: number;
+  r2Sql: number;
+  unmeasured: number;
+  /**
+   * Reads that declined a too-deep offset WITHOUT issuing a query (#11142).
+   *
+   * A fourth counter because the other three cannot see this one. `r2Sql`
+   * moves when a query fails; the emulated-offset cap is checked before any SQL
+   * is built, so nothing is sent, nothing fails, and the answer went out as a
+   * bare 200 whose body was byte-identical to end-of-feed -- on ten paginated
+   * routes, edge-cached for the TTL.
+   *
+   * Counted at the single check in `offsetBeyondEmulationCap` rather than at
+   * each route's `?? build...([])`, because there are 92 of those and the whole
+   * design of this labelling is that no handler has to remember it.
+   */
+  offsetCapDeclined: number;
+}
+
+export function degradedSnapshot(): DegradedSnapshot {
+  return {
+    postgresTier: currentDataApiTierFallbackGeneration(),
+    r2Sql: currentR2SqlFailureGeneration(),
+    unmeasured: unmeasuredGeneration,
+    offsetCapDeclined: currentOffsetCapDeclineGeneration(),
+  };
+}
+
+/**
+ * What moved since `before`, split by how long it will stay true.
+ *
+ * TRANSIENT is a tier that failed or backed off -- a DATA_API subrequest that
+ * did not land, an r2-sql timeout, the account rate-limit breaker declining to
+ * ask. It will likely succeed on the next request, so the answer is labelled
+ * AND barred from the edge cache; persisting it would prolong the outage
+ * (#1760).
+ *
+ * UNMEASURED is a stable decline: a projection this route never precomputes,
+ * an artifact that is absent. Still labelled -- a caller must not read those
+ * zeros as measured -- but cacheable for the whole TTL, because it will answer
+ * the same way for the whole TTL (#10189).
+ */
+export function degradedSince(before: DegradedSnapshot): {
+  transient: boolean;
+  unmeasured: boolean;
+} {
+  const now = degradedSnapshot();
+  return {
+    transient:
+      now.postgresTier !== before.postgresTier || now.r2Sql !== before.r2Sql,
+    // An offset-cap decline is UNMEASURED, not transient: the same offset
+    // declines identically for the whole TTL, so the answer stays cacheable and
+    // merely stops claiming to be measured. Barring it from the cache would
+    // re-run a refusal that cannot change.
+    unmeasured:
+      now.unmeasured !== before.unmeasured ||
+      now.offsetCapDeclined !== before.offsetCapDeclined,
+  };
+}
+
+/**
+ * Label a response whose data tier declined while it was being served.
+ *
+ * Called from the router (`workers/api.ts`), which is the ONE point every
+ * route passes -- the same argument #9110 made for labelling inside
+ * `withEdgeCache` rather than in each handler, applied to the 71 tier-reading
+ * handlers in `workers/request-handlers/entities.ts` that #9110 never covered
+ * because not one of them uses `withEdgeCache`.
+ *
+ * HEADER ONLY, no cache-control rewrite. These routes have no server-side
+ * cache to poison -- measured live 2026-08-09, an api.metagraph.sh response
+ * carries no `cf-cache-status` at all, so the Workers Cache API inside
+ * `withEdgeCache` is the only cache in play and it makes its own decision from
+ * the same snapshot. Rewriting `cache-control` here would instead make every
+ * response in an isolate uncacheable for the length of an r2-sql cooldown,
+ * which is load amplification aimed at the exact condition the breaker exists
+ * to relieve.
+ *
+ * A 304 is skipped: the caller already holds the body its ETag names, and
+ * there is nothing in a 304 to mislabel. A response that already carries the
+ * header is left alone rather than re-set, so a handler that classified its
+ * own degradation keeps its own wording.
+ *
+ * IN PLACE, returning nothing, which is a deliberate difference from
+ * `withDegradedHeader`'s copy-on-immutable fallback. The one response class
+ * with immutable headers is a body read back out of the edge cache, and
+ * `withEdgeCache` only ever stored a MEASURED answer there -- so a throw here
+ * means a concurrent request degraded while this one was served from cache,
+ * and relabelling a known-good cached body on that evidence would be the false
+ * positive rather than the catch. Swallowing it is the correct answer, not the
+ * convenient one. Mutating also keeps the router's return type exactly what
+ * the dispatch inferred, so the label costs no signature change at ~40 return
+ * sites.
+ */
+export function labelDegradedResponse(
+  response: Response,
+  before: DegradedSnapshot,
+): void {
+  if (response.status !== 200) return;
+  if (response.headers.has(DEGRADED_HEADER)) return;
+  const moved = degradedSince(before);
+  if (!moved.transient && !moved.unmeasured) return;
+  try {
+    response.headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
+  } catch {
+    // An immutable-headers response: see above.
+  }
+}
+
+// Edge-cache wrapper for the Postgres-backed analytics routes (audit #6). Each
+// of these re-runs a full-window Postgres aggregation on EVERY request, yet
+// the result only changes when the health cron writes a new snapshot — so a
+// cross-colo / agent-polling burst re-executes the same 7d/30d aggregation
+// needlessly (D1 fully eliminated 2026-07-17 -- see this file's own header).
+// Mirrors the
+// live-overlay collection cache exactly (the CACHEABLE_OVERLAY_ROUTE_IDS path):
+// same Cache API, same `edge-cache.metagraph.sh` key host, same last_run_at
+// keying, same conditional-GET 304 short-circuit, same ctx.waitUntil put.
+//
+// The key varies on everything that changes the body: contract_version (a deploy
+// can never serve a cross-version payload) + a freshness stamp + the request
+// path (carries netuid) + the canonical search (carries `window`). The stamp is
+// the health cron snapshot (`last_run_at`) for every route, including chain/
+// identity-history -- its own bespoke `readIdentityHistoryCacheStamp` stamp was
+// retired alongside the D1 read it existed to bust on (D1 fully eliminated,
+// 2026-07-16), the same way the neurons/neuron_daily-backed stamps were
+// retired when #4772 dropped those tables from D1. `resolveCacheStamp` stays
+// as an override hook for any future bespoke-stamp need, just unused today.
+// `keyParts` is the extra namespace segment per route. When the stamp is cold
+// (null), caching is skipped entirely so a cold-KV/empty payload can never seed
+// a stale entry — identical to the overlay cache's `if (lastRunAt)` guard. The
+// cache is transparent: body/shape/headers are whatever buildResponse() produced;
+// only 200s are cached, never errors.
+// Loose, structural ExecutionContext -- every call site here either receives
+// the real Workers-runtime ExecutionContext or, from a handler invoked with no
+// ctx (e.g. a direct unit-test call), the `= {}` default; both only ever need
+// `waitUntil`, so a full ExecutionContext isn't required to satisfy this type.
+export interface EdgeCacheCtx {
+  waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+/**
+ * An edge-cache label scoped to its chain.
+ *
+ * MAINNET KEEPS ITS BARE LABEL, so every warm entry survives this change and a
+ * mainnet request hits the key it hit before. The `/{network}/` prefix is
+ * stripped before dispatch, so without this the two chains reach these handlers
+ * with byte-identical paths and would share one cache entry -- and since their
+ * shapes are identical, a testnet card served to a mainnet caller would look
+ * completely well-formed.
+ */
+export function edgeCacheScope(
+  label: string,
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+): string {
+  return network === DEFAULT_CHAIN_NETWORK ? label : `${label}:${network}`;
+}
+
+export async function withStampedEdgeCache(
+  request: Request,
+  ctx: EdgeCacheCtx | undefined,
+  env: Env,
+  keyParts: string,
+  buildResponse: (cacheRequest: Request) => Response | Promise<Response>,
+  cachePathAndSearch: string | null,
+  resolveCacheStamp: (env: Env) => Promise<string | null>,
+): Promise<Response> {
+  const isHead = request.method === "HEAD";
+  // Only opt HEAD into the GET cache path for handlers that accept the
+  // normalized request. Legacy zero-arg builders may close over the original
+  // HEAD request and return a bodyless response, which must not seed the GET
+  // cache for later clients.
+  const normalizesHead = isHead && buildResponse.length > 0;
+  const cacheRequest = normalizesHead
+    ? new Request(request, { method: "GET" })
+    : request;
+  // `globalThis.caches` (not the bare `caches` global) so the optional
+  // chain actually guards: Node/vitest has no Cache API global at all,
+  // unlike the real Workers runtime where `caches` is always populated --
+  // the bare identifier's ambient `declare const caches: CacheStorage` types
+  // it as unconditionally present, which would be true at compile time but
+  // false at this test-runtime.
+  const cache =
+    cacheRequest.method === "GET"
+      ? (globalThis as { caches?: CacheStorage }).caches?.default
+      : null;
+  // Cheap freshness read. On a hit this + the cache match is the whole request
+  // (no D1 aggregation at all for the handler body).
+  let stamp = null;
+  if (cache) {
+    stamp = await resolveCacheStamp(env);
+  }
+  let cacheKey = null;
+  if (cache && stamp) {
+    const url = new URL(cacheRequest.url);
+    const cacheRoute = cachePathAndSearch ?? `${url.pathname}${url.search}`;
+    cacheKey = new Request(
+      `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
+        contractVersion(env),
+      )}/${encodeURIComponent(stamp)}/${keyParts}${cacheRoute}`,
+    );
+    const hit = await cache.match(cacheKey);
+    if (hit) {
+      // Honour conditional requests against the cached body's weak ETag so
+      // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
+      if (ifNoneMatchSatisfied(request, hit.headers.get("etag") || "")) {
+        return withCacheStatus(
+          new Response(null, { status: 304, headers: hit.headers }),
+          "hit",
+        );
+      }
+      return withCacheStatus(
+        normalizesHead
+          ? new Response(null, { status: hit.status, headers: hit.headers })
+          : hit,
+        "hit",
+      );
+    }
+  }
+  const before = degradedSnapshot();
+  const built = await buildResponse(cacheRequest);
+  // #9110: the generation counter already told us the tier degraded while this
+  // request was being served -- it is what suppresses caching two lines down.
+  // Until now that was the ONLY thing it did, so 16 of the 21 tier-reading
+  // handlers returned an unlabelled empty payload: `total: 0`, `ok: true`, and
+  // no way for a caller to tell it from a measured zero.
+  //
+  // Labelling here rather than in each handler is deliberate. Only 5 of the 21
+  // remembered to call markDataApiTierFallbackResponse; a per-handler flag is
+  // exactly the thing the 22nd handler will forget. Every one of them already
+  // goes through this function.
+  //
+  // The counter is module-global, so a CONCURRENT request degrading can label
+  // this one too. That is the same trade the cache-suppression below already
+  // makes, and it errs the safe way: a false "degraded" makes good data look
+  // suspect, where the bug it replaces made missing data look measured.
+  //
+  // #10270: the r2-sql counter joined the two this used to read by name. It
+  // was declared for exactly this comparison and had no reader -- see
+  // `degradedSnapshot`. The suppression below is what it was declared FOR: an
+  // r2-sql decline is a 60s account-wide breaker, and caching its empty answer
+  // for the full TTL outlives the condition that produced it.
+  const moved = degradedSince(before);
+  const degraded =
+    DATA_API_TIER_FALLBACK_RESPONSES.has(built) || moved.transient;
+  // #10189: an unmeasured answer is labelled but NOT made uncacheable. See
+  // `unmeasured` above for why the two signals have to be separate -- a
+  // projection decline is stable for the whole TTL, where a tier failure is
+  // transient and caching it would prolong the outage.
+  const labelled = built.status === 200 && !built.headers.has(DEGRADED_HEADER);
+  let response = built;
+  if (labelled && degraded) {
+    response = markDataApiTierFallbackResponse(built);
+  } else if (labelled && moved.unmeasured) {
+    response = withDegradedHeader(built);
+  }
+  // Never cache errors / non-200s (a cold Postgres tier still returns a 200
+  // empty envelope; a 400 bad-window or 5xx must not be persisted).
+  if (
+    cache &&
+    cacheKey &&
+    response.status === 200 &&
+    !DATA_API_TIER_FALLBACK_RESPONSES.has(response) &&
+    !moved.transient
+  ) {
+    ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
+  }
+  // Stamped AFTER the `cache.put` above, which stores `response.clone()`, so
+  // the stored copy stays unlabelled. See `withCacheStatus`.
+  return withCacheStatus(
+    normalizesHead
+      ? new Response(null, {
+          status: response.status,
+          headers: response.headers,
+        })
+      : response,
+    "miss",
+  );
+}

--- a/workers/explorer-directory-entry.ts
+++ b/workers/explorer-directory-entry.ts
@@ -1,0 +1,80 @@
+// The two default website requests can use the shared protocol and handlers
+// without initializing the complete router, cron jobs or OAuth provider.
+import {
+  handleAccountHolderDirectory,
+  handleValidatorOperatorDirectory,
+} from "./request-handlers/explorer-directories.ts";
+import { withStampedEdgeCache } from "./edge-cache.ts";
+import { readExplorerDirectoryCacheStamp } from "./data-api-tier.ts";
+import {
+  auditRouteResponse,
+  withRequestUsageTelemetry,
+  withResponseTiming,
+} from "./request-lifecycle.ts";
+import { recordMatchedUsageRollup } from "./usage-rollup.ts";
+
+export const EXPLORER_DIRECTORY_ENTRIES = [
+  {
+    path: "/api/v1/accounts/directory",
+    id: "account-holder-directory",
+    artifactTemplate: "/metagraph/accounts/directory.json",
+    artifactPath: "/metagraph/accounts/directory.json",
+    handle: handleAccountHolderDirectory,
+  },
+  {
+    path: "/api/v1/validators/operators",
+    id: "validator-operator-directory",
+    artifactTemplate: "/metagraph/validators/operators.json",
+    artifactPath: "/metagraph/validators/operators.json",
+    handle: handleValidatorOperatorDirectory,
+  },
+] as const;
+
+const usageMatchers = EXPLORER_DIRECTORY_ENTRIES.map(({ path }) => ({
+  path,
+  pattern: new RegExp(`^${path}$`),
+}));
+
+export async function handleDefaultExplorerDirectory(
+  request: Request,
+  env: Env,
+  ctx: { waitUntil?: (promise: Promise<unknown>) => void },
+): Promise<Response | null> {
+  // Variants continue through the existing router's query, network, method and
+  // payment gates. This entry owns only the two anonymous default reads.
+  if (
+    (request.method !== "GET" && request.method !== "HEAD") ||
+    env.METAGRAPH_NEURONS_SOURCE !== "data-api" ||
+    request.headers.has("authorization") ||
+    request.headers.has("x-payment") ||
+    request.headers.has("payment-signature") ||
+    request.headers.has("upgrade")
+  )
+    return null;
+  const url = new URL(request.url);
+  if (url.search) return null;
+  const entry = EXPLORER_DIRECTORY_ENTRIES.find(
+    (row) => row.path === url.pathname,
+  );
+  if (!entry) return null;
+  const response = await withRequestUsageTelemetry(
+    request,
+    env,
+    ctx,
+    () =>
+      withResponseTiming(() => {
+        recordMatchedUsageRollup(env, ctx, url.pathname, false, usageMatchers);
+        return withStampedEdgeCache(
+          request,
+          ctx,
+          env,
+          entry.id,
+          (cacheRequest) => entry.handle(cacheRequest, env),
+          entry.path,
+          readExplorerDirectoryCacheStamp,
+        );
+      }),
+    () => entry.id,
+  );
+  return auditRouteResponse(request, env, ctx, response, () => entry);
+}

--- a/workers/explorer-directory-entry.ts
+++ b/workers/explorer-directory-entry.ts
@@ -46,6 +46,7 @@ export async function handleDefaultExplorerDirectory(
     (request.method !== "GET" && request.method !== "HEAD") ||
     env.METAGRAPH_NEURONS_SOURCE !== "data-api" ||
     request.headers.has("authorization") ||
+    request.headers.has("x-api-key") ||
     request.headers.has("x-payment") ||
     request.headers.has("payment-signature") ||
     request.headers.has("upgrade")

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -3,7 +3,7 @@
 // (issue #510, de-monolith) as a leaf module: it imports only contract/config
 // constants and nothing from api.ts, so every request-handler module can share
 // these without an import cycle.
-import { CACHE_SECONDS, CONTRACT_VERSION } from "../src/contracts.ts";
+import { CACHE_SECONDS, CONTRACT_VERSION } from "../src/contract-constants.ts";
 import { JSON_CONTENT_TYPE } from "./config.ts";
 
 export type CacheProfile = "short" | "standard" | "static";

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -1,3 +1,19 @@
+import {
+  withStampedEdgeCache,
+  unmeasured,
+  markDataApiTierFallbackResponse,
+  edgeCacheScope,
+  type EdgeCacheCtx,
+} from "../edge-cache.ts";
+export {
+  DEGRADED_TIER_UNAVAILABLE,
+  DEGRADED_HEADER,
+  unmeasured,
+  degradedSnapshot,
+  labelDegradedResponse,
+  edgeCacheScope,
+  type EdgeCacheCtx,
+} from "../edge-cache.ts";
 // Analytics handlers + the edge-cache guard that protects them.
 //
 // D1 fully eliminated (2026-07-17, reconfirmed live 2026-07-25 -- zero D1
@@ -52,22 +68,16 @@ import { loadChainWeightsFromArtifact } from "../../src/chain-weights-artifact.t
 import { loadChainWeightSettersColdTier } from "../../src/chain-weight-setters-loader.ts";
 import { loadChainWeightSettersFromArtifact } from "../../src/chain-weight-setters-artifact.ts";
 import { registerModuleStateReset } from "../../src/module-state-registry.ts";
-import {
-  errorResponse,
-  ifNoneMatchSatisfied,
-  withCacheStatus,
-} from "../http.ts";
+import { errorResponse } from "../http.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
 import {
   contractVersion,
   envelopeResponse,
   publishedAt,
 } from "../responses.ts";
-import { currentDataApiTierFallbackGeneration } from "../data-api-tier.ts";
-import { currentR2SqlFailureGeneration } from "../../src/r2-sql.ts";
-import { currentOffsetCapDeclineGeneration } from "../../src/r2-sql-blocks.ts";
+
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.ts";
-import {} from "../../src/route-limits.ts";
+
 import { formatGlobalIncidents } from "../../src/health-serving.ts";
 import {
   applyQueryFilters,
@@ -248,235 +258,6 @@ function analyticsQueryError(error: QueryError): Response {
   });
 }
 
-const DATA_API_TIER_FALLBACK_RESPONSES = new WeakSet<Response>();
-
-/**
- * The header a degraded response carries (#9110).
- *
- * A tier miss used to be invisible to the caller: the empty payload came back
- * `ok: true` with the same headers as a real one, so `total_extrinsics: 0` from
- * a missed tier read exactly like a measured zero. Observed live —
- * /api/v1/chain/calls?window=30d returned 0 in the same minute ?window=7d
- * returned 1,347,135, and 5,118,674 on the next attempt. That is worse than an
- * error: a client retries a 503 and publishes a zero.
- *
- * A HEADER and not a body field, deliberately. Writing `meta.degraded` into the
- * envelope means re-serialising it, which invalidates the ETag
- * `envelopeResponse` already computed — and recomputing it breaks conditional
- * requests, because the retry recomputes the ETag from the UNLABELLED body and
- * no longer matches. That is not hypothetical; it broke
- * "a warm cache honours conditional requests with a 304" when this was tried
- * body-first. The header carries the same information, costs no
- * re-serialisation, and works for the CSV variants too.
- */
-export const DEGRADED_HEADER = "x-metagraph-degraded";
-export const DEGRADED_TIER_UNAVAILABLE = "tier_unavailable";
-
-/**
- * An UNMEASURED answer is not the same thing as a DEGRADED one, and #10189
- * turns on keeping them apart.
- *
- * #9110 gave withEdgeCache one signal for both: tryDataApiTier's counter set
- * the `x-metagraph-degraded` header AND suppressed caching, which was right
- * while the two always coincided -- a tier that just failed will probably
- * succeed next minute, so caching the failure prolongs it.
- *
- * A projection decline is different. `loadChainFeesFromArtifact` and its
- * siblings return null on an absent artifact, an unknown window, or a scope
- * they never precompute -- states that are stable for the whole cache TTL, not
- * transient failures. Those answers SHOULD carry the header (a caller must not
- * read zeros as measured) and SHOULD still be cacheable, which is what the
- * suite already asserts in a dozen places ("chain-signers ... is
- * edge-cacheable", "a healthy CSV response is edge-cached").
- *
- * So this counter labels without suppressing, and tryDataApiTier's keeps
- * doing both. Wrapping the final `?? build…()` operand is what makes it exact:
- * `??` short-circuits, so it runs on precisely the requests that get an empty
- * body and never on one carrying data.
- *
- * Measured 2026-08-08, driving each route with no flag forced -- the
- * configuration production actually runs -- 9 of 12 answered `ok: true` with
- * zeros and no header at all.
- */
-let unmeasuredGeneration = 0;
-
-registerModuleStateReset(
-  "workers/request-handlers/analytics.ts:unmeasured",
-  () => {
-    unmeasuredGeneration = 0;
-  },
-);
-
-export function unmeasured<T>(stub: T): T {
-  unmeasuredGeneration += 1;
-  return stub;
-}
-
-/**
- * Set the degraded header, returning the SAME object where possible.
- *
- * Identity matters: `withEdgeCache` reads a WeakSet on the object it gets
- * back, and handlers pass this response straight on, so returning a copy would
- * break that invariant. A response read back out of the edge cache has
- * immutable headers -- that path does not reach here today, and copying is the
- * right fallback if it ever does, rather than throwing on a degraded response.
- */
-function withDegradedHeader(response: Response): Response {
-  try {
-    response.headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
-    return response;
-  } catch {
-    const headers = new Headers(response.headers);
-    headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  }
-}
-
-/**
- * Tag a response as having used the empty-fallback path, and say so to the
- * caller.
- *
- * Adds the never-cache WeakSet membership on top of the header (the #1760 bug
- * class it exists for): a tier that just failed will likely succeed on the next
- * request, so persisting the failure would prolong it. An UNMEASURED answer
- * takes the header alone -- see `unmeasured`.
- */
-function markDataApiTierFallbackResponse(response: Response): Response {
-  const marked = withDegradedHeader(response);
-  DATA_API_TIER_FALLBACK_RESPONSES.add(marked);
-  return marked;
-}
-
-/**
- * Every "this answer was not measured" counter, read as one value (#10270).
- *
- * There are three of them and they lived in three modules, so each place that
- * wanted to know whether an answer was real had to remember the full list.
- * `withEdgeCache` remembered two; the r2-sql one it never knew about at all,
- * even though `src/r2-sql.ts` declares its counter with "same contract as the
- * Postgres tier's fallback generation: a caller can snapshot this before a
- * read and compare after". Nothing outside its own test file ever did --
- * measured repo-wide, `currentR2SqlFailureGeneration` had zero production
- * readers -- which is why `/accounts/{ss58}/counterparties` could answer
- * `counterparty_count: 0, transfers_scanned: 0` with `ok: true` and no header
- * while the lakehouse was rate-limited. That route's Postgres rung is
- * `"retired"` in wrangler.jsonc, so the r2-sql read IS the tier; a signal
- * nobody reads is the same as no signal.
- */
-export interface DegradedSnapshot {
-  postgresTier: number;
-  r2Sql: number;
-  unmeasured: number;
-  /**
-   * Reads that declined a too-deep offset WITHOUT issuing a query (#11142).
-   *
-   * A fourth counter because the other three cannot see this one. `r2Sql`
-   * moves when a query fails; the emulated-offset cap is checked before any SQL
-   * is built, so nothing is sent, nothing fails, and the answer went out as a
-   * bare 200 whose body was byte-identical to end-of-feed -- on ten paginated
-   * routes, edge-cached for the TTL.
-   *
-   * Counted at the single check in `offsetBeyondEmulationCap` rather than at
-   * each route's `?? build...([])`, because there are 92 of those and the whole
-   * design of this labelling is that no handler has to remember it.
-   */
-  offsetCapDeclined: number;
-}
-
-export function degradedSnapshot(): DegradedSnapshot {
-  return {
-    postgresTier: currentDataApiTierFallbackGeneration(),
-    r2Sql: currentR2SqlFailureGeneration(),
-    unmeasured: unmeasuredGeneration,
-    offsetCapDeclined: currentOffsetCapDeclineGeneration(),
-  };
-}
-
-/**
- * What moved since `before`, split by how long it will stay true.
- *
- * TRANSIENT is a tier that failed or backed off -- a DATA_API subrequest that
- * did not land, an r2-sql timeout, the account rate-limit breaker declining to
- * ask. It will likely succeed on the next request, so the answer is labelled
- * AND barred from the edge cache; persisting it would prolong the outage
- * (#1760).
- *
- * UNMEASURED is a stable decline: a projection this route never precomputes,
- * an artifact that is absent. Still labelled -- a caller must not read those
- * zeros as measured -- but cacheable for the whole TTL, because it will answer
- * the same way for the whole TTL (#10189).
- */
-export function degradedSince(before: DegradedSnapshot): {
-  transient: boolean;
-  unmeasured: boolean;
-} {
-  const now = degradedSnapshot();
-  return {
-    transient:
-      now.postgresTier !== before.postgresTier || now.r2Sql !== before.r2Sql,
-    // An offset-cap decline is UNMEASURED, not transient: the same offset
-    // declines identically for the whole TTL, so the answer stays cacheable and
-    // merely stops claiming to be measured. Barring it from the cache would
-    // re-run a refusal that cannot change.
-    unmeasured:
-      now.unmeasured !== before.unmeasured ||
-      now.offsetCapDeclined !== before.offsetCapDeclined,
-  };
-}
-
-/**
- * Label a response whose data tier declined while it was being served.
- *
- * Called from the router (`workers/api.ts`), which is the ONE point every
- * route passes -- the same argument #9110 made for labelling inside
- * `withEdgeCache` rather than in each handler, applied to the 71 tier-reading
- * handlers in `workers/request-handlers/entities.ts` that #9110 never covered
- * because not one of them uses `withEdgeCache`.
- *
- * HEADER ONLY, no cache-control rewrite. These routes have no server-side
- * cache to poison -- measured live 2026-08-09, an api.metagraph.sh response
- * carries no `cf-cache-status` at all, so the Workers Cache API inside
- * `withEdgeCache` is the only cache in play and it makes its own decision from
- * the same snapshot. Rewriting `cache-control` here would instead make every
- * response in an isolate uncacheable for the length of an r2-sql cooldown,
- * which is load amplification aimed at the exact condition the breaker exists
- * to relieve.
- *
- * A 304 is skipped: the caller already holds the body its ETag names, and
- * there is nothing in a 304 to mislabel. A response that already carries the
- * header is left alone rather than re-set, so a handler that classified its
- * own degradation keeps its own wording.
- *
- * IN PLACE, returning nothing, which is a deliberate difference from
- * `withDegradedHeader`'s copy-on-immutable fallback. The one response class
- * with immutable headers is a body read back out of the edge cache, and
- * `withEdgeCache` only ever stored a MEASURED answer there -- so a throw here
- * means a concurrent request degraded while this one was served from cache,
- * and relabelling a known-good cached body on that evidence would be the false
- * positive rather than the catch. Swallowing it is the correct answer, not the
- * convenient one. Mutating also keeps the router's return type exactly what
- * the dispatch inferred, so the label costs no signature change at ~40 return
- * sites.
- */
-export function labelDegradedResponse(
-  response: Response,
-  before: DegradedSnapshot,
-): void {
-  if (response.status !== 200) return;
-  if (response.headers.has(DEGRADED_HEADER)) return;
-  const moved = degradedSince(before);
-  if (!moved.transient && !moved.unmeasured) return;
-  try {
-    response.headers.set(DEGRADED_HEADER, DEGRADED_TIER_UNAVAILABLE);
-  } catch {
-    // An immutable-headers response: see above.
-  }
-}
-
 async function analyticsMeta(
   env: Env,
   artifactPath: string,
@@ -492,184 +273,6 @@ async function analyticsMeta(
     published_at: await publishedAt(env),
     source: LIVE_CRON_PROBER,
   };
-}
-
-// Edge-cache wrapper for the Postgres-backed analytics routes (audit #6). Each
-// of these re-runs a full-window Postgres aggregation on EVERY request, yet
-// the result only changes when the health cron writes a new snapshot — so a
-// cross-colo / agent-polling burst re-executes the same 7d/30d aggregation
-// needlessly (D1 fully eliminated 2026-07-17 -- see this file's own header).
-// Mirrors the
-// live-overlay collection cache exactly (the CACHEABLE_OVERLAY_ROUTE_IDS path):
-// same Cache API, same `edge-cache.metagraph.sh` key host, same last_run_at
-// keying, same conditional-GET 304 short-circuit, same ctx.waitUntil put.
-//
-// The key varies on everything that changes the body: contract_version (a deploy
-// can never serve a cross-version payload) + a freshness stamp + the request
-// path (carries netuid) + the canonical search (carries `window`). The stamp is
-// the health cron snapshot (`last_run_at`) for every route, including chain/
-// identity-history -- its own bespoke `readIdentityHistoryCacheStamp` stamp was
-// retired alongside the D1 read it existed to bust on (D1 fully eliminated,
-// 2026-07-16), the same way the neurons/neuron_daily-backed stamps were
-// retired when #4772 dropped those tables from D1. `resolveCacheStamp` stays
-// as an override hook for any future bespoke-stamp need, just unused today.
-// `keyParts` is the extra namespace segment per route. When the stamp is cold
-// (null), caching is skipped entirely so a cold-KV/empty payload can never seed
-// a stale entry — identical to the overlay cache's `if (lastRunAt)` guard. The
-// cache is transparent: body/shape/headers are whatever buildResponse() produced;
-// only 200s are cached, never errors.
-// Loose, structural ExecutionContext -- every call site here either receives
-// the real Workers-runtime ExecutionContext or, from a handler invoked with no
-// ctx (e.g. a direct unit-test call), the `= {}` default; both only ever need
-// `waitUntil`, so a full ExecutionContext isn't required to satisfy this type.
-export interface EdgeCacheCtx {
-  waitUntil?: (promise: Promise<unknown>) => void;
-}
-
-/**
- * An edge-cache label scoped to its chain.
- *
- * MAINNET KEEPS ITS BARE LABEL, so every warm entry survives this change and a
- * mainnet request hits the key it hit before. The `/{network}/` prefix is
- * stripped before dispatch, so without this the two chains reach these handlers
- * with byte-identical paths and would share one cache entry -- and since their
- * shapes are identical, a testnet card served to a mainnet caller would look
- * completely well-formed.
- */
-export function edgeCacheScope(
-  label: string,
-  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
-): string {
-  return network === DEFAULT_CHAIN_NETWORK ? label : `${label}:${network}`;
-}
-
-export async function withEdgeCache(
-  request: Request,
-  ctx: EdgeCacheCtx | undefined,
-  env: Env,
-  keyParts: string,
-  buildResponse: (cacheRequest: Request) => Response | Promise<Response>,
-  cachePathAndSearch: string | null = null,
-  resolveCacheStamp: ((env: Env) => Promise<string | null>) | null = null,
-): Promise<Response> {
-  const isHead = request.method === "HEAD";
-  // Only opt HEAD into the GET cache path for handlers that accept the
-  // normalized request. Legacy zero-arg builders may close over the original
-  // HEAD request and return a bodyless response, which must not seed the GET
-  // cache for later clients.
-  const normalizesHead = isHead && buildResponse.length > 0;
-  const cacheRequest = normalizesHead
-    ? new Request(request, { method: "GET" })
-    : request;
-  // `globalThis.caches` (not the bare `caches` global) so the optional
-  // chain actually guards: Node/vitest has no Cache API global at all,
-  // unlike the real Workers runtime where `caches` is always populated --
-  // the bare identifier's ambient `declare const caches: CacheStorage` types
-  // it as unconditionally present, which would be true at compile time but
-  // false at this test-runtime.
-  const cache =
-    cacheRequest.method === "GET"
-      ? (globalThis as { caches?: CacheStorage }).caches?.default
-      : null;
-  // Cheap freshness read. On a hit this + the cache match is the whole request
-  // (no D1 aggregation at all for the handler body).
-  let stamp = null;
-  if (cache) {
-    if (typeof resolveCacheStamp === "function") {
-      // Some projections have a producer-specific watermark. In particular,
-      // neuron-derived directories must not be invalidated by an unrelated
-      // health cron, or held stale across a completed neuron snapshot.
-      stamp = await resolveCacheStamp(env);
-    } else {
-      stamp = (await readHealthMetaKv(env))?.last_run_at ?? null;
-    }
-  }
-  let cacheKey = null;
-  if (cache && stamp) {
-    const url = new URL(cacheRequest.url);
-    const cacheRoute = cachePathAndSearch ?? `${url.pathname}${url.search}`;
-    cacheKey = new Request(
-      `https://edge-cache.metagraph.sh/analytics/${encodeURIComponent(
-        contractVersion(env),
-      )}/${encodeURIComponent(stamp)}/${keyParts}${cacheRoute}`,
-    );
-    const hit = await cache.match(cacheKey);
-    if (hit) {
-      // Honour conditional requests against the cached body's weak ETag so
-      // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
-      if (ifNoneMatchSatisfied(request, hit.headers.get("etag") || "")) {
-        return withCacheStatus(
-          new Response(null, { status: 304, headers: hit.headers }),
-          "hit",
-        );
-      }
-      return withCacheStatus(
-        normalizesHead
-          ? new Response(null, { status: hit.status, headers: hit.headers })
-          : hit,
-        "hit",
-      );
-    }
-  }
-  const before = degradedSnapshot();
-  const built = await buildResponse(cacheRequest);
-  // #9110: the generation counter already told us the tier degraded while this
-  // request was being served -- it is what suppresses caching two lines down.
-  // Until now that was the ONLY thing it did, so 16 of the 21 tier-reading
-  // handlers returned an unlabelled empty payload: `total: 0`, `ok: true`, and
-  // no way for a caller to tell it from a measured zero.
-  //
-  // Labelling here rather than in each handler is deliberate. Only 5 of the 21
-  // remembered to call markDataApiTierFallbackResponse; a per-handler flag is
-  // exactly the thing the 22nd handler will forget. Every one of them already
-  // goes through this function.
-  //
-  // The counter is module-global, so a CONCURRENT request degrading can label
-  // this one too. That is the same trade the cache-suppression below already
-  // makes, and it errs the safe way: a false "degraded" makes good data look
-  // suspect, where the bug it replaces made missing data look measured.
-  //
-  // #10270: the r2-sql counter joined the two this used to read by name. It
-  // was declared for exactly this comparison and had no reader -- see
-  // `degradedSnapshot`. The suppression below is what it was declared FOR: an
-  // r2-sql decline is a 60s account-wide breaker, and caching its empty answer
-  // for the full TTL outlives the condition that produced it.
-  const moved = degradedSince(before);
-  const degraded =
-    DATA_API_TIER_FALLBACK_RESPONSES.has(built) || moved.transient;
-  // #10189: an unmeasured answer is labelled but NOT made uncacheable. See
-  // `unmeasured` above for why the two signals have to be separate -- a
-  // projection decline is stable for the whole TTL, where a tier failure is
-  // transient and caching it would prolong the outage.
-  const labelled = built.status === 200 && !built.headers.has(DEGRADED_HEADER);
-  let response = built;
-  if (labelled && degraded) {
-    response = markDataApiTierFallbackResponse(built);
-  } else if (labelled && moved.unmeasured) {
-    response = withDegradedHeader(built);
-  }
-  // Never cache errors / non-200s (a cold Postgres tier still returns a 200
-  // empty envelope; a 400 bad-window or 5xx must not be persisted).
-  if (
-    cache &&
-    cacheKey &&
-    response.status === 200 &&
-    !DATA_API_TIER_FALLBACK_RESPONSES.has(response) &&
-    !moved.transient
-  ) {
-    ctx?.waitUntil?.(cache.put(cacheKey, response.clone()));
-  }
-  // Stamped AFTER the `cache.put` above, which stores `response.clone()`, so
-  // the stored copy stays unlabelled. See `withCacheStatus`.
-  return withCacheStatus(
-    normalizesHead
-      ? new Response(null, {
-          status: response.status,
-          headers: response.headers,
-        })
-      : response,
-    "miss",
-  );
 }
 
 // Postgres-backed 7d/30d daily uptime + latency trends across all subnets
@@ -2885,3 +2488,24 @@ export {
   canonicalAnalyticsCacheRoute,
   markDataApiTierFallbackResponse,
 };
+
+export async function withEdgeCache(
+  request: Request,
+  ctx: EdgeCacheCtx | undefined,
+  env: Env,
+  keyParts: string,
+  buildResponse: (cacheRequest: Request) => Response | Promise<Response>,
+  cachePathAndSearch: string | null = null,
+  resolveCacheStamp: ((env: Env) => Promise<string | null>) | null = null,
+): Promise<Response> {
+  return withStampedEdgeCache(
+    request,
+    ctx,
+    env,
+    keyParts,
+    buildResponse,
+    cachePathAndSearch,
+    resolveCacheStamp ??
+      (async (source) => (await readHealthMetaKv(source))?.last_run_at ?? null),
+  );
+}

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -1,3 +1,8 @@
+import { metagraphMeta } from "../responses.ts";
+export {
+  handleAccountHolderDirectory,
+  handleValidatorOperatorDirectory,
+} from "./explorer-directories.ts";
 // Single-entity chain-data handlers: the cheap per-key D1 lookups behind the
 // metagraph, account, block, and extrinsic routes (extracted from workers/api.ts
 // per #1763).
@@ -91,12 +96,7 @@ import {
   overlayFeaturedValidators,
 } from "../../src/metagraph-neurons.ts";
 import { buildAccountsList } from "../../src/accounts-list.ts";
-import { buildAccountHolderDirectory } from "../../src/account-holder-directory.ts";
-import { buildValidatorOperatorDirectory } from "../../src/validator-operator-directory.ts";
-import {
-  readCurrentAccountDirectory,
-  readCurrentValidatorDirectory,
-} from "../../src/explorer-directory-current.ts";
+
 import { buildTopHoldersList } from "../../src/top-holders.ts";
 import {
   buildDeregistrationHistory,
@@ -934,26 +934,6 @@ function parseBooleanParam(
   return { value: raw === "true" };
 }
 
-// --- Per-UID metagraph (#1304/#1305) --- D1 fully eliminated (2026-07-17);
-// neurons' D1 write path was retired in #4772/#4909 (see handleSubnetMetagraph
-// below), so this now serves a schema-stable literal rather than a live
-// query, like the other Postgres-backed analytics routes.
-async function metagraphMeta(
-  env: Env,
-  artifactPath: string,
-  generatedAt: unknown,
-  publishedAtPromise: Promise<string | null> | null = null,
-) {
-  return {
-    artifact_path: artifactPath,
-    cache: "short",
-    contract_version: contractVersion(env),
-    generated_at: generatedAt,
-    published_at: await (publishedAtPromise ?? publishedAt(env)),
-    source: "metagraph-snapshot",
-  };
-}
-
 export async function handleSubnetMetagraph(
   request: Request,
   env: Env,
@@ -1388,38 +1368,6 @@ export async function handleGlobalValidators(
   );
 }
 
-export async function handleValidatorOperatorDirectory(
-  request: Request,
-  env: Env,
-) {
-  const publishedAtPromise = publishedAt(env);
-  const materialized =
-    env.METAGRAPH_NEURONS_SOURCE === "data-api"
-      ? await readCurrentValidatorDirectory(env.METAGRAPH_CONTROL)
-      : null;
-  const data =
-    materialized ??
-    ((await tryDataApiTier(
-      env,
-      request,
-      "METAGRAPH_NEURONS_SOURCE",
-    )) as ReturnType<typeof buildValidatorOperatorDirectory> | null) ??
-    buildValidatorOperatorDirectory(null);
-  return envelopeResponse(
-    request,
-    {
-      data,
-      meta: await metagraphMeta(
-        env,
-        "/metagraph/validators/operators.json",
-        data.captured_at,
-        publishedAtPromise,
-      ),
-    },
-    "short",
-  );
-}
-
 // GET /api/v1/accounts?sort=total_stake|total_emission|subnet_count|uid_count|
 // validator_count|stake_dominance|last_active&limit=20 (#4324/5.3): site-wide
 // accounts leaderboard — every currently-registered hotkey, miners included,
@@ -1490,35 +1438,6 @@ export async function handleAccountsList(request: Request, env: Env, url: URL) {
         env,
         "/metagraph/accounts.json",
         data.captured_at,
-      ),
-    },
-    "short",
-  );
-}
-
-export async function handleAccountHolderDirectory(request: Request, env: Env) {
-  const publishedAtPromise = publishedAt(env);
-  const materialized =
-    env.METAGRAPH_NEURONS_SOURCE === "data-api"
-      ? await readCurrentAccountDirectory(env.METAGRAPH_CONTROL)
-      : null;
-  const data =
-    materialized ??
-    ((await tryDataApiTier(
-      env,
-      request,
-      "METAGRAPH_NEURONS_SOURCE",
-    )) as ReturnType<typeof buildAccountHolderDirectory> | null) ??
-    buildAccountHolderDirectory([], { priceByNetuid: NO_ALPHA_PRICES });
-  return envelopeResponse(
-    request,
-    {
-      data,
-      meta: await metagraphMeta(
-        env,
-        "/metagraph/accounts/directory.json",
-        data.captured_at,
-        publishedAtPromise,
       ),
     },
     "short",

--- a/workers/request-handlers/explorer-directories.ts
+++ b/workers/request-handlers/explorer-directories.ts
@@ -1,0 +1,71 @@
+// Canonical website projections share the same handlers at both entry points.
+import { envelopeResponse, publishedAt } from "../responses.ts";
+import { tryDataApiTier } from "../data-api-tier.ts";
+import { NO_ALPHA_PRICES } from "../../src/metagraph-neurons.ts";
+import { buildAccountHolderDirectory } from "../../src/account-holder-directory.ts";
+import { buildValidatorOperatorDirectory } from "../../src/validator-operator-directory.ts";
+import {
+  readCurrentAccountDirectory,
+  readCurrentValidatorDirectory,
+} from "../../src/explorer-directory-current.ts";
+import { metagraphMeta } from "../responses.ts";
+export async function handleValidatorOperatorDirectory(
+  request: Request,
+  env: Env,
+) {
+  const publishedAtPromise = publishedAt(env);
+  const materialized =
+    env.METAGRAPH_NEURONS_SOURCE === "data-api"
+      ? await readCurrentValidatorDirectory(env.METAGRAPH_CONTROL)
+      : null;
+  const data =
+    materialized ??
+    ((await tryDataApiTier(
+      env,
+      request,
+      "METAGRAPH_NEURONS_SOURCE",
+    )) as ReturnType<typeof buildValidatorOperatorDirectory> | null) ??
+    buildValidatorOperatorDirectory(null);
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: await metagraphMeta(
+        env,
+        "/metagraph/validators/operators.json",
+        data.captured_at,
+        publishedAtPromise,
+      ),
+    },
+    "short",
+  );
+}
+
+export async function handleAccountHolderDirectory(request: Request, env: Env) {
+  const publishedAtPromise = publishedAt(env);
+  const materialized =
+    env.METAGRAPH_NEURONS_SOURCE === "data-api"
+      ? await readCurrentAccountDirectory(env.METAGRAPH_CONTROL)
+      : null;
+  const data =
+    materialized ??
+    ((await tryDataApiTier(
+      env,
+      request,
+      "METAGRAPH_NEURONS_SOURCE",
+    )) as ReturnType<typeof buildAccountHolderDirectory> | null) ??
+    buildAccountHolderDirectory([], { priceByNetuid: NO_ALPHA_PRICES });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: await metagraphMeta(
+        env,
+        "/metagraph/accounts/directory.json",
+        data.captured_at,
+        publishedAtPromise,
+      ),
+    },
+    "short",
+  );
+}

--- a/workers/request-lifecycle.ts
+++ b/workers/request-lifecycle.ts
@@ -1,0 +1,588 @@
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import {
+  withRequestTiming,
+  serverTimingHeader,
+} from "../src/request-timing.ts";
+import { degradedSnapshot, labelDegradedResponse } from "./edge-cache.ts";
+// Request telemetry and response auditing, shared with the small directory entry.
+import {
+  isUsageTelemetryConfigured,
+  recordExceptionEvent,
+  recordUsageEvent,
+  parseUserAgentClient,
+  statusClassOf,
+  anonymousUsageDistinctId,
+  sanitizeUsageLabel,
+  USAGE_ACCOUNT_NAMESPACE,
+  USAGE_WORKER_NAMESPACE,
+  type UsageEvent,
+} from "../src/usage-telemetry.ts";
+import {
+  newSpanId,
+  newTraceId,
+  recordTraceSpan,
+  shouldRecordTraceSpan,
+} from "../src/tracing.ts";
+import { errorResponse } from "./http.ts";
+import {
+  ResponseSchemaDriftError,
+  validateResponseTripwire,
+} from "../src/response-validation-tripwire.ts";
+import { urlProjects } from "../src/projection-signal.ts";
+import { ANONYMOUS_CLIENT_KEY, resolveClientIp } from "./config.ts";
+type Ctx = { waitUntil?: (promise: Promise<unknown>) => void };
+export interface AuditRoute {
+  id: string;
+  artifactTemplate?: string;
+  artifactPath?: string;
+}
+// #9446: the caller's tier, for the usage_event `auth_tier` dimension.
+//
+// `authTier` has been declared on UsageEvent since #8993 and populated ONLY on
+// the MCP path, so on REST -- the surface with 99% of the traffic -- the
+// question the tier system exists to answer ("what share of usage is
+// authenticated, and on which tier") had no data behind it at all.
+//
+// A WeakMap keyed on the Request, rather than a new parameter threaded from
+// four gate sites up through handleRequest to this wrapper. The gate already
+// resolves the tier (applyTieredRateLimit returns it and every caller
+// discarded it); this carries that answer back out without reshaping the
+// signature of every function in between, which is the same reasoning the MCP
+// side used when it put authTier on its ctx rather than passing it down.
+//
+// WeakMap and not a Map: the key is the request object itself, so an entry
+// becomes collectable the moment the request is done. There is nothing to
+// evict, nothing to size, and no way for one request's tier to be read by
+// another -- the failure mode a keyed cache would have.
+let requestAuthTier = new WeakMap<Request, string>();
+
+/**
+ * The account a request authenticated as, for its usage-event distinct_id.
+ *
+ * A SECOND WeakMap rather than widening the one above to an object: the tier
+ * is set by every gate and the account only by a key-verified one, so a single
+ * entry would have to encode "tier known, account not" as a partial object at
+ * every call site. Two maps say that by which one has an entry, and both stay
+ * collectable with the request for the reasons the tier map already documents.
+ */
+let requestAccountId = new WeakMap<Request, string>();
+
+/**
+ * An error code resolved somewhere the RESPONSE cannot carry it.
+ *
+ * `withUsageTelemetry` reads `error_code` off the response header, which works
+ * for every route that answers through `errorResponse`. It cannot work for a
+ * refusal whose whole design is that the response says nothing distinguishing
+ * -- the chain-firehose caps (#10606), where telling the caller which limit it
+ * hit tells a scraper whether to rotate addresses. Same WeakMap-on-the-Request
+ * shape as the tier above, and the same collectability argument.
+ */
+let requestErrorCode = new WeakMap<Request, string>();
+
+/** Record an error code the response is deliberately not allowed to carry. */
+export function markRequestErrorCode(request: Request, code: unknown): void {
+  if (typeof code === "string" && code) requestErrorCode.set(request, code);
+}
+
+/**
+ * Record the tier a request authenticated on, for its usage event.
+ *
+ * Called from the tiered-rate-limit gates, which are the only places that
+ * verify a key. Exported for tests.
+ *
+ * `accountId` is optional so the pre-#10606 two-argument form still compiles
+ * and still means what it did -- a gate that resolves no account passes
+ * nothing, and the caller stays anonymous rather than being attributed to an
+ * account it never presented.
+ */
+export function markRequestAuthTier(
+  request: Request,
+  tier: unknown,
+  accountId?: unknown,
+): void {
+  if (typeof tier === "string" && tier) requestAuthTier.set(request, tier);
+  if (typeof accountId === "string" && accountId) {
+    requestAccountId.set(request, accountId);
+  }
+}
+
+/**
+ * Who to count this request under, for the usage event's distinct_id.
+ *
+ * ## WHY REST HAD NO ANSWER TO THIS
+ *
+ * Every REST usage event carried the same literal id, so `uniq(distinct_id)`
+ * was 1 across 142 routes and the surface with ~99% of this project's traffic
+ * could not say how many callers it had. See USAGE_EVENT_DISTINCT_ID's own
+ * header for the measurement and for how it surfaced.
+ *
+ * ## THE TWO NAMESPACES, AND WHY THEY ARE DIFFERENT KINDS OF THING
+ *
+ * An `account:` id is an identity the caller PRESENTED -- it authenticated
+ * with a key belonging to that account. An `ip:` id is an observation we made
+ * about the connection. Naming them apart keeps that distinction queryable,
+ * and it is what `assignUsagePersonProcessing` reads to decide which callers
+ * become person profiles (only the first: see its header for why that is a
+ * cost gate and not a label).
+ *
+ * ## THE HASH IS SALTED, AND UNSALTED IS NOT AN OPTION
+ *
+ * IPv4 is 2^32 addresses -- small enough that an unsalted digest is a
+ * reversible encoding of the address rather than a pseudonym, and it would put
+ * a recoverable client IP in a third party's event store. So a missing salt
+ * degrades to the old shared id instead of hashing without one: no salt, no
+ * anonymous identity, and the count stays as uninformative as it was rather
+ * than becoming informative and leaky.
+ *
+ * Resolved through `resolveClientIp` -- the same cf-connecting-ip-only path
+ * the rate limiters use, not a second IP-extraction scheme that could disagree
+ * with the thing enforcing the per-IP quotas this was written to diagnose.
+ */
+async function resolveUsageDistinctId(
+  request: Request,
+  env: Env,
+): Promise<string | undefined> {
+  const accountId = requestAccountId.get(request);
+  if (accountId) return `${USAGE_ACCOUNT_NAMESPACE}${accountId}`;
+  // Read off the declared field rather than by index, so the access is typed
+  // against Env. The name is documented once as USAGE_DISTINCT_ID_SALT_ENV in
+  // src/usage-telemetry.ts, for the ops side that has to set it.
+  const salt: string | undefined = env.USAGE_DISTINCT_ID_SALT;
+  if (!salt) return undefined;
+  const ip = resolveClientIp(request);
+  // `resolveClientIp` NEVER returns falsy -- absent `cf-connecting-ip` collapses
+  // to ANONYMOUS_CLIENT_KEY, one fixed bucket, which is the right failure mode
+  // for a rate limiter and the wrong one here. Hashing it would mint a single
+  // confident-looking `ip:` id shared by every caller we could not resolve, and
+  // a count built on that reads as "one caller" exactly the way the shared
+  // fallback already did -- except now it looks specific. So an unresolved
+  // address falls back to the shared id, which at least says so.
+  if (ip !== ANONYMOUS_CLIENT_KEY) {
+    return anonymousUsageDistinctId(salt, ip);
+  }
+  // #10606: a Worker-to-Worker subrequest has no client address and IS a
+  // caller. `cf-worker` is set by Cloudflare, not by the sender, so it is
+  // trustworthy and low-cardinality -- one value per calling Worker -- and
+  // `resolveUsageClient` above already trusts it for the `client` dimension
+  // for exactly that reason.
+  //
+  // RANKED BELOW THE ADDRESS, matching `resolveUsageClient`'s own precedence:
+  // a Worker proxying a browser forwards the end user's `cf-connecting-ip`,
+  // and the person behind the proxy is the more interesting caller than the
+  // proxy. Only when there is no address at all does the calling Worker
+  // become the best available answer.
+  //
+  // Worth having rather than collapsing to the shared id: #9004 found ONE
+  // Worker (`zeronode.workers.dev`) was 82% of `block-detail`, which was in
+  // turn the largest route in the project -- a caller that dominated the
+  // traffic and could not be counted.
+  // Guarded on the SANITISED value, not the raw header: the id is what has to
+  // be non-empty, and checking the input instead would let a header that
+  // sanitises away become the bare namespace -- `worker:`, a caller whose name
+  // is the empty string, which reads as an identity and is not one.
+  const callingWorker = sanitizeUsageLabel(request.headers.get("cf-worker"));
+  if (callingWorker) {
+    return `${USAGE_WORKER_NAMESPACE}${callingWorker}`;
+  }
+  return undefined;
+}
+
+/**
+ * Who made this request, for the usage_event `client` dimension.
+ *
+ * #9004: a Cloudflare Worker subrequest sends NO User-Agent, so all of it
+ * landed in the "no client" bucket. That is not a rounding error here -- it was
+ * ~93% of `block-detail`, the single largest route in the project at 758,995
+ * events/day, and identifying it required a live `wrangler tail` because the
+ * telemetry could not answer it. One Worker (`zeronode.workers.dev`) turned out
+ * to be 82% of that route: ~380K requests/day, each one a Worker invocation, a
+ * Hyperdrive round-trip AND a PostHog event.
+ *
+ * Cloudflare sets `cf-worker` on Worker-to-Worker subrequests, so it is
+ * trustworthy (not caller-supplied) and low-cardinality (one value per calling
+ * Worker). Prefixed `worker:` so provenance rides with the value and a
+ * UA-derived name can never be confused with a subrequest origin -- the same
+ * discipline $mcp_client_name_source applies on the MCP side.
+ *
+ * User-Agent wins when both are present: a real client behind a Worker proxy is
+ * more interesting than the proxy.
+ */
+function resolveUsageClient(request: Request): string | undefined {
+  const fromUserAgent = parseUserAgentClient(
+    request.headers.get("user-agent"),
+  ).clientName;
+  if (fromUserAgent) return fromUserAgent;
+  const cfWorker = request.headers.get("cf-worker");
+  return cfWorker ? `worker:${cfWorker}` : undefined;
+}
+
+/**
+ * Run the request pipeline and record exactly one usage event for it. Returns
+ * the handler's response untouched, and never converts a telemetry failure into
+ * a request failure: an unconfigured deployment skips the work entirely, and a
+ * recorder that rejects, throws, or a waitUntil that throws is swallowed.
+ *
+ * @param {Request} request
+ * @param {object} env
+ * @param {object} ctx ExecutionContext (may be a bare object in tests).
+ * @param {() => Promise<Response>} handle
+ * @param {{recordUsageEvent?: typeof recordUsageEvent}} [deps]
+ * @returns {Promise<Response>}
+ */
+export async function withRequestUsageTelemetry(
+  request: Request,
+  env: Env,
+  ctx: Ctx,
+  handle: () => Promise<Response>,
+  resolveRoute: (url: URL) => string | null,
+  deps: {
+    recordUsageEvent?: typeof recordUsageEvent;
+    recordExceptionEvent?: typeof recordExceptionEvent;
+  } = {},
+) {
+  const record = deps.recordUsageEvent ?? recordUsageEvent;
+  const recordException = deps.recordExceptionEvent ?? recordExceptionEvent;
+  if (!isUsageTelemetryConfigured(env)) {
+    return handle();
+  }
+
+  // A subscription upgrade (GraphQL subscriptions reuse the /api/v1/graphql
+  // path over a WebSocket) opens a long-lived socket rather than serving a
+  // request/response pair, so its latency would be meaningless. Recognized the
+  // same way handleRequest itself dispatches it.
+  if (request.headers.get("upgrade") === "websocket") {
+    return handle();
+  }
+
+  const route = resolveRoute(new URL(request.url));
+  if (route === null) {
+    return handle();
+  }
+
+  const startedAt = Date.now();
+  // #8963: request dimensions resolved once, up front, so they are recorded
+  // even when the handler throws (the finally block below still fires).
+  const method = request.method;
+  const client = resolveUsageClient(request);
+  let statusClass;
+  let ok = false;
+  // metagraphed#7733: errorResponse() (workers/http.ts) already sets this on
+  // every REST error -- the same established code (invalid_query,
+  // method_not_allowed, ai_error, ...) every route handler already uses, not
+  // a new taxonomy. Undefined for a success response or one that predates
+  // this convention, same "omitted, not just falsy" contract as MCP's
+  // errorCode (#7726).
+  let errorCode;
+  try {
+    const response = await handle();
+    // 4xx is a route correctly rejecting a bad request, not a broken route;
+    // only 5xx (and a thrown handler, which leaves ok false) is a failure.
+    ok = response.status < 500;
+    // Recorded alongside `ok`, not instead of it: `ok` folds every 4xx in with
+    // the successes (a route correctly rejecting a bad request is not a
+    // failure), which makes "are callers sending us garbage" unanswerable.
+    statusClass = statusClassOf(response.status);
+    errorCode =
+      response.headers.get("x-metagraph-error-code") ??
+      // #10606: a refusal whose response is deliberately uniform records its
+      // code out of band. Second, never first -- a real header is the response
+      // this request actually served, and must win.
+      requestErrorCode.get(request) ??
+      undefined;
+    // metagraphed#7734: GraphQL execution errors are a spec-mandated 200
+    // with a populated `errors` array (src/graphql.ts) -- status alone
+    // can't distinguish that from a real success, so this one code (set
+    // only when execute() surfaced a genuine resolver fault, never a
+    // deliberate/expected GraphQLError -- see graphql.ts's own
+    // genuineFaults comment) is a narrow, explicit exception to the
+    // status-based rule above. Every other route/code keeps the existing
+    // status<500 semantics untouched.
+    if (errorCode === "graphql_execution_error") {
+      ok = false;
+    }
+    return response;
+  } catch (error) {
+    // #9430: until now this wrapper was try/finally with NO catch, and
+    // workers/api.entry.ts dropped Sentry's withSentry() wrap without
+    // replacing it (#7766) -- so an uncaught throw anywhere in the REST
+    // pipeline produced a usage_event with ok:false and NOTHING ELSE. No
+    // stack, no PostHog Issue, no message: the single most severe class of
+    // failure this Worker can have was also the least diagnosable, and
+    // src/usage-telemetry.ts's own header documented the hole rather than
+    // closing it ("a truly uncaught throw has no dedicated $exception capture
+    // of its own ... just without a stack trace").
+    //
+    // Rethrown unchanged: this observes the failure, it does not handle it.
+    // The runtime still produces its own 1101/500 exactly as before, and the
+    // finally block below still records the same ok:false usage event -- so
+    // the only behavioral difference is that the stack now reaches PostHog.
+    //
+    // `route` is already resolved and low-cardinality, giving the capture the
+    // same fingerprint grouping (`<route>:<type>`) every hand-placed REST
+    // capture site already gets.
+    scheduleExceptionEvent(env, ctx, recordException, {
+      error,
+      route,
+      errorCode: "internal_error",
+    });
+    throw error;
+  } finally {
+    const endedAt = Date.now();
+    // Read AFTER the handler, since the gate that resolves it runs inside.
+    // Absent for a route with no tiered gate, which is the honest answer --
+    // those routes did not check a key, so "anonymous" would be a claim the
+    // request never actually made. Same omitted-not-defaulted contract every
+    // other optional dimension here follows.
+    const authTier = requestAuthTier.get(request);
+    scheduleUsageEvent(
+      env,
+      ctx,
+      record,
+      {
+        route,
+        ok,
+        durationMs: endedAt - startedAt,
+        method,
+        ...(statusClass ? { statusClass } : {}),
+        ...(client ? { client } : {}),
+        ...(errorCode ? { errorCode } : {}),
+        ...(authTier ? { authTier } : {}),
+      },
+      () => resolveUsageDistinctId(request, env),
+    );
+    // metagraphed#7768: PostHog distributed tracing (alpha), one root span
+    // per request -- replaces @sentry/cloudflare's automatic withSentry() HTTP
+    // instrumentation. Off by default (POSTHOG_TRACES_SAMPLE_RATE unset --
+    // see src/tracing.ts's own header for why); set it as a deployed var to
+    // match Sentry's old 0.05. Reuses this chokepoint's own route/ok/duration
+    // -- see src/tracing.ts's header for why this is an independent span (no
+    // parent) rather than nested under anything.
+    // Outcome-aware since the AI-Observability tier measurement: this Worker's
+    // REST rate is 0 (see src/tracing.ts's header for why its ~1.1M req/day
+    // stays dark), which previously meant a 5xx here produced no span EVER.
+    // Failures now always reach the recorder, bounded there by the storm
+    // guard, so "REST is dark" costs throughput visibility without also
+    // costing incident visibility.
+    if (shouldRecordTraceSpan(env, { name: route, ok })) {
+      scheduleTraceSpan(env, ctx, {
+        traceId: newTraceId(),
+        spanId: newSpanId(),
+        name: route,
+        startTimeMs: startedAt,
+        endTimeMs: endedAt,
+        ok,
+        serviceName: "metagraphed-api",
+        attributes: { route, error_code: errorCode },
+      });
+    }
+  }
+}
+
+/**
+ * Hand an exception to the recorder without ever blocking or failing the
+ * response. Mirrors scheduleUsageEvent/scheduleTraceSpan exactly -- telemetry
+ * must never surface into the request path, least of all on a path that is
+ * already failing.
+ */
+export function scheduleExceptionEvent(
+  env: Env,
+  ctx: Ctx,
+  record: typeof recordExceptionEvent,
+  event: Parameters<typeof recordExceptionEvent>[1],
+) {
+  try {
+    const pending = Promise.resolve(record(env, event)).catch(() => false);
+    if (typeof ctx?.waitUntil === "function") {
+      ctx.waitUntil(pending);
+    }
+  } catch {
+    // Telemetry must never surface into the request path.
+  }
+}
+
+function scheduleTraceSpan(
+  env: Env,
+  ctx: Ctx,
+  span: Parameters<typeof recordTraceSpan>[1],
+) {
+  try {
+    const pending = Promise.resolve(recordTraceSpan(env, span)).catch(
+      () => false,
+    );
+    if (typeof ctx?.waitUntil === "function") {
+      ctx.waitUntil(pending);
+    }
+  } catch {
+    // Telemetry must never surface into the request path.
+  }
+}
+
+/**
+ * Hand the event to the recorder without ever blocking or failing the response.
+ *
+ * @param {object} env
+ * @param {object} ctx
+ * @param {typeof recordUsageEvent} record
+ * @param {object} event
+ */
+function scheduleUsageEvent(
+  env: Env,
+  ctx: Ctx,
+  record: typeof recordUsageEvent,
+  event: UsageEvent,
+  /**
+   * Resolves the caller's distinct_id, INSIDE the scheduled work.
+   *
+   * A thunk rather than a resolved string because resolving it hashes, and
+   * `withUsageTelemetry` awaits its telemetry in a `finally` -- an await there
+   * happens before the function returns, so computing this eagerly would put a
+   * SubtleCrypto digest in front of every response on a Worker serving ~1.1M
+   * requests a day. Deferring it into the waitUntil keeps the request path
+   * exactly as long as it was.
+   */
+  resolveDistinctId?: () => Promise<string | undefined>,
+) {
+  try {
+    const pending = Promise.resolve(
+      resolveDistinctId
+        ? resolveDistinctId().then((distinctId) =>
+            record(env, event, distinctId ? { distinctId } : {}),
+          )
+        : record(env, event),
+    ).catch(() => false);
+    if (typeof ctx?.waitUntil === "function") {
+      ctx.waitUntil(pending);
+    }
+  } catch {
+    // Telemetry must never surface into the request path.
+  }
+}
+
+/**
+ * Staged response audit for the routes the in-path tripwire cannot reach
+ * (#10984). The entity handlers (per-UID metagraph, accounts, blocks,
+ * extrinsics, chain-*) assemble their envelopes outside handleApiRequest's
+ * generic seam, so METAGRAPH_VALIDATE_RESPONSES never sees them -- and
+ * turning enforcement on for bodies never validated anywhere is how #10897
+ * spent 26 hours serving 500s. This is the warn-first path the issue
+ * prescribes:
+ *
+ *   METAGRAPH_AUDIT_RESPONSES unset  -- off (the flag check is the only cost)
+ *   "warn"                           -- validate a CLONE under waitUntil and
+ *                                       log each drift fingerprint; the body
+ *                                       the caller gets is untouched
+ *   "enforce"                        -- validate in-path and substitute the
+ *                                       same refusal the generic seam serves
+ *
+ * Promotion is a flag flip, not a deploy of new logic: enforce reuses exactly
+ * the code warn exercised. The route's TEMPLATE comes from matchRoute (the
+ * #10985 lookup), so the resolver never sees a concrete path. A response the
+ * generic seam already validated gets re-parsed here only while the audit
+ * flag is set -- the staging cost, paid on purpose and only during staging.
+ *
+ * `projected` is passed when the request carried a fields/sections parameter:
+ * the handler-level projections (metagraph-neurons, emission-pipeline) never
+ * set meta.projection, so the URL is the only honest signal at this seam.
+ */
+// EXPORTED for its own tests: the drift arm needs a body no local route
+// serves (the entity stores are empty locally, and empty arrays validate), so
+// the suite hands it crafted responses directly.
+export async function auditRouteResponse(
+  request: Request,
+  env: Env,
+  ctx: Ctx,
+  response: Response,
+  resolveRoute: (pathname: string) => AuditRoute | null,
+): Promise<Response> {
+  const mode = env.METAGRAPH_AUDIT_RESPONSES as string | undefined;
+  if (mode !== "warn" && mode !== "enforce") return response;
+  if (response.status !== 200) return response;
+  if (!response.headers.get("content-type")?.includes("json")) return response;
+  const url = new URL(request.url);
+  const matched = resolveRoute(url.pathname);
+  if (!matched?.artifactTemplate) return response;
+  // The three levers are declared once, in src/projection-signal.ts, because
+  // the MCP dispatch answers the same question about the same contract and was
+  // answering it differently -- which is to say not at all (#11142).
+  const projected = urlProjects(url.searchParams);
+  const run = async (body: unknown) => {
+    await validateResponseTripwire(
+      matched.id,
+      body,
+      matched.artifactTemplate,
+      projected,
+    );
+  };
+  if (mode === "warn") {
+    const clone = response.clone();
+    ctx.waitUntil?.(
+      (async () => {
+        try {
+          await run(await clone.json());
+        } catch (err) {
+          if (err instanceof ResponseSchemaDriftError) {
+            console.warn(
+              `[METAGRAPH_AUDIT_RESPONSES] ${matched.id} DRIFTED (warn):`,
+              JSON.stringify(err.detail).slice(0, 2000),
+            );
+          }
+        }
+      })(),
+    );
+    return response;
+  }
+  try {
+    await run(await response.clone().json());
+    return response;
+  } catch (err) {
+    if (err instanceof ResponseSchemaDriftError) {
+      console.error(
+        `[METAGRAPH_AUDIT_RESPONSES] ${matched.id} refused:`,
+        err.detail,
+      );
+      return errorResponse(
+        "response_schema_drift",
+        `The ${matched.id} response did not match its published schema and was refused rather than served.`,
+        500,
+        { artifact_path: matched.artifactPath },
+      );
+    }
+    return response;
+  }
+}
+
+export async function withResponseTiming<T extends Response>(
+  handle: () => Promise<T>,
+): Promise<T> {
+  return withRequestTiming(async () => {
+    const before = degradedSnapshot();
+    const response = await handle();
+    labelDegradedResponse(response, before);
+    // WHERE THE MILLISECONDS WENT, as the standard header a browser's devtools
+    // panel already renders. Set here for the same reason the degraded label is
+    // -- one point every route passes -- and built from marks collected at the
+    // three storage boundaries rather than by instrumenting handlers, so a
+    // route written next year is covered without its author doing anything.
+    //
+    // IN PLACE, swallowing an immutable-headers throw, exactly as
+    // `labelDegradedResponse` documents. The one response class with immutable
+    // headers is a body read back out of the edge cache, whose timings belong
+    // to the request that STORED it -- losing the header there is correct,
+    // because this request spent none of that time.
+    const timing = serverTimingHeader();
+    if (timing !== null) {
+      try {
+        response.headers.set("server-timing", timing);
+      } catch {
+        // A cached body; see above.
+      }
+    }
+    return response;
+  });
+}
+
+registerModuleStateReset("workers/request-lifecycle.ts", () => {
+  requestAuthTier = new WeakMap();
+  requestAccountId = new WeakMap();
+  requestErrorCode = new WeakMap();
+});

--- a/workers/responses.ts
+++ b/workers/responses.ts
@@ -7,7 +7,7 @@ import {
   ARTIFACT_BASE_PATH,
   CONTRACT_VERSION,
   PRIMARY_DOMAIN,
-} from "../src/contracts.ts";
+} from "../src/contract-constants.ts";
 
 /**
  * The `service-desc` link every API response carries.
@@ -163,4 +163,20 @@ export async function envelopeResponse(
     status: 200,
     headers,
   });
+}
+
+export async function metagraphMeta(
+  env: Env,
+  artifactPath: string,
+  generatedAt: unknown,
+  publishedAtPromise: Promise<string | null> | null = null,
+) {
+  return {
+    artifact_path: artifactPath,
+    cache: "short",
+    contract_version: contractVersion(env),
+    generated_at: generatedAt,
+    published_at: await (publishedAtPromise ?? publishedAt(env)),
+    source: "metagraph-snapshot",
+  };
 }

--- a/workers/usage-rollup.ts
+++ b/workers/usage-rollup.ts
@@ -1,0 +1,108 @@
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
+// One shared buffer for both the complete router and the default directories.
+import {
+  foldObservations,
+  observeRequest,
+  type UsageObservation,
+  type RouteMatcher,
+} from "../src/usage-rollup.ts";
+import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
+type Ctx = { waitUntil?: (promise: Promise<unknown>) => void };
+// Fire-and-forget ALL-TRAFFIC usage rollup (#8597) -- keyed and keyless alike.
+//
+// Distinct from recordApiKeyUsage below, which it does not replace: that one is
+// per-account and only fires for requests presenting a key, powering the tenant
+// dashboard. This one has no account dimension and fires for EVERY API request,
+// because keyless traffic is the majority by design and is the entire subject
+// of the "does the free tier cost too much" question ADR 0022 defers.
+//
+// Same posture as recordApiKeyUsage: ctx.waitUntil so it adds no latency, and
+// it swallows its own failure -- a rollup miss must never surface as an error
+// on the actual API call.
+// #8823: observations are BUFFERED in the isolate and flushed in batches.
+//
+// Until this landed, foldObservations was handed a single-element array on
+// every request, so N requests meant N DATA_API subrequests, N postgres()
+// clients (withAccountsSql builds a fresh one per invocation), and N upserts
+// -- and a flood of `/api/v1/<random>` 404s all collapse to the single
+// (day, "unmatched", "edge") row, so those N upserts serialised on one row
+// lock against a self-hosted database whose capacity is ours. Nothing
+// throttles that path: /api/* is run_worker_first and the generic 404 is
+// reached without passing any of the per-surface limiters.
+//
+// The flush triggers are count-OR-age, evaluated synchronously as each
+// observation arrives (Workers has no timer that runs outside a request, so
+// the age check can only fire when a LATER request arrives -- which is
+// exactly when a flush is affordable). Both bounds are deliberately small:
+// they cap what an isolate can lose on eviction, which is the one accuracy
+// cost of buffering.
+const USAGE_ROLLUP_FLUSH_COUNT = 64;
+
+const USAGE_ROLLUP_FLUSH_AGE_MS = 10_000;
+
+let usageRollupBuffer: UsageObservation[] = [];
+
+let usageRollupBufferedAtMs = 0;
+
+// Exported for the tests that assert the batching property; not part of any
+// route's behaviour.
+export function usageRollupBufferSize(): number {
+  return usageRollupBuffer.length;
+}
+
+// Drain the buffer into ONE subrequest carrying every folded bucket. Drains
+// before the fetch so a concurrent request in the same isolate cannot send
+// the same observations twice. A failed POST loses that batch, the same
+// best-effort posture the single-observation write already had -- a rollup
+// miss must never surface on the API call that triggered it.
+export function flushUsageRollup(env: Env, ctx: Ctx | undefined): void {
+  if (usageRollupBuffer.length === 0) return;
+  if (!env.DATA_API?.fetch || !env.API_KEY_LOOKUP_INTERNAL_TOKEN) return;
+  const buckets = foldObservations(usageRollupBuffer);
+  usageRollupBuffer = [];
+  usageRollupBufferedAtMs = 0;
+  const pending = env.DATA_API.fetch(
+    new Request("https://api.metagraph.sh/api/v1/internal/usage-rollup", {
+      method: "POST",
+      headers: {
+        [API_KEY_LOOKUP_TOKEN_HEADER]: env.API_KEY_LOOKUP_INTERNAL_TOKEN,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ buckets }),
+    }),
+  ).catch(() => {});
+  if (typeof ctx?.waitUntil === "function") {
+    ctx.waitUntil(pending);
+  }
+}
+
+export function recordMatchedUsageRollup(
+  env: Env,
+  ctx: Ctx | undefined,
+  pathname: string,
+  keyed: boolean,
+  matchers: readonly RouteMatcher[],
+): void {
+  if (!env.DATA_API?.fetch || !env.API_KEY_LOOKUP_INTERNAL_TOKEN) return;
+  const observation = observeRequest(pathname, matchers, {
+    keyed,
+  });
+  const nowMs = Date.now();
+  if (usageRollupBuffer.length === 0) usageRollupBufferedAtMs = nowMs;
+  usageRollupBuffer.push(observation);
+  // A buffer spanning midnight needs no special case: each observation
+  // carries its own `day` and foldObservations groups on it, so the batch
+  // simply emits two buckets.
+  if (
+    usageRollupBuffer.length < USAGE_ROLLUP_FLUSH_COUNT &&
+    nowMs - usageRollupBufferedAtMs < USAGE_ROLLUP_FLUSH_AGE_MS
+  ) {
+    return;
+  }
+  flushUsageRollup(env, ctx);
+}
+
+registerModuleStateReset("workers/usage-rollup.ts", () => {
+  usageRollupBuffer = [];
+  usageRollupBufferedAtMs = 0;
+});


### PR DESCRIPTION
Freshly published account-directory requests still spent more than 500 ms before their first cache lookup, even after deployment preserved split modules. The deployment entry still imported the complete API router and OAuth composition.

Serve the two anonymous default directory reads through a small entry that reuses their existing handlers, minute-bounded snapshot cache, response audit, timing, PostHog usage events, and shared usage-rollup buffer. Load the general router and OAuth provider when another request needs them. Query variants, authenticated/payment requests, other methods, and other routes retain the existing dispatch path; Durable Object exports, scheduled jobs, and queue consumers remain available.

The eager JavaScript graph falls from 2,455,124 to 876,290 bytes (64.3% smaller), and contains neither the general router nor the API catalogue. The full module graph remains subject to the existing bundle budget.

Validation:

- Unsharded coverage: 22,542 tests pass across 985 files, with 11 skipped. Changed runtime coverage is 220/220 lines and 187/188 branches (99.75% counting branches).
- All 75 repository checks pass, along with lint, formatting and typecheck; checks include the Worker deploy dry-run and public-safety scan.
- Real workerd tests execute the compiled deployment entry for both directories, invalid queries, GraphQL, anonymous MCP, and OAuth token rejection.
- Directory regression tests compare complete responses with the general router and cover shared cache keys, snapshot advancement, cold HEAD requests, conditional responses, source-backed fallback, delegation, usage telemetry, and cost-rollup preservation.

Refs #11760. Keep the issue open until the first production cache misses under a newly published snapshot meet its latency criterion.
