### PR TITLE
fix(alarms): retain incidents until all conditions recover

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -795,37 +795,6 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     });
   }
 
-  // FLAPPING (#11488). A lane that recovers between episodes never builds a run
-  // the minimum can reach, however often it breaks: `chain-detail-staleness`
-  // sat 851s behind a 300s threshold for 12.5 minutes, recorded `stale`, and
-  // opened nothing, because no single episode lasted the 45 minutes three
-  // consecutive quarter-hourly ticks would need.
-  //
-  // AFTER the run loops and gated on their output, so a lane in a long unbroken
-  // run -- which is also 100% faulty by this measure -- reports once as `stale`
-  // rather than twice. The run rule is the better description when it applies;
-  // this only speaks where it cannot.
-  const alreadyQualified = new Set(qualified.map((alarm) => alarm.lane));
-  for (const [lane, rate] of Object.entries(faultRates)) {
-    if (!isFlapping(rate, alreadyQualified.has(lane))) continue;
-    const record = latest[lane];
-    // No latest verdict for a lane with rows in the window means the two reads
-    // disagree; the silence loop below is the right reporter for that.
-    if (!record) continue;
-    if (nowMs - record.checked_at > LANE_ALARM_MAX_VERDICT_AGE_MS) continue;
-    qualified.push({
-      lane,
-      kind: "flapping",
-      since: rate.since,
-      ticks: rate.faulty,
-      sampled: rate.sampled,
-      detail: record.detail,
-      age_ms: record.age_ms,
-      cadence_ms: cadenceFor(lane),
-    });
-    alreadyQualified.add(lane);
-  }
-
   for (const record of Object.values(latest)) {
     // A lane already alarming as STALE is not also alarming as SILENT. The
     // watchdog said so itself; that it then stopped saying so is the same
@@ -851,6 +820,30 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
       age_ms: record.age_ms,
       cadence_ms: cadenceMs,
     });
+  }
+
+  // Flapping covers lanes whose repeated failures never build a long run.
+  // Evaluate it after both run and silence findings: a stopped watchdog may
+  // also have a bad failure rate, but still needs only one incident.
+  const qualifiedLanes = new Set(qualified.map((alarm) => alarm.lane));
+  for (const [lane, rate] of Object.entries(faultRates)) {
+    if (!isFlapping(rate, qualifiedLanes.has(lane))) continue;
+    const record = latest[lane];
+    // The reads disagree when a rate has no matching latest verdict. Do not
+    // invent a current finding from that incomplete view.
+    if (!record) continue;
+    if (nowMs - record.checked_at > LANE_ALARM_MAX_VERDICT_AGE_MS) continue;
+    qualified.push({
+      lane,
+      kind: "flapping",
+      since: rate.since,
+      ticks: rate.faulty,
+      sampled: rate.sampled,
+      detail: record.detail,
+      age_ms: record.age_ms,
+      cadence_ms: cadenceFor(lane),
+    });
+    qualifiedLanes.add(lane);
   }
 
   // Worst first, so the per-tick cap keeps the longest-running faults rather
@@ -921,6 +914,15 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     ) {
       continue;
     }
+    // A single healthy tick does not clear a flapping finding. Use the same
+    // complete set as the open path, before its cap and issue deduplication,
+    // or the next tick will reopen the incident we just falsely resolved.
+    if (qualifiedLanes.has(lane)) continue;
+    // An attempted history read with no result for this lane cannot prove
+    // recovery. This also covers loadLaneFaultRates returning {} on failure.
+    if (input.faultRates !== undefined && faultRates[lane] === undefined) {
+      continue;
+    }
     close.push({ lane, issue: open.issue, record });
   }
 
@@ -933,7 +935,6 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
   // that stopped qualifying has stopped alarming, and an issue about it should
   // stop growing too. Membership rather than the alarm itself, because what a
   // recurrence needs is the NEWEST row, and `alarm.since` is the oldest.
-  const qualifiedLanes = new Set(qualified.map((alarm) => alarm.lane));
   const update: LaneAlarmPlan["update"] = [];
   for (const [lane, openIssue] of Object.entries(openAlarms)) {
     if (!isDeadLetterLane(lane)) continue;
@@ -1044,14 +1045,11 @@ export function laneAlarmIssueBody(alarm: LaneAlarm, nowMs: number): string {
     `ORDER BY checked_at DESC LIMIT 40;`,
     "```",
     "",
-    // A PROMISE THIS ISSUE CAN KEEP. "Closed automatically on the first `ok`
-    // verdict" is true of a producer and impossible for a dead-letter lane --
-    // nothing writes one `ok`, so the sentence told the reader to wait for an
-    // event that cannot happen, on the one lane whose issue a human has to
-    // close.
+    // Producer recovery also requires its failure rate to clear. Dead-letter
+    // lanes instead need acknowledgement because nothing can un-lose a message.
     isDeadLetterLane(alarm.lane)
       ? "This will NOT close itself: nothing writes a dead-letter lane `ok`, because\nnothing un-loses a message. Closing it is a decision, and the next loss after\nit closes opens a fresh alarm. Until then, further losses arrive here as\ncomments."
-      : "Closed automatically on the first `ok` verdict.",
+      : "Closed automatically after a fresh `ok` verdict with no active alarm condition and readable fault-rate history.",
     "Opened by the lane-health reader (`src/lane-alarm.ts`); the record it reads",
     "is also served at `GET /api/v1/self-health`.",
   );
@@ -1087,7 +1085,7 @@ export function laneAlarmRecoveryComment(
   const detail = record.detail ? ` (\`${record.detail}\`)` : "";
   return (
     `\`${lane}\` reported **ok** at ${new Date(record.checked_at).toISOString()}${detail}. ` +
-    `Closing automatically.`
+    `No active alarm condition remains. Closing automatically.`
   );
 }
 

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -1377,6 +1377,14 @@ describe("runLaneAlarm", () => {
           checked_at: NOW - 1000,
         },
       ],
+      rates: [
+        {
+          lane: "neurons-staleness",
+          sampled: 96,
+          faulty: 0,
+          since: NOW - 24 * HOUR,
+        },
+      ],
     });
     const github = fakeGitHub({
       "neurons-staleness": { issue: 4242, updatedAt: NOW },
@@ -1388,6 +1396,54 @@ describe("runLaneAlarm", () => {
     assert.equal(out.recovered, 1);
     assert.equal(out.closed, 1);
     assert.deepEqual(github.closed, [4242]);
+  });
+
+  test("keeps the existing incident when the fresh ok still has an alarming failure rate", async () => {
+    const db = healthDb({
+      latest: [{ ...record({ lane: "container:decode", verdict: "ok" }) }],
+      rates: [
+        {
+          lane: "container:decode",
+          sampled: 96,
+          faulty: 34,
+          since: NOW - 24 * HOUR,
+        },
+      ],
+    });
+    const github = fakeGitHub({
+      "container:decode": { issue: 77, updatedAt: NOW },
+    });
+    const capture = vi.fn(async () => true);
+    const out = await runLaneAlarm(db.env, {
+      github,
+      now: () => NOW,
+      recordException: capture,
+    });
+    assert.equal(out.closed, 0);
+    assert.deepEqual(github.closed, []);
+    assert.deepEqual(github.opened, []);
+    assert.equal(capture.mock.calls.length, 0);
+  });
+
+  test("does not close an incident when its fault-rate query fails", async () => {
+    const db = healthDb({
+      latest: [{ ...record({ lane: "a", verdict: "ok" }) }],
+    });
+    const onQuery = pg.control.onQuery;
+    pg.control.onQuery = (query) => {
+      onQuery?.(query);
+      if (query.text.includes("AS sampled"))
+        throw new Error("history unavailable");
+    };
+    const github = fakeGitHub({ a: { issue: 77, updatedAt: NOW } });
+    const out = await runLaneAlarm(db.env, {
+      github,
+      now: () => NOW,
+      recordException: async () => true,
+    });
+    assert.equal(out.ok, true);
+    assert.equal(out.closed, 0);
+    assert.deepEqual(github.closed, []);
   });
 
   // THE END OF THE HOLE THE TOKEN OPENED. A dead-letter lane never reports
@@ -1889,6 +1945,7 @@ describe("runLaneAlarm", () => {
       latest: [
         { lane: "a", verdict: "ok", age_ms: 1, detail: null, checked_at: NOW },
       ],
+      rates: [{ lane: "a", sampled: 96, faulty: 0, since: NOW - 24 * HOUR }],
     });
     const github = fakeGitHub({ a: { issue: 5, updatedAt: NOW } });
     github.close = async () => {
@@ -2305,6 +2362,78 @@ describe("flapping: a lane that recovers between episodes (#11488)", () => {
     assert.equal(plan.open.length, 0);
   });
 
+  test("a healthy tick cannot close an incident that still qualifies as flapping", () => {
+    const lane = "container:decode";
+    const input = {
+      ...base,
+      latest: { [lane]: record({ lane, verdict: "ok" }) },
+      faultRates: {
+        [lane]: { sampled: 96, faulty: 32, since: NOW - 24 * HOUR },
+      },
+      observedMaxGap: { [lane]: 15 * 60_000 },
+    };
+    const first = laneAlarmPlan(input);
+    assert.deepEqual(
+      first.open.map((alarm) => alarm.lane),
+      [lane],
+    );
+
+    const openAlarms = { [lane]: { issue: 77, updatedAt: NOW } };
+    for (let tick = 1; tick <= 4; tick += 1) {
+      const nowMs = NOW + tick * 30 * 60_000;
+      const next = laneAlarmPlan({
+        ...input,
+        nowMs,
+        latest: { [lane]: record({ lane, verdict: "ok", checked_at: nowMs }) },
+        openAlarms,
+      });
+      assert.deepEqual(next.open, [], "the original incident already exists");
+      assert.deepEqual(next.close, [], "the failure rate has not recovered");
+    }
+
+    const recovered = laneAlarmPlan({
+      ...input,
+      openAlarms,
+      faultRates: {
+        [lane]: { sampled: 96, faulty: 31, since: NOW - 24 * HOUR },
+      },
+    });
+    assert.deepEqual(
+      recovered.close.map((entry) => entry.issue),
+      [77],
+    );
+    assert.deepEqual(recovered.open, []);
+  });
+
+  test.each(["ok", "unknown"] as const)(
+    "a silent lane with a last %s verdict opens only one incident despite its failure rate",
+    (verdict) => {
+      const plan = laneAlarmPlan({
+        ...base,
+        latest: {
+          a: record({ lane: "a", verdict, checked_at: NOW - 2 * HOUR }),
+        },
+        faultRates: { a: { sampled: 96, faulty: 32, since: NOW - 24 * HOUR } },
+        observedMaxGap: { a: 15 * 60_000 },
+      });
+      assert.deepEqual(
+        plan.open.map((alarm) => alarm.kind),
+        ["silent"],
+      );
+      assert.equal(plan.suppressed, 0);
+    },
+  );
+
+  test("a missing rate from an attempted history read cannot prove recovery", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "ok" }) },
+      faultRates: {},
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
+    });
+    assert.deepEqual(plan.close, []);
+  });
+
   test("too few samples is an anecdote, not a rate", () => {
     // A daily lane that logged twice, once badly, reads as 50% faulty. That is
     // not a rate and must not open an issue.
@@ -2344,6 +2473,8 @@ describe("flapping: a lane that recovers between episodes (#11488)", () => {
     );
     assert.ok(body.includes("32 of its last 96 ticks (33%)"));
     assert.ok(body.includes("recovering between each one"));
+    assert.ok(body.includes("no active alarm condition"));
+    assert.ok(!body.includes("first `ok` verdict"));
   });
 });
 
@@ -2460,7 +2591,8 @@ describe("flapping edge cases", () => {
 
   test("a stale-dated verdict is residue, not a flap", () => {
     // Same bound the stale loop applies: a verdict older than the max age is
-    // left over from a lane nobody reads any more.
+    // left over from a lane nobody reads any more. An uncalibrated cadence
+    // leaves it to the flapping age guard rather than qualifying as silent.
     const plan = laneAlarmPlan({
       ...base,
       latest: {
@@ -2471,9 +2603,8 @@ describe("flapping edge cases", () => {
         }),
       },
       faultRates: { a: { sampled: 96, faulty: 96, since: NOW - 24 * HOUR } },
-      observedMaxGap: { a: 15 * 60_000 },
     });
-    assert.equal(plan.open.filter((a) => a.kind === "flapping").length, 0);
+    assert.deepEqual(plan.open, []);
   });
 
   test("a flapping alarm with no sample count reports 0%, never NaN", () => {


### PR DESCRIPTION
## Summary

Closes #11995.

An incident with 32 faulty ticks out of 96 could close on a fresh healthy tick even though the same 24-hour failure rate immediately qualified it to reopen. Recovery now requires every active alarm condition to clear, so one ongoing fault retains one incident.

## What Changed

- Evaluate silence before flapping and share the complete set of qualifying lanes with recovery and dead-letter updates.
- Keep existing incidents open when the fault-rate history read fails or omits their lane.
- Describe the actual recovery condition in issue text and cover the open/retain/close sequence, overlapping findings, and failed history reads.

The existing silence guard in `src/lane-alarm.ts:907` and lane shaping in `src/self-health.ts:369` provide the same model: stored health must satisfy the current alarm predicates before it can establish recovery. Alarm thresholds and real recurrence detection are preserved.

## Registry Safety

- [x] Links a tracked, currently-open issue.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema contracts are unchanged.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run validate`
- [x] `npm run test:coverage -- --maxWorkers=4` — all 985 test files passed; 22,548 tests passed and 11 skipped. Changed runtime coverage is 11/11 lines and 12/12 branches.
- [x] `git diff --check`

The original implementation fails the new lifecycle assertions. All 123 lane-alarm tests pass with the fix. Production verification will check the deployed revision and subsequent ordinary alarm ticks; this change does not by itself repair the underlying producer faults.
