### PR TITLE
fix(ui): withhold unsupported subnet stake totals and rankings

### DIFF
--- a/apps/ui/src/components/metagraphed/subnets-index/directory.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-index/directory.tsx
@@ -115,14 +115,6 @@ export function DirectorySection({
         format: (value) =>
           typeof value === "number" ? `${value >= 0 ? "+" : ""}${formatPct(value, 1)}` : "—",
       },
-      {
-        key: "stake",
-        label: "Total stake",
-        kind: "number",
-        sortable: true,
-        value: (row) => row.total_stake_alpha ?? null,
-        format: (value) => (typeof value === "number" ? `${fmtAlpha(value)} α` : "—"),
-      },
       { key: "health", label: "Health", kind: "status", value: (row) => row.health ?? "unknown" },
       {
         key: "volume",

--- a/apps/ui/src/components/metagraphed/subnets-index/rankings.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-index/rankings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { AnalyticsSection, BrandIcon, LeaderCards, RangeControl } from "@jsonbored/ui-kit";
-import { ErrorState } from "@/components/metagraphed/states";
+import { EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { useNearViewport } from "@/hooks/use-near-viewport";
 import { economicsQuery, subnetMoversQuery } from "@/lib/metagraphed/queries";
 import {
@@ -20,7 +20,7 @@ const FEATURED = 3;
 
 const FOOTNOTE: Record<RankMetric, string> = {
   emission: "ranked by share of daily emission, changed over the window",
-  stake: "ranked by alpha staked, changed over the window",
+  stake: "Choose emission, price change, or validator count above.",
   price: "ranked by price CHANGE — one subnet's alpha price is not another's",
   validators: "ranked by validators holding a permit, changed over the window",
 };
@@ -47,6 +47,7 @@ export function RankingsSection({
   nameOf: (netuid: number) => string;
   domainOf: (netuid: number) => string | undefined;
 }) {
+  const stakeUnavailable = metric === "stake";
   const resolved = resolveWindow(metric, window);
   const { ref, nearViewport } = useNearViewport("0px 0px");
   // The movers slice is aligned with the metric so the deltas that DO land
@@ -62,7 +63,7 @@ export function RankingsSection({
     // The directory is the route's opening answer. Movers provide a separate
     // comparative reading below it, so wait until that evidence region is
     // actually approached instead of competing with the first result list.
-    enabled: nearViewport,
+    enabled: nearViewport && !stakeUnavailable,
     retry: 0,
   });
   const economics = useQuery({ ...economicsQuery({ fields: "directory" }), retry: 0 });
@@ -97,16 +98,23 @@ export function RankingsSection({
             value={metric}
             onChange={(next) => onMetric(next as RankMetric)}
           />
-          <RangeControl
-            label="Window"
-            options={windowsFor(metric)}
-            value={resolved}
-            onChange={onWindow}
-          />
+          {!stakeUnavailable ? (
+            <RangeControl
+              label="Window"
+              options={windowsFor(metric)}
+              value={resolved}
+              onChange={onWindow}
+            />
+          ) : null}
         </>
       }
       visual={
-        !nearViewport || loading ? (
+        stakeUnavailable ? (
+          <EmptyState
+            title="Stake ranking is unavailable"
+            description="The available figures describe voting weight, not token holdings. Comparable stake values are unavailable; choose another ranking above."
+          />
+        ) : !nearViewport || loading ? (
           <LeaderCards
             items={[]}
             featured={FEATURED}
@@ -143,7 +151,9 @@ export function RankingsSection({
         ) : null
       }
       footnote={
-        !nearViewport ? (
+        stakeUnavailable ? (
+          FOOTNOTE.stake
+        ) : !nearViewport ? (
           `${resolved} · ${FOOTNOTE[metric]} · chain-direct`
         ) : loading ? (
           `loading ${resolved} subnet rankings by ${metric}`

--- a/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.test.ts
@@ -64,7 +64,7 @@ describe("windowsFor / resolveWindow", () => {
 describe("rankSubnets", () => {
   const movers = [
     mover({ netuid: 1, stake_pct_change: 10, emission_pct_change: -2 }),
-    mover({ netuid: 2, stake_pct_change: -5 }),
+    mover({ netuid: 2, stake_pct_change: -5, emission_pct_change: 10 }),
   ];
   const econ: SubnetEconomics[] = [
     { netuid: 1, emission_share: 0.01, total_stake_alpha: 100, validator_count: 4 },
@@ -76,24 +76,21 @@ describe("rankSubnets", () => {
     expect(
       rankSubnets("emission", "30d", movers, econ, name, noDomain).map((r) => r.netuid),
     ).toEqual([2, 3, 1]);
-    expect(rankSubnets("stake", "30d", movers, econ, name, noDomain).map((r) => r.netuid)).toEqual([
-      2, 3, 1,
-    ]);
     expect(
       rankSubnets("validators", "30d", movers, econ, name, noDomain).map((r) => r.netuid),
     ).toEqual([2, 3, 1]);
   });
 
   it("takes the delta from movers and converts its percentage to a fraction", () => {
-    const ranked = rankSubnets("stake", "30d", movers, econ, name, noDomain);
-    expect(ranked.find((r) => r.netuid === 1)?.delta).toBeCloseTo(0.1);
-    expect(ranked.find((r) => r.netuid === 2)?.delta).toBeCloseTo(-0.05);
+    const ranked = rankSubnets("emission", "30d", movers, econ, name, noDomain);
+    expect(ranked.find((r) => r.netuid === 1)?.delta).toBeCloseTo(-0.02);
+    expect(ranked.find((r) => r.netuid === 2)?.delta).toBeCloseTo(0.1);
   });
 
   it("keeps a subnet the movers slice omitted, with no delta", () => {
     // `/subnets/movers` serves at most 100 rows of 129 and ranks by CHANGE, so
     // ranking off it would quietly exclude a large subnet that did not move.
-    const ranked = rankSubnets("stake", "30d", movers, econ, name, noDomain);
+    const ranked = rankSubnets("emission", "30d", movers, econ, name, noDomain);
     expect(ranked.map((r) => r.netuid)).toContain(3);
     expect(ranked.find((r) => r.netuid === 3)?.delta).toBeUndefined();
   });
@@ -142,8 +139,18 @@ describe("rankSubnets", () => {
     expect(rankSubnets("emission", "7d", [], partial, name, noDomain)).toEqual([]);
   });
 
+  it("does not invent a stake ranking from incomparable quantities or a capped movers slice", () => {
+    const assets: SubnetEconomics[] = [
+      { netuid: 0, total_stake_alpha: 1_000_000, alpha_price_tao: 1 },
+      { netuid: 1, total_stake_alpha: 10, alpha_price_tao: 100 },
+      { netuid: 2, total_stake_alpha: 100, alpha_price_tao: 0.01 },
+      { netuid: 3, total_stake_alpha: 1_000 },
+    ];
+    expect(rankSubnets("stake", "30d", movers, assets, name, noDomain)).toEqual([]);
+  });
+
   it("honours the limit", () => {
-    expect(rankSubnets("stake", "30d", movers, econ, name, noDomain, 2)).toHaveLength(2);
+    expect(rankSubnets("emission", "30d", movers, econ, name, noDomain, 2)).toHaveLength(2);
   });
 
   it("maps every non-price metric onto a sort the endpoint accepts", () => {
@@ -224,6 +231,42 @@ describe("directoryRows", () => {
     const rows = directoryRows(subnets, econ, () => undefined);
     expect(rows).toHaveLength(2);
     expect(rows[1]?.alpha_price_tao).toBeUndefined();
+    expect(rows[0]).not.toHaveProperty("total_stake_alpha");
+  });
+
+  it("keeps the Root row while withholding its ambiguous legacy stake aggregate", () => {
+    const rows = directoryRows(
+      [{ netuid: 0, name: "Root" }] as Subnet[],
+      [{ netuid: 0, total_stake_alpha: 6_420_000, alpha_price_tao: 1 }],
+      () => undefined,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toHaveProperty("total_stake_alpha");
+    expect(rows[0]?.name).toBe("Root");
+  });
+
+  it("does not publish weighted stake as native holdings for any subnet or partial snapshot", () => {
+    const assets: SubnetEconomics[] = [
+      { netuid: 1, total_stake_alpha: 10, alpha_price_tao: 100 },
+      { netuid: 2, total_stake_alpha: 100, alpha_price_tao: 0.01 },
+      { netuid: 3, total_stake_alpha: 0 },
+      { netuid: 4, total_stake_alpha: 9_007_199_254_740_991 },
+      { netuid: 5 },
+    ];
+    const rows = directoryRows(
+      assets.map(({ netuid }) => ({ netuid }) as Subnet),
+      assets,
+      () => undefined,
+    );
+    expect(rows).toHaveLength(5);
+    for (const row of rows) expect(row).not.toHaveProperty("total_stake_alpha");
+    expect(rows.map((row) => row.alpha_price_tao)).toEqual([
+      100,
+      0.01,
+      undefined,
+      undefined,
+      undefined,
+    ]);
   });
 
   it("normalises the price change from a percentage to a fraction at the join", () => {

--- a/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.ts
+++ b/apps/ui/src/components/metagraphed/subnets-index/subnets-index-logic.ts
@@ -17,7 +17,6 @@ export type RankWindow = "7d" | "30d" | "90d";
 
 export const METRIC_OPTIONS = [
   { value: "emission", label: "Emission" },
-  { value: "stake", label: "Stake" },
   { value: "price", label: "Price" },
   { value: "validators", label: "Validators" },
 ] as const;
@@ -107,10 +106,14 @@ export function rankSubnets(
   domainOf: (netuid: number) => string | undefined,
   limit = 18,
 ): RankedSubnet[] {
+  // The legacy economics stake field originates in metagraph voting weights,
+  // mixing inherited alpha and weighted root TAO. It is not token holdings.
+  // Keep old metric=stake URLs safe until a certified valuation is available.
+  if (metric === "stake") return [];
+
   const change = new Map<number, number | "new" | undefined>();
   for (const mover of movers) {
     if (metric === "emission") change.set(mover.netuid, pctToFraction(mover.emission_pct_change));
-    else if (metric === "stake") change.set(mover.netuid, pctToFraction(mover.stake_pct_change));
     else if (metric === "validators") {
       change.set(
         mover.netuid,
@@ -148,17 +151,6 @@ export function rankSubnets(
         netuid: row.netuid,
         sort: share,
         value: fmtPct(share, 3),
-        delta: change.get(row.netuid),
-      });
-      continue;
-    }
-    if (metric === "stake") {
-      const stake = row.total_stake_alpha;
-      if (typeof stake !== "number" || !Number.isFinite(stake)) continue;
-      rows.push({
-        netuid: row.netuid,
-        sort: stake,
-        value: `${fmtAlpha(stake)} α`,
         delta: change.get(row.netuid),
       });
       continue;
@@ -241,7 +233,6 @@ export interface DirectoryRow extends Subnet {
   emission_share?: number;
   alpha_price_tao?: number;
   alpha_price_change_7d?: number;
-  total_stake_alpha?: number;
   subnet_volume_tao?: number;
   domain?: string;
 }
@@ -269,8 +260,6 @@ export function directoryRows(
       // Normalised at the join, so the column and the ranking cannot disagree
       // about whether this field is a percentage or a fraction.
       alpha_price_change_7d: pctToFraction(econ?.alpha_price_change_7d),
-      total_stake_alpha:
-        typeof econ?.total_stake_alpha === "number" ? econ.total_stake_alpha : undefined,
       subnet_volume_tao: econ?.subnet_volume_tao,
       domain: domainOf(subnet.netuid),
     };

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -13,7 +13,6 @@ import {
   directoryRows,
   filterDirectory,
   specSubnets,
-  fmtAlpha,
   type RankMetric,
   type RankWindow,
 } from "@/components/metagraphed/subnets-index/subnets-index-logic";
@@ -147,7 +146,6 @@ export function SubnetsPage() {
     [domains.data],
   );
 
-  const totalStake = econRows.reduce((acc, row) => acc + (row.total_stake_alpha ?? 0), 0);
   const probedStates = Object.values(health.data?.data ?? {});
   const healthy = probedStates.filter((entry) => entry.health === "ok").length;
   const probedCount = probedStates.length;
@@ -167,7 +165,6 @@ export function SubnetsPage() {
       value: probedCount > 0 ? `${formatNumber(healthy)} / ${formatNumber(probedCount)}` : "—",
       loading: health.isPending,
     },
-    { label: "Total stake", value: `${fmtAlpha(totalStake)} α`, loading: economics.isPending },
   ];
 
   const rawRows: RawRow[] = API_PATHS.map((path) => ({

--- a/apps/ui/src/routes/-subnets-total-stake-tile.test.ts
+++ b/apps/ui/src/routes/-subnets-total-stake-tile.test.ts
@@ -2,40 +2,18 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-// #6271 (historical): /subnets showed no stake figure at all. Six prior PR
-// attempts were closed by the maintainer -- the recurring mistakes: (1) a
-// static latest value instead of an actual trend, (2) cramming a 5th tile
-// into a fixed-column grid producing an orphaned single tile at mobile/tablet
-// widths, and (3) an out-of-sync Suspense fallback skeleton count causing a
-// layout shift when data loads.
-//
-// #8248 replaced the card strip with `SubnetsCompactStats`, an inline text
-// line. #11613 replaced THAT with the hero's `FactStrip`, so the specific
-// shape this file used to pin -- an AsyncPanel, a statPhase ternary, a Coins
-// glyph -- is gone twice over.
-//
-// What survives every one of those rewrites is the PROPERTY the six closed
-// PRs kept getting wrong, and it is the only thing asserted here now: the
-// total-stake figure is summed from the economics rows the page already
-// holds, and it is never a hardcoded number.
-//
-// Source assertions rather than a render: the page composes TanStack
-// Router/Query context a node-environment test cannot stand up.
+// #12014: the old #6271 regression required summing raw alpha across
+// different subnet assets. A measured number still needs a common unit.
+// Keep the unsupported headline absent until a certified TAO valuation can
+// replace it. The rendered unit/sort/recovery behavior is covered in
+// directory-secondary-state.spec.ts.
 const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
 const page = read("./-subnets-index-page.tsx");
 
-describe("#6271 the /subnets stake figure is measured, not written down", () => {
-  it("sums it from the economics rows rather than stating a number", () => {
-    expect(page).toContain('economicsQuery({ fields: "directory" })');
-    expect(page).toMatch(/const totalStake = econRows\.reduce\(/);
-    expect(page).toContain("row.total_stake_alpha ?? 0");
-  });
-
-  it("reads the ALPHA field, which is the one /api/v1/economics serves", () => {
-    // The TAO twin does not exist on that route -- 0 of 129 rows carried one
-    // when this was checked against production -- and reading it resolved
-    // undefined for every subnet (#11612).
-    expect(page).not.toContain("total_stake_tao");
+describe("#12014 the subnet hero does not imply a common alpha asset", () => {
+  it("does not sum per-subnet token quantities into a headline", () => {
+    expect(page).not.toContain("row.total_stake_alpha");
+    expect(page).not.toContain('label: "Total stake"');
   });
 
   it("never hardcodes a stake figure", () => {
@@ -55,9 +33,5 @@ describe("#6271 the /subnets stake figure is measured, not written down", () => 
     ]) {
       expect(page, `${retired} is back on /subnets`).not.toContain(retired);
     }
-  });
-
-  it("states the figure once, in the hero, so no second copy can drift", () => {
-    expect((page.match(/label: "Total stake"/g) ?? []).length).toBe(1);
   });
 });

--- a/apps/ui/tests/e2e/directory-secondary-state.spec.ts
+++ b/apps/ui/tests/e2e/directory-secondary-state.spec.ts
@@ -194,3 +194,34 @@ test.describe("directory secondary analytics", () => {
     expect(mobileLeadLabel).toContain("Name");
   });
 });
+
+test("subnet directory withholds weighted stake and old ranking links recover honestly", async ({
+  page,
+}) => {
+  let moversRequests = 0;
+  await page.route("**/api/v1/subnets/movers*", async (route) => {
+    moversRequests += 1;
+    await route.continue();
+  });
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await gotoThroughRestart(page, "/subnets?metric=stake");
+
+  const directory = page.locator("section#directory");
+  await expect(directory.getByRole("columnheader", { name: /stake/i })).toHaveCount(0);
+  await expect(page.locator(".mg-hero").getByText("Total stake", { exact: true })).toHaveCount(0);
+  const root = directory.getByRole("row").filter({ has: page.locator('a[href="/subnets/0"]') });
+  await expect(root).toHaveCount(1);
+  await expect(directory.getByRole("columnheader", { name: "Price", exact: true })).toBeVisible();
+
+  const rankings = page.locator("section#rankings");
+  await rankings.scrollIntoViewIfNeeded();
+  await expect(rankings.getByText("Stake ranking is unavailable", { exact: true })).toBeVisible();
+  await expect(rankings.getByRole("group", { name: "Window", exact: true })).toHaveCount(0);
+  expect(moversRequests).toBe(0);
+  await rankings.getByRole("radio", { name: "Emission", exact: true }).click();
+  await expect(rankings.getByText("Stake ranking is unavailable", { exact: true })).toHaveCount(0);
+  await expect(
+    rankings.getByRole("group", { name: "Subnets ranked by emission over 30d", exact: true }),
+  ).toBeVisible();
+  await expect.poll(() => moversRequests).toBeGreaterThan(0);
+});


### PR DESCRIPTION
The subnet directory presented a voting-weight aggregate as alpha holdings and ranked unlike values as comparable stake. Remove the unsupported hero total, table/CSV stake column and stake ranking until canonical holdings and valuation are available. Existing `?metric=stake` links show an explanatory state and working alternatives without requesting that ranking. Other directory metrics and the current design remain intact.

The [v454 source formula](https://github.com/RaoFoundation/subtensor/blob/v454/pallets/subtensor/src/staking/stake_utils.rs#L235) combines inherited alpha and weighted inherited root TAO for all netuids. Relabeling that legacy quantity or multiplying it by alpha price would still misstate holdings. Public API semantics are unchanged in this first slice; ingestion, versioned contracts and certified valuation remain open in #12014.

## Validation

UI lint, formatting, typecheck, production Worker build and all 2,404 UI unit tests passed. Four directory browser checks cover legacy stake-link recovery and absence of the unsupported request; responsive overflow passes at 375/768/1024/1280. Initial client bundle is 281KB against the 400KB budget, docs/news budgets and SSR isolation pass. The capture matrix has no page overflow or page errors.

Both before and after show an existing shared DataTable label defect; #12040 separately fixes that root cause. Screenshot-specific styles were not applied.

## Visual evidence

Local production Worker builds with recorded API fixtures; fixed viewport, explicit light/dark theme, identical before/after actions. These are implementation captures, not production deployment proof.

| Viewport / theme | Before | After |
| --- | --- | --- |
| 375×812 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/before-375-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/after-375-light.png) |
| 375×812 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/before-375-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/after-375-dark.png) |
| 768×1024 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/before-768-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/after-768-light.png) |
| 768×1024 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/before-768-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/after-768-dark.png) |
| 1280×800 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/before-1280-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/after-1280-light.png) |
| 1280×800 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/before-1280-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/units/after-1280-dark.png) |

Closes #12037
Refs #12014, #12012
