### PR TITLE
fix(ui): hydrate browser wallet state consistently

### DIFF
--- a/apps/ui/src/hooks/use-wallet.ts
+++ b/apps/ui/src/hooks/use-wallet.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import {
   getConnectedWallet,
   setConnectedWallet,
@@ -52,6 +53,7 @@ export function isStaleWallet(
  * header comment and docs/adr/0018-native-staking-architecture.md).
  */
 export function useWallet() {
+  const hydrated = useHydrated();
   const [wallet, setWallet] = useState<ConnectedWallet | null>(() => getConnectedWallet());
   const [status, setStatus] = useState<WalletStatus>(() => (wallet ? "connected" : "idle"));
   const [accounts, setAccounts] = useState<InjectedAccountWithMeta[]>([]);
@@ -122,11 +124,14 @@ export function useWallet() {
   }, []);
 
   return {
-    wallet,
-    status,
+    // Browser persistence and injected extensions are absent from server HTML.
+    // Match that first render before exposing them, including nested boundaries
+    // that hydrate after the global shell has already mounted.
+    wallet: hydrated ? wallet : null,
+    status: hydrated ? status : "idle",
     accounts,
     error,
-    hasExtension: hasInjectedWallet(),
+    hasExtension: hydrated && hasInjectedWallet(),
     connect,
     selectAccount,
     disconnect,

--- a/apps/ui/tests/e2e/settings-state.spec.ts
+++ b/apps/ui/tests/e2e/settings-state.spec.ts
@@ -6,6 +6,9 @@ const OWNER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 async function signInAsOwner(page: Page, connected = true) {
   await page.addInitScript(
     ({ address, connected }) => {
+      // A supervised server restart can briefly navigate to an opaque error
+      // document. Seed storage only once the app origin is available.
+      if (window.location.origin === "null") return;
       const expiresAtMs = Date.now() + 60 * 60 * 1000;
       // useWallet rechecks stored accounts after hydration. Supply the smallest
       // compliant extension shape so that this fixture verifies the same
@@ -42,6 +45,39 @@ function envelope(data: unknown) {
 }
 
 test.describe("Settings record states", () => {
+  for (const connected of [false, true]) {
+    test(`hydrates wallet panels without replacing their first interaction (${connected ? "saved wallet" : "installed extension"})`, async ({
+      page,
+    }) => {
+      await signInAsOwner(page, connected);
+      const errors: string[] = [];
+      page.on("pageerror", (error) => errors.push(error.message));
+      const session = await page.context().newCDPSession(page);
+      await session.send("Emulation.setCPUThrottlingRate", { rate: 12 });
+      await gotoThroughRestart(page, "/settings");
+      if (connected) {
+        await expect(page.locator("#wallet").getByText("Connected via fixture")).toBeVisible();
+        await expect(
+          page.locator("#keys").getByRole("group", { name: "API key management" }),
+        ).toBeVisible();
+      } else {
+        const trigger = page
+          .locator("#alerts")
+          .getByRole("button", { name: "Connect wallet", exact: true });
+        // A single real pointer interaction must survive nested hydration.
+        await trigger.click();
+        await expect(trigger).toHaveAttribute("aria-expanded", "true");
+        const popoverId = await trigger.getAttribute("aria-controls");
+        await expect(
+          page
+            .locator(`[id="${popoverId}"]`)
+            .getByRole("button", { name: "Connect Wallet", exact: true }),
+        ).toBeVisible();
+      }
+      expect(errors).toEqual([]);
+    });
+  }
+
   for (const section of ["keys", "alerts"]) {
     test(`connects a wallet from ${section} without requesting a signature`, async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 812 });


### PR DESCRIPTION
An installed wallet extension or saved wallet changes the first browser render relative to server HTML. On settings, React can replace the nested wallet panel during the first pointer interaction, report hydration error 418, and lose the click. The global shell hydration signal does not prevent this nested mismatch.

The shared wallet hook now uses the existing router hydration guard for rendered wallet/status/extension values. Its initial output matches SSR, then browser state becomes available after the boundary hydrates. Existing connection, persistence and account-verification logic remain in their current paths.

## Validation

Both new production-build browser regressions fail against the previous build and pass with the fix. They exercise installed-extension and saved-wallet fresh loads with 12× CPU throttling, require zero browser errors, and verify a single pointer click opens the contextual picker. All 11 settings cases and the complete 620 browser checks passed without retries. All 2,404 UI unit tests, lint, formatting, typecheck, Worker build, SSR isolation, public-safety and export checks passed. Initial preload closure is 280 KiB gzip against the unchanged 300 KiB budget.

The storage fixture also skips opaque startup/error documents so a supervised local-server restart cannot produce fixture-only localStorage errors. No assertion is weakened. Evidence uses local Worker builds and recorded/synthetic API fixtures; deployment is verified separately.

Closes #12055
Refs #12030, #12033, #12012
