### PR TITLE
fix(schemas): accept supported nominator page limits

### DIFF
--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -64895,7 +64895,7 @@
             "type": "string"
           },
           "limit": {
-            "maximum": 100,
+            "maximum": 2000,
             "minimum": 0,
             "type": "integer"
           },

--- a/schemas-src/routes/validator-nominators.ts
+++ b/schemas-src/routes/validator-nominators.ts
@@ -9,6 +9,7 @@
 // via repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
+import { GLOBAL_VALIDATOR_LIMIT_MAX } from "../../src/route-limits.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES = [
@@ -60,7 +61,9 @@ export const ValidatorNominatorsArtifactSchema = z
       .describe(
         "The resolved sort actually applied (an omitted sort resolves to net_staked).",
       ),
-    limit: z.int().min(0).max(100),
+    // Echo the supported request limit, including pages above the cold-tier
+    // in-memory slice cap. The response boundary must accept a served page.
+    limit: z.int().min(0).max(GLOBAL_VALIDATOR_LIMIT_MAX),
     offset: z.int().min(0),
     nominator_count: z
       .int()

--- a/tests/validator-nominators.test.ts
+++ b/tests/validator-nominators.test.ts
@@ -10,6 +10,7 @@ import {
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
+import { ValidatorNominatorsArtifactSchema } from "../schemas-src/routes/validator-nominators.ts";
 
 // One GROUP BY coldkey, event_kind row.
 function row(
@@ -543,6 +544,35 @@ describe("buildValidatorNominators — count and concentration", () => {
     }) as Row;
     assert.equal(d.limit, served);
     assert.equal((d.nominators as Row[]).length, served);
+  });
+
+  test.each([101, 200, 2000])(
+    "a served page of %i satisfies the published response contract",
+    (limit) => {
+      const page = nominators(
+        ...Array.from({ length: limit }, (_, i) => i + 1),
+      );
+      const output = buildValidatorNominators(page, HOTKEY, {
+        limit,
+        totalCount: 3020,
+        alreadyPaged: true,
+      });
+      const parsed = ValidatorNominatorsArtifactSchema.parse(output);
+      assert.equal(parsed.limit, limit);
+      assert.equal(parsed.nominators.length, limit);
+    },
+  );
+
+  test("the response contract rejects a page beyond the route's 2000 ceiling", () => {
+    const output = buildValidatorNominators([], HOTKEY, {
+      limit: 2001,
+      totalCount: 3020,
+      alreadyPaged: true,
+    });
+    assert.equal(
+      ValidatorNominatorsArtifactSchema.safeParse(output).success,
+      false,
+    );
   });
 
   test("the in-memory slice is still capped at NOMINATOR_LIMIT_MAX", () => {


### PR DESCRIPTION
## Summary

Accept the full supported nominator page range at the response boundary. Requests already allow up to 2,000 rows, but the response schema capped the echoed limit at 100. Valid `limit=200` requests consequently failed response validation and returned a server error.

Closes #12004.

## What Changed

Use the handler's existing `GLOBAL_VALIDATOR_LIMIT_MAX` for the response field and regenerate OpenAPI. The request ceiling stays at 2,000, oversized responses remain invalid, and the separate in-memory slice limit stays in place. Generated TypeScript types remain unchanged because this field remains a number.

## Validation

- Actual builder output for 101, 200, and 2,000 rows reproduces the original schema rejection and now parses successfully. A limit of 2,001 remains invalid.
- All 373 focused validator and schema tests pass.
- Full unsharded coverage: 986 files; 22,562 tests passed, 11 skipped.
- Build, lint, formatting, typecheck, repository validation, public safety, and diff checks pass.
