### PR TITLE
fix(ui): preserve comparison mode and single-subnet links

### DIFF
--- a/apps/ui/src/routes/-compare-page.tsx
+++ b/apps/ui/src/routes/-compare-page.tsx
@@ -49,7 +49,8 @@ export function ComparePage() {
   const navigate = useNavigate();
   const subnets = useMemo(() => parseNetuids(search.subnets), [search.subnets]);
   const validators = useMemo(() => parseHotkeys(search.validators), [search.validators]);
-  const kind = validators.length > 0 && subnets.length === 0 ? "validators" : "subnets";
+  const kind =
+    search.kind || (validators.length > 0 && subnets.length === 0 ? "validators" : "subnets");
 
   return (
     <AppShell>
@@ -85,8 +86,8 @@ export function ComparePage() {
                 to: "/compare",
                 search:
                   next === "subnets"
-                    ? { subnets: search.subnets, validators: "" }
-                    : { subnets: "", validators: search.validators },
+                    ? { kind: next, subnets: search.subnets, validators: "" }
+                    : { kind: next, subnets: "", validators: search.validators },
               })
             }
           />

--- a/apps/ui/src/routes/compare.tsx
+++ b/apps/ui/src/routes/compare.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import {
   defineSearchSchema,
+  enumSearch,
   stripDefaultSearchParams,
   stringSearch,
   type SearchOutput,
@@ -18,7 +19,19 @@ import { ComparePage } from "./-compare-page";
  * out (`?subnets=%5B19%2C1%5D`) and 307 every shared link to that shape.
  */
 export const compareSearchSchema = defineSearchSchema({
-  subnets: stringSearch(),
+  // Empty means a legacy link: infer its kind from the selected entities.
+  kind: enumSearch(["", "subnets", "validators"] as const, ""),
+  subnets: {
+    defaultValue: "",
+    parse(value: unknown) {
+      // TanStack JSON-parses a single netuid in legacy `?subnets=19` links.
+      // Keep the validated value a CSV string, just like multi-subnet links.
+      if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+        return String(value);
+      }
+      return typeof value === "string" ? value : "";
+    },
+  },
   validators: stringSearch(),
 });
 

--- a/apps/ui/tests/e2e/compare-loading.spec.ts
+++ b/apps/ui/tests/e2e/compare-loading.spec.ts
@@ -1,6 +1,115 @@
 import { expect, test } from "@playwright/test";
 import { gotoThroughRestart } from "./server-restart.ts";
 
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+test.describe("comparison mode", () => {
+  for (const width of [375, 1280]) {
+    test(`preserves an empty validator comparison through reload and browser history at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 812 });
+      const requests: string[] = [];
+      page.on("request", (request) => {
+        if (new URL(request.url()).pathname.startsWith("/api/v1/compare")) {
+          requests.push(request.url());
+        }
+      });
+      await gotoThroughRestart(page, "/compare");
+      const subnets = page.getByRole("radio", { name: "Subnets", exact: true });
+      const validators = page.getByRole("radio", { name: "Validators", exact: true });
+
+      await validators.click();
+      await expect(validators).toHaveAttribute("aria-checked", "true");
+      await expect(page).toHaveURL(/\?kind=validators$/);
+      await expect(page.getByText("Pick two validators", { exact: true })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Browse validators" })).toHaveAttribute(
+        "href",
+        "/validators",
+      );
+
+      await page.reload();
+      await expect(validators).toHaveAttribute("aria-checked", "true");
+      await expect(page.getByText("Pick two validators", { exact: true })).toBeVisible();
+
+      // The shared radio control's keyboard path must persist the same URL state.
+      await validators.focus();
+      await page.keyboard.press("ArrowLeft");
+      await expect(subnets).toHaveAttribute("aria-checked", "true");
+      await expect(page).toHaveURL(/\?kind=subnets$/);
+      await expect(page.getByText("Pick two subnets", { exact: true })).toBeVisible();
+
+      await page.goBack();
+      await expect(validators).toHaveAttribute("aria-checked", "true");
+      await expect(page).toHaveURL(/\?kind=validators$/);
+      await page.goBack();
+      await expect(subnets).toHaveAttribute("aria-checked", "true");
+      await expect(page).toHaveURL(/\/compare$/);
+      await page.goForward();
+      await expect(validators).toHaveAttribute("aria-checked", "true");
+      await expect(page.getByText("Pick two validators", { exact: true })).toBeVisible();
+      expect(requests).toEqual([]);
+    });
+  }
+
+  for (const scenario of [
+    { query: "subnets=19", kind: "Subnets", entity: "subnet" },
+    { query: "subnets=0", kind: "Subnets", entity: "subnet" },
+    { query: `validators=${ALICE}`, kind: "Validators", entity: "validator" },
+    {
+      query: `kind=unknown&validators=${ALICE}`,
+      kind: "Validators",
+      entity: "validator",
+    },
+  ]) {
+    test(`keeps the one-selection handoff for ${scenario.query}`, async ({ page }) => {
+      await gotoThroughRestart(page, `/compare?${scenario.query}`);
+      await expect(page.getByRole("radio", { name: scenario.kind, exact: true })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      await expect(
+        page.getByText(`Add one more ${scenario.entity}`, { exact: true }),
+      ).toBeVisible();
+      await expect(page.getByRole("link", { name: `Browse ${scenario.entity}s` })).toBeVisible();
+      await page.reload();
+      await expect(
+        page.getByText(`Add one more ${scenario.entity}`, { exact: true }),
+      ).toBeVisible();
+    });
+  }
+
+  test("loads both validators from an existing comparison link without an explicit kind", async ({
+    page,
+  }) => {
+    let requestedHotkeys: string | null = null;
+    await page.route("**/api/v1/compare/validators?**", async (route) => {
+      requestedHotkeys = new URL(route.request().url()).searchParams.get("hotkeys");
+      await route.fulfill({
+        json: {
+          ok: true,
+          data: {
+            validator_count: 2,
+            validators: [
+              { hotkey: ALICE, coldkey_identity: { name: "Alice" } },
+              { hotkey: BOB, coldkey_identity: { name: "Bob" } },
+            ],
+          },
+          meta: {},
+        },
+      });
+    });
+    await gotoThroughRestart(page, `/compare?validators=${ALICE},${BOB}`);
+    await expect(page.getByRole("radio", { name: "Validators", exact: true })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    await expect(page.getByRole("table", { name: "Comparison of Alice, Bob" })).toBeVisible();
+    expect(requestedHotkeys).toBe(`${ALICE},${BOB}`);
+  });
+});
+
 test.describe("comparison ledger loading", () => {
   test("keeps the selected columns and metric rows visible on a delayed mobile response", async ({
     page,


### PR DESCRIPTION
Selecting Validators on an empty comparison now stores its mode in the URL and retains it through reload and browser history. Existing shared links still infer their mode when no explicit mode is present. Single-netuid links, including Root 0, are normalized instead of discarded by TanStack numeric parsing. Comparison data remains deferred until two selections exist.

## Validation

UI lint, formatting, typecheck and production Worker build passed. All 2,403 UI unit tests and all configured browser projects passed: 140 overflow, 256 interaction and 210 token checks. Eight focused browser cases cover empty modes, keyboard, reload/history, one/root/two-entity links and delayed loading. The empty-mode regression fails at the expected assertion against untouched main. Initial client bundle is 281KB against the 400KB budget; docs/news budgets pass. Independent source review found no actionable regression.

## Visual evidence

Local production Worker builds with recorded API fixtures; fixed viewport, explicit light/dark theme, identical before/after actions. These are implementation captures, not production deployment proof.

| Viewport / theme | Before | After |
| --- | --- | --- |
| 375×812 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/before-mobile-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/after-mobile-light.png) |
| 375×812 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/before-mobile-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/after-mobile-dark.png) |
| 768×1024 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/before-tablet-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/after-tablet-light.png) |
| 768×1024 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/before-tablet-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/after-tablet-dark.png) |
| 1280×800 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/before-desktop-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/after-desktop-light.png) |
| 1280×800 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/before-desktop-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/compare/after-desktop-dark.png) |

Closes #12036
Refs #12023, #12012
