### PR TITLE
fix(nominators): persist full-scan delivery receipts

### DIFF
--- a/migrations/neon/0035_nominator_scan_receipts.sql
+++ b/migrations/neon/0035_nominator_scan_receipts.sql
@@ -1,0 +1,9 @@
+-- #11997: preserve full-scan delivery evidence independently of the mutable
+-- position ledger. One coldkey is never split across chunks, so replacing its
+-- receipt on replay is idempotent. Self-stake never writes this table.
+CREATE TABLE IF NOT EXISTS nominator_scan_receipts (
+  captured_at BIGINT NOT NULL,
+  coldkey TEXT NOT NULL,
+  row_count INTEGER NOT NULL CHECK (row_count > 0),
+  PRIMARY KEY (captured_at, coldkey)
+);

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -37,6 +37,7 @@ import {
   type NeonWriteResult,
 } from "./neon-write.ts";
 import { NOMINATOR_POSITION_INSERT_COLUMNS } from "./account-nominator-positions.ts";
+import { writeNominatorScanReceipts } from "./nominator-scan-receipts.ts";
 import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
 import {
   neonWriteBufferEnabled,
@@ -82,6 +83,8 @@ export interface NominatorPositionsMirrorOutcome {
   attempted: boolean;
   write?: NeonWriteResult;
   prune?: NeonWriteResult;
+  /** Full-scan receipts must land before acknowledging a delivered chunk. */
+  coverage?: NeonWriteResult;
   /** The pass tally, SURFACED so an inverted caller can require it (#10109).
    * It was written but not reported, so once this lane is Neon's the request
    * could answer ok while nominator_positions_passes -- a table with no other
@@ -209,6 +212,23 @@ export async function mirrorNominatorPositionsToNeon(
     true,
   );
 
+  // The position key excludes source: a newer self-stake write can replace
+  // alpha's source and timestamp. Preserve full-scan evidence separately,
+  // after durable data and pruning, before a pass can be counted complete.
+  let coverage: NeonWriteResult | undefined;
+  if (prune.ok && source === POSITION_SOURCE_ALPHA) {
+    coverage = await writeNominatorScanReceipts(sql, input.rows);
+    await recordNeonWriteVerdict(
+      laneDb,
+      `${NOMINATOR_POSITIONS_NEON_LANE}-coverage`,
+      coverage,
+      now(),
+      buffered,
+      true,
+    );
+    if (!coverage.ok) return { attempted: true, write, prune, coverage };
+  }
+
   // AFTER THE PRUNE, BEFORE THE TALLY (metagraphed-infra#414). Recomputes
   // share_fraction from the raw shares of this pass, which is what lets the
   // producer stop buffering the whole keyspace to compute a pool-normalised
@@ -274,7 +294,7 @@ export async function mirrorNominatorPositionsToNeon(
       true,
     );
   }
-  return { attempted: true, write, prune, pass: passResult };
+  return { attempted: true, write, prune, coverage, pass: passResult };
 }
 
 /**

--- a/src/nominator-scan-receipts.ts
+++ b/src/nominator-scan-receipts.ts
@@ -1,0 +1,60 @@
+// Full-scan delivery evidence must outlive a position's current source (#11997).
+// A self-stake refresh can replace an alpha row on the same position key, so
+// the mutable ledger cannot also be the record of which coldkeys alpha visited.
+import type { NeonWriteResult, PgUnsafe } from "./neon-write.ts";
+
+export const NOMINATOR_SCAN_RECEIPTS_RETENTION_MS = 30 * 24 * 60 * 60_000;
+
+/** One receipt per (capture, coldkey), written after its positions and prune.
+ * The producer never splits a coldkey across chunks. Replacing its row count
+ * therefore preserves replay idempotence, unlike an additive delivery tally.
+ * Counts describe the accepted payload, including duplicate position keys,
+ * so their sum can be compared with the producer's declared pass_total. */
+export async function writeNominatorScanReceipts(
+  sql: PgUnsafe,
+  rows: readonly Record<string, unknown>[],
+): Promise<NeonWriteResult> {
+  if (rows.length === 0) return { ok: true, rows: 0, statements: 0 };
+  const receipts = new Map<
+    string,
+    { captured_at: number; coldkey: string; row_count: number }
+  >();
+  let oldestCapture = Infinity;
+  // These rows already passed the route schema and the ledger's PostgreSQL
+  // constraints. Coerce its BIGINT representation without changing the stamp.
+  for (const row of rows) {
+    const capturedAt = Number(row.captured_at);
+    const coldkey = String(row.coldkey);
+    oldestCapture = Math.min(oldestCapture, capturedAt);
+    const key = JSON.stringify([capturedAt, coldkey]);
+    const receipt = receipts.get(key);
+    if (receipt) receipt.row_count += 1;
+    else receipts.set(key, { captured_at: capturedAt, coldkey, row_count: 1 });
+  }
+  const captured = [...receipts.values()];
+  try {
+    await sql.unsafe(
+      `WITH expired AS (
+         DELETE FROM nominator_scan_receipts WHERE captured_at < $1::bigint
+       )
+       INSERT INTO nominator_scan_receipts (captured_at, coldkey, row_count)
+       SELECT * FROM UNNEST($2::bigint[], $3::text[], $4::int[])
+       ON CONFLICT (captured_at, coldkey) DO UPDATE
+         SET row_count = EXCLUDED.row_count`,
+      [
+        oldestCapture - NOMINATOR_SCAN_RECEIPTS_RETENTION_MS,
+        captured.map((row) => row.captured_at),
+        captured.map((row) => row.coldkey),
+        captured.map((row) => row.row_count),
+      ],
+    );
+    return { ok: true, rows: captured.length, statements: 1 };
+  } catch (error) {
+    return {
+      ok: false,
+      rows: 0,
+      statements: 0,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -340,6 +340,13 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     reason: "written with nominator_positions",
     producer: "validator_nominators",
   },
+  nominator_scan_receipts: {
+    column: "captured_at",
+    kind: "ms",
+    maxAgeMs: missedTicksMs("validator_nominators", 1.5),
+    reason: "full-scan delivery receipts, independent of self-stake refreshes",
+    producer: "validator_nominators",
+  },
   validator_nominator_counts_passes: {
     column: "captured_at",
     kind: "ms",

--- a/tests/data-api-self-stake-sync.test.ts
+++ b/tests/data-api-self-stake-sync.test.ts
@@ -52,13 +52,15 @@ CREATE TABLE IF NOT EXISTS nominator_positions (
   captured_at    BIGINT  NOT NULL,
   PRIMARY KEY (coldkey, hotkey, netuid)
 );`;
-const MIGRATION = fs.readFileSync(
-  path.join(
-    process.cwd(),
-    "migrations/neon/0027_nominator_positions_source.sql",
-  ),
-  "utf8",
-);
+const MIGRATION =
+  fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "migrations/neon/0027_nominator_positions_source.sql",
+    ),
+    "utf8",
+  ) +
+  fs.readFileSync("migrations/neon/0035_nominator_scan_receipts.sql", "utf8");
 
 let db: PGlite;
 

--- a/tests/nominator-positions-neon-write.test.ts
+++ b/tests/nominator-positions-neon-write.test.ts
@@ -243,7 +243,11 @@ describe("mirrorNominatorPositionsToNeon", () => {
     assert.ok(sql.calls[1].text.startsWith("DELETE"));
     assert.deepEqual(
       spy.rows.map((r) => r.lane),
-      ["neon:nominator-positions", "neon:nominator-positions-prune"],
+      [
+        "neon:nominator-positions",
+        "neon:nominator-positions-prune",
+        "neon:nominator-positions-coverage",
+      ],
     );
   });
 
@@ -273,14 +277,15 @@ describe("mirrorNominatorPositionsToNeon", () => {
     const kinds = sql.calls.map((call) => call.text.split(" ")[0]);
     assert.deepEqual(
       kinds,
-      ["INSERT", "DELETE", "UPDATE", "INSERT"],
-      `expected upsert, prune, normalise, tally -- got ${kinds.join(", ")}`,
+      ["INSERT", "DELETE", "WITH", "UPDATE", "INSERT"],
+      `expected upsert, prune, receipt, normalise, tally -- got ${kinds.join(", ")}`,
     );
     assert.deepEqual(
       spy.rows.map((r) => r.lane),
       [
         "neon:nominator-positions",
         "neon:nominator-positions-prune",
+        "neon:nominator-positions-coverage",
         "neon:nominator-positions-normalize",
         "neon:nominator-positions-pass",
       ],

--- a/tests/nominator-scan-receipts.test.ts
+++ b/tests/nominator-scan-receipts.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, describe, test, vi } from "vitest";
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import worker from "../workers/data-api.ts";
+import {
+  coldkeyMaxCapturedAt,
+  mirrorNominatorPositionsToNeon,
+  POSITION_SOURCE_SELF_STAKE,
+} from "../src/nominator-positions-neon-write.ts";
+import {
+  NOMINATOR_SCAN_RECEIPTS_RETENTION_MS,
+  writeNominatorScanReceipts,
+} from "../src/nominator-scan-receipts.ts";
+
+const NOW = 1_785_800_000_000;
+const COLDKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const HOTKEY = "5FyVinYphF6JS5FZHzhMQffxtgbz1WxwUEBAxTRo9nABwb5g";
+const migrations = [
+  "0005_remaining_d1_tables.sql",
+  "0006_lane_health.sql",
+  "0007_hand_created_tables.sql",
+  "0025_nominator_positions_shares.sql",
+  "0027_nominator_positions_source.sql",
+  "0035_nominator_scan_receipts.sql",
+];
+let db: PGlite;
+let failReceipts = false;
+const sql = {
+  async unsafe(text: string, values: unknown[] = []) {
+    if (failReceipts && text.includes("INSERT INTO nominator_scan_receipts")) {
+      throw new Error("receipt storage unavailable");
+    }
+    return (await db.query(text, values)).rows;
+  },
+};
+const position = (coldkey = COLDKEY, capturedAt = NOW, hotkey = HOTKEY) => ({
+  coldkey,
+  hotkey,
+  netuid: 1,
+  share_fraction: 1,
+  captured_at: capturedAt,
+});
+const mirror = (rows: ReturnType<typeof position>[], source?: string) =>
+  mirrorNominatorPositionsToNeon(
+    {},
+    null,
+    { rows, coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows), source },
+    { sql, now: () => NOW },
+  );
+const receipts = async () =>
+  (
+    await db.query<{ captured_at: number; coldkey: string; row_count: number }>(
+      "SELECT * FROM nominator_scan_receipts ORDER BY captured_at, coldkey",
+    )
+  ).rows;
+
+beforeAll(async () => {
+  db = new PGlite();
+  for (const file of migrations) {
+    await db.exec(fs.readFileSync(`migrations/neon/${file}`, "utf8"));
+  }
+});
+afterAll(async () => db.close());
+beforeEach(async () => {
+  await db.exec(
+    "TRUNCATE nominator_positions, nominator_positions_passes, nominator_scan_receipts, lane_health",
+  );
+  failReceipts = false;
+  pg.control.postgres = sql.unsafe;
+  pg.control.answers = [];
+  pg.control.rows = null;
+  pg.control.failNext = null;
+  pg.control.onQuery = null;
+});
+
+describe("full-scan receipts", () => {
+  test("replaying a complete coldkey chunk does not inflate its receipt", async () => {
+    const rows = [
+      position(),
+      position(COLDKEY, NOW, "another-hotkey"),
+      position("other-coldkey"),
+    ];
+    assert.equal((await mirror(rows)).coverage?.ok, true);
+    const first = await receipts();
+    assert.deepEqual(
+      first.map((r) => r.row_count),
+      [2, 1],
+    );
+    assert.equal((await mirror(rows)).coverage?.ok, true);
+    assert.deepEqual(await receipts(), first);
+  });
+
+  test("self-stake source takeover cannot erase or freshen full-scan evidence", async () => {
+    const rows = Array.from({ length: 100 }, (_, i) =>
+      position(`coldkey-${i}`),
+    );
+    assert.equal((await mirror(rows)).coverage?.rows, 100);
+    const original = await receipts();
+    const topUp = rows
+      .slice(0, 30)
+      .map((row) => ({ ...row, captured_at: NOW + 1000 }));
+    const out = await mirror(topUp, POSITION_SOURCE_SELF_STAKE);
+    assert.equal(out.write?.ok, true);
+    assert.equal(out.coverage, undefined);
+    assert.deepEqual(await receipts(), original);
+    const counts = (
+      await db.query(
+        "SELECT COUNT(*) AS total, COUNT(*) FILTER (WHERE source = 'alpha') AS alpha FROM nominator_positions",
+      )
+    ).rows[0];
+    assert.deepEqual(counts, { total: 100, alpha: 70 });
+  });
+
+  test("a delayed scan records its own capture without overwriting newer position data", async () => {
+    await mirror([position(COLDKEY, NOW + 1000)], POSITION_SOURCE_SELF_STAKE);
+    assert.equal((await mirror([position()])).coverage?.ok, true);
+    assert.deepEqual(await receipts(), [
+      { captured_at: NOW, coldkey: COLDKEY, row_count: 1 },
+    ]);
+    const row = (
+      await db.query("SELECT captured_at, source FROM nominator_positions")
+    ).rows[0];
+    assert.deepEqual(row, {
+      captured_at: NOW + 1000,
+      source: POSITION_SOURCE_SELF_STAKE,
+    });
+  });
+
+  test("keeps captures distinct and expires only receipts outside the history window", async () => {
+    const cutoff = NOW - NOMINATOR_SCAN_RECEIPTS_RETENTION_MS;
+    await writeNominatorScanReceipts(sql, [position(COLDKEY, cutoff - 1)]);
+    await writeNominatorScanReceipts(sql, [position(COLDKEY, cutoff)]);
+    await writeNominatorScanReceipts(sql, [position()]);
+    assert.deepEqual(
+      (await receipts()).map((r) => r.captured_at),
+      [cutoff, NOW],
+    );
+    await writeNominatorScanReceipts(sql, [position(COLDKEY, NOW - 1000)]);
+    assert.deepEqual(
+      (await receipts()).map((r) => r.captured_at),
+      [cutoff, NOW - 1000, NOW],
+    );
+  });
+
+  test("an empty chunk does not access storage", async () => {
+    const unsafe = vi.fn();
+    assert.deepEqual(await writeNominatorScanReceipts({ unsafe }, []), {
+      ok: true,
+      rows: 0,
+      statements: 0,
+    });
+    assert.equal(unsafe.mock.calls.length, 0);
+  });
+
+  test.each([new Error("unavailable"), "disconnected"])(
+    "reports a receipt failure in band: %s",
+    async (error) => {
+      const out = await writeNominatorScanReceipts(
+        {
+          unsafe: async () => {
+            throw error;
+          },
+        },
+        [position()],
+      );
+      assert.equal(out.ok, false);
+      assert.equal(out.reason, error instanceof Error ? error.message : error);
+    },
+  );
+
+  test("a failed receipt withholds the pass tally after positions have landed", async () => {
+    failReceipts = true;
+    const rows = [position()];
+    const out = await mirrorNominatorPositionsToNeon(
+      {},
+      null,
+      {
+        rows,
+        coldkeyMaxCapturedAt: coldkeyMaxCapturedAt(rows),
+        pass: { capturedAt: NOW, expectedRows: 1, receivedRows: 1, nowMs: NOW },
+      },
+      { sql, now: () => NOW },
+    );
+    assert.equal(out.write?.ok, true);
+    assert.equal(out.prune?.ok, true);
+    assert.equal(out.coverage?.ok, false);
+    assert.equal(out.pass, undefined);
+    assert.deepEqual(
+      (await db.query("SELECT * FROM nominator_positions_passes")).rows,
+      [],
+    );
+  });
+
+  test("the HTTP writer returns a retryable error when a receipt fails", async () => {
+    failReceipts = true;
+    const response = await worker.fetch(
+      new Request(
+        "https://example.test/api/v1/internal/nominator-positions-sync",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-nominator-positions-sync-token": "receipt-test-secret",
+          },
+          body: JSON.stringify({ rows: [position()], pass_total: 1 }),
+        },
+      ),
+      {
+        ...pgMockEnv(),
+        NOMINATOR_POSITIONS_SYNC_SECRET: "receipt-test-secret",
+      } as never,
+      { waitUntil() {} } as never,
+    );
+    assert.equal(response.status, 502);
+    assert.deepEqual(
+      (await db.query("SELECT * FROM nominator_positions_passes")).rows,
+      [],
+    );
+  });
+
+  test("the queue retries a receipt failure and acknowledges its successful replay", async () => {
+    const calls: string[] = [];
+    const message = {
+      body: {
+        lane: "nominator-positions",
+        captured_at: NOW,
+        key_complete: true,
+        pass_total: 1,
+        rows: [position()],
+      },
+      ack: () => calls.push("ack"),
+      retry: () => calls.push("retry"),
+    };
+    failReceipts = true;
+    await worker.queue!(
+      { messages: [message] } as never,
+      pgMockEnv() as never,
+      { waitUntil() {} } as never,
+    );
+    assert.deepEqual(calls, ["retry"]);
+    failReceipts = false;
+    await worker.queue!(
+      { messages: [message] } as never,
+      pgMockEnv() as never,
+      { waitUntil() {} } as never,
+    );
+    assert.deepEqual(calls, ["retry", "ack"]);
+    assert.deepEqual(await receipts(), [
+      { captured_at: NOW, coldkey: COLDKEY, row_count: 1 },
+    ]);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -2705,7 +2705,7 @@ async function handleNominatorPositionsSync(
     // serve both. And nominator_positions_passes has no other writer once this
     // inverts, so a tally that did not land leaves a completeness ledger
     // nobody can tell is empty.
-    const failed = [neon.write, neon.prune, neon.pass].filter(
+    const failed = [neon.write, neon.prune, neon.coverage, neon.pass].filter(
       (r) => r && !r.ok,
     );
     if (!neon.attempted || failed.length > 0) {
@@ -9764,9 +9764,12 @@ export default {
           coldkeyMaxCapturedAt: cutoffs,
           pass,
         });
-        const failed = [neon.write, neon.prune, neon.pass].filter(
-          (r) => r && !r.ok,
-        );
+        const failed = [
+          neon.write,
+          neon.prune,
+          neon.coverage,
+          neon.pass,
+        ].filter((r) => r && !r.ok);
         if (!neon.attempted || failed.length > 0) {
           throw new Error(
             `nominator-positions neon write failed: ${


### PR DESCRIPTION
## Summary

Record full-scan delivery receipts independently of the current position ledger. A self-stake refresh can replace an alpha position's source and capture time, erasing the evidence used to measure a completed nominator scan.

Closes #11998. Refs #11997. This is the additive writer and migration rollout; the watchdog will switch to these receipts after a complete instrumented scan is verified.

## What Changed

- Add `nominator_scan_receipts`, keyed by capture and coldkey, retaining 30 days of delivery evidence. Whole-coldkey payload replay replaces its accepted row count and cannot inflate coverage.
- Persist receipts after positions and pruning, before pass tallying. Receipt failure returns HTTP 502 or retries the queued chunk. Self-stake writes leave receipts unchanged.
- Classify receipt freshness under the daily full-scan producer.

## Registry Safety

- No public API or schema contract changes; this migration is additive. Generated artifacts were produced by the build and the diff contains no deploy-owned artifacts.
- No secrets, private infrastructure identifiers, or production wallet data. Tests use synthetic records and existing development fixtures.
- The existing migration workflow applies the table on merge. If a Worker becomes active before migration completion, affected chunks fail retryably rather than being acknowledged without receipts.

## Validation

- Build, lint, formatting, typecheck, `npm run validate`, and `git diff --check` pass.
- Full unsharded coverage: 986 files; 22,558 tests passed, 11 skipped. Changed executable lines 28/28 and branches 14/14 covered (100%).
- PostgreSQL integration tests cover 100 scan coldkeys followed by 30 self-stake replacements, delayed captures, replay, history expiry, HTTP 502 and queue retry. Existing self-stake isolation tests pass.
- Migration applied and schema/primary key verified on an isolated Neon branch.
