### PR TITLE
fix(ui-kit): remove repeated mobile labels from desktop tables

### DIFF
--- a/apps/ui/tests/e2e/sticky-table-header.spec.ts
+++ b/apps/ui/tests/e2e/sticky-table-header.spec.ts
@@ -39,6 +39,38 @@ const TABLE_VIEWPORTS = [
 ];
 const CARD_VIEWPORT = { name: "tablet", width: 768, height: 1024 };
 
+test("compact card labels follow the table breakpoint when the viewport resizes", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await gotoThroughRestart(page, "/subnets");
+  const table = page.locator(".mg-dt[data-mobile-label-template]").first();
+  const cells = table.locator("tbody .mg-dt-row").first().locator("td");
+  await expect(table).toBeVisible();
+  await expect(cells.first()).toBeVisible();
+
+  for (const width of [1280, 1023, 1024, 375, 768, 1280]) {
+    await page.setViewportSize({ width, height: 800 });
+    const cards = width < 1024;
+    const labels = await cells.evaluateAll((nodes) =>
+      nodes.map((node) => getComputedStyle(node, "::before").content),
+    );
+    expect(labels.length).toBeGreaterThan(3);
+    if (cards) {
+      expect(labels.every((label) => label !== "none" && label !== '""')).toBe(true);
+      await expect(table.locator("thead")).toBeHidden();
+    } else {
+      expect(labels.every((label) => label === "none" || label === "normal")).toBe(true);
+      await expect(table.locator("thead")).toBeVisible();
+    }
+    const dimensions = await page.evaluate(() => ({
+      viewport: innerWidth,
+      document: document.documentElement.scrollWidth,
+    }));
+    expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
+  }
+});
+
 // Playwright's default is 30s per test, and these do not fit in it: the
 // settle sequence (goto, up to 5s for networkidle or a 2s fallback, fonts)
 // runs before a table wait that has to tolerate /chain/extrinsics taking

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -4388,7 +4388,7 @@ function DataTable({
       "data-mobile-label-template": useCompactMobileLabels ? captionId : void 0,
       "data-dense": dense ? "true" : void 0,
       children: [
-        useCompactMobileLabels ? /* @__PURE__ */ jsxRuntime.jsx("style", { children: shown.map(
+        useCompactMobileLabels ? /* @__PURE__ */ jsxRuntime.jsx("style", { media: "(max-width: 1023px)", children: shown.map(
           (column, index) => `[data-mobile-label-template=${JSON.stringify(captionId)}] tbody td:nth-child(${index + 1})::before{content:${JSON.stringify(column.label)}}`
         ).join("") }) : null,
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mg-dt-caption", children: [

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -4362,7 +4362,7 @@ function DataTable({
       "data-mobile-label-template": useCompactMobileLabels ? captionId : void 0,
       "data-dense": dense ? "true" : void 0,
       children: [
-        useCompactMobileLabels ? /* @__PURE__ */ jsx("style", { children: shown.map(
+        useCompactMobileLabels ? /* @__PURE__ */ jsx("style", { media: "(max-width: 1023px)", children: shown.map(
           (column, index) => `[data-mobile-label-template=${JSON.stringify(captionId)}] tbody td:nth-child(${index + 1})::before{content:${JSON.stringify(column.label)}}`
         ).join("") }) : null,
         /* @__PURE__ */ jsxs("div", { className: "mg-dt-caption", children: [

--- a/packages/ui-kit/src/components/metagraphed/data-table/data-table.tsx
+++ b/packages/ui-kit/src/components/metagraphed/data-table/data-table.tsx
@@ -415,7 +415,7 @@ export function DataTable<Row>({
       data-dense={dense ? "true" : undefined}
     >
       {useCompactMobileLabels ? (
-        <style>
+        <style media="(max-width: 1023px)">
           {shown
             .map(
               (column, index) =>


### PR DESCRIPTION
Desktop tables were printing the mobile label before every cell value, adding repeated text and clipping metrics. Scope the compact-label stylesheet to the existing card-layout breakpoint, through 1023px. Desktop cells show their data cleanly; mobile and tablet retain their label/value layout. Shared ui-kit runtime bundles are regenerated from source.

## Validation

All 192 ui-kit tests and 2,403 UI tests pass, with shared-package/UI lint, formatting, typecheck, production Worker build and bundle budgets. All 600 configured browser checks pass. The new browser regression measures actual pseudo-element content, header visibility and overflow across 1280→1023→1024→375→768→1280px; unchanged main fails at the expected desktop-label assertion. Independent review found no actionable issue.

## Visual evidence

Local production Worker builds use recorded API fixtures and identical explicit themes. Twelve fixed-viewport captures confirm zero overflow; all nine desktop labels disappear while the nine mobile/tablet labels remain. These are local implementation captures, not deployment proof. The separate unsupported stake metric visible in both revisions is corrected by #12043.

| Viewport / theme | Before | After |
| --- | --- | --- |
| 375×812 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/before-mobile-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/after-mobile-light.png) |
| 375×812 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/before-mobile-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/after-mobile-dark.png) |
| 768×1024 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/before-tablet-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/after-tablet-light.png) |
| 768×1024 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/before-tablet-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/after-tablet-dark.png) |
| 1280×800 / light | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/before-desktop-light.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/after-desktop-light.png) |
| 1280×800 / dark | ![Before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/before-desktop-dark.png) | ![After](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/table-labels/after-desktop-dark.png) |

Closes #12040
Refs #12013, #12012
