### PR TITLE
fix(ui): preserve operator identity through directory adapters

### DIFF
--- a/apps/ui/src/components/metagraphed/validators-index/validators-index-logic.test.ts
+++ b/apps/ui/src/components/metagraphed/validators-index/validators-index-logic.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   deserializeOperatorRows,
   serializeOperatorRows,
+  type SerializedOperatorRow,
 } from "@/lib/metagraphed/validator-operators";
 
 const validator = (over: Partial<GlobalValidator> & { hotkey: string }): GlobalValidator =>
@@ -54,15 +55,27 @@ const named = (name: string) =>
 
 describe("operatorRows", () => {
   const rows = [
-    validator({ hotkey: "5A", coldkey_identity: named("Yuma"), total_stake_tao: 100, take: 0.18 }),
-    validator({ hotkey: "5B", coldkey_identity: named("Yuma"), total_stake_tao: 900, take: 0.09 }),
+    validator({
+      hotkey: "5A",
+      coldkey: "owner-a",
+      coldkey_identity: named("Yuma"),
+      total_stake_tao: 100,
+      take: 0.18,
+    }),
+    validator({
+      hotkey: "5B",
+      coldkey: "owner-a",
+      coldkey_identity: named("Yuma"),
+      total_stake_tao: 900,
+      take: 0.09,
+    }),
     validator({ hotkey: "5C", total_stake_tao: 500 }),
     validator({ hotkey: "5D", total_stake_tao: 50 }),
   ];
 
   it("sums an operator's keys and ranks operators by the sum", () => {
     const operators = operatorRows(rows);
-    expect(operators.map((o) => o.key)).toEqual(["Yuma", "5C", "5D"]);
+    expect(operators.map((o) => o.key)).toEqual(["coldkey:owner-a", "hotkey:5C", "hotkey:5D"]);
     expect(operators[0]).toMatchObject({ keyCount: 2, totalStakeTao: 1000, named: true });
   });
 
@@ -85,10 +98,107 @@ describe("operatorRows", () => {
     expect(deserializeOperatorRows(serialized)).toEqual(operators);
   });
 
+  it("keeps equal-name owners separate through grouping and SSR serialization", () => {
+    const operators = operatorRows([
+      validator({ hotkey: "first", coldkey: "owner-a", coldkey_identity: named("Shared Name") }),
+      validator({ hotkey: "second", coldkey: "owner-b", coldkey_identity: named("Shared Name") }),
+      validator({ hotkey: "third", coldkey_identity: named("Shared Name") }),
+      validator({ hotkey: "fourth", coldkey_identity: named("Shared Name") }),
+    ]);
+    const restored = deserializeOperatorRows(serializeOperatorRows(operators));
+    expect(restored).toEqual(operators);
+    expect(restored).toHaveLength(4);
+    expect(new Set(restored.map((row) => row.key)).size).toBe(4);
+    expect(restored.every((row) => row.name === "Shared Name")).toBe(true);
+  });
+
+  it("keeps owner identity stable through names and primary-key changes", () => {
+    const before = operatorRows([
+      validator({
+        hotkey: "first",
+        coldkey: "owner",
+        coldkey_identity: named("Old Name"),
+        total_stake_tao: 2,
+      }),
+      validator({ hotkey: "second", coldkey: "owner", total_stake_tao: 1 }),
+    ])[0]!;
+    const after = operatorRows([
+      validator({ hotkey: "first", coldkey: "owner", total_stake_tao: 1 }),
+      validator({
+        hotkey: "second",
+        coldkey: "owner",
+        coldkey_identity: named("New Name"),
+        total_stake_tao: 2,
+      }),
+    ])[0]!;
+    expect(after.key).toBe(before.key);
+    expect(after.name).toBe("New Name");
+    expect(after.primaryHotkey).toBe("second");
+    expect(deserializeOperatorRows(serializeOperatorRows([after]))[0]).toEqual(after);
+  });
+
+  it("keeps ambiguous and missing ownership separate and orders ties deterministically", () => {
+    const rows = [
+      validator({ hotkey: "second", coldkey: "owner" }),
+      validator({ hotkey: "first", coldkey: "owner" }),
+      validator({ hotkey: "ambiguous", coldkey: "owner", coldkey_count: 2 }),
+      validator({ hotkey: "unknown", coldkey: "owner", coldkey_count: undefined }),
+    ];
+    const forward = operatorRows(rows);
+    expect(operatorRows([...rows].reverse())).toEqual(forward);
+    expect(forward.map((row) => row.key)).toEqual([
+      "hotkey:ambiguous",
+      "coldkey:owner",
+      "hotkey:unknown",
+    ]);
+    expect(forward[1]!.keys.map((row) => row.hotkey)).toEqual(["first", "second"]);
+  });
+
+  it("reads older SSR tuples without treating their labels as row identity", () => {
+    const tuples: SerializedOperatorRow[] = [
+      ["Shared Name", [], "first", "owner-a", 1, 0, 0, 1, 1, null, null],
+      ["Shared Name", [], "second", "owner-b", 1, 0, 4, 1, 1, null, null],
+    ];
+    const rows = deserializeOperatorRows(tuples);
+    expect(rows.map((row) => row.key)).toEqual(["hotkey:first", "hotkey:second"]);
+    expect(rows.map((row) => row.name)).toEqual(["Shared Name", "Shared Name"]);
+    expect(rows.map((row) => row.nominators)).toEqual([0, 4]);
+  });
+
+  it.each([
+    [3, 3],
+    [3, null],
+    [null, 3],
+    [0, 0],
+  ])("does not sum member nominator counts %s and %s", (first, second) => {
+    const rows = operatorRows([
+      validator({ hotkey: "first", coldkey: "owner", nominator_count: first }),
+      validator({ hotkey: "second", coldkey: "owner", nominator_count: second }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.nominators).toBeNull();
+    const legacy = serializeOperatorRows(rows)[0]!;
+    legacy[6] = 6;
+    expect(deserializeOperatorRows([legacy])[0]!.nominators).toBeNull();
+  });
+
+  it("keeps opaque future IDs while compacting IDs derived from existing addresses", () => {
+    const rows = operatorRows([
+      validator({ hotkey: "known", coldkey: "owner" }),
+      validator({ hotkey: "unknown" }),
+    ]);
+    const compact = serializeOperatorRows(rows);
+    expect(compact[0]?.[11]).toBe(1);
+    expect(compact[1]).toHaveLength(11);
+    rows[0]!.key = "operator:future-id";
+    expect(deserializeOperatorRows(serializeOperatorRows(rows))).toEqual(rows);
+  });
+
   it("compacts display precision and reconstructs take ranges from child keys", () => {
     const operators = operatorRows([
       validator({
         hotkey: "5A",
+        coldkey: "owner-a",
         coldkey_identity: named("Yuma"),
         total_stake_tao: 100.123456789,
         total_emission_tao: 1.23456789,
@@ -97,6 +207,7 @@ describe("operatorRows", () => {
       }),
       validator({
         hotkey: "5B",
+        coldkey: "owner-a",
         coldkey_identity: named("Yuma"),
         total_stake_tao: 10.987654321,
         total_emission_tao: 0.123456789,
@@ -111,7 +222,8 @@ describe("operatorRows", () => {
     ]);
     const serialized = serializeOperatorRows(operators);
 
-    expect(serialized.every((row) => row.length === 11)).toBe(true);
+    expect(serialized.map((row) => row.length)).toEqual([12, 11]);
+    expect(serialized[0]?.[11]).toBe(1);
     expect(serialized[0]?.[1]).toEqual([
       ["5A", 100.12346, 0.123457],
       ["5B", 10.98765, 0.012346],
@@ -139,19 +251,21 @@ describe("operatorRows", () => {
     // merging them would invent an operator that does not exist.
     const operators = operatorRows(rows);
     expect(operators.filter((o) => !o.named).map((o) => o.keyCount)).toEqual([1, 1]);
-    expect(operators.find((o) => o.key === "5C")?.name).toBe("5C");
+    expect(operators.find((o) => o.key === "hotkey:5C")?.name).toBe("5C");
   });
 
   it("weights APY by stake, so a dust key cannot move the headline", () => {
     const weighted = operatorRows([
       validator({
         hotkey: "5A",
+        coldkey: "owner-a",
         coldkey_identity: named("Yuma"),
         total_stake_tao: 999,
         apy_estimate: 0.1,
       }),
       validator({
         hotkey: "5B",
+        coldkey: "owner-a",
         coldkey_identity: named("Yuma"),
         total_stake_tao: 1,
         apy_estimate: 10,
@@ -172,8 +286,20 @@ describe("operatorRows", () => {
   // gives it (#11695).
   it("counts memberships off the scalar that survives the projection", () => {
     const rows = operatorRows([
-      validator({ hotkey: "5A", coldkey_identity: named("Yuma"), subnet_count: 2, subnets: [] }),
-      validator({ hotkey: "5B", coldkey_identity: named("Yuma"), subnet_count: 3, subnets: [] }),
+      validator({
+        hotkey: "5A",
+        coldkey: "owner-a",
+        coldkey_identity: named("Yuma"),
+        subnet_count: 2,
+        subnets: [],
+      }),
+      validator({
+        hotkey: "5B",
+        coldkey: "owner-a",
+        coldkey_identity: named("Yuma"),
+        subnet_count: 3,
+        subnets: [],
+      }),
     ]);
     expect(rows[0]?.memberships).toBe(5);
   });
@@ -186,7 +312,7 @@ describe("operatorRows", () => {
     ).toBe(7);
   });
 
-  it("sums nominators only when at least one key reports them", () => {
+  it("preserves available singleton nominator counts", () => {
     expect(operatorRows([validator({ hotkey: "5A" })])[0]?.nominators).toBeNull();
     expect(operatorRows([validator({ hotkey: "5A", nominator_count: 4 })])[0]?.nominators).toBe(4);
   });
@@ -217,7 +343,7 @@ describe("concentration", () => {
 
   it("collapses everything past the head into one residual", () => {
     const { segments } = concentration(operators, 2);
-    expect(segments.map((s) => s.key)).toEqual(["54", "53", "rest"]);
+    expect(segments.map((s) => s.key)).toEqual(["hotkey:54", "hotkey:53", "rest"]);
     expect(segments[2]).toMatchObject({ label: "2 more operators", value: 30 });
   });
 
@@ -234,6 +360,7 @@ describe("filterOperators", () => {
   const operators = operatorRows([
     validator({
       hotkey: "5AAAAAAAAAAAAAAA",
+      coldkey: "owner-a",
       coldkey_identity: named("Yuma"),
       total_stake_tao: 5000,
     }),
@@ -246,9 +373,11 @@ describe("filterOperators", () => {
   });
 
   it("searches the operator name, its primary hotkey and every child key", () => {
-    expect(filterOperators(operators, { q: "yuma" }).map((o) => o.key)).toEqual(["Yuma"]);
+    expect(filterOperators(operators, { q: "yuma" }).map((o) => o.key)).toEqual([
+      "coldkey:owner-a",
+    ]);
     expect(filterOperators(operators, { q: "5bbb" }).map((o) => o.key)).toEqual([
-      "5BBBBBBBBBBBBBBB",
+      "hotkey:5BBBBBBBBBBBBBBB",
     ]);
   });
 

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -8,6 +8,7 @@ import { isSchemaDrift, normalizeDriftStatus } from "./schema-drift";
 import { isUsableTimestamp } from "./format";
 import {
   serializeOperatorRows,
+  operatorNominatorCount,
   shortKey,
   type OperatorRow,
   type SerializedOperatorRow,
@@ -8776,6 +8777,7 @@ export function projectOperatorValidator(validator: GlobalValidator): OperatorVa
   return {
     hotkey: validator.hotkey,
     coldkey: validator.coldkey,
+    coldkey_count: validator.coldkey_count,
     coldkey_identity:
       validator.coldkey_identity === null
         ? null
@@ -8900,18 +8902,22 @@ export function normalizeValidatorOperatorDirectory(raw: unknown): ValidatorOper
           children.length > 0
             ? children
             : [{ hotkey: primaryHotkey, totalStakeTao, take: takeMin }];
+        const keyCount = coerceFiniteNumber(entry.hotkey_count) ?? keys.length;
         return [
           {
-            key: identityName ?? primaryHotkey,
+            key: firstString(entry.operator_id) ?? `hotkey:${primaryHotkey}`,
             name: identityName ?? shortKey(primaryHotkey),
             named: identityName !== null,
             keys,
-            keyCount: coerceFiniteNumber(entry.hotkey_count) ?? keys.length,
+            keyCount,
             primaryHotkey,
             coldkey: firstString(entry.coldkey) ?? null,
             totalStakeTao,
             totalEmissionTao: coerceFiniteNumber(entry.total_emission_tao) ?? 0,
-            nominators: coerceFiniteNumber(entry.nominator_count) ?? null,
+            nominators: operatorNominatorCount(
+              coerceFiniteNumber(entry.nominator_count) ?? null,
+              Math.max(keyCount, keys.length),
+            ),
             memberships: coerceFiniteNumber(entry.membership_count) ?? 0,
             uidCount: coerceFiniteNumber(entry.uid_count) ?? 0,
             takeMin,

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2846,6 +2846,8 @@ export interface GlobalValidator {
 export interface OperatorValidator {
   hotkey: string;
   coldkey: string | null;
+  /** Distinct observed owners; absent on older projected cache entries. */
+  coldkey_count?: number;
   coldkey_identity: Pick<ColdkeyIdentity, "has_identity" | "name"> | null;
   subnet_count: number;
   uid_count: number;

--- a/apps/ui/src/lib/metagraphed/validator-operators.ts
+++ b/apps/ui/src/lib/metagraphed/validator-operators.ts
@@ -14,7 +14,7 @@ export interface OperatorKey {
 }
 
 export interface OperatorRow {
-  /** Grouping key: the declared identity name, or the hotkey when unnamed. */
+  /** Stable row ID scoped to the query's network, independent of display name. */
   key: string;
   name: string;
   /** Whether the name is self-declared or a truncated key standing in for one. */
@@ -58,6 +58,8 @@ export type SerializedOperatorRow = [
   uidCount: number,
   singleKeyTake: number | null,
   apyEstimate: number | null,
+  // Omitted = primary hotkey; 1 = the owner already stored at index 3.
+  operatorId?: string | 1,
 ];
 
 const declaredName = (validator: OperatorValidator): string | null => {
@@ -73,13 +75,16 @@ export const shortKey = (key: string): string =>
 /**
  * Validator keys aggregated into operators, largest first.
  *
- * A key with no declared identity is its own operator of one: two anonymous
- * keys sharing nothing but their anonymity are not the same team.
+ * Only one matching observed owner establishes shared membership. Missing or
+ * conflicting evidence stays hotkey-scoped; declared names never group keys.
  */
 export function operatorRows(validators: readonly OperatorValidator[]): OperatorRow[] {
   const groups = new Map<string, OperatorValidator[]>();
   for (const validator of validators) {
-    const key = declaredName(validator) ?? validator.hotkey;
+    const key =
+      validator.coldkey_count === 1 && validator.coldkey?.trim()
+        ? `coldkey:${validator.coldkey}`
+        : `hotkey:${validator.hotkey}`;
     const group = groups.get(key);
     if (group) group.push(validator);
     else groups.set(key, [validator]);
@@ -87,15 +92,15 @@ export function operatorRows(validators: readonly OperatorValidator[]): Operator
 
   const rows: OperatorRow[] = [];
   for (const [key, keys] of groups) {
-    const sorted = [...keys].sort((a, b) => b.total_stake_tao - a.total_stake_tao);
+    const sorted = [...keys].sort(
+      (a, b) => b.total_stake_tao - a.total_stake_tao || a.hotkey.localeCompare(b.hotkey),
+    );
     const primary = sorted[0]!;
-    const named = declaredName(primary) !== null;
+    const name = declaredName(primary);
+    const named = name !== null;
     const takes = sorted
       .map((validator) => validator.take)
       .filter((take): take is number => typeof take === "number" && Number.isFinite(take));
-    const nominatorCounts = sorted
-      .map((validator) => validator.nominator_count)
-      .filter((count): count is number => typeof count === "number");
     const totalStakeTao = sorted.reduce((acc, validator) => acc + validator.total_stake_tao, 0);
 
     let weighted = 0;
@@ -110,7 +115,7 @@ export function operatorRows(validators: readonly OperatorValidator[]): Operator
 
     rows.push({
       key,
-      name: named ? key : shortKey(primary.hotkey),
+      name: name ?? shortKey(primary.hotkey),
       named,
       keys: sorted.map((validator) => ({
         hotkey: validator.hotkey,
@@ -122,7 +127,7 @@ export function operatorRows(validators: readonly OperatorValidator[]): Operator
       coldkey: primary.coldkey,
       totalStakeTao,
       totalEmissionTao: sorted.reduce((acc, validator) => acc + validator.total_emission_tao, 0),
-      nominators: nominatorCounts.length > 0 ? nominatorCounts.reduce((a, b) => a + b, 0) : null,
+      nominators: operatorNominatorCount(primary.nominator_count, sorted.length),
       memberships: sorted.reduce((acc, validator) => acc + (validator.subnet_count ?? 0), 0),
       uidCount: sorted.reduce((acc, validator) => acc + validator.uid_count, 0),
       takeMin: takes.length > 0 ? Math.min(...takes) : null,
@@ -131,12 +136,21 @@ export function operatorRows(validators: readonly OperatorValidator[]): Operator
       dominance: null,
     });
   }
-  const ranked = rows.sort((a, b) => b.totalStakeTao - a.totalStakeTao);
+  const ranked = rows.sort(
+    (a, b) => b.totalStakeTao - a.totalStakeTao || a.primaryHotkey.localeCompare(b.primaryHotkey),
+  );
   const listedStake = ranked.reduce((acc, row) => acc + row.totalStakeTao, 0);
   return ranked.map((row) => ({
     ...row,
     dominance: listedStake > 0 ? row.totalStakeTao / listedStake : null,
   }));
+}
+
+/** Per-hotkey counts cannot establish unique accounts across an operator's keys. */
+export function operatorNominatorCount(count: number | null, keyCount: number): number | null {
+  return keyCount === 1 && count !== null && Number.isSafeInteger(count) && count >= 0
+    ? count
+    : null;
 }
 
 function compactDecimal(value: number, decimals: number): number {
@@ -149,25 +163,33 @@ function compactNullableDecimal(value: number | null, decimals: number): number 
 }
 
 export function serializeOperatorRows(rows: readonly OperatorRow[]): SerializedOperatorRow[] {
-  return rows.map((row) => [
-    row.named ? row.key : null,
-    row.keyCount > 1
-      ? row.keys.map((key) => [
-          key.hotkey,
-          compactDecimal(key.totalStakeTao, 5),
-          compactNullableDecimal(key.take, 6),
-        ])
-      : [],
-    row.primaryHotkey,
-    row.coldkey,
-    compactDecimal(row.totalStakeTao, 5),
-    compactDecimal(row.totalEmissionTao, 5),
-    row.nominators,
-    row.memberships,
-    row.uidCount,
-    row.keyCount === 1 ? compactNullableDecimal(row.takeMin, 6) : null,
-    compactNullableDecimal(row.apyEstimate, 8),
-  ]);
+  return rows.map((row) => {
+    const serialized: SerializedOperatorRow = [
+      row.named ? row.name : null,
+      row.keyCount > 1
+        ? row.keys.map((key) => [
+            key.hotkey,
+            compactDecimal(key.totalStakeTao, 5),
+            compactNullableDecimal(key.take, 6),
+          ])
+        : [],
+      row.primaryHotkey,
+      row.coldkey,
+      compactDecimal(row.totalStakeTao, 5),
+      compactDecimal(row.totalEmissionTao, 5),
+      row.nominators,
+      row.memberships,
+      row.uidCount,
+      row.keyCount === 1 ? compactNullableDecimal(row.takeMin, 6) : null,
+      compactNullableDecimal(row.apyEstimate, 8),
+    ];
+    // Most IDs are losslessly reconstructible from addresses already present.
+    // Repeating full addresses here exceeds the directory's HTML budget.
+    if (row.key !== `hotkey:${row.primaryHotkey}`) {
+      serialized.push(row.coldkey !== null && row.key === `coldkey:${row.coldkey}` ? 1 : row.key);
+    }
+    return serialized;
+  });
 }
 
 export function deserializeOperatorRows(rows: readonly SerializedOperatorRow[]): OperatorRow[] {
@@ -186,7 +208,13 @@ export function deserializeOperatorRows(rows: readonly SerializedOperatorRow[]):
       .map((key) => key.take)
       .filter((take): take is number => typeof take === "number");
     return {
-      key: identityName ?? primaryHotkey,
+      // Older dehydrated tuples contain a label but no ownership evidence.
+      key:
+        typeof row[11] === "string"
+          ? row[11]
+          : row[11] === 1 && row[3]
+            ? `coldkey:${row[3]}`
+            : `hotkey:${primaryHotkey}`,
       name: identityName ?? shortKey(primaryHotkey),
       named: identityName !== null,
       keys,
@@ -195,7 +223,7 @@ export function deserializeOperatorRows(rows: readonly SerializedOperatorRow[]):
       coldkey: row[3],
       totalStakeTao: row[4],
       totalEmissionTao: row[5],
-      nominators: row[6],
+      nominators: operatorNominatorCount(row[6], keys.length),
       memberships: row[7],
       uidCount: row[8],
       takeMin: takes.length > 0 ? Math.min(...takes) : null,

--- a/apps/ui/src/lib/metagraphed/validators.test.ts
+++ b/apps/ui/src/lib/metagraphed/validators.test.ts
@@ -151,6 +151,36 @@ describe("validatorsQuery", () => {
 });
 
 describe("validatorOperatorDirectoryQuery", () => {
+  it("preserves additive IDs through normalization and SSR while keeping display names separate", () => {
+    const compact = normalizeValidatorOperatorDirectory({
+      operators: [
+        {
+          operator_id: "coldkey:owner-a",
+          ownership_basis: "single_coldkey",
+          identity_name: "Shared Name",
+          primary_hotkey: "first",
+        },
+        {
+          operator_id: "coldkey:owner-b",
+          ownership_basis: "single_coldkey",
+          identity_name: "Shared Name",
+          primary_hotkey: "second",
+        },
+        { identity_name: "Shared Name", primary_hotkey: "legacy" },
+        { operator_id: 123, identity_name: "Shared Name", primary_hotkey: "malformed" },
+      ],
+    });
+    const rows = deserializeOperatorRows(compact.operators);
+    expect(rows.map((row) => row.key)).toEqual([
+      "coldkey:owner-a",
+      "coldkey:owner-b",
+      "hotkey:legacy",
+      "hotkey:malformed",
+    ]);
+    expect(rows.every((row) => row.name === "Shared Name")).toBe(true);
+    expect(new Set(rows.map((row) => row.key)).size).toBe(4);
+  });
+
   it("uses a dedicated cache lane for the already-grouped SSR result", () => {
     const options = validatorOperatorDirectoryQuery();
     expect(options.queryKey).toContain("validator-operator-directory");
@@ -203,14 +233,14 @@ describe("validatorOperatorDirectoryQuery", () => {
     expect(compact.hotkey_count).toBe(3);
     expect(rows).toHaveLength(2);
     expect(rows[0]).toMatchObject({
-      key: "Tensor Team",
+      key: "hotkey:hk-large",
       name: "Tensor Team",
       named: true,
       keyCount: 2,
       primaryHotkey: "hk-large",
       totalStakeTao: 100,
       totalEmissionTao: 8,
-      nominators: 10,
+      nominators: null,
       memberships: 6,
       uidCount: 8,
       takeMin: 0.1,
@@ -220,7 +250,7 @@ describe("validatorOperatorDirectoryQuery", () => {
     });
     expect(rows[0]!.keys.map((key) => key.hotkey)).toEqual(["hk-large", "hk-small"]);
     expect(rows[1]).toMatchObject({
-      key: "anonymous-hotkey",
+      key: "hotkey:anonymous-hotkey",
       named: false,
       keyCount: 1,
       takeMin: null,
@@ -238,6 +268,7 @@ describe("projectOperatorValidator", () => {
         {
           hotkey: "hk",
           coldkey: "ck",
+          coldkey_count: 1,
           coldkey_identity: {
             has_identity: true,
             name: "Operator",
@@ -260,6 +291,7 @@ describe("projectOperatorValidator", () => {
     expect(projectOperatorValidator(validator)).toEqual({
       hotkey: "hk",
       coldkey: "ck",
+      coldkey_count: 1,
       coldkey_identity: { has_identity: true, name: "Operator" },
       subnet_count: 2,
       uid_count: 3,

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -396,9 +396,7 @@ export function ValidatorsPage() {
               }
             />
           }
-          footnote={`${formatNumber(
-            listed.data.hotkey_count,
-          )} hotkeys grouped by declared identity · chain-direct`}
+          footnote={`${formatNumber(listed.data.hotkey_count)} validator hotkeys · chain-direct`}
         >
           <ValidatorCompareBar />
         </AnalyticsSection>

--- a/apps/ui/tests/e2e/directory-secondary-state.spec.ts
+++ b/apps/ui/tests/e2e/directory-secondary-state.spec.ts
@@ -1,6 +1,77 @@
 import { expect, test } from "@playwright/test";
 import { gotoThroughRestart } from "./server-restart.ts";
 
+test.describe("operator identity compatibility", () => {
+  test.use({ serviceWorkers: "block" });
+
+  for (const width of [375, 1280]) {
+    test(`equal-name owners expand independently at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 812 });
+      await gotoThroughRestart(page, "/settings");
+      await page.waitForFunction(() => window.__MG_HYDRATED__ === true);
+      await page.route("**/api/v1/validators/operators*", async (route) => {
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: {
+              validator_count: 4,
+              operators: ["first", "second"].map((owner) => ({
+                operator_id: `coldkey:${owner}`,
+                ownership_basis: "single_coldkey",
+                identity_name: "Shared Name",
+                primary_hotkey: `${owner}-primary`,
+                coldkey: owner,
+                hotkey_count: 2,
+                hotkeys: ["primary", "secondary"].map((member) => ({
+                  hotkey: `${owner}-${member}`,
+                  total_stake_tao: 5,
+                  take: null,
+                })),
+                total_stake_tao: 10,
+                total_emission_tao: 0,
+                membership_count: 2,
+                uid_count: 2,
+                nominator_count: null,
+              })),
+            },
+          },
+        });
+      });
+      if (width < 768) {
+        await page.getByRole("button", { name: "Open menu", exact: true }).click();
+        await page
+          .getByRole("dialog", { name: "Site navigation" })
+          .getByRole("link", { name: "Validators", exact: true })
+          .click();
+      } else {
+        await page.getByRole("link", { name: "Validators", exact: true }).first().click();
+      }
+
+      const table = page.locator("section#operators table");
+      await expect(
+        page.getByText("4 validator hotkeys · chain-direct", { exact: true }),
+      ).toBeVisible();
+      const rows = table.locator("tbody > tr.mg-dt-row");
+      await expect(rows).toHaveCount(2);
+      await rows.nth(0).getByRole("button", { name: "Expand row", exact: true }).click();
+      await expect(table.locator('tr[data-expanded="true"]')).toHaveCount(1);
+      await expect(
+        rows.nth(1).getByRole("button", { name: "Expand row", exact: true }),
+      ).toHaveAttribute("aria-expanded", "false");
+      await expect(table.locator('a[href="/validators/first-secondary"]')).toBeVisible();
+      await expect(table.locator('a[href="/validators/second-secondary"]')).toHaveCount(0);
+
+      await rows.nth(1).getByRole("button", { name: "Expand row", exact: true }).click();
+      await expect(table.locator('tr[data-expanded="true"]')).toHaveCount(1);
+      await expect(table.locator('a[href="/validators/first-secondary"]')).toHaveCount(0);
+      await expect(table.locator('a[href="/validators/second-secondary"]')).toBeVisible();
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        width,
+      );
+    });
+  }
+});
+
 test.describe("directory secondary analytics", () => {
   test("keeps account holders immediate while deferring the separate activity ledger", async ({
     page,


### PR DESCRIPTION
Two directory operators with the same displayed name shared a UI row key, so expanding one also expanded the other. Client normalization and server-rendered tuples now preserve stable operator IDs independently of labels. Older responses fall back to the primary hotkey; fallback grouping requires one matching observed owner.

Per-hotkey nominator counts no longer become a purported unique total across multiple keys. Known singleton zero remains zero. The compact tuple preserves IDs without repeating addresses already present, keeping the directory within its existing HTML budget.

Deploy this compatibility change before the grouping API delivery in #12048. It works with both existing responses and the additive identity fields planned there.

## Validation

All 620 configured browser checks and 2,414 UI unit tests passed, along with lint, formatting, typecheck, production Worker build, public-safety scan and export ratchet. The new same-name regression fails against the previous implementation and passes at 375px and 1280px.

The recorded existing API fixture produces 234 KiB of directory HTML against the unchanged 245 KiB ceiling. A separate local integration with the new grouping builder produces 446 unique operator IDs from 1,035 hotkeys and 223 KiB HTML. Multi-key nominator totals remain null. These are fixture results, not production measurements.

## Visual evidence

Local production Worker builds with a synthetic equal-name owner fixture, fixed viewports and explicit themes. One expansion affects two rows before and one row after; all twelve captures have no horizontal page overflow. Existing design tokens and directory layout are preserved.

| Viewport / theme | Before | After |
| --- | --- | --- |
| 375×812 / light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-mobile-light.png)<br><sub>Before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-mobile-light.png)<br><sub>After</sub> |
| 375×812 / dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-mobile-dark.png)<br><sub>Before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-mobile-dark.png)<br><sub>After</sub> |
| 768×1024 / light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-tablet-light.png)<br><sub>Before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-tablet-light.png)<br><sub>After</sub> |
| 768×1024 / dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-tablet-dark.png)<br><sub>Before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-tablet-dark.png)<br><sub>After</sub> |
| 1280×800 / light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-desktop-light.png)<br><sub>Before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-desktop-light.png)<br><sub>After</sub> |
| 1280×800 / dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/before-desktop-dark.png)<br><sub>Before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/epic-12012/operator-ui-identity/after-desktop-dark.png)<br><sub>After</sub> |

Closes #12050
Refs #12016, #12012
