### PR TITLE
feat(data): define finalized Root basket observation storage

### DIFF
--- a/migrations/neon/0036_root_basket_observations.sql
+++ b/migrations/neon/0036_root_basket_observations.sql
@@ -1,0 +1,148 @@
+-- Internal finalized observations only; no producer or published current view.
+-- v454 types: subtensor 14cde6410fe8ec81a940e290c56f94a632a0988d.
+-- Unconstrained NUMERIC is intentional: NUMERIC(p,0) rounds fractional input
+-- BEFORE a CHECK sees it. These domains reject rather than round fractions.
+DO $$ BEGIN
+CREATE DOMAIN root_basket_u64 AS NUMERIC
+  CHECK (VALUE = trunc(VALUE) AND VALUE >= 0 AND VALUE <= 18446744073709551615);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+CREATE DOMAIN root_basket_u128 AS NUMERIC
+  CHECK (VALUE = trunc(VALUE) AND VALUE >= 0 AND VALUE <= 340282366920938463463374607431768211455);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+CREATE DOMAIN root_basket_i128 AS NUMERIC
+  CHECK (VALUE = trunc(VALUE) AND VALUE >= -170141183460469231731687303715884105728 AND VALUE <= 170141183460469231731687303715884105727);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+CREATE DOMAIN root_basket_u32 AS NUMERIC
+  CHECK (VALUE = trunc(VALUE) AND VALUE >= 0 AND VALUE <= 4294967295);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+CREATE DOMAIN root_basket_u16 AS NUMERIC
+  CHECK (VALUE = trunc(VALUE) AND VALUE >= 0 AND VALUE <= 65535);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+CREATE DOMAIN root_basket_hash32 AS TEXT
+  CHECK (VALUE ~ '^0x[0-9a-f]{64}$');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS root_basket_captures (
+  capture_id UUID PRIMARY KEY,
+  network TEXT NOT NULL CHECK (network IN ('finney', 'test', 'local')),
+  network_genesis_hash root_basket_hash32 NOT NULL,
+  finalized_block_hash root_basket_hash32 NOT NULL,
+  finalized_block root_basket_u64 NOT NULL,
+  runtime_spec_version root_basket_u32 NOT NULL CHECK (runtime_spec_version = 454),
+  runtime_api_version root_basket_u16 NOT NULL CHECK (runtime_api_version = 3),
+  decoder_version TEXT NOT NULL CHECK (decoder_version = 'subtensor-v454-14cde641-v1'),
+  metadata_sha256 root_basket_hash32 NOT NULL,
+  started_at_ms root_basket_u64 NOT NULL,
+  finished_at_ms root_basket_u64 NOT NULL CHECK (finished_at_ms >= started_at_ms),
+  expected_pages root_basket_u32 NOT NULL CHECK (expected_pages > 0),
+  expected_funds root_basket_u32 NOT NULL,
+  index_status TEXT NOT NULL CHECK (index_status IN ('published', 'not_published')),
+  index_completed_block root_basket_u64,
+  bag_index_q64_bits root_basket_u128 NOT NULL,
+  stake_index_q64_bits root_basket_u128 NOT NULL,
+  CHECK (
+    (index_status = 'published' AND index_completed_block IS NOT NULL AND index_completed_block <= finalized_block)
+    OR (index_status = 'not_published' AND index_completed_block IS NULL
+      AND bag_index_q64_bits = 18446744073709551616 AND stake_index_q64_bits = 18446744073709551616)
+  ),
+  UNIQUE (network_genesis_hash, finalized_block_hash, decoder_version)
+);
+CREATE INDEX IF NOT EXISTS root_basket_captures_history
+  ON root_basket_captures (network_genesis_hash, finalized_block DESC);
+
+-- Source manifest counts are expectations, not a persisted-completeness stamp.
+-- A future writer must verify receipts/children before publishing any capture.
+CREATE TABLE IF NOT EXISTS root_basket_capture_pages (
+  capture_id UUID NOT NULL REFERENCES root_basket_captures (capture_id),
+  page_index root_basket_u32 NOT NULL,
+  start_after root_basket_hash32,
+  next_after root_basket_hash32,
+  response_sha256 root_basket_hash32 NOT NULL,
+  fund_count root_basket_u16 NOT NULL CHECK (fund_count <= 256),
+  PRIMARY KEY (capture_id, page_index),
+  CHECK ((page_index = 0) = (start_after IS NULL)),
+  CHECK (start_after IS NULL OR next_after IS NULL OR start_after <> next_after)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS root_basket_capture_page_cursors
+  ON root_basket_capture_pages (capture_id, start_after) NULLS NOT DISTINCT;
+CREATE UNIQUE INDEX IF NOT EXISTS root_basket_capture_terminal_page
+  ON root_basket_capture_pages (capture_id) WHERE next_after IS NULL;
+
+CREATE OR REPLACE FUNCTION root_basket_preserve_receipt() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW IS DISTINCT FROM OLD THEN
+    RAISE EXCEPTION 'root basket receipt is immutable' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS root_basket_receipt_immutable ON root_basket_capture_pages;
+CREATE TRIGGER root_basket_receipt_immutable
+  BEFORE UPDATE ON root_basket_capture_pages
+  FOR EACH ROW EXECUTE FUNCTION root_basket_preserve_receipt();
+
+CREATE TABLE IF NOT EXISTS root_basket_fund_snapshots (
+  capture_id UUID NOT NULL,
+  hotkey root_basket_hash32 NOT NULL,
+  page_index root_basket_u32 NOT NULL,
+  shares_atomic root_basket_u64 NOT NULL CHECK (shares_atomic > 0),
+  spot_nav_rao root_basket_u64 NOT NULL,
+  realizable_nav_rao root_basket_u64 NOT NULL,
+  deposited_rao root_basket_u64 NOT NULL,
+  redeemed_rao root_basket_u64 NOT NULL,
+  raw_spot_price_q64_bits root_basket_u128 NOT NULL,
+  display_price_q64_bits root_basket_u128 NOT NULL,
+  display_shares_q64_bits root_basket_u128 NOT NULL,
+  stake_price_q64_bits root_basket_u128 NOT NULL,
+  staker_twr_q64_bits root_basket_u128 NOT NULL,
+  pending_entitlement_q64_bits root_basket_u128 NOT NULL,
+  provisional BOOLEAN NOT NULL,
+  first_block root_basket_u64 NOT NULL,
+  price_divisor_q64_bits root_basket_u128,
+  rate0_q32_bits root_basket_i128,
+  tr_splice_q64_bits root_basket_u128,
+  holdings_count root_basket_u32 NOT NULL,
+  targets_count root_basket_u32 NOT NULL,
+  PRIMARY KEY (capture_id, hotkey),
+  FOREIGN KEY (capture_id, page_index) REFERENCES root_basket_capture_pages (capture_id, page_index),
+  CHECK (
+    (provisional AND first_block = 0 AND price_divisor_q64_bits IS NULL AND rate0_q32_bits IS NULL AND tr_splice_q64_bits IS NULL)
+    OR (NOT provisional AND first_block > 0 AND price_divisor_q64_bits IS NOT NULL AND price_divisor_q64_bits > 0
+      AND rate0_q32_bits IS NOT NULL AND tr_splice_q64_bits IS NOT NULL AND tr_splice_q64_bits > 0)
+  )
+);
+CREATE INDEX IF NOT EXISTS root_basket_fund_address_history
+  ON root_basket_fund_snapshots (hotkey, capture_id);
+
+CREATE TABLE IF NOT EXISTS root_basket_holdings (
+  capture_id UUID NOT NULL,
+  hotkey root_basket_hash32 NOT NULL,
+  netuid root_basket_u16 NOT NULL,
+  quantity_atomic root_basket_u64 NOT NULL,
+  quantity_unit TEXT NOT NULL,
+  spot_value_rao root_basket_u64 NOT NULL,
+  realizable_value_rao root_basket_u64 NOT NULL,
+  PRIMARY KEY (capture_id, hotkey, netuid),
+  FOREIGN KEY (capture_id, hotkey) REFERENCES root_basket_fund_snapshots (capture_id, hotkey),
+  CHECK ((netuid = 0 AND quantity_unit = 'rao') OR (netuid > 0 AND quantity_unit = 'alpha_atomic'))
+);
+CREATE TABLE IF NOT EXISTS root_basket_targets (
+  capture_id UUID NOT NULL,
+  hotkey root_basket_hash32 NOT NULL,
+  netuid root_basket_u16 NOT NULL,
+  weight root_basket_u16 NOT NULL,
+  PRIMARY KEY (capture_id, hotkey, netuid),
+  FOREIGN KEY (capture_id, hotkey) REFERENCES root_basket_fund_snapshots (capture_id, hotkey)
+);

--- a/schemas-src/root-basket-capture.ts
+++ b/schemas-src/root-basket-capture.ts
@@ -1,0 +1,217 @@
+// Internal observation contract; no public route or publication pointer.
+// SCALE types are pinned to subtensor 14cde6410fe8ec81a940e290c56f94a632a0988d
+// (v454), rpc_info/basket_info.rs and staking/beta_pricing.rs.
+import { z } from "zod";
+import { BittensorNetworkSchema } from "./shared.ts";
+
+function integerString(bits: number, signed = false) {
+  const bound = 1n << BigInt(signed ? bits - 1 : bits);
+  return z
+    .string()
+    .max(signed ? 40 : 39)
+    .regex(signed ? /^(0|[1-9]\d*|-[1-9]\d*)$/ : /^(0|[1-9]\d*)$/)
+    .pipe(
+      z.string().refine(
+        (value) => {
+          const integer = BigInt(value);
+          return integer >= (signed ? -bound : 0n) && integer < bound;
+        },
+        `Outside ${signed ? "i" : "u"}${bits} range`,
+      ),
+    );
+}
+
+const u64 = integerString(64);
+const q64 = integerString(128);
+const i128 = integerString(128, true);
+const hash = z.string().regex(/^0x[0-9a-f]{64}$/);
+const account = hash;
+const count = z.int().min(0).max(4_294_967_295);
+const netuid = z.int().min(0).max(65_535);
+const oneQ64 = "18446744073709551616";
+
+function greaterUnsigned(left: string, right: string): boolean {
+  // Object refinements can still run after a scalar validation issue.
+  // Compare only validated quantities so safeParse never throws on bad input.
+  const a = u64.safeParse(left);
+  const b = u64.safeParse(right);
+  return a.success && b.success && BigInt(a.data) > BigInt(b.data);
+}
+
+const holding = z
+  .object({
+    netuid,
+    quantity_atomic: u64,
+    // Root cash uses rao; every other quantity belongs to its own subnet.
+    quantity_unit: z.enum(["rao", "alpha_atomic"]),
+    spot_value_rao: u64,
+    realizable_value_rao: u64,
+  })
+  .strict()
+  .refine(
+    (row) => (row.netuid === 0) === (row.quantity_unit === "rao"),
+    "Only netuid 0 holds rao; other quantities are subnet alpha atoms",
+  );
+
+const target = z.object({ netuid, weight: netuid }).strict();
+const baseline = z.discriminatedUnion("provisional", [
+  z
+    .object({
+      provisional: z.literal(true),
+      first_block: z.literal("0"),
+      price_divisor_q64_bits: z.null(),
+      rate0_q32_bits: z.null(),
+      tr_splice_q64_bits: z.null(),
+    })
+    .strict(),
+  z
+    .object({
+      provisional: z.literal(false),
+      first_block: u64.refine((value) => value !== "0"),
+      price_divisor_q64_bits: q64.refine((value) => value !== "0"),
+      rate0_q32_bits: i128,
+      tr_splice_q64_bits: q64.refine((value) => value !== "0"),
+    })
+    .strict(),
+]);
+
+const fund = z
+  .object({
+    hotkey: account,
+    page_index: count,
+    shares_atomic: u64.refine((value) => value !== "0"),
+    spot_nav_rao: u64,
+    realizable_nav_rao: u64,
+    deposited_rao: u64,
+    redeemed_rao: u64,
+    raw_spot_price_q64_bits: q64,
+    display_price_q64_bits: q64,
+    // Quantity, not price: human display beta = bits / (2^64 * 10^9).
+    display_shares_q64_bits: q64,
+    stake_price_q64_bits: q64,
+    staker_twr_q64_bits: q64,
+    // The runtime's staker_yield field is a mark, not an annualized return.
+    pending_entitlement_q64_bits: q64,
+    baseline,
+    // Required arrays: [] is a complete empty part; missing is invalid.
+    holdings: z.array(holding).max(65_536),
+    targets: z.array(target).max(65_536),
+  })
+  .strict();
+
+const page = z
+  .object({
+    page_index: count,
+    start_after: account.nullable(),
+    next_after: account.nullable(),
+    response_sha256: hash,
+    fund_count: z.int().min(0).max(256),
+  })
+  .strict();
+
+const index = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("published"),
+      completed_block: u64,
+      bag_q64_bits: q64,
+      stake_q64_bits: q64,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("not_published"),
+      completed_block: z.null(),
+      bag_q64_bits: z.literal(oneQ64),
+      stake_q64_bits: z.literal(oneQ64),
+    })
+    .strict(),
+]);
+
+/** A complete source observation, not proof its rows have been persisted.
+ * All reads use the same finalized hash. Persistence must later verify every
+ * receipt and child row before advertising completeness; this slice serves none.
+ * The capture/address key deliberately makes no claim about immutable fund life.
+ */
+export const RootBasketCaptureSchema = z
+  .object({
+    capture_id: z.uuid(),
+    network: BittensorNetworkSchema,
+    network_genesis_hash: hash,
+    finalized_block_hash: hash,
+    finalized_block: u64,
+    runtime_spec_version: z.literal(454),
+    runtime_api_version: z.literal(3),
+    decoder_version: z.literal("subtensor-v454-14cde641-v1"),
+    metadata_sha256: hash,
+    started_at_ms: u64,
+    finished_at_ms: u64,
+    expected_pages: count.min(1),
+    expected_funds: count,
+    index,
+    pages: z.array(page).min(1),
+    funds: z.array(fund),
+  })
+  .strict()
+  .superRefine((capture, ctx) => {
+    const issue = (message: string) =>
+      ctx.addIssue({ code: "custom", message });
+    if (greaterUnsigned(capture.started_at_ms, capture.finished_at_ms)) {
+      issue("Capture finish precedes start");
+    }
+    if (
+      capture.index.completed_block !== null &&
+      greaterUnsigned(capture.index.completed_block, capture.finalized_block)
+    ) {
+      issue("Index completion is after the finalized source block");
+    }
+    if (
+      capture.pages.length !== capture.expected_pages ||
+      capture.funds.length !== capture.expected_funds
+    ) {
+      issue("Manifest counts do not match the observed rows");
+    }
+    const fundCounts = new Map<number, number>();
+    for (const row of capture.funds) {
+      fundCounts.set(row.page_index, (fundCounts.get(row.page_index) ?? 0) + 1);
+    }
+    const seenCursors = new Set<string>();
+    for (const [position, row] of capture.pages.entries()) {
+      const expectedStart =
+        position === 0 ? null : capture.pages[position - 1]!.next_after;
+      if (
+        row.page_index !== position ||
+        row.start_after !== expectedStart ||
+        (position > 0 && row.start_after === null) ||
+        (position === capture.pages.length - 1) !== (row.next_after === null)
+      ) {
+        issue(
+          "Pagination must form one contiguous chain ending in a terminal receipt",
+        );
+      }
+      if (row.next_after !== null) {
+        if (seenCursors.has(row.next_after))
+          issue("Pagination repeated a cursor");
+        seenCursors.add(row.next_after);
+      }
+      if ((fundCounts.get(position) ?? 0) !== row.fund_count) {
+        issue("Receipt fund count does not match its observations");
+      }
+    }
+    const seenFunds = new Set<string>();
+    for (const row of capture.funds) {
+      if (seenFunds.has(row.hotkey))
+        issue("Duplicate fund address within a capture");
+      seenFunds.add(row.hotkey);
+      if (row.page_index >= capture.pages.length)
+        issue("Fund references an absent receipt");
+      if (greaterUnsigned(row.baseline.first_block, capture.finalized_block)) {
+        issue("Baseline stamp is after the finalized source block");
+      }
+      for (const part of [row.holdings, row.targets]) {
+        if (new Set(part.map((entry) => entry.netuid)).size !== part.length) {
+          issue("Duplicate netuid within a complete fund part");
+        }
+      }
+    }
+  });

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -723,6 +723,46 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     coveredBy: "subnet-lifecycle",
   },
 
+  // Unserved observation storage has no scheduled writer yet (#12019).
+  // Enable cadence and completeness checks when the producer is introduced.
+  // Child rows have no arrival stamp; a parent capture timestamp cannot prove
+  // their persistence or supply the child's stamp required by crossCheckSql.
+  root_basket_captures: {
+    column: "finished_at_ms",
+    kind: "ms",
+    maxAgeMs: null,
+    reason:
+      "storage contract only; no producer or published current view (#12019)",
+  },
+  root_basket_capture_pages: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason:
+      "no child timestamp; no producer or published current view (#12019)",
+  },
+  root_basket_fund_snapshots: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason:
+      "no child timestamp; no producer or published current view (#12019)",
+  },
+  root_basket_holdings: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason:
+      "no child timestamp; no producer or published current view (#12019)",
+  },
+  root_basket_targets: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason:
+      "no child timestamp; no producer or published current view (#12019)",
+  },
+
   // Written by scripts/neon-migrate.ts, once per migration. The same "only
   // when a human acts" class as api_keys above.
   schema_migrations: {

--- a/tests/fixtures/root-basket-capture.ts
+++ b/tests/fixtures/root-basket-capture.ts
@@ -1,0 +1,94 @@
+import type { z } from "zod";
+import type { RootBasketCaptureSchema } from "../../schemas-src/root-basket-capture.ts";
+
+/** Synthetic exact arithmetic, not a network capture or performance result.
+ * Root cash = 1 TAO; 16 alpha at 0.125 plus 6 alpha at 0.5 give spot NAV 6.
+ * Realizable marks total 5. Raw supply 2 beta with divisor 1.5 displays as 3.
+ */
+export function syntheticBasketCapture(): z.input<
+  typeof RootBasketCaptureSchema
+> {
+  const q64 = (numerator: bigint, denominator = 1n) =>
+    ((numerator * (1n << 64n)) / denominator).toString();
+  return {
+    capture_id: "00000000-0000-4000-8000-000000000001",
+    network: "local",
+    network_genesis_hash: `0x${"01".repeat(32)}`,
+    finalized_block_hash: `0x${"02".repeat(32)}`,
+    finalized_block: "500",
+    runtime_spec_version: 454,
+    runtime_api_version: 3,
+    decoder_version: "subtensor-v454-14cde641-v1",
+    metadata_sha256: `0x${"03".repeat(32)}`,
+    started_at_ms: "1000",
+    finished_at_ms: "2000",
+    expected_pages: 1,
+    expected_funds: 1,
+    index: {
+      status: "published",
+      completed_block: "100",
+      bag_q64_bits: q64(7n, 4n),
+      stake_q64_bits: q64(3n, 2n),
+    },
+    pages: [
+      {
+        page_index: 0,
+        start_after: null,
+        next_after: null,
+        response_sha256: `0x${"04".repeat(32)}`,
+        fund_count: 1,
+      },
+    ],
+    funds: [
+      {
+        hotkey: `0x${"11".repeat(32)}`,
+        page_index: 0,
+        shares_atomic: "2000000000",
+        spot_nav_rao: "6000000000",
+        realizable_nav_rao: "5000000000",
+        deposited_rao: "4000000000",
+        redeemed_rao: "0",
+        raw_spot_price_q64_bits: q64(3n),
+        display_price_q64_bits: q64(2n),
+        display_shares_q64_bits: q64(3_000_000_000n),
+        stake_price_q64_bits: q64(45n, 32n),
+        staker_twr_q64_bits: q64(9n, 8n),
+        pending_entitlement_q64_bits: q64(3n, 16n),
+        baseline: {
+          provisional: false,
+          first_block: "90",
+          price_divisor_q64_bits: q64(3n, 2n),
+          rate0_q32_bits: "536870912",
+          tr_splice_q64_bits: q64(5n, 4n),
+        },
+        holdings: [
+          {
+            netuid: 0,
+            quantity_atomic: "1000000000",
+            quantity_unit: "rao",
+            spot_value_rao: "1000000000",
+            realizable_value_rao: "1000000000",
+          },
+          {
+            netuid: 19,
+            quantity_atomic: "16000000000",
+            quantity_unit: "alpha_atomic",
+            spot_value_rao: "2000000000",
+            realizable_value_rao: "1500000000",
+          },
+          {
+            netuid: 50,
+            quantity_atomic: "6000000000",
+            quantity_unit: "alpha_atomic",
+            spot_value_rao: "3000000000",
+            realizable_value_rao: "2500000000",
+          },
+        ],
+        targets: [
+          { netuid: 19, weight: 2 },
+          { netuid: 50, weight: 1 },
+        ],
+      },
+    ],
+  };
+}

--- a/tests/root-basket-capture.test.ts
+++ b/tests/root-basket-capture.test.ts
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { RootBasketCaptureSchema } from "../schemas-src/root-basket-capture.ts";
+import { syntheticBasketCapture } from "./fixtures/root-basket-capture.ts";
+
+const parse = (value: unknown) =>
+  RootBasketCaptureSchema.safeParse(value).success;
+
+function withFund(change: Record<string, unknown>) {
+  const capture = syntheticBasketCapture();
+  return { ...capture, funds: [{ ...capture.funds[0]!, ...change }] };
+}
+
+describe("finalized basket observation contract", () => {
+  test("returns validation errors for malformed temporal fields without throwing", () => {
+    for (const value of ["bad", "1.2", "1e3", "18446744073709551616"]) {
+      for (const field of [
+        "finalized_block",
+        "started_at_ms",
+        "finished_at_ms",
+      ]) {
+        assert.equal(
+          parse({ ...syntheticBasketCapture(), [field]: value }),
+          false,
+        );
+      }
+      const capture = syntheticBasketCapture();
+      assert.equal(
+        parse({
+          ...capture,
+          index: { ...capture.index, completed_block: value },
+        }),
+        false,
+      );
+      assert.equal(
+        parse(
+          withFund({
+            baseline: { ...capture.funds[0]!.baseline, first_block: value },
+          }),
+        ),
+        false,
+      );
+    }
+  });
+
+  test("preserves raw/display scales and distinct spot/realizable marks exactly", () => {
+    const capture = RootBasketCaptureSchema.parse(syntheticBasketCapture());
+    const fund = capture.funds[0]!;
+    const q = 1n << 64n;
+    const rao = 1_000_000_000n;
+    assert.equal(BigInt(fund.display_shares_q64_bits) / (q * rao), 3n);
+    assert.equal(BigInt(fund.shares_atomic) / rao, 2n);
+    assert.equal(
+      (BigInt(fund.display_shares_q64_bits) *
+        BigInt(fund.display_price_q64_bits)) /
+        (q * q),
+      BigInt(fund.spot_nav_rao),
+    );
+    assert.equal(
+      fund.holdings.reduce((sum, row) => sum + BigInt(row.spot_value_rao), 0n),
+      6n * rao,
+    );
+    assert.equal(
+      fund.holdings.reduce(
+        (sum, row) => sum + BigInt(row.realizable_value_rao),
+        0n,
+      ),
+      5n * rao,
+    );
+    // A quarter of the raw supply has different spot and realizable marks.
+    assert.equal(
+      (500_000_000n * BigInt(fund.spot_nav_rao)) / BigInt(fund.shares_atomic),
+      1_500_000_000n,
+    );
+    assert.equal(
+      (500_000_000n * BigInt(fund.realizable_nav_rao)) /
+        BigInt(fund.shares_atomic),
+      1_250_000_000n,
+    );
+  });
+
+  for (const value of [
+    "0.5",
+    "1e3",
+    "01",
+    "-0",
+    "-1",
+    "18446744073709551616",
+    2_000_000_000,
+    null,
+    "bogus",
+  ]) {
+    test(`rejects noncanonical raw quantity ${String(value)}`, () => {
+      assert.equal(parse(withFund({ shares_atomic: value })), false);
+    });
+  }
+  test("preserves >2^53 and maximum u64/u128 quantities without Number conversion", () => {
+    const capture = RootBasketCaptureSchema.parse(
+      withFund({
+        shares_atomic: "18446744073709551615",
+        spot_nav_rao: "9007199254740993",
+        display_shares_q64_bits: "340282366920938463463374607431768211455",
+      }),
+    );
+    assert.equal(capture.funds[0]!.spot_nav_rao, "9007199254740993");
+    assert.equal(
+      parse(
+        withFund({
+          display_shares_q64_bits: "340282366920938463463374607431768211456",
+        }),
+      ),
+      false,
+    );
+  });
+  test("preserves signed Q32 bits while rejecting signed overflow and fractions", () => {
+    const baseline = syntheticBasketCapture().funds[0]!.baseline;
+    for (const value of [
+      "-170141183460469231731687303715884105728",
+      "170141183460469231731687303715884105727",
+    ]) {
+      assert.equal(
+        parse(withFund({ baseline: { ...baseline, rate0_q32_bits: value } })),
+        true,
+      );
+    }
+    for (const value of [
+      "-170141183460469231731687303715884105729",
+      "170141183460469231731687303715884105728",
+      "-0.5",
+    ]) {
+      assert.equal(
+        parse(withFund({ baseline: { ...baseline, rate0_q32_bits: value } })),
+        false,
+      );
+    }
+  });
+  test("distinguishes an empty complete part from a missing part", () => {
+    assert.equal(parse(withFund({ targets: [] })), true);
+    assert.equal(parse(withFund({ targets: null })), false);
+    assert.equal(parse(withFund({ holdings: undefined })), false);
+  });
+  test("accepts a zero-row terminal receipt but rejects partial pagination", () => {
+    const capture = syntheticBasketCapture();
+    capture.expected_funds = 0;
+    capture.funds = [];
+    capture.pages[0]!.fund_count = 0;
+    assert.equal(parse(capture), true);
+    capture.pages[0]!.next_after = `0x${"22".repeat(32)}`;
+    assert.equal(parse(capture), false);
+    capture.expected_pages = 2;
+    capture.pages.push({
+      ...capture.pages[0]!,
+      page_index: 1,
+      start_after: capture.pages[0]!.next_after,
+      next_after: null,
+    });
+    assert.equal(parse(capture), true);
+  });
+  test("rejects cursor gaps, cycles, duplicate pages, and mismatched receipt counts", () => {
+    const capture = syntheticBasketCapture();
+    assert.equal(parse({ ...capture, expected_pages: 2 }), false);
+    assert.equal(parse({ ...capture, expected_funds: 2 }), false);
+    assert.equal(
+      parse({ ...capture, pages: [{ ...capture.pages[0]!, fund_count: 0 }] }),
+      false,
+    );
+    const cursor = `0x${"22".repeat(32)}`;
+    const pages = [
+      { ...capture.pages[0]!, next_after: cursor },
+      {
+        ...capture.pages[0]!,
+        page_index: 1,
+        start_after: cursor,
+        next_after: cursor,
+        fund_count: 0,
+      },
+      {
+        ...capture.pages[0]!,
+        page_index: 2,
+        start_after: cursor,
+        next_after: null,
+        fund_count: 0,
+      },
+    ];
+    assert.equal(parse({ ...capture, expected_pages: 3, pages }), false);
+    assert.equal(
+      parse({ ...capture, pages: [{ ...capture.pages[0]!, page_index: 2 }] }),
+      false,
+    );
+    assert.equal(parse(withFund({ page_index: 1 })), false);
+  });
+  test("does not turn provisional or unpublished index values into historical identity", () => {
+    const capture = syntheticBasketCapture();
+    capture.index = {
+      status: "not_published",
+      completed_block: null,
+      bag_q64_bits: "18446744073709551616",
+      stake_q64_bits: "18446744073709551616",
+    };
+    capture.funds[0]!.baseline = {
+      provisional: true,
+      first_block: "0",
+      price_divisor_q64_bits: null,
+      rate0_q32_bits: null,
+      tr_splice_q64_bits: null,
+    };
+    assert.equal(parse(capture), true);
+    assert.equal(
+      parse({ ...capture, index: { ...capture.index, completed_block: "0" } }),
+      false,
+    );
+    assert.equal(
+      parse(
+        withFund({
+          baseline: { ...capture.funds[0]!.baseline, first_block: "90" },
+        }),
+      ),
+      false,
+    );
+  });
+  test("keeps source and index freshness separate and rejects future stamps", () => {
+    const capture = syntheticBasketCapture();
+    assert.equal(parse(capture), true); // block 500, completed index block 100
+    assert.equal(parse({ ...capture, finished_at_ms: "999" }), false);
+    assert.equal(
+      parse({
+        ...capture,
+        index: { ...capture.index, completed_block: "501" },
+      }),
+      false,
+    );
+    assert.equal(
+      parse(
+        withFund({
+          baseline: { ...capture.funds[0]!.baseline, first_block: "501" },
+        }),
+      ),
+      false,
+    );
+  });
+  test("requires canonical hashes, account bytes, audited runtime, and unique scoped assets", () => {
+    const capture = syntheticBasketCapture();
+    assert.equal(parse({ ...capture, network_genesis_hash: "0x1234" }), false);
+    assert.equal(parse({ ...capture, runtime_spec_version: 455 }), false);
+    assert.equal(parse({ ...capture, runtime_api_version: 2 }), false);
+    assert.equal(parse({ ...capture, extra: true }), false);
+    assert.equal(parse(withFund({ hotkey: `0x${"AB".repeat(32)}` })), false);
+    assert.equal(
+      parse(
+        withFund({
+          holdings: [
+            {
+              ...capture.funds[0]!.holdings[0]!,
+              quantity_unit: "alpha_atomic",
+            },
+          ],
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      parse(
+        withFund({
+          holdings: [
+            capture.funds[0]!.holdings[0],
+            capture.funds[0]!.holdings[0],
+          ],
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      parse(withFund({ targets: [{ netuid: 19, weight: 0.5 }] })),
+      false,
+    );
+    assert.equal(
+      parse(withFund({ targets: [{ netuid: 19, weight: 65536 }] })),
+      false,
+    );
+    assert.equal(
+      parse(
+        withFund({
+          targets: [
+            { netuid: 19, weight: 2 },
+            { netuid: 19, weight: 1 },
+          ],
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      parse({
+        ...capture,
+        expected_funds: 2,
+        pages: [{ ...capture.pages[0]!, fund_count: 2 }],
+        funds: [capture.funds[0], capture.funds[0]],
+      }),
+      false,
+    );
+  });
+  test("keeps an observed zero NAV distinct from unavailable input", () => {
+    assert.equal(
+      parse(
+        withFund({
+          spot_nav_rao: "0",
+          raw_spot_price_q64_bits: "0",
+          display_price_q64_bits: "0",
+        }),
+      ),
+      true,
+    );
+    assert.equal(parse(withFund({ spot_nav_rao: null })), false);
+  });
+});

--- a/tests/root-basket-storage.test.ts
+++ b/tests/root-basket-storage.test.ts
@@ -1,0 +1,438 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, describe, test } from "vitest";
+import { RootBasketCaptureSchema } from "../schemas-src/root-basket-capture.ts";
+import { syntheticBasketCapture } from "./fixtures/root-basket-capture.ts";
+
+let db: PGlite;
+const secondId = "00000000-0000-4000-8000-000000000002";
+const otherAccount = `0x${"22".repeat(32)}`;
+
+// Test-only insertion: exercises the migration itself, not mocked SQL matching.
+async function insert(table: string, row: Record<string, unknown>) {
+  const columns = Object.keys(row);
+  return db.query(
+    `INSERT INTO ${table} (${columns.join(",")}) VALUES (${columns.map((_, i) => `$${i + 1}`).join(",")})`,
+    Object.values(row),
+  );
+}
+
+async function store(capture = syntheticBasketCapture()) {
+  const { index, pages, funds, ...metadata } =
+    RootBasketCaptureSchema.parse(capture);
+  await insert("root_basket_captures", {
+    ...metadata,
+    index_status: index.status,
+    index_completed_block: index.completed_block,
+    bag_index_q64_bits: index.bag_q64_bits,
+    stake_index_q64_bits: index.stake_q64_bits,
+  });
+  for (const page of pages)
+    await insert("root_basket_capture_pages", {
+      capture_id: capture.capture_id,
+      ...page,
+    });
+  for (const { baseline, holdings, targets, ...fund } of funds) {
+    await insert("root_basket_fund_snapshots", {
+      capture_id: capture.capture_id,
+      ...fund,
+      ...baseline,
+      holdings_count: holdings.length,
+      targets_count: targets.length,
+    });
+    for (const row of holdings)
+      await insert("root_basket_holdings", {
+        capture_id: capture.capture_id,
+        hotkey: fund.hotkey,
+        ...row,
+      });
+    for (const row of targets)
+      await insert("root_basket_targets", {
+        capture_id: capture.capture_id,
+        hotkey: fund.hotkey,
+        ...row,
+      });
+  }
+}
+
+beforeAll(async () => {
+  db = new PGlite();
+  await db.exec(
+    readFileSync("migrations/neon/0036_root_basket_observations.sql", "utf8"),
+  );
+});
+afterAll(async () => db.close());
+beforeEach(async () => {
+  await db.exec("TRUNCATE root_basket_captures CASCADE");
+});
+
+describe("root basket observation storage constraints", () => {
+  test("reapplying the migration preserves observations and receipt immutability", async () => {
+    await store();
+    await db.exec(
+      readFileSync("migrations/neon/0036_root_basket_observations.sql", "utf8"),
+    );
+    assert.equal(
+      (await db.query("SELECT * FROM root_basket_fund_snapshots")).rows.length,
+      1,
+    );
+    await assert.rejects(
+      db.query("UPDATE root_basket_capture_pages SET response_sha256 = $1", [
+        otherAccount,
+      ]),
+      /receipt is immutable/,
+    );
+  });
+
+  test("stores exact synthetic quantities and keeps indexes independently dated", async () => {
+    const capture = syntheticBasketCapture();
+    capture.funds[0]!.deposited_rao = "9007199254740993";
+    await store(capture);
+    const row = (
+      await db.query<{
+        deposited_rao: string;
+        display_beta: string;
+        spot_nav: string;
+        real_nav: string;
+      }>(`
+      SELECT deposited_rao::text, (display_shares_q64_bits / 18446744073709551616 / 1000000000)::text AS display_beta,
+        spot_nav_rao::text AS spot_nav, realizable_nav_rao::text AS real_nav FROM root_basket_fund_snapshots
+    `)
+    ).rows[0]!;
+    assert.equal(row.deposited_rao, "9007199254740993");
+    assert.equal(BigInt(row.display_beta.split(".")[0]!), 3n);
+    assert.equal(row.spot_nav, "6000000000");
+    assert.equal(row.real_nav, "5000000000");
+    assert.deepEqual(
+      (
+        await db.query(
+          "SELECT finalized_block::text, index_completed_block::text FROM root_basket_captures",
+        )
+      ).rows,
+      [{ finalized_block: "500", index_completed_block: "100" }],
+    );
+  });
+
+  for (const [domain, minimum, maximum] of [
+    ["root_basket_u16", "0", "65535"],
+    ["root_basket_u32", "0", "4294967295"],
+    ["root_basket_u64", "0", "18446744073709551615"],
+    ["root_basket_u128", "0", "340282366920938463463374607431768211455"],
+    [
+      "root_basket_i128",
+      "-170141183460469231731687303715884105728",
+      "170141183460469231731687303715884105727",
+    ],
+  ]) {
+    test(`${domain} preserves bounds and rejects fractional input before any rounding`, async () => {
+      for (const value of [minimum!, maximum!]) {
+        assert.equal(
+          (
+            await db.query<{ value: string }>(
+              `SELECT ($1::${domain})::text AS value`,
+              [value],
+            )
+          ).rows[0]!.value,
+          value,
+        );
+      }
+      for (const value of [
+        (BigInt(minimum!) - 1n).toString(),
+        (BigInt(maximum!) + 1n).toString(),
+        "0.5",
+        "1.1",
+        "-0.1",
+        "NaN",
+        "Infinity",
+        "-Infinity",
+      ]) {
+        await assert.rejects(
+          db.query(`SELECT $1::${domain}`, [value]),
+          /check constraint/,
+        );
+      }
+    });
+  }
+  test("actual quantity, fixed-point, and weight columns reject fractional numeric binds", async () => {
+    await store();
+    await assert.rejects(
+      db.query("UPDATE root_basket_holdings SET quantity_atomic = $1", ["1.4"]),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.query(
+        "UPDATE root_basket_fund_snapshots SET display_shares_q64_bits = $1",
+        ["1.4"],
+      ),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.query("UPDATE root_basket_fund_snapshots SET rate0_q32_bits = $1", [
+        "-0.1",
+      ]),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.query("UPDATE root_basket_targets SET weight = $1", ["65534.9"]),
+      /check constraint/,
+    );
+  });
+  test("allows an empty terminal page and complete empty targets without fabricating holdings", async () => {
+    const capture = syntheticBasketCapture();
+    capture.funds[0]!.targets = [];
+    await store(capture);
+    assert.deepEqual(
+      (
+        await db.query(
+          "SELECT holdings_count::text, targets_count::text FROM root_basket_fund_snapshots",
+        )
+      ).rows,
+      [{ holdings_count: "3", targets_count: "0" }],
+    );
+    await db.exec("TRUNCATE root_basket_captures CASCADE");
+    capture.funds = [];
+    capture.expected_funds = 0;
+    capture.pages[0]!.fund_count = 0;
+    await store(capture);
+    assert.deepEqual(
+      (
+        await db.query(
+          "SELECT next_after, fund_count::text FROM root_basket_capture_pages",
+        )
+      ).rows,
+      [{ next_after: null, fund_count: "0" }],
+    );
+  });
+  test("conflicting receipt insertion or update cannot replace the accepted response", async () => {
+    const capture = syntheticBasketCapture();
+    await store(capture);
+    await assert.rejects(
+      insert("root_basket_capture_pages", {
+        capture_id: capture.capture_id,
+        ...capture.pages[0]!,
+        response_sha256: otherAccount,
+      }),
+      /duplicate key/,
+    );
+    await assert.rejects(
+      db.query("UPDATE root_basket_capture_pages SET response_sha256 = $1", [
+        otherAccount,
+      ]),
+      /receipt is immutable/,
+    );
+    await db.exec(
+      "UPDATE root_basket_capture_pages SET response_sha256 = response_sha256",
+    );
+    assert.equal(
+      (
+        await db.query<{ response_sha256: string }>(
+          "SELECT response_sha256 FROM root_basket_capture_pages",
+        )
+      ).rows[0]!.response_sha256,
+      capture.pages[0]!.response_sha256,
+    );
+    assert.equal(
+      (
+        await db.query<{ n: number }>(
+          "SELECT count(*)::int AS n FROM root_basket_capture_pages",
+        )
+      ).rows[0]!.n,
+      1,
+    );
+  });
+  test("rejects duplicate terminal pages, repeated cursors, and self-repeating cursors", async () => {
+    const capture = syntheticBasketCapture();
+    await store(capture);
+    await assert.rejects(
+      insert("root_basket_capture_pages", {
+        capture_id: capture.capture_id,
+        ...capture.pages[0]!,
+        page_index: 1,
+        start_after: otherAccount,
+      }),
+      /duplicate key/,
+    );
+    await assert.rejects(
+      insert("root_basket_capture_pages", {
+        capture_id: capture.capture_id,
+        ...capture.pages[0]!,
+        page_index: 1,
+        start_after: otherAccount,
+        next_after: otherAccount,
+      }),
+      /check constraint/,
+    );
+    const next = `0x${"33".repeat(32)}`;
+    await insert("root_basket_capture_pages", {
+      capture_id: capture.capture_id,
+      ...capture.pages[0]!,
+      page_index: 1,
+      start_after: otherAccount,
+      next_after: next,
+    });
+    await assert.rejects(
+      insert("root_basket_capture_pages", {
+        capture_id: capture.capture_id,
+        ...capture.pages[0]!,
+        page_index: 2,
+        start_after: otherAccount,
+        next_after: next,
+      }),
+      /duplicate key/,
+    );
+  });
+  test("prevents cross-capture child references without conflating address history", async () => {
+    const first = syntheticBasketCapture();
+    await store(first);
+    const second = syntheticBasketCapture();
+    second.capture_id = secondId;
+    second.finalized_block_hash = `0x${"05".repeat(32)}`;
+    second.funds[0]!.hotkey = otherAccount;
+    await store(second);
+    for (const table of ["root_basket_holdings", "root_basket_targets"]) {
+      const row =
+        table === "root_basket_holdings"
+          ? first.funds[0]!.holdings[0]!
+          : first.funds[0]!.targets[0]!;
+      await assert.rejects(
+        insert(table, {
+          capture_id: secondId,
+          hotkey: first.funds[0]!.hotkey,
+          ...row,
+        }),
+        /foreign key/,
+      );
+    }
+    await assert.rejects(
+      db.query(
+        "UPDATE root_basket_fund_snapshots SET page_index = 1 WHERE capture_id = $1",
+        [secondId],
+      ),
+      /foreign key/,
+    );
+    // Same baseline height under another observed address is not a uniqueness collision.
+    assert.equal(
+      (
+        await db.query<{ n: number }>(
+          "SELECT count(*)::int AS n FROM root_basket_fund_snapshots",
+        )
+      ).rows[0]!.n,
+      2,
+    );
+  });
+  test("keys the same address independently at a different finalized capture", async () => {
+    await store();
+    const second = syntheticBasketCapture();
+    second.capture_id = secondId;
+    second.finalized_block_hash = `0x${"05".repeat(32)}`;
+    await store(second);
+    assert.equal(
+      (
+        await db.query<{ n: number }>(
+          "SELECT count(*)::int AS n FROM root_basket_fund_snapshots",
+        )
+      ).rows[0]!.n,
+      2,
+    );
+  });
+  test("rejects malformed account/hash bytes and conflicting source identity", async () => {
+    await store();
+    for (const value of ["0x12", `0x${"FF".repeat(32)}`, "not-an-address"]) {
+      await assert.rejects(
+        db.query("UPDATE root_basket_holdings SET hotkey = $1", [value]),
+        /check constraint/,
+      );
+      await assert.rejects(
+        db.query("UPDATE root_basket_captures SET finalized_block_hash = $1", [
+          value,
+        ]),
+        /check constraint/,
+      );
+    }
+    const duplicate = syntheticBasketCapture();
+    duplicate.capture_id = secondId;
+    await assert.rejects(store(duplicate), /duplicate key/);
+  });
+  test("rejects duplicate holdings/targets and wrong native units", async () => {
+    const capture = syntheticBasketCapture();
+    await store(capture);
+    const identity = {
+      capture_id: capture.capture_id,
+      hotkey: capture.funds[0]!.hotkey,
+    };
+    await assert.rejects(
+      insert("root_basket_holdings", {
+        ...identity,
+        ...capture.funds[0]!.holdings[0]!,
+      }),
+      /duplicate key/,
+    );
+    await assert.rejects(
+      insert("root_basket_targets", {
+        ...identity,
+        ...capture.funds[0]!.targets[0]!,
+      }),
+      /duplicate key/,
+    );
+    await assert.rejects(
+      db.exec(
+        "UPDATE root_basket_holdings SET quantity_unit = 'alpha_atomic' WHERE netuid = 0",
+      ),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.exec(
+        "UPDATE root_basket_holdings SET quantity_unit = 'rao' WHERE netuid = 19",
+      ),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.exec("UPDATE root_basket_targets SET weight = 65536"),
+      /check constraint/,
+    );
+  });
+  test("keeps absent index/baseline explicit and rejects incoherent freshness fields", async () => {
+    const capture = syntheticBasketCapture();
+    capture.index = {
+      status: "not_published",
+      completed_block: null,
+      bag_q64_bits: "18446744073709551616",
+      stake_q64_bits: "18446744073709551616",
+    };
+    capture.funds[0]!.baseline = {
+      provisional: true,
+      first_block: "0",
+      price_divisor_q64_bits: null,
+      rate0_q32_bits: null,
+      tr_splice_q64_bits: null,
+    };
+    await store(capture);
+    await assert.rejects(
+      db.exec("UPDATE root_basket_captures SET index_completed_block = 0"),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.exec("UPDATE root_basket_captures SET bag_index_q64_bits = 0"),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.exec("UPDATE root_basket_fund_snapshots SET first_block = 90"),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.exec(
+        "UPDATE root_basket_fund_snapshots SET price_divisor_q64_bits = 1",
+      ),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.exec("UPDATE root_basket_captures SET finished_at_ms = 999"),
+      /check constraint/,
+    );
+    await assert.rejects(
+      db.exec("UPDATE root_basket_captures SET runtime_spec_version = 455"),
+      /check constraint/,
+    );
+  });
+});

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -12,6 +12,7 @@
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
 import { describe, test } from "vitest";
 import { tablesInMigrations } from "../scripts/validate-declared-tables-exist.ts";
 import {
@@ -137,6 +138,32 @@ function neonTables(): Set<string> {
 }
 
 describe("TABLE_FRESHNESS coverage", () => {
+  test("unserved basket storage generates only reads supported by its actual migration", async () => {
+    const db = new PGlite();
+    try {
+      await db.exec(
+        readFileSync(
+          "migrations/neon/0036_root_basket_observations.sql",
+          "utf8",
+        ),
+      );
+      const spec = Object.fromEntries(
+        Object.entries(TABLE_FRESHNESS).filter(([table]) =>
+          table.startsWith("root_basket_"),
+        ),
+      );
+      const swept = freshnessTables().filter((table) => table in spec);
+      // A redirected stamp also reads the child's own column in the hourly
+      // cross-check. The migration, not a SQL-shaped mock, proves both reads.
+      await db.query(freshnessSql(swept, spec));
+      const crossCheck = crossCheckSql(spec);
+      if (crossCheck) await db.query(crossCheck);
+      assert.deepEqual(swept, ["root_basket_captures"]);
+    } finally {
+      await db.close();
+    }
+  });
+
   test("every table the repo has committed to is classified", () => {
     // THE LOAD-BEARING TEST. A table absent from the map is one nobody has
     // decided the freshness meaning of, and it would be swept by nothing --


### PR DESCRIPTION
The existing aggregate records do not preserve finalized basket observations with lossless units, source identity and pagination evidence. This adds a strict internal capture contract and normalized PostgreSQL storage for captures, page receipts, fund observations, holdings and targets.

The contract pins the audited runtime/decoder and keeps raw integer and fixed-point values as decimal strings. PostgreSQL domains reject fractional and out-of-range inputs without silently rounding them. Captures distinguish index completion from the finalized source block; source counts describe expectations, not persistence completeness. Receipt constraints and capture-scoped foreign keys prevent conflicting or cross-capture relationships. Keys use the address at capture time without asserting an immutable historical fund identity.

The migration supports safe reapplication, preserving existing rows and immutable receipt checks. Freshness classification explicitly records that these tables have no producer; generated watchdog queries are tested against the actual migration. The existing merge-triggered Neon workflow applies the additive DDL. No collector, public endpoint or publication pointer is introduced, and the new tables do not imply data availability.

## Validation

Full unsharded backend coverage passed: **991 files, 22,651 tests passed and 11 skipped**. Independent review caught and corrected an invalid child-table freshness query; the regression executes the generated SQL against the actual migration.

Synthetic fixtures cover exact arithmetic, runtime/source boundaries, complete empty pages and parts, partial/cyclic pagination, duplicate records, numeric limits, foreign keys, receipt updates and migration reapplication. Database checks run the actual SQL in PGlite. Required build, formatting, lint, type, schema/contract drift, migration and public-safety checks pass. Final contract generation and documentation drift checks pass against the current integration base.

Closes #12051
Refs #12018, #12012
