### PR TITLE
fix(neon): drain arrivals made during a buffer flush

### DIFF
--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -821,6 +821,57 @@ describe("a truncated drain must come back (#10722)", () => {
   });
 });
 
+test("arrivals during an untruncated flush retain their count and request another drain", async () => {
+  const storage = fakeStorage();
+  await enqueueStatement(
+    storage,
+    stmt("nominator-positions", "positions"),
+    NOW,
+  );
+  const applied: string[] = [];
+  const deps = {
+    laneHealthDb: laneSpy().db,
+    now: () => NOW,
+    sql: {
+      async unsafe(text: string) {
+        applied.push(text);
+        if (text === "positions") {
+          // Enqueues can run while the alarm awaits Postgres. The original
+          // list had room to spare, but its snapshot cannot see these writes.
+          await enqueueStatement(
+            storage,
+            stmt("nominator-positions", "receipt"),
+            NOW + 1,
+          );
+          await enqueueStatement(
+            storage,
+            stmt("nominator-positions", "pass"),
+            NOW + 2,
+          );
+        }
+        return [];
+      },
+    },
+  };
+
+  const first = await flushBuffer(storage, {}, CTX, deps);
+  assert.equal(first.ok, true);
+  assert.equal(first.drained, 1);
+  assert.equal(first.remaining, true, "new arrivals need the backlog retry");
+  assert.equal(
+    await storage.get("pending"),
+    2,
+    "the ceiling must count new arrivals",
+  );
+  assert.deepEqual(applied, ["positions"]);
+
+  const second = await flushBuffer(storage, {}, CTX, deps);
+  assert.equal(second.remaining, false);
+  assert.equal(await storage.get("pending"), 0);
+  assert.equal(await countPending(storage), 0);
+  assert.deepEqual(applied, ["positions", "receipt", "pass"]);
+});
+
 describe("the enqueue is O(1) (#10755)", () => {
   // THE BUG. enqueueStatement called countPending(), which lists every chunk
   // in the buffer and sorts them -- on every enqueue. Cloudflare's logs:
@@ -942,7 +993,7 @@ describe("an orphaned alarm must not block the buffer forever (#10763)", () => {
 });
 
 describe("the flush never scans either (#10775)", () => {
-  test("a TRUNCATED drain does not list the remaining backlog", async () => {
+  test("a TRUNCATED drain probes one remaining key without scanning the backlog", async () => {
     // The same O(n) that #10755 removed from the enqueue, reintroduced in the
     // alarm's reconcile. Measured in production: the flush at 13:23:12 drained
     // its 500 and never came back for the rest, because the scan outran the
@@ -951,11 +1002,11 @@ describe("the flush never scans either (#10775)", () => {
     for (let i = 0; i < FLUSH_LIST_LIMIT + 30; i += 1) {
       await enqueueStatement(storage, stmt("neurons", `S${i}`), NOW);
     }
-    let listsAfterDrain = 0;
+    const limitsAfterDrain: Array<number | undefined> = [];
     const realList = storage.list.bind(storage);
     let draining = false;
     storage.list = async (options) => {
-      if (draining) listsAfterDrain += 1;
+      if (draining) limitsAfterDrain.push(options.limit);
       return realList(options);
     };
     const out = await flushBuffer(storage, {}, CTX, {
@@ -969,12 +1020,16 @@ describe("the flush never scans either (#10775)", () => {
       },
     });
     assert.equal(out.remaining, true, "it must report work left");
-    assert.equal(listsAfterDrain, 0, "and must not scan to work that out");
+    assert.deepEqual(
+      limitsAfterDrain,
+      [1],
+      "remaining work needs only one key, never a scan",
+    );
   });
 
   test("a clean drain still reconciles the counter to exactly zero", async () => {
-    // Drift correction lives here: an untruncated flush emptied the buffer by
-    // definition, so 0 is exact and free.
+    // With no new arrivals, the bounded probe confirms the buffer is empty
+    // and can reset a drifted counter exactly.
     const storage = fakeStorage();
     for (let i = 0; i < 3; i += 1) {
       await enqueueStatement(storage, stmt("l", `S${i}`), NOW);

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -312,10 +312,6 @@ export async function flushBuffer(
     limit: FLUSH_LIST_LIMIT,
   });
   const groups = groupChunkKeys([...stored.keys()]);
-  // A full page back means there is almost certainly more behind it. Cheaper
-  // and more honest than a second count: the caller only needs to know whether
-  // to come back, not exactly how much is left.
-  const truncated = stored.size >= FLUSH_LIST_LIMIT;
   if (groups.length === 0) {
     // RECORD IT. An empty drain returning silently is why "the alarm never
     // fired" and "the alarm fired and found nothing" were indistinguishable
@@ -465,21 +461,15 @@ export async function flushBuffer(
   }
 
   await storage.delete(drainedKeys);
-  // O(1) ON BOTH PATHS (#10775). This reconciled with countPending() when the
-  // drain was truncated -- which is the same full storage.list() that #10755
-  // removed from the enqueue, just moved into the alarm. Measured in
-  // production: the flush at 13:23:12 drained its 500 and then did NOT come
-  // back for the remainder, because the scan on a large backlog outran the
-  // handler.
-  //
-  // A clean drain still reconciles to the TRUE value, and that is where drift
-  // gets corrected: an untruncated flush has emptied the buffer by definition,
-  // so 0 is exact and costs nothing to write. A truncated one decrements, which
-  // can drift slightly but is bounded and self-corrects on the next clean
-  // drain -- and a counter that is slightly high only makes the ceiling
-  // slightly conservative, which is the safe direction.
+  // Enqueues can arrive while SQL is in flight (#12001). Even an untruncated
+  // initial listing cannot prove the buffer is empty after those awaits.
+  // Probe ONE remaining chunk, never scan the backlog (#10775). Preserve new
+  // arrivals in the counter and send them through the short backlog retry.
+  // Only a confirmed empty buffer can reconcile a drifted counter to zero.
+  const remaining =
+    (await storage.list({ prefix: STATEMENT_PREFIX, limit: 1 })).size > 0;
   await storage.put({
-    [PENDING_KEY]: truncated
+    [PENDING_KEY]: remaining
       ? Math.max(
           0,
           ((await storage.get<number>(PENDING_KEY)) ?? 0) -
@@ -533,7 +523,7 @@ export async function flushBuffer(
       ),
     );
   }
-  return { drained, undecodable, ok: true, remaining: truncated };
+  return { drained, undecodable, ok: true, remaining };
 }
 
 /**


### PR DESCRIPTION
## Summary

Keep statements that arrive during a Neon flush on the short backlog retry. A flush previously treated an untruncated initial storage listing as proof that the buffer was still empty after awaiting Postgres. Concurrent enqueues then lost their pending count and could wait another ten-minute interval.

Closes #12001.

## What Changed

Probe one remaining storage key after the drain. If work remains, decrement the pending count by the statements actually settled and return `remaining: true`, which uses the existing ten-second retry. Reconcile the counter to zero only after confirming the buffer is empty. Storage work stays bounded; failed statements and their successors remain buffered.

## Validation

- The new concurrency regression fails on the old code. It enqueues a receipt and completion statement while a position write is in flight, then verifies that both remain counted and drain in order on the next pass.
- All 109 focused buffer tests pass, including truncation, transient conflict retry, permanent failure, ceiling enforcement, counter drift, and bounded storage access.
- Full unsharded coverage: 986 files; 22,559 tests passed, 11 skipped. Changed executable lines 2/2 and branches 2/2 covered (100%).
- Build, lint, formatting, typecheck, repository validation, public safety, and diff checks pass.

Production verification of the receipt writer exposed this delay: its full scan initially had 18,400 of 104,295 rows delivered after the first successful drain. All 104,295 rows arrived on the next buffer interval. This change removes the unnecessary interval between those drains.
