### PR TITLE
fix(probes): reconcile display aliases by stable identity

### DIFF
--- a/src/observations-neon.ts
+++ b/src/observations-neon.ts
@@ -58,25 +58,49 @@ export interface ObservationWrite {
  *
  * Ranks each stable surface's ok-latency rows by latency and counts them,
  * passing every row through so uptime still totals over all checks.
+ * A current status owns its display alias. If history contains another key
+ * under that alias, retain it under a history-qualified identity instead of
+ * colliding with or merging into the current surface. Metadata comes from
+ * the latest check, so missing older metadata cannot split one identity.
  */
 function rankedChecksCte(): string {
-  return `WITH ranked AS (
+  return `WITH windowed AS (
+    SELECT surface_id, COALESCE(surface_key, surface_id) AS surface_key,
+           netuid, ok, latency_ms, checked_at
+    FROM surface_checks
+    WHERE checked_at >= $1 AND checked_at < $2
+  ), latest_identity AS (
+    SELECT DISTINCT ON (c.surface_key)
+      c.surface_key, c.netuid,
+      COALESCE(s.surface_id, c.surface_id) AS alias,
+      s.surface_id IS NOT NULL AS current_alias, c.checked_at
+    FROM windowed c
+    LEFT JOIN surface_status s ON s.surface_key = c.surface_key
+    ORDER BY c.surface_key, c.checked_at DESC, c.surface_id DESC
+  ), identities AS (
+    SELECT surface_key, netuid,
+      CASE WHEN ROW_NUMBER() OVER (
+        PARTITION BY alias
+        ORDER BY current_alias DESC, checked_at DESC, surface_key
+      ) = 1 THEN alias ELSE 'history:' || surface_key END AS surface_id
+    FROM latest_identity
+  ), ranked AS (
     SELECT
-      surface_id,
-      COALESCE(surface_key, surface_id) AS surface_key,
-      netuid,
+      i.surface_id,
+      c.surface_key,
+      i.netuid,
       ok,
       latency_ms,
       CASE WHEN ${OK_LATENCY} THEN ROW_NUMBER() OVER (
-        PARTITION BY COALESCE(surface_key, surface_id), netuid,
+        PARTITION BY c.surface_key,
                      CASE WHEN ${OK_LATENCY} THEN 0 ELSE 1 END
         ORDER BY latency_ms
       ) END AS rn,
       COUNT(*) FILTER (WHERE ${OK_LATENCY}) OVER (
-        PARTITION BY COALESCE(surface_key, surface_id), netuid
+        PARTITION BY c.surface_key
       ) AS lat_cnt
-    FROM surface_checks
-    WHERE checked_at >= $1 AND checked_at < $2
+    FROM windowed c
+    JOIN identities i ON i.surface_key = c.surface_key
   )`;
 }
 
@@ -115,26 +139,13 @@ async function attempt(
  * One probe sweep: a surface_checks row per surface, plus the latest-status
  * upsert.
  *
- * THE RENAME, AND WHY IT IS TWO STATEMENTS. the store's upsert names two conflict
- * targets -- surface_key when present, so a display-id rename updates the alias
- * in place, and surface_id as the fallback for keyless rows. Postgres permits
- * exactly ONE ON CONFLICT clause per statement, and both arbiters exist in Neon
- * (idx_surface_status_key partial-unique, surface_status_pkey), so they cannot
- * be combined.
+ * A display alias may already belong to another stable key (#12005). Evict
+ * that obsolete latest-status alias and upsert by stable key in ONE statement,
+ * so an occupied alias cannot abort the sweep or leave a half-applied rename.
+ * Raw checks remain intact. Keyless rows retain the display-id arbiter.
  *
- * Splitting rows by whether surface_key is present would ALMOST work, and fails
- * on the one case the second arbiter was added for: a keyed row whose
- * surface_id already exists under a different key raises a unique violation
- * instead of updating. So the rename is RESOLVED FIRST -- the row holding this
- * surface_key adopts the new surface_id -- and the upsert then has a single
- * arbiter with nothing left to collide on. Verified against the live schema:
- * one row, the new id, and last_ok preserved.
- *
- * LAST_OK IS A HIGH-WATER MARK (#9634). Every other column takes what this run
- * measured; last_ok records when the surface was last seen WORKING, so a run
- * that did not see it working has observed nothing about it and must not clear
- * it. COALESCE rather than a WHERE guard, because excluded.last_ok is
- * authoritative whenever it is non-null and only "we do not know" arrives null.
+ * Older probes still enter history, but cannot evict a newer alias or replace
+ * newer status. last_ok remains a high-water mark of measured successes.
  */
 export async function persistProbesToNeon(
   sql: ObservationsSql,
@@ -165,30 +176,51 @@ export async function persistProbesToNeon(
             row.checked_at_ms,
           ],
         );
-        if (row.surface_key) {
-          // Resolve the rename before the upsert -- see this function's header.
-          await sql.unsafe(
-            `UPDATE surface_status SET surface_id = $1
-              WHERE surface_key = $2 AND surface_id <> $1`,
-            [row.surface_id, row.surface_key],
-          );
-        }
+        const keyed = Boolean(row.surface_key);
         await sql.unsafe(
-          `INSERT INTO surface_status
+          `${
+            keyed
+              ? `WITH displaced_alias AS (
+             DELETE FROM surface_status
+             WHERE surface_id = $1 AND surface_key IS DISTINCT FROM $2
+               AND COALESCE(last_checked, 0) <= $11
+               AND NOT EXISTS (
+                 SELECT 1 FROM surface_status newer
+                 WHERE newer.surface_key = $2 AND newer.last_checked > $11
+               )
+             RETURNING surface_id
+           )`
+              : ""
+          }
+           INSERT INTO surface_status
              (surface_id, surface_key, netuid, kind, url, provider, status,
               classification, latency_ms, status_code, last_checked, last_ok,
               consecutive_failures, updated_at)
-           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
-           ON CONFLICT (surface_id) DO UPDATE SET
-             surface_key=excluded.surface_key,
+           SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14
+           ${
+             keyed
+               ? `FROM (SELECT COUNT(*) FROM displaced_alias) displaced
+             WHERE NOT EXISTS (
+               SELECT 1 FROM surface_status newer
+               WHERE newer.surface_id = $1
+                 AND newer.surface_key IS DISTINCT FROM $2
+                 AND newer.last_checked > $11
+             )`
+               : ""
+           }
+           ON CONFLICT ${keyed ? "(surface_key) WHERE surface_key IS NOT NULL" : "(surface_id)"} DO UPDATE SET
+             surface_id=excluded.surface_id,
+             surface_key=COALESCE(excluded.surface_key, surface_status.surface_key),
              netuid=excluded.netuid, kind=excluded.kind, url=excluded.url,
              provider=excluded.provider, status=excluded.status,
              classification=excluded.classification,
              latency_ms=excluded.latency_ms, status_code=excluded.status_code,
              last_checked=excluded.last_checked,
-             last_ok=COALESCE(excluded.last_ok, surface_status.last_ok),
+             last_ok=GREATEST(excluded.last_ok, surface_status.last_ok),
              consecutive_failures=excluded.consecutive_failures,
-             updated_at=excluded.updated_at`,
+             updated_at=excluded.updated_at
+           WHERE surface_status.last_checked IS NULL
+              OR surface_status.last_checked <= excluded.last_checked`,
           [
             row.surface_id,
             row.surface_key ?? null,
@@ -259,25 +291,20 @@ export async function rollupUptimeDailyToNeon(
   days: { date: string; start: number; end: number }[],
   runAt: number,
 ): Promise<ObservationWrite> {
-  const conflictColumns = `
-       surface_key = excluded.surface_key,
-       netuid = excluded.netuid,
-       samples = excluded.samples,
-       ok_count = excluded.ok_count,
-       uptime_ratio = excluded.uptime_ratio,
-       avg_latency_ms = excluded.avg_latency_ms,
-       latency_samples = excluded.latency_samples,
-       p50_latency_ms = excluded.p50_latency_ms,
-       p95_latency_ms = excluded.p95_latency_ms,
-       p99_latency_ms = excluded.p99_latency_ms,
-       status = excluded.status,
-       updated_at = excluded.updated_at`;
   return attempt(
     sql,
     async () => {
       for (const { date, start, end } of days) {
         await sql.unsafe(
-          `${rankedChecksCte()}
+          // Today and yesterday are recomputed from the retained raw window.
+          // Replace the day's aliases atomically, including alias swaps; an
+          // upsert cannot arbitrate both (display id, day) and (stable key, day).
+          // No raw checks means no evidence to replace a previous rollup.
+          `${rankedChecksCte()}, replaced_day AS (
+             DELETE FROM surface_uptime_daily
+             WHERE day = $3 AND EXISTS (SELECT 1 FROM ranked)
+             RETURNING surface_id
+           )
            INSERT INTO surface_uptime_daily
              (surface_id, surface_key, netuid, day, samples, ok_count,
               uptime_ratio, latency_samples, avg_latency_ms, p50_latency_ms,
@@ -304,8 +331,8 @@ export async function rollupUptimeDailyToNeon(
              END,
              $4
            FROM ranked
-           GROUP BY surface_key, netuid
-           ON CONFLICT (surface_id, day) DO UPDATE SET${conflictColumns}`,
+           CROSS JOIN (SELECT COUNT(*) FROM replaced_day) previous
+           GROUP BY surface_key, netuid`,
           [start, end, date, runAt],
         );
       }

--- a/tests/observations-neon-identity.test.ts
+++ b/tests/observations-neon-identity.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, test } from "vitest";
+import type { SurfaceUptimeDaily } from "../generated/db/types.ts";
+import {
+  persistProbesToNeon,
+  rollupUptimeDailyToNeon,
+} from "../src/observations-neon.ts";
+
+let db: PGlite;
+const sql = {
+  async unsafe(text: string, values: unknown[] = []) {
+    return (await db.query(text, values)).rows;
+  },
+};
+const day = { date: "2026-09-03", start: 0, end: 10_000 };
+const probe = (id: string, key: string | null, at: number, ok = true) => ({
+  surface_id: id,
+  surface_key: key,
+  netuid: 28,
+  kind: "data-artifact",
+  status: ok ? "ok" : "failed",
+  classification: ok ? "success" : "timeout",
+  checked_at_ms: at,
+  last_ok_ms: ok ? at : null,
+  latency_ms: ok ? 10 : 100,
+});
+
+beforeAll(async () => {
+  db = new PGlite();
+  await db.exec(
+    fs.readFileSync("migrations/neon/0002_probe_observations.sql", "utf8"),
+  );
+});
+afterAll(async () => db.close());
+beforeEach(async () => {
+  await db.exec(
+    "TRUNCATE surface_checks, surface_status, surface_uptime_daily",
+  );
+});
+
+test("an occupied alias can be reassigned without losing stable-key last_ok or checks", async () => {
+  assert.equal(
+    (
+      await persistProbesToNeon(
+        sql,
+        [probe("old", "key-a", 100), probe("new", "key-b", 100)],
+        100,
+      )
+    ).ok,
+    true,
+  );
+  assert.equal(
+    (await persistProbesToNeon(sql, [probe("new", "key-a", 200, false)], 200))
+      .ok,
+    true,
+  );
+  const status = (
+    await db.query(
+      "SELECT surface_id,surface_key,last_ok FROM surface_status WHERE surface_key='key-a'",
+    )
+  ).rows;
+  assert.deepEqual(status, [
+    { surface_id: "new", surface_key: "key-a", last_ok: 100 },
+  ]);
+  assert.equal(
+    (
+      await db.query<{ n: number }>(
+        "SELECT count(*)::int n FROM surface_checks",
+      )
+    ).rows[0]!.n,
+    3,
+  );
+});
+
+test("swapping display aliases and replaying a sweep preserves both current identities", async () => {
+  await persistProbesToNeon(
+    sql,
+    [probe("one", "key-a", 100), probe("two", "key-b", 100)],
+    100,
+  );
+  const changed = [probe("two", "key-a", 200), probe("one", "key-b", 200)];
+  for (let i = 0; i < 2; i++)
+    assert.equal((await persistProbesToNeon(sql, changed, 200)).ok, true);
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT surface_id,surface_key FROM surface_status ORDER BY surface_key",
+      )
+    ).rows,
+    [
+      { surface_id: "two", surface_key: "key-a" },
+      { surface_id: "one", surface_key: "key-b" },
+    ],
+  );
+  assert.equal(
+    (
+      await db.query<{ n: number }>(
+        "SELECT count(*)::int n FROM surface_checks",
+      )
+    ).rows[0]!.n,
+    4,
+  );
+});
+
+test("an older rename cannot evict the other key currently holding its requested alias", async () => {
+  await persistProbesToNeon(
+    sql,
+    [probe("current", "key-a", 300), probe("occupied", "key-b", 100)],
+    300,
+  );
+  assert.equal(
+    (await persistProbesToNeon(sql, [probe("occupied", "key-a", 200)], 400)).ok,
+    true,
+  );
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT surface_id,surface_key FROM surface_status ORDER BY surface_key",
+      )
+    ).rows,
+    [
+      { surface_id: "current", surface_key: "key-a" },
+      { surface_id: "occupied", surface_key: "key-b" },
+    ],
+  );
+});
+
+test("last_ok never moves backwards when a new failed probe carries an older cached success", async () => {
+  await persistProbesToNeon(sql, [probe("current", "key-a", 300)], 300);
+  await persistProbesToNeon(
+    sql,
+    [{ ...probe("current", "key-a", 400, false), last_ok_ms: 100 }],
+    400,
+  );
+  assert.deepEqual(
+    (await db.query("SELECT last_checked,last_ok,status FROM surface_status"))
+      .rows,
+    [{ last_checked: 400, last_ok: 300, status: "failed" }],
+  );
+});
+
+test("a rejected status update rolls back alias eviction while keeping the measured check", async () => {
+  await persistProbesToNeon(
+    sql,
+    [probe("old", "key-a", 100), probe("new", "key-b", 100)],
+    100,
+  );
+  const previous = (
+    await db.query("SELECT * FROM surface_status ORDER BY surface_key")
+  ).rows;
+  await db.exec(
+    "ALTER TABLE surface_status ADD CONSTRAINT test_provider CHECK (provider <> 'reject')",
+  );
+  try {
+    assert.equal(
+      (
+        await persistProbesToNeon(
+          sql,
+          [{ ...probe("new", "key-a", 200), provider: "reject" }],
+          200,
+        )
+      ).ok,
+      false,
+    );
+    assert.deepEqual(
+      (await db.query("SELECT * FROM surface_status ORDER BY surface_key"))
+        .rows,
+      previous,
+    );
+    assert.equal(
+      (
+        await db.query<{ n: number }>(
+          "SELECT count(*)::int n FROM surface_checks",
+        )
+      ).rows[0]!.n,
+      3,
+    );
+  } finally {
+    await db.exec("ALTER TABLE surface_status DROP CONSTRAINT test_provider");
+  }
+});
+
+test("older probes preserve a newer identity and status, including keyless delivery", async () => {
+  await persistProbesToNeon(sql, [probe("new", "key-a", 300)], 300);
+  await persistProbesToNeon(sql, [probe("new", "key-a", 200, false)], 400);
+  await persistProbesToNeon(sql, [probe("new", "key-b", 100)], 500);
+  await persistProbesToNeon(sql, [probe("plain", null, 300)], 300);
+  await persistProbesToNeon(sql, [probe("plain", null, 200, false)], 400);
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT surface_id,surface_key,status,last_checked,last_ok FROM surface_status ORDER BY surface_id",
+      )
+    ).rows,
+    [
+      {
+        surface_id: "new",
+        surface_key: "key-a",
+        status: "ok",
+        last_checked: 300,
+        last_ok: 300,
+      },
+      {
+        surface_id: "plain",
+        surface_key: null,
+        status: "ok",
+        last_checked: 300,
+        last_ok: 300,
+      },
+    ],
+  );
+});
+
+test("reused display aliases roll up into distinct stable identities without duplicate samples", async () => {
+  await persistProbesToNeon(sql, [probe("shared", "key-a", 100)], 100);
+  await persistProbesToNeon(sql, [probe("shared", "key-b", 200, false)], 200);
+  for (const runAt of [300, 400])
+    assert.equal((await rollupUptimeDailyToNeon(sql, [day], runAt)).ok, true);
+  const rows = (
+    await db.query<
+      Pick<
+        SurfaceUptimeDaily,
+        | "surface_id"
+        | "surface_key"
+        | "samples"
+        | "ok_count"
+        | "latency_samples"
+      >
+    >(
+      "SELECT surface_id,surface_key,samples,ok_count,latency_samples FROM surface_uptime_daily ORDER BY surface_key",
+    )
+  ).rows;
+  assert.equal(rows.length, 2);
+  assert.equal(new Set(rows.map((r) => r.surface_id)).size, 2);
+  assert.deepEqual(
+    rows.map(({ surface_id: _, ...r }) => r),
+    [
+      { surface_key: "key-a", samples: 1, ok_count: 1, latency_samples: 1 },
+      { surface_key: "key-b", samples: 1, ok_count: 0, latency_samples: 0 },
+    ],
+  );
+  assert.equal(rows[1]!.surface_id, "shared");
+});
+
+test("daily identity follows the latest alias and metadata while retaining all measurements", async () => {
+  await persistProbesToNeon(sql, [probe("z-old", "key-a", 100)], 100);
+  await persistProbesToNeon(
+    sql,
+    [{ ...probe("a-new", "key-a", 200, false), netuid: null }],
+    200,
+  );
+  assert.equal((await rollupUptimeDailyToNeon(sql, [day], 300)).ok, true);
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT surface_id,surface_key,netuid,samples,ok_count,uptime_ratio,latency_samples,p50_latency_ms FROM surface_uptime_daily",
+      )
+    ).rows,
+    [
+      {
+        surface_id: "a-new",
+        surface_key: "key-a",
+        netuid: null,
+        samples: 2,
+        ok_count: 1,
+        uptime_ratio: 0.5,
+        latency_samples: 1,
+        p50_latency_ms: 10,
+      },
+    ],
+  );
+});
+
+test("a failed recomputation preserves the previous day atomically and leaves other days untouched", async () => {
+  await persistProbesToNeon(sql, [probe("plain", null, 100)], 100);
+  assert.equal(
+    (
+      await rollupUptimeDailyToNeon(
+        sql,
+        [day, { ...day, date: "2026-09-02" }],
+        200,
+      )
+    ).ok,
+    true,
+  );
+  const previous = (
+    await db.query("SELECT * FROM surface_uptime_daily ORDER BY day")
+  ).rows;
+  await persistProbesToNeon(sql, [probe("plain", null, 300)], 300);
+  await db.exec(
+    "ALTER TABLE surface_uptime_daily ADD CONSTRAINT test_samples CHECK (samples < 2)",
+  );
+  try {
+    assert.equal((await rollupUptimeDailyToNeon(sql, [day], 400)).ok, false);
+    assert.deepEqual(
+      (await db.query("SELECT * FROM surface_uptime_daily ORDER BY day")).rows,
+      previous,
+    );
+  } finally {
+    await db.exec(
+      "ALTER TABLE surface_uptime_daily DROP CONSTRAINT test_samples",
+    );
+  }
+  assert.equal((await rollupUptimeDailyToNeon(sql, [day], 500)).ok, true);
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT day,samples FROM surface_uptime_daily ORDER BY day",
+      )
+    ).rows,
+    [
+      { day: "2026-09-02", samples: 1 },
+      { day: "2026-09-03", samples: 2 },
+    ],
+  );
+});

--- a/tests/observations-neon.test.ts
+++ b/tests/observations-neon.test.ts
@@ -74,50 +74,6 @@ describe("persistProbesToNeon", () => {
     consecutive_failures: 0,
   };
 
-  test("the rename is resolved BEFORE the upsert", async () => {
-    // Postgres allows exactly one ON CONFLICT clause, and surface_status needs
-    // two arbiters (surface_key for a display-id rename, surface_id for keyless
-    // rows). Adopting the new id onto the key's row first leaves a single
-    // arbiter with nothing to collide on. Order is the whole mechanism: run the
-    // upsert first and it inserts a second row, then the UPDATE hits the unique
-    // index.
-    const { sql, texts } = recordingSql();
-    await persistProbesToNeon(sql, [probe], 900);
-    const t = texts();
-    const updateAt = t.findIndex((x) => x.includes("UPDATE surface_status"));
-    const upsertAt = t.findIndex((x) =>
-      x.includes("INSERT INTO surface_status"),
-    );
-    assert.ok(updateAt >= 0, "no rename resolution was issued");
-    assert.ok(upsertAt >= 0, "no status upsert was issued");
-    assert.ok(updateAt < upsertAt, "the upsert ran before the rename resolved");
-  });
-
-  test("a keyless row skips the rename step entirely", async () => {
-    const { sql, texts } = recordingSql();
-    await persistProbesToNeon(sql, [{ ...probe, surface_key: null }], 900);
-    assert.equal(
-      texts().some((t) => t.includes("UPDATE surface_status")),
-      false,
-    );
-  });
-
-  test("last_ok is COALESCEd, so a run that saw nothing cannot clear it", async () => {
-    // #9634: last_ok is a high-water mark. readLiveSurfaceStatus degrades to an
-    // empty array on a transport failure, and a bare last_ok=excluded.last_ok
-    // turned that read-side degrade into permanent write-side data loss.
-    const { sql, texts } = recordingSql();
-    await persistProbesToNeon(sql, [probe], 900);
-    const upsert = texts().find((t) =>
-      t.includes("INSERT INTO surface_status"),
-    )!;
-    assert.ok(
-      upsert.includes(
-        "last_ok=COALESCE(excluded.last_ok, surface_status.last_ok)",
-      ),
-    );
-  });
-
   test("ok binds as a BOOLEAN, not 0/1", async () => {
     // surface_checks.ok is INTEGER in D1 and BOOLEAN in Neon. Asserted by TYPE:
     // 0 == false loosely, so a value check would pass on the exact bug.


### PR DESCRIPTION
When a surface's display alias is reused by another stable identity, the probe writer can hit `surface_status_pkey` and abandon the remainder of the sweep. Daily uptime aggregation can also produce two rows for one display alias and fail its upsert. Both failures were observed in production.

Reconcile occupied aliases and stable-key status in one atomic statement, preserving measured checks, newer status, and the last successful probe time. Aggregate daily measurements by stable identity, select the current alias where available, and retain displaced history under a distinct identity. Replace each recomputed day's aliases atomically so swaps and replays cannot leave duplicate or partially updated rollups. An empty raw window preserves the prior rollup.

Validation: nine PostgreSQL regression tests use the actual observation migration and cover occupied aliases, swaps, replay, stale deliveries, last-success preservation, both rollback paths, alias reuse, and daily measurement totals. All 23 focused observation tests pass. The full unsharded backend suite passes: 987 files, 22,565 tests, 11 skipped. Changed executable lines and branches have 100% coverage (2 lines, 6 branches). Build, lint, typecheck, formatting, registry validation, public-safety validation, and the existing unreferenced-export gate pass.

Closes #12005.
