### PR TITLE
fix(probes): preserve success history across alias displacement

### DIFF
--- a/src/observations-neon.ts
+++ b/src/observations-neon.ts
@@ -142,6 +142,8 @@ async function attempt(
  * A display alias may already belong to another stable key (#12005). Evict
  * that obsolete latest-status alias and upsert by stable key in ONE statement,
  * so an occupied alias cannot abort the sweep or leave a half-applied rename.
+ * Keep displaced stable-key status under a history alias: the next probe may
+ * have no cached last_ok, and deleting its status would lose a measured success.
  * Raw checks remain intact. Keyless rows retain the display-id arbiter.
  *
  * Older probes still enter history, but cannot evict a newer alias or replace
@@ -180,14 +182,25 @@ export async function persistProbesToNeon(
         await sql.unsafe(
           `${
             keyed
-              ? `WITH displaced_alias AS (
-             DELETE FROM surface_status
+              ? `WITH alias_conflict AS (
+             SELECT surface_id, surface_key FROM surface_status
              WHERE surface_id = $1 AND surface_key IS DISTINCT FROM $2
                AND COALESCE(last_checked, 0) <= $11
                AND NOT EXISTS (
                  SELECT 1 FROM surface_status newer
                  WHERE newer.surface_key = $2 AND newer.last_checked > $11
                )
+           ), displaced_alias AS (
+             UPDATE surface_status SET surface_id = 'history:' || surface_key
+             WHERE surface_id IN (
+               SELECT surface_id FROM alias_conflict WHERE surface_key IS NOT NULL
+             )
+             RETURNING surface_id
+           ), displaced_keyless AS (
+             DELETE FROM surface_status
+             WHERE surface_id IN (
+               SELECT surface_id FROM alias_conflict WHERE surface_key IS NULL
+             )
              RETURNING surface_id
            )`
               : ""
@@ -200,6 +213,7 @@ export async function persistProbesToNeon(
            ${
              keyed
                ? `FROM (SELECT COUNT(*) FROM displaced_alias) displaced
+             CROSS JOIN (SELECT COUNT(*) FROM displaced_keyless) legacy
              WHERE NOT EXISTS (
                SELECT 1 FROM surface_status newer
                WHERE newer.surface_id = $1

--- a/tests/observations-neon-identity.test.ts
+++ b/tests/observations-neon-identity.test.ts
@@ -127,6 +127,45 @@ test("an older rename cannot evict the other key currently holding its requested
   );
 });
 
+test("a failed alias swap retains both keys' measured successes when the status read was unavailable", async () => {
+  await persistProbesToNeon(
+    sql,
+    [probe("one", "key-a", 100), probe("two", "key-b", 120)],
+    120,
+  );
+  assert.equal(
+    (
+      await persistProbesToNeon(
+        sql,
+        [probe("two", "key-a", 200, false), probe("one", "key-b", 200, false)],
+        200,
+      )
+    ).ok,
+    true,
+  );
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT surface_id,surface_key,status,last_ok FROM surface_status ORDER BY surface_key",
+      )
+    ).rows,
+    [
+      {
+        surface_id: "two",
+        surface_key: "key-a",
+        status: "failed",
+        last_ok: 100,
+      },
+      {
+        surface_id: "one",
+        surface_key: "key-b",
+        status: "failed",
+        last_ok: 120,
+      },
+    ],
+  );
+});
+
 test("last_ok never moves backwards when a new failed probe carries an older cached success", async () => {
   await persistProbesToNeon(sql, [probe("current", "key-a", 300)], 300);
   await persistProbesToNeon(
@@ -138,6 +177,66 @@ test("last_ok never moves backwards when a new failed probe carries an older cac
     (await db.query("SELECT last_checked,last_ok,status FROM surface_status"))
       .rows,
     [{ last_checked: 400, last_ok: 300, status: "failed" }],
+  );
+});
+
+test("a displaced stable identity keeps its prior status until it returns under a new alias", async () => {
+  await persistProbesToNeon(sql, [probe("shared", "key-a", 100)], 100);
+  await persistProbesToNeon(sql, [probe("shared", "key-b", 200)], 200);
+  const prior = (
+    await db.query(
+      "SELECT last_ok,last_checked,status FROM surface_status WHERE surface_key='key-a'",
+    )
+  ).rows;
+  assert.deepEqual(prior, [{ last_ok: 100, last_checked: 100, status: "ok" }]);
+  assert.equal(
+    (
+      await persistProbesToNeon(
+        sql,
+        [probe("returned", "key-a", 300, false)],
+        300,
+      )
+    ).ok,
+    true,
+  );
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT surface_id,last_ok,last_checked,status FROM surface_status WHERE surface_key='key-a'",
+      )
+    ).rows,
+    [
+      {
+        surface_id: "returned",
+        last_ok: 100,
+        last_checked: 300,
+        status: "failed",
+      },
+    ],
+  );
+});
+
+test("a keyed probe can replace a legacy keyless alias without losing raw checks", async () => {
+  await persistProbesToNeon(sql, [probe("shared", null, 100)], 100);
+  assert.equal(
+    (await persistProbesToNeon(sql, [probe("shared", "key-a", 200)], 200)).ok,
+    true,
+  );
+  assert.deepEqual(
+    (
+      await db.query(
+        "SELECT surface_id,surface_key,last_ok FROM surface_status",
+      )
+    ).rows,
+    [{ surface_id: "shared", surface_key: "key-a", last_ok: 200 }],
+  );
+  assert.equal(
+    (
+      await db.query<{ n: number }>(
+        "SELECT count(*)::int n FROM surface_checks",
+      )
+    ).rows[0]!.n,
+    2,
   );
 });
 


### PR DESCRIPTION
If two surface aliases swap while the prior-status read is unavailable, failed probes can arrive with unknown cached last-success times. Removing an occupied alias deleted the displaced key's stored success; its later alias update then wrote null even though the database had already measured a success.

Move displaced stable-key status to a history alias until that identity returns, so the next upsert retains its measured success and current-status fields. Legacy keyless aliases remain replaceable. Alias reconciliation stays atomic, preserving stale-delivery guards, raw checks, and rollback behavior.

Validation: the actual PostgreSQL migration reproduced a success timestamp of 120 becoming null during a failed alias swap. All 26 focused observation tests now pass, including failed swaps, a displaced key returning later, keyless replacement, replays, and both rollback paths. The full unsharded coverage run passes: 988 files, 22,584 tests, 11 skipped. Build, lint, typecheck, formatting, registry validation, public-safety validation, and the unreferenced-export gate pass.

Closes #12009.
