### PR TITLE
fix(data): preserve retry windows with valid KV persistence

### DIFF
--- a/docs/live-rpc-cache.md
+++ b/docs/live-rpc-cache.md
@@ -1,0 +1,66 @@
+# Live-reader cache and retry windows
+
+Live readers use `src/live-rpc-cache.ts` to keep logical retry windows separate
+from physical storage expiration. Workers KV requires an `expirationTtl` of at
+least 60 seconds. A failure retained for 60 seconds must not turn a 10-second
+retry window into a minute of unavailable data. The shared writer persists a
+versioned envelope with an absolute logical expiry; the reader treats that
+envelope as a miss at the expiry boundary even while KV still holds it.
+These are shared-reader cache windows; HTTP response-cache policies remain a
+separate layer.
+
+| Reader                             | Successful observation | Failure retry window |
+| ---------------------------------- | ---------------------: | -------------------: |
+| Account balance                    |                    60s |                  10s |
+| Legacy Root claim                  |                   120s |                  10s |
+| Address mapping                    |                  3600s |                  10s |
+| Chain burn                         |                   120s |                  10s |
+| Child/parent delegation            |                   120s |                  10s |
+| Crowdloan detail                   |                   120s |                  10s |
+| Network parameters                 |                   300s |                  10s |
+| Randomness                         |                    30s |                  10s |
+| Subnet burn                        |                   120s |                  10s |
+| Subnet lease                       |                   120s |                  10s |
+| Subnet conviction                  |                    60s |                  10s |
+| Subnet recycled registration count |                   600s |                  10s |
+| Sudo key                           |                  3600s |                  10s |
+| Upgrade radar                      |                   300s |                  30s |
+
+Failures are written to `<existing-key>:failure:v1`. They cannot overwrite the
+successful observation at the existing key, including when an overlapping
+request fails after another request has recovered. Readers prefer the successful
+observation for its existing cache lifetime. This policy uses separate keys
+because KV offers no conditional compare-and-swap write. It does not rely on a
+read-before-write race check or on deleting a failure after success.
+
+Successful bodies retain their existing keys and shapes. Legacy failure writes
+with unsupported 10s/30s expiration could not persist on Workers KV. Randomness
+also had an unsupported 30s **success** expiration; its new `network:randomness:v2`
+namespace holds an envelope with a 30s logical lifetime and 60s physical expiry,
+so old readers cannot mistake that envelope for a public response.
+
+Network prefixes remain part of both keys. Legacy Root-claim compatibility still
+checks the finalized head and runtime before looking in the cache, and applies
+the same runtime predicate to successful and failed observations. A negative
+cache hit suppresses its storage reads, not these mandatory compatibility checks.
+The network-parameter freshness reader continues to read only the successful
+key without making an RPC call. A recent failed attempt cannot advance the
+freshness timestamp or mark unavailable data current. Request cache hits retain
+the original timestamps, nulls, empty results and status reasons; envelopes never
+enter REST, GraphQL or MCP response bodies.
+
+Expired or malformed failure envelopes are misses. Read and write failures remain
+non-fatal through each reader's existing fallback. The crowdloan directory still
+does not cache a degraded result; its detail reader uses the shared policy. The
+upgrade radar's separately captured release sources retain their existing policy.
+Authentication lookup caches are outside this live-reader change.
+
+KV remains eventually consistent. A failure may not immediately reach another
+location, so this is best-effort suppression rather than a global request lock.
+Propagation delay cannot extend an envelope's absolute logical expiry. No
+production RPC requests are needed to validate these semantics: the hermetic
+suite rejects provider-invalid writes, exercises logical and physical boundaries,
+and verifies recovery and overlapping success/failure writes.
+
+Provider references: [KV write and concurrent-write semantics](https://developers.cloudflare.com/kv/api/write-key-value-pairs/)
+and [KV consistency](https://developers.cloudflare.com/kv/concepts/how-kv-works/).

--- a/src/account-balance.ts
+++ b/src/account-balance.ts
@@ -9,6 +9,7 @@
 // Crypto's SubtleCrypto.digest() has no BLAKE2b algorithm either. @noble/hashes
 // is audited, zero-dependency, pure JS, and verified working in workerd
 // (wrangler dev) with output identical to node:crypto's blake2b512.
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { blake2b } from "@noble/hashes/blake2.js";
 import { chainRpc } from "./chain-rpc.ts";
 import type { FieldSources } from "./field-provenance.ts";
@@ -31,7 +32,8 @@ const FINNEY_SS58_DECODED_LENGTH = 35;
 const FINNEY_SS58_CHECKSUM_LENGTH = 2; // prefix < 64 → 2-byte SS58 checksum
 const SS58_PREIMAGE = new TextEncoder().encode("SS58PRE");
 export const BALANCE_KV_TTL = 60; // seconds
-export const BALANCE_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const BALANCE_NEGATIVE_KV_TTL = 10;
 export const BALANCE_RPC_TIMEOUT_MS = 5000;
 
 // System::Account(AccountId) storage prefix = twox128("System") ++ twox128("Account").
@@ -243,9 +245,9 @@ async function loadAccountBalanceSnapshot(
   const cacheKey = networkKvKey(`balance:${ss58}`, network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as AccountBalanceResult;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -301,10 +303,11 @@ async function loadAccountBalanceSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk ? BALANCE_KV_TTL : BALANCE_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? BALANCE_KV_TTL : BALANCE_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/account-root-claim.ts
+++ b/src/account-root-claim.ts
@@ -22,6 +22,7 @@
 // Blake2_128Concat + storageMapPrefix reuse the child-hotkey-delegation
 // pattern; I96F32 decode mirrors network-parameters' fixed-point split.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { blake2b } from "@noble/hashes/blake2.js";
 import { encodeAccountId32 } from "./ss58.ts";
 import { isFinneySs58Address } from "./account-balance.ts";
@@ -34,7 +35,8 @@ import {
 } from "./chain-network.ts";
 
 export const ROOT_CLAIM_KV_TTL = 120; // seconds
-export const ROOT_CLAIM_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const ROOT_CLAIM_NEGATIVE_KV_TTL = 10;
 export const ROOT_CLAIM_RPC_TIMEOUT_MS = 5000;
 const I96F32_SCALE = 2n ** 32n;
 const I96F32_BYTES = 16;
@@ -482,21 +484,20 @@ async function loadAccountRootClaimSnapshot(
   const compatibility = await rootClaimCompatibility(network);
   const cacheKey = networkKvKey(`root-claim:v2:${ss58}`, network);
   const kv = env?.METAGRAPH_CONTROL;
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get<AccountRootClaimResultSnapshot>(cacheKey, {
-        type: "json",
-      });
-      if (
-        cached?.schema_version === 1 &&
-        cached.ss58 === ss58 &&
-        cached.compatibility?.spec_name === compatibility.spec_name &&
-        cached.compatibility?.spec_version === compatibility.spec_version &&
-        Object.hasOwn(cached, "claim_type") &&
-        Object.hasOwn(cached, "hotkeys")
-      ) {
-        return cached;
-      }
+      const cached = await readLiveRpcCache<AccountRootClaimResultSnapshot>(
+        kv,
+        cacheKey,
+        (value) =>
+          value.schema_version === 1 &&
+          value.ss58 === ss58 &&
+          value.compatibility?.spec_name === compatibility.spec_name &&
+          value.compatibility?.spec_version === compatibility.spec_version &&
+          Object.hasOwn(value, "claim_type") &&
+          Object.hasOwn(value, "hotkeys"),
+      );
+      if (cached) return cached;
     } catch {
       // non-fatal
     }
@@ -516,13 +517,14 @@ async function loadAccountRootClaimSnapshot(
       queried_at: queriedAt,
       compatibility: context,
     };
-    if (kv?.put) {
+    if (typeof kv?.put === "function") {
       try {
-        await kv.put(cacheKey, JSON.stringify(payload), {
-          expirationTtl:
+        await writeLiveRpcCache(kv, cacheKey, payload, {
+          ttlSeconds:
             context.status === "unavailable"
               ? ROOT_CLAIM_NEGATIVE_KV_TTL
               : ROOT_CLAIM_KV_TTL,
+          negative: context.status === "unavailable",
         });
       } catch {
         // non-fatal

--- a/src/address-mapping.ts
+++ b/src/address-mapping.ts
@@ -12,6 +12,7 @@
 // rpcUrlForNetwork() for Substrate-native methods; eth_call is the
 // Ethereum-native sibling on that identical endpoint). Mirrors
 // src/sudo-key.ts's live-RPC + KV-cache shape.
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { encodeAccountId32 } from "./ss58.ts";
 import { functionSelector } from "./evm-precompiles.ts";
 import type { FieldSources } from "./field-provenance.ts";
@@ -25,7 +26,8 @@ const ADDRESS_MAPPING_PRECOMPILE_ADDRESS =
   "0x000000000000000000000000000000000000080c";
 const ADDRESS_MAPPING_SELECTOR = functionSelector("addressMapping(address)");
 export const ADDRESS_MAPPING_KV_TTL = 3600; // seconds -- deterministic given h160, never changes
-export const ADDRESS_MAPPING_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const ADDRESS_MAPPING_NEGATIVE_KV_TTL = 10;
 export const ADDRESS_MAPPING_RPC_TIMEOUT_MS = 5000;
 const FINNEY_SS58_PREFIX = 42;
 
@@ -92,9 +94,9 @@ async function loadAddressMappingSnapshot(
   const cacheKey = networkKvKey(`evm-address-mapping:${normalized}`, network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as AddressMappingResult;
     } catch {
       // KV read failure is non-fatal -- fall through to the live RPC.
@@ -141,12 +143,13 @@ async function loadAddressMappingSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk
           ? ADDRESS_MAPPING_KV_TTL
           : ADDRESS_MAPPING_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/chain-burn.ts
+++ b/src/chain-burn.ts
@@ -22,6 +22,7 @@
 // "this value is unset chain-wide" rather than like a bug. The control that catches it
 // is reading a value you already know by another route: Tempo[64] must be 360.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpc } from "./chain-rpc.ts";
 import {
   type ChainNetworkId,
@@ -37,6 +38,7 @@ type Row = Record<string, unknown>;
  * costs TAO. */
 export const CHAIN_BURN_KV_TTL = 120;
 /** A failed read is re-tried soon rather than cached as an answer. */
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
 export const CHAIN_BURN_NEGATIVE_KV_TTL = 10;
 /** Larger than the single-subnet timeout: this is one call carrying ~129 keys. */
 export const CHAIN_BURN_RPC_TIMEOUT_MS = 12_000;
@@ -179,9 +181,9 @@ async function loadChainBurnSnapshot(
 ): Promise<Row> {
   const cacheKey = networkKvKey("chain-burn", network);
   const kv = env?.METAGRAPH_CONTROL;
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as Row;
     } catch {
       // A KV read failure is non-fatal -- fall through to the live RPC.
@@ -226,10 +228,11 @@ async function loadChainBurnSnapshot(
     payload = buildChainBurn(null, null, { queriedAt });
   }
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk ? CHAIN_BURN_KV_TTL : CHAIN_BURN_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? CHAIN_BURN_KV_TTL : CHAIN_BURN_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // A KV write failure is non-fatal.

--- a/src/child-hotkey-delegation.ts
+++ b/src/child-hotkey-delegation.ts
@@ -36,6 +36,7 @@
 // twox64/twox128 (src/twox-storage-key.ts), which needed a hand-rolled
 // implementation because no XXHash64 dependency exists in this repo.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { blake2b } from "@noble/hashes/blake2.js";
 import { encodeAccountId32 } from "./ss58.ts";
 import { isFinneySs58Address } from "./account-balance.ts";
@@ -48,7 +49,8 @@ import {
 } from "./chain-network.ts";
 
 export const CHILD_HOTKEY_KV_TTL = 120; // seconds -- live chain state, same profile as subnet-lease.ts
-export const CHILD_HOTKEY_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const CHILD_HOTKEY_NEGATIVE_KV_TTL = 10;
 export const CHILD_HOTKEY_RPC_TIMEOUT_MS = 5000;
 // A hotkey having children/parents on more than a handful of subnets would
 // be extraordinary; this stays a single state_getKeysPaged page in every
@@ -329,9 +331,9 @@ async function loadChildHotkeyGraph(
   // different child/parent sets on testnet.
   const cacheKey = networkKvKey(`${cacheKeyPrefix}:${ss58}`, network);
   const kv = env?.METAGRAPH_CONTROL;
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as ChildHotkeyGraphSnapshot;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -359,10 +361,11 @@ async function loadChildHotkeyGraph(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: ok ? CHILD_HOTKEY_KV_TTL : CHILD_HOTKEY_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: ok ? CHILD_HOTKEY_KV_TTL : CHILD_HOTKEY_NEGATIVE_KV_TTL,
+        negative: !ok,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/crowdloans.ts
+++ b/src/crowdloans.ts
@@ -47,6 +47,7 @@
 // SubnetLeaseShares (#6719). `contributors_count` on each record already gives
 // the aggregate; the per-contributor breakdown is a future extension.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpcResult } from "./chain-rpc.ts";
 
 import { encodeAccountId32 } from "./ss58.ts";
@@ -65,7 +66,8 @@ import {
 type Row = Record<string, unknown>;
 
 export const CROWDLOANS_KV_TTL = 120; // seconds -- same freshness profile as subnet-lease.ts
-export const CROWDLOANS_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const CROWDLOANS_NEGATIVE_KV_TTL = 10;
 
 /**
  * `degraded.reason` when the crowdloan storage batch read did not land (#9898).
@@ -439,9 +441,9 @@ async function loadCrowdloanSnapshot(
   const cacheKey = networkKvKey(`crowdloan:${id}`, network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as Row;
     } catch {
       // KV read failure is non-fatal.
@@ -485,10 +487,11 @@ async function loadCrowdloanSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk ? CROWDLOANS_KV_TTL : CROWDLOANS_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? CROWDLOANS_KV_TTL : CROWDLOANS_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/live-rpc-cache.ts
+++ b/src/live-rpc-cache.ts
@@ -1,0 +1,88 @@
+// Logical retry windows are independent of Workers KV's 60-second expiry floor.
+// https://developers.cloudflare.com/kv/api/write-key-value-pairs/#parameters
+const LIVE_RPC_CACHE_MIN_KV_TTL = 60;
+
+/** Minimal binding surface, also accepted by the conviction reader's KvLike. */
+interface LiveRpcKv {
+  get?: (key: string, options: { type: "json" }) => Promise<unknown>;
+  put?: (
+    key: string,
+    value: string,
+    options: { expirationTtl: number },
+  ) => Promise<unknown>;
+}
+
+interface ShortCacheEntry {
+  live_rpc_cache_version: 1;
+  expires_at_ms: number;
+  value: unknown;
+}
+
+function shortCacheValue(raw: unknown): unknown {
+  if (raw === null || typeof raw !== "object") return null;
+  const entry = raw as ShortCacheEntry;
+  if (
+    entry.live_rpc_cache_version !== 1 ||
+    !Number.isSafeInteger(entry.expires_at_ms) ||
+    entry.expires_at_ms <= Date.now() ||
+    entry.value === null ||
+    typeof entry.value !== "object" ||
+    Array.isArray(entry.value)
+  ) {
+    return null;
+  }
+  return entry.value;
+}
+
+/** Failures never share a write key with successes. KV has no compare-and-swap. */
+export function liveRpcFailureCacheKey(key: string): string {
+  return `${key}:failure:v1`;
+}
+
+/**
+ * Prefer a successful observation for its existing TTL, even if an overlapping
+ * request failed later. Legacy successful bodies keep their original key/shape.
+ * Storage errors propagate to the reader's existing non-fatal fallback.
+ */
+export async function readLiveRpcCache<T>(
+  kv: LiveRpcKv,
+  key: string,
+  accepts: (value: T) => boolean = () => true,
+): Promise<T | null> {
+  const raw = await kv.get!(key, { type: "json" });
+  const value =
+    raw &&
+    typeof raw === "object" &&
+    Object.hasOwn(raw, "live_rpc_cache_version")
+      ? shortCacheValue(raw)
+      : raw;
+  if (value != null && accepts(value as T)) return value as T;
+  const failure = shortCacheValue(
+    await kv.get!(liveRpcFailureCacheKey(key), { type: "json" }),
+  );
+  return failure != null && accepts(failure as T) ? (failure as T) : null;
+}
+
+/** Logical expiry is exclusive; retained failure keys cannot extend retry time. */
+export async function writeLiveRpcCache(
+  kv: LiveRpcKv,
+  key: string,
+  value: unknown,
+  { ttlSeconds, negative }: { ttlSeconds: number; negative: boolean },
+): Promise<void> {
+  const body =
+    negative || ttlSeconds < LIVE_RPC_CACHE_MIN_KV_TTL
+      ? {
+          live_rpc_cache_version: 1,
+          expires_at_ms: Date.now() + ttlSeconds * 1000,
+          value,
+        }
+      : value;
+  await kv.put!(
+    negative ? liveRpcFailureCacheKey(key) : key,
+    JSON.stringify(body),
+    {
+      expirationTtl: Math.max(LIVE_RPC_CACHE_MIN_KV_TTL, ttlSeconds),
+    },
+  );
+}

--- a/src/network-parameters.ts
+++ b/src/network-parameters.ts
@@ -26,6 +26,7 @@
 // PendingChildKeyCooldown raw result 0x201c000000000000 -> a plain u64
 // block count (7200, no TAO conversion).
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpcResult } from "./chain-rpc.ts";
 
 import { blockEmissionForIssuance } from "./block-emission.ts";
@@ -37,7 +38,8 @@ import {
 } from "./chain-network.ts";
 
 export const NETWORK_PARAMETERS_KV_TTL = 300; // seconds -- governance-adjustable, changes rarely but not never
-export const NETWORK_PARAMETERS_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const NETWORK_PARAMETERS_NEGATIVE_KV_TTL = 10;
 export const NETWORK_PARAMETERS_RPC_TIMEOUT_MS = 5000;
 
 // twox128("SubtensorModule") ++ twox128("TaoWeight").
@@ -453,6 +455,8 @@ export interface NetworkParameters extends NetworkParametersSnapshot {
  * which is precisely a lane that cannot go stale and therefore cannot be gated on.
  *
  * Null when KV is unbound or cold — the caller reports `missing`, not an age.
+ * Only read the successful key: freshness consumers treat its timestamp as a
+ * current observation, so a separately cached failure must not advance it.
  */
 export async function readCachedNetworkParametersSnapshot(
   env: Env,
@@ -488,11 +492,12 @@ async function loadNetworkParametersSnapshot(
   const cacheKey = networkKvKey("network:parameters", network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get<NetworkParametersSnapshot>(cacheKey, {
-        type: "json",
-      });
+      const cached = await readLiveRpcCache<NetworkParametersSnapshot>(
+        kv,
+        cacheKey,
+      );
       if (cached) return cached;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -652,12 +657,13 @@ async function loadNetworkParametersSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk
           ? NETWORK_PARAMETERS_KV_TTL
           : NETWORK_PARAMETERS_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/randomness.ts
+++ b/src/randomness.ts
@@ -17,6 +17,7 @@
 // changes). Cross-checked against that module's already-verified
 // twox-storage-key.ts output at write time -- see tests/randomness.test.ts.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpcResult } from "./chain-rpc.ts";
 
 import type { FieldSources } from "./field-provenance.ts";
@@ -27,7 +28,8 @@ import {
 } from "./chain-network.ts";
 
 export const RANDOMNESS_KV_TTL = 30; // seconds -- pulses land ~3s apart, but this is a snapshot, not a feed
-export const RANDOMNESS_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const RANDOMNESS_NEGATIVE_KV_TTL = 10;
 export const RANDOMNESS_RPC_TIMEOUT_MS = 5000;
 
 // twox128("Drand") ++ twox128("LastStoredRound").
@@ -126,14 +128,12 @@ async function loadRandomnessSnapshot(
   network?: ChainNetworkId,
 ): Promise<RandomnessSnapshot> {
   // Drand rounds differ per chain -- testnet stores its own pulse history.
-  const cacheKey = networkKvKey("network:randomness", network);
+  const cacheKey = networkKvKey("network:randomness:v2", network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get<RandomnessSnapshot>(cacheKey, {
-        type: "json",
-      });
+      const cached = await readLiveRpcCache<RandomnessSnapshot>(kv, cacheKey);
       if (cached) return cached;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -174,10 +174,11 @@ async function loadRandomnessSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk ? RANDOMNESS_KV_TTL : RANDOMNESS_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? RANDOMNESS_KV_TTL : RANDOMNESS_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/subnet-burn.ts
+++ b/src/subnet-burn.ts
@@ -26,6 +26,7 @@
 // a raw state_getStorage RPC call for netuid 1 (result 0x20a1070000000000 =
 // 500000 rao, matching Subtensor.recycle(1) exactly).
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpcResult } from "./chain-rpc.ts";
 
 import { isU16Netuid } from "./subnet-recycled.ts";
@@ -36,7 +37,8 @@ import {
 } from "./chain-network.ts";
 
 export const BURN_KV_TTL = 120; // seconds — moves within minutes during registration bursts
-export const BURN_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const BURN_NEGATIVE_KV_TTL = 10;
 export const BURN_RPC_TIMEOUT_MS = 5000;
 
 // twox128("SubtensorModule") ++ twox128("Burn").
@@ -112,9 +114,9 @@ async function loadSubnetBurnSnapshot(
   const cacheKey = networkKvKey(`burn:${netuid}`, network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as Row;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -162,10 +164,11 @@ async function loadSubnetBurnSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk ? BURN_KV_TTL : BURN_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? BURN_KV_TTL : BURN_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/subnet-lease.ts
+++ b/src/subnet-lease.ts
@@ -34,6 +34,7 @@
 // single hardcoded prefix, this file needs three different item prefixes so
 // they're computed via that shared module rather than each hardcoded here.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpcResult } from "./chain-rpc.ts";
 
 import { encodeAccountId32 } from "./ss58.ts";
@@ -52,7 +53,8 @@ import {
 type Row = Record<string, unknown>;
 
 export const SUBNET_LEASE_KV_TTL = 120; // seconds -- same freshness profile as subnet-burn.ts
-export const SUBNET_LEASE_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const SUBNET_LEASE_NEGATIVE_KV_TTL = 10;
 export const SUBNET_LEASE_RPC_TIMEOUT_MS = 5000;
 
 interface StorageFetchResult {
@@ -220,9 +222,9 @@ async function loadSubnetLeaseSnapshot(
   const cacheKey = networkKvKey(`lease:${netuid}`, network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as Row;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -315,12 +317,11 @@ async function loadSubnetLeaseSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk
-          ? SUBNET_LEASE_KV_TTL
-          : SUBNET_LEASE_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? SUBNET_LEASE_KV_TTL : SUBNET_LEASE_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/subnet-lock-state.ts
+++ b/src/subnet-lock-state.ts
@@ -62,6 +62,7 @@
 // The field order is not a guess that happens to fit: on a live sample the
 // U64F64's INTEGER part equalled `locked_mass` exactly with a zero fraction,
 // which only holds if both are being read from the right offsets.
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { encodeAccountId32 } from "./ss58.ts";
 import { buildSubnetConviction } from "./subnet-conviction.ts";
 import {
@@ -79,6 +80,7 @@ export const SUBNET_CONVICTION_RPC_TIMEOUT_MS = 5000;
 export const LOCK_STATE_KV_TTL = 60;
 /** Seconds a DECLINE stays cached. Short enough that a blip clears quickly,
  * long enough that a throttled endpoint is not retried on every request. */
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
 export const LOCK_STATE_NEGATIVE_KV_TTL = 10;
 const LOCK_STATE_KV_PREFIX = "subnet-conviction:v1";
 
@@ -233,9 +235,9 @@ export async function loadSubnetConvictionChainTier(
   }
 
   const cacheKey = `${LOCK_STATE_KV_PREFIX}:${netuid}`;
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = (await kv.get(cacheKey, { type: "json" })) as {
+      const cached = (await readLiveRpcCache(kv, cacheKey)) as {
         board: ReturnType<typeof buildSubnetConviction> | null;
       } | null;
       // A cached DECLINE is stored as an explicit null board, so it is
@@ -314,12 +316,18 @@ async function remember<T>(
   cacheKey: string,
   board: T,
 ): Promise<T> {
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify({ board }), {
-        expirationTtl:
-          board === null ? LOCK_STATE_NEGATIVE_KV_TTL : LOCK_STATE_KV_TTL,
-      });
+      await writeLiveRpcCache(
+        kv,
+        cacheKey,
+        { board },
+        {
+          ttlSeconds:
+            board === null ? LOCK_STATE_NEGATIVE_KV_TTL : LOCK_STATE_KV_TTL,
+          negative: board === null,
+        },
+      );
     } catch {
       // A KV write failure is non-fatal.
     }

--- a/src/subnet-recycled.ts
+++ b/src/subnet-recycled.ts
@@ -33,6 +33,7 @@
 // (bittensor 10.4.0, substrate.create_storage_key("SubtensorModule",
 // "RAORecycledForRegistration", [netuid])) across netuid 0/1/4/101/65535.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpcResult } from "./chain-rpc.ts";
 
 import type { FieldSources } from "./field-provenance.ts";
@@ -45,7 +46,8 @@ import {
 type Row = Record<string, unknown>;
 
 export const RECYCLED_KV_TTL = 600; // seconds — a registration-count counter, not a live price
-export const RECYCLED_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const RECYCLED_NEGATIVE_KV_TTL = 10;
 export const RECYCLED_RPC_TIMEOUT_MS = 5000;
 export const MAX_U16_NETUID = 65535;
 
@@ -130,9 +132,9 @@ async function loadSubnetRecycledSnapshot(
   const cacheKey = networkKvKey(`recycled:${netuid}`, network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as Row;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -182,10 +184,11 @@ async function loadSubnetRecycledSnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk ? RECYCLED_KV_TTL : RECYCLED_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? RECYCLED_KV_TTL : RECYCLED_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/sudo-key.ts
+++ b/src/sudo-key.ts
@@ -10,6 +10,7 @@
 // Server-side SS58 encoding lives in src/ss58.ts (extracted #4688) -- see
 // that module's header for why @noble/hashes' blake2b is required over
 // node:crypto's createHash("blake2b512") (unsupported in workerd).
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
 import { chainRpcResult } from "./chain-rpc.ts";
 
 import { encodeAccountId32 } from "./ss58.ts";
@@ -38,7 +39,8 @@ export const SUDO_KEY_FIELD_SOURCES = {
 } as const satisfies FieldSources;
 
 export const SUDO_KEY_KV_TTL = 3600; // seconds — the sudo key changes extremely rarely
-export const SUDO_KEY_NEGATIVE_KV_TTL = 10; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const SUDO_KEY_NEGATIVE_KV_TTL = 10;
 export const SUDO_KEY_RPC_TIMEOUT_MS = 5000;
 // SS58 prefix 42 is the generic Substrate format Bittensor uses on every
 // network, so the encoding is network-independent even though the key is not.
@@ -70,9 +72,9 @@ async function loadSudoKeySnapshot(
   const cacheKey = networkKvKey("sudo:key", network);
   const kv = env?.METAGRAPH_CONTROL;
 
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
+      const cached = await readLiveRpcCache(kv, cacheKey);
       if (cached) return cached as Row;
     } catch {
       // KV read failure is non-fatal — fall through to the live RPC.
@@ -115,10 +117,11 @@ async function loadSudoKeySnapshot(
     queried_at: queriedAt,
   };
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: rpcOk ? SUDO_KEY_KV_TTL : SUDO_KEY_NEGATIVE_KV_TTL,
+      await writeLiveRpcCache(kv, cacheKey, payload, {
+        ttlSeconds: rpcOk ? SUDO_KEY_KV_TTL : SUDO_KEY_NEGATIVE_KV_TTL,
+        negative: !rpcOk,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/upgrade-radar.ts
+++ b/src/upgrade-radar.ts
@@ -25,6 +25,8 @@
 // publishes no schedule, so a predicted date would be our guess wearing the
 // costume of a fact. The radar reports observed states only.
 
+import { readLiveRpcCache, writeLiveRpcCache } from "./live-rpc-cache.ts";
+
 /**
  * The upgrade lifecycle state, derived from the three spec-version readings.
  *
@@ -518,7 +520,8 @@ export const SOAK_ALERT_STATE_KEY = "upgrade-radar:last-soak-alert-spec";
 // well inside the upstream's 2-3 day release cadence.
 
 export const UPGRADE_RADAR_KV_TTL = 300; // seconds
-export const UPGRADE_RADAR_NEGATIVE_KV_TTL = 30; // seconds
+// Logical retry seconds; physical KV expiration is at least 60 seconds.
+export const UPGRADE_RADAR_NEGATIVE_KV_TTL = 30;
 export const UPGRADE_RADAR_RPC_TIMEOUT_MS = 5000;
 export const UPGRADE_RADAR_GITHUB_TIMEOUT_MS = 8000;
 
@@ -674,7 +677,7 @@ export async function refreshUpgradeRadarSources(
     stale_upstreams: stale,
   };
   const kv = env?.METAGRAPH_CONTROL;
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
       await kv.put(UPGRADE_RADAR_SOURCES_KEY, JSON.stringify(snapshot), {
         expirationTtl: UPGRADE_RADAR_SOURCES_KV_TTL,
@@ -712,11 +715,12 @@ export async function readUpgradeRadarSources(
  */
 export async function loadUpgradeRadar(env: Env): Promise<UpgradeRadar> {
   const kv = env?.METAGRAPH_CONTROL;
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
-      const cached = await kv.get<UpgradeRadar>(UPGRADE_RADAR_CACHE_KEY, {
-        type: "json",
-      });
+      const cached = await readLiveRpcCache<UpgradeRadar>(
+        kv,
+        UPGRADE_RADAR_CACHE_KEY,
+      );
       if (cached) return cached;
     } catch {
       // Fall through to a live read.
@@ -736,13 +740,14 @@ export async function loadUpgradeRadar(env: Env): Promise<UpgradeRadar> {
     observedAt,
   });
 
-  if (kv?.put) {
+  if (typeof kv?.put === "function") {
     try {
-      await kv.put(UPGRADE_RADAR_CACHE_KEY, JSON.stringify(radar), {
-        expirationTtl:
+      await writeLiveRpcCache(kv, UPGRADE_RADAR_CACHE_KEY, radar, {
+        ttlSeconds:
           radar.pending_upgrade === "unknown"
             ? UPGRADE_RADAR_NEGATIVE_KV_TTL
             : UPGRADE_RADAR_KV_TTL,
+        negative: radar.pending_upgrade === "unknown",
       });
     } catch {
       // Non-fatal.
@@ -838,7 +843,7 @@ export async function evaluateUpgradeRadarScan(env: Env): Promise<{
   }
 
   let lastAlertedSpec: unknown = null;
-  if (kv?.get) {
+  if (typeof kv?.get === "function") {
     try {
       lastAlertedSpec = await kv.get(SOAK_ALERT_STATE_KEY);
     } catch {

--- a/tests/account-balance-loader.test.ts
+++ b/tests/account-balance-loader.test.ts
@@ -307,9 +307,12 @@ describe("loadAccountBalance", () => {
     try {
       const data = await loadAccountBalance(mockEnv(env), SS58);
       assert.equal(data.balance_tao, null);
-      assert.equal(putKey, `balance:${SS58}`);
-      assert.equal(putValue!.balance_tao, null);
-      assert.equal(putOptions!.expirationTtl, BALANCE_NEGATIVE_KV_TTL);
+      assert.equal(putKey, `balance:${SS58}:failure:v1`);
+      assert.equal(putValue!.value.balance_tao, null);
+      assert.equal(
+        putOptions!.expirationTtl,
+        Math.max(60, BALANCE_NEGATIVE_KV_TTL),
+      );
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/account-balance.test.ts
+++ b/tests/account-balance.test.ts
@@ -495,9 +495,13 @@ test("GET /accounts/{ss58}/balance briefly negative-caches RPC failures", async 
         {},
       );
       assert.equal(res.status, 200);
-      assert.equal(putKey, `balance:${SS58}`);
-      assert.equal(putValue!.balance_tao, null);
-      assert.equal(putOptions!.expirationTtl, 10);
+      assert.equal(putKey, `balance:${SS58}:failure:v1`);
+      assert.equal(putValue!.value.balance_tao, null);
+      assert.equal(putOptions!.expirationTtl, 60);
+      const body = await res.json();
+      assert.equal(body.data.balance_tao, null);
+      assert.equal(body.data.queried_at, putValue!.value.queried_at);
+      assert.equal(Object.hasOwn(body.data, "live_rpc_cache_version"), false);
     },
   );
 });

--- a/tests/account-root-claim-compatibility.test.ts
+++ b/tests/account-root-claim-compatibility.test.ts
@@ -160,7 +160,14 @@ test("upgrade invalidates cached legacy defaults and uses the v2 network namespa
   assert.equal(upgraded.compatibility.status, "unsupported");
   assert.equal(upgraded.claim_type, null);
   assert.equal(upgraded.hotkeys, null);
-  assert.ok(keys.every((key) => key === `testnet:root-claim:v2:${SS58}`));
+  assert.ok(
+    keys.every((key) =>
+      [
+        `testnet:root-claim:v2:${SS58}`,
+        `testnet:root-claim:v2:${SS58}:failure:v1`,
+      ].includes(key),
+    ),
+  );
   assert.ok(calls.every((call) => call.url.includes("test.finney")));
 });
 

--- a/tests/account-root-claim.test.ts
+++ b/tests/account-root-claim.test.ts
@@ -355,8 +355,11 @@ describe("loadAccountRootClaim", () => {
       }),
       SS58,
     );
-    assert.equal(stored!.opts.expirationTtl, ROOT_CLAIM_NEGATIVE_KV_TTL);
-    assert.equal(stored!.value.hotkeys, null);
+    assert.equal(
+      stored!.opts.expirationTtl,
+      Math.max(60, ROOT_CLAIM_NEGATIVE_KV_TTL),
+    );
+    assert.equal(stored!.value.value.hotkeys, null);
   });
 
   test("treats non-ok RPC and JSON-RPC errors as failures", async () => {
@@ -414,7 +417,10 @@ describe("loadAccountRootClaim", () => {
       SS58,
     );
     assert.equal(payload.hotkeys, null);
-    assert.equal(stored!.expirationTtl, ROOT_CLAIM_NEGATIVE_KV_TTL);
+    assert.equal(
+      stored!.expirationTtl,
+      Math.max(60, ROOT_CLAIM_NEGATIVE_KV_TTL),
+    );
   });
 
   test("nulls out when a per-hotkey claimable fetch fails", async () => {
@@ -613,7 +619,10 @@ describe("loadAccountRootClaim", () => {
       SS58,
     );
     assert.equal(payload.hotkeys, null);
-    assert.equal(stored!.opts.expirationTtl, ROOT_CLAIM_NEGATIVE_KV_TTL);
+    assert.equal(
+      stored!.opts.expirationTtl,
+      Math.max(60, ROOT_CLAIM_NEGATIVE_KV_TTL),
+    );
   });
 
   test("nulls when claimed/threshold RPC is non-ok", async () => {

--- a/tests/address-mapping.test.ts
+++ b/tests/address-mapping.test.ts
@@ -225,7 +225,10 @@ describe("loadAddressMapping", () => {
     })) as unknown as typeof fetch;
     try {
       await loadAddressMapping(mockEnv(env), H160);
-      assert.equal(putOptions!.expirationTtl, ADDRESS_MAPPING_NEGATIVE_KV_TTL);
+      assert.equal(
+        putOptions!.expirationTtl,
+        Math.max(60, ADDRESS_MAPPING_NEGATIVE_KV_TTL),
+      );
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/chain-burn.test.ts
+++ b/tests/chain-burn.test.ts
@@ -270,7 +270,7 @@ describe("loadChainBurn", () => {
         },
       };
       await loadChainBurn(env as never);
-      assert.equal(puts[0]?.ttl, expected);
+      assert.equal(puts[0]?.ttl, Math.max(60, expected));
     }
   });
 

--- a/tests/child-hotkey-delegation.test.ts
+++ b/tests/child-hotkey-delegation.test.ts
@@ -462,7 +462,10 @@ describe("loadAccountChildren", () => {
     const restore = stubFetch(async () => ({ ok: false }));
     try {
       await loadAccountChildren(env as unknown as Env, KNOWN_SS58);
-      assert.equal(putOptions!.expirationTtl, CHILD_HOTKEY_NEGATIVE_KV_TTL);
+      assert.equal(
+        putOptions!.expirationTtl,
+        Math.max(60, CHILD_HOTKEY_NEGATIVE_KV_TTL),
+      );
       assert.equal(CHILD_HOTKEY_NEGATIVE_KV_TTL, 10);
     } finally {
       restore();

--- a/tests/crowdloans.test.ts
+++ b/tests/crowdloans.test.ts
@@ -594,7 +594,10 @@ describe("loadCrowdloan", () => {
     )) as Row;
     assert.equal(out.exists, null);
     assert.equal(out.crowdloan, null);
-    assert.equal(puts[0].options?.expirationTtl, CROWDLOANS_NEGATIVE_KV_TTL);
+    assert.equal(
+      puts[0].options?.expirationTtl,
+      Math.max(60, CROWDLOANS_NEGATIVE_KV_TTL),
+    );
   });
 
   test("an undecodable record is exists:null, not a partial row", async () => {

--- a/tests/live-rpc-cache.test.ts
+++ b/tests/live-rpc-cache.test.ts
@@ -1,0 +1,351 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import {
+  liveRpcFailureCacheKey,
+  readLiveRpcCache,
+  writeLiveRpcCache,
+} from "../src/live-rpc-cache.ts";
+import { loadAccountBalance } from "../src/account-balance.ts";
+import { loadAccountRootClaim } from "../src/account-root-claim.ts";
+import { loadAddressMapping } from "../src/address-mapping.ts";
+import { loadChainBurn } from "../src/chain-burn.ts";
+import {
+  loadAccountChildren,
+  loadAccountParents,
+} from "../src/child-hotkey-delegation.ts";
+import { loadCrowdloan } from "../src/crowdloans.ts";
+import {
+  loadNetworkParameters,
+  readCachedNetworkParametersSnapshot,
+} from "../src/network-parameters.ts";
+import { loadRandomnessStatus } from "../src/randomness.ts";
+import { loadSubnetBurn } from "../src/subnet-burn.ts";
+import { loadSubnetLease } from "../src/subnet-lease.ts";
+import { loadSubnetConvictionChainTier } from "../src/subnet-lock-state.ts";
+import { loadSubnetRecycled } from "../src/subnet-recycled.ts";
+import { loadSudoKey } from "../src/sudo-key.ts";
+import { loadUpgradeRadar } from "../src/upgrade-radar.ts";
+import { mergeFreshness } from "../src/health-serving.ts";
+import { mockEnv } from "./row-type.ts";
+
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const START = Date.parse("2026-09-05T10:00:00Z");
+
+// Faithful to KV's expiry floor and physical deletion, without pretending to
+// model worldwide propagation. Rejected writes do not enter the store.
+function providerKv() {
+  const records = new Map<string, { value: string; expiresAt: number }>();
+  const writes: { key: string; ttl: number; value: unknown }[] = [];
+  return {
+    records,
+    writes,
+    async get(key: string) {
+      const record = records.get(key);
+      if (!record || record.expiresAt <= Date.now()) return null;
+      return JSON.parse(record.value);
+    },
+    async put(key: string, value: string, options: { expirationTtl: number }) {
+      assert.ok(options.expirationTtl >= 60, "KV requires at least 60 seconds");
+      writes.push({
+        key,
+        ttl: options.expirationTtl,
+        value: JSON.parse(value),
+      });
+      records.set(key, {
+        value,
+        expiresAt: Date.now() + options.expirationTtl * 1000,
+      });
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(START);
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+test("provider stub rejects the inherited invalid persistence options", async () => {
+  const kv = providerKv();
+  for (const expirationTtl of [10, 30]) {
+    await assert.rejects(kv.put("key", "{}", { expirationTtl }));
+  }
+  assert.equal(kv.records.size, 0);
+});
+
+test.each([10, 30])(
+  "%is failures persist for 60s but stop suppressing retries at the logical boundary",
+  async (ttlSeconds) => {
+    const kv = providerKv();
+    const payload = {
+      queried_at: new Date().toISOString(),
+      count: null,
+      reason: "unavailable",
+    };
+    await writeLiveRpcCache(kv, "finney:item", payload, {
+      ttlSeconds,
+      negative: true,
+    });
+    assert.equal(kv.writes[0].ttl, 60);
+    assert.equal(kv.records.has("finney:item"), false);
+    vi.setSystemTime(START + ttlSeconds * 1000 - 1);
+    assert.deepEqual(await readLiveRpcCache(kv, "finney:item"), payload);
+    vi.setSystemTime(START + ttlSeconds * 1000);
+    assert.equal(await readLiveRpcCache(kv, "finney:item"), null);
+    assert.ok(
+      await kv.get(liveRpcFailureCacheKey("finney:item")),
+      "physical record still exists",
+    );
+    vi.setSystemTime(START + 60_000);
+    assert.equal(await kv.get(liveRpcFailureCacheKey("finney:item")), null);
+  },
+);
+
+test("a delayed failure cannot overwrite a recovered success, including a measured zero", async () => {
+  const kv = providerKv();
+  const failure = { value: null, queried_at: new Date().toISOString() };
+  await writeLiveRpcCache(kv, "item", failure, {
+    ttlSeconds: 10,
+    negative: true,
+  });
+  vi.setSystemTime(START + 10_000);
+  const recovered = { value: 0, queried_at: new Date().toISOString() };
+  await writeLiveRpcCache(kv, "item", recovered, {
+    ttlSeconds: 120,
+    negative: false,
+  });
+  vi.setSystemTime(START + 11_000);
+  await writeLiveRpcCache(kv, "item", failure, {
+    ttlSeconds: 10,
+    negative: true,
+  });
+  assert.deepEqual(await readLiveRpcCache(kv, "item"), recovered);
+  assert.deepEqual(
+    await kv.get("item"),
+    recovered,
+    "success retains the legacy storage shape",
+  );
+  assert.equal(kv.writes[1].ttl, 120);
+});
+
+test("short positive observations expire logically without becoming a failure", async () => {
+  const kv = providerKv();
+  await writeLiveRpcCache(
+    kv,
+    "randomness:v2",
+    { round: 42 },
+    { ttlSeconds: 30, negative: false },
+  );
+  assert.equal(kv.writes[0].key, "randomness:v2");
+  assert.equal(kv.writes[0].ttl, 60);
+  vi.setSystemTime(START + 29_999);
+  assert.deepEqual(await readLiveRpcCache(kv, "randomness:v2"), { round: 42 });
+  vi.setSystemTime(START + 30_000);
+  assert.equal(await readLiveRpcCache(kv, "randomness:v2"), null);
+});
+
+test.each([
+  null,
+  "invalid",
+  42,
+  {},
+  { live_rpc_cache_version: 2, expires_at_ms: START + 10_000, value: {} },
+  { live_rpc_cache_version: 1, expires_at_ms: "later", value: {} },
+  { live_rpc_cache_version: 1, expires_at_ms: START, value: {} },
+  { live_rpc_cache_version: 1, expires_at_ms: START + 10_000 },
+  { live_rpc_cache_version: 1, expires_at_ms: START + 10_000, value: null },
+  {
+    live_rpc_cache_version: 1,
+    expires_at_ms: START + 10_000,
+    value: "invalid",
+  },
+  { live_rpc_cache_version: 1, expires_at_ms: START + 10_000, value: [] },
+])("an unreadable or expired failure %j is a cache miss", async (value) => {
+  const kv = providerKv();
+  await kv.put(liveRpcFailureCacheKey("item"), JSON.stringify(value), {
+    expirationTtl: 60,
+  });
+  assert.equal(await readLiveRpcCache(kv, "item"), null);
+});
+
+test("runtime predicates reject old positive observations and incompatible failures", async () => {
+  const kv = providerKv();
+  await writeLiveRpcCache(
+    kv,
+    "root",
+    { runtime: 440 },
+    { ttlSeconds: 120, negative: false },
+  );
+  await writeLiveRpcCache(
+    kv,
+    "root",
+    { runtime: 454 },
+    { ttlSeconds: 10, negative: true },
+  );
+  assert.deepEqual(
+    await readLiveRpcCache(
+      kv,
+      "root",
+      (value: { runtime: number }) => value.runtime === 454,
+    ),
+    { runtime: 454 },
+  );
+  assert.equal(
+    await readLiveRpcCache(
+      kv,
+      "root",
+      (value: { runtime: number }) => value.runtime === 455,
+    ),
+    null,
+  );
+});
+
+test("unreadable storage still reaches the reader's existing non-fatal fallback", async () => {
+  const kv = providerKv();
+  const fetchSpy = vi.fn(async () => new Response(null, { status: 503 }));
+  vi.stubGlobal("fetch", fetchSpy);
+  kv.records.set(`balance:${SS58}`, {
+    value: "not json",
+    expiresAt: START + 60_000,
+  });
+  const env = mockEnv({
+    METAGRAPH_CONTROL: {
+      ...kv,
+      put: async () => {
+        throw new Error("write unavailable");
+      },
+    },
+  });
+  assert.equal((await loadAccountBalance(env, SS58)).balance_tao, null);
+  assert.equal(fetchSpy.mock.calls.length, 1);
+});
+
+const readers: {
+  name: string;
+  load: (env: Env) => Promise<unknown>;
+  ttl: number;
+  requiredRpc?: number;
+}[] = [
+  { name: "balance", load: (env) => loadAccountBalance(env, SS58), ttl: 10 },
+  {
+    name: "root claim",
+    load: (env) => loadAccountRootClaim(env, SS58),
+    ttl: 10,
+    requiredRpc: 1,
+  },
+  {
+    name: "mapping",
+    load: (env) => loadAddressMapping(env, `0x${"12".repeat(20)}`),
+    ttl: 10,
+  },
+  { name: "chain burn", load: (env) => loadChainBurn(env), ttl: 10 },
+  { name: "children", load: (env) => loadAccountChildren(env, SS58), ttl: 10 },
+  { name: "parents", load: (env) => loadAccountParents(env, SS58), ttl: 10 },
+  { name: "crowdloan detail", load: (env) => loadCrowdloan(env, 1), ttl: 10 },
+  {
+    name: "network parameters",
+    load: (env) => loadNetworkParameters(env),
+    ttl: 10,
+  },
+  { name: "randomness", load: (env) => loadRandomnessStatus(env), ttl: 10 },
+  { name: "subnet burn", load: (env) => loadSubnetBurn(env, 1), ttl: 10 },
+  { name: "lease", load: (env) => loadSubnetLease(env, 1), ttl: 10 },
+  {
+    name: "conviction",
+    load: (env) =>
+      loadSubnetConvictionChainTier(1, { kv: env.METAGRAPH_CONTROL }),
+    ttl: 10,
+  },
+  { name: "recycled", load: (env) => loadSubnetRecycled(env, 1), ttl: 10 },
+  { name: "sudo", load: (env) => loadSudoKey(env), ttl: 10 },
+  { name: "upgrade radar", load: (env) => loadUpgradeRadar(env), ttl: 30 },
+];
+
+test.each(readers)(
+  "$name preserves the failure payload and retries after $ttl seconds",
+  async ({ load, ttl, requiredRpc = 0 }) => {
+    const kv = providerKv();
+    const env = mockEnv({ METAGRAPH_CONTROL: kv });
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const original = await load(env);
+    assert.equal(kv.writes.length, 1);
+    assert.equal(kv.writes[0].ttl, 60);
+    assert.ok(kv.writes[0].key.endsWith(":failure:v1"));
+    const firstRpcCount = fetchSpy.mock.calls.length;
+    vi.setSystemTime(START + ttl * 1000 - 1);
+    assert.deepEqual(
+      await load(env),
+      original,
+      "cached failure retains timestamps, nulls, and reasons",
+    );
+    assert.equal(
+      kv.writes.length,
+      1,
+      "reading never renews the logical expiry",
+    );
+    assert.equal(fetchSpy.mock.calls.length, firstRpcCount + requiredRpc);
+    vi.setSystemTime(START + ttl * 1000);
+    await load(env);
+    assert.equal(
+      kv.writes.length,
+      2,
+      "logical expiry permits another observation before KV deletion",
+    );
+    assert.ok(fetchSpy.mock.calls.length > firstRpcCount + requiredRpc);
+  },
+);
+
+test("network isolation and passive freshness cannot turn failed reads into current observations", async () => {
+  const kv = providerKv();
+  const env = mockEnv({ METAGRAPH_CONTROL: kv });
+  const fetchSpy = vi.fn(async () => new Response(null, { status: 503 }));
+  vi.stubGlobal("fetch", fetchSpy);
+  const finney = await loadNetworkParameters(env);
+  const calls = fetchSpy.mock.calls.length;
+  const cached = await readCachedNetworkParametersSnapshot(env);
+  const cachedQueriedAt = cached?.queried_at;
+  assert.equal(cached, null);
+  assert.equal(finney.queried_at, new Date().toISOString());
+  const freshness = mergeFreshness(
+    { sources: [] },
+    { last_run_at: new Date().toISOString() },
+    { parametersQueriedAt: cachedQueriedAt, now: Date.now() },
+  );
+  const sources = freshness?.sources;
+  assert.ok(Array.isArray(sources));
+  assert.equal(
+    sources.find((source: { id: string }) => source.id === "chain-parameters")
+      .status,
+    "missing",
+  );
+  assert.equal(await readCachedNetworkParametersSnapshot(env, "testnet"), null);
+  vi.setSystemTime(START + 10_000);
+  assert.equal(await readCachedNetworkParametersSnapshot(env), null);
+  assert.equal(
+    fetchSpy.mock.calls.length,
+    calls,
+    "freshness inspection cannot refresh its own source",
+  );
+});
+
+test("the balance reader recovers to a real zero immediately after its failure expires", async () => {
+  const kv = providerKv();
+  const env = mockEnv({ METAGRAPH_CONTROL: kv });
+  const fetchSpy = vi.fn(async () => new Response(null, { status: 503 }));
+  vi.stubGlobal("fetch", fetchSpy);
+  const failure = await loadAccountBalance(env, SS58);
+  assert.equal(failure.balance_tao, null);
+  vi.setSystemTime(START + 10_000);
+  fetchSpy.mockImplementation(async () =>
+    Response.json({ jsonrpc: "2.0", id: 1, result: null }),
+  );
+  const success = await loadAccountBalance(env, SS58);
+  assert.equal(success.balance_tao, 0);
+  assert.notEqual(success.queried_at, failure.queried_at);
+  assert.deepEqual(await loadAccountBalance(env, SS58), success);
+  assert.equal(fetchSpy.mock.calls.length, 2);
+});

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -521,7 +521,7 @@ describe("loadNetworkParameters", () => {
         await loadNetworkParameters(env);
         assert.equal(
           putOptions!.expirationTtl,
-          NETWORK_PARAMETERS_NEGATIVE_KV_TTL,
+          Math.max(60, NETWORK_PARAMETERS_NEGATIVE_KV_TTL),
         );
       },
     );

--- a/tests/randomness.test.ts
+++ b/tests/randomness.test.ts
@@ -215,9 +215,9 @@ describe("loadRandomnessStatus", () => {
     } as unknown as Env;
     await withFetchStub(goldenFetchStub(), async () => {
       await loadRandomnessStatus(env);
-      assert.equal(putKey, "network:randomness");
-      assert.equal(putValue!.last_stored_round, GOLDEN_LAST_ROUND);
-      assert.equal(putOptions!.expirationTtl, RANDOMNESS_KV_TTL);
+      assert.equal(putKey, "network:randomness:v2");
+      assert.equal(putValue!.value.last_stored_round, GOLDEN_LAST_ROUND);
+      assert.equal(putOptions!.expirationTtl, Math.max(60, RANDOMNESS_KV_TTL));
       assert.equal(RANDOMNESS_KV_TTL, 30);
     });
   });
@@ -245,7 +245,10 @@ describe("loadRandomnessStatus", () => {
       },
       async () => {
         await loadRandomnessStatus(env);
-        assert.equal(putOptions!.expirationTtl, RANDOMNESS_NEGATIVE_KV_TTL);
+        assert.equal(
+          putOptions!.expirationTtl,
+          Math.max(60, RANDOMNESS_NEGATIVE_KV_TTL),
+        );
       },
     );
   });

--- a/tests/subnet-burn.test.ts
+++ b/tests/subnet-burn.test.ts
@@ -241,7 +241,7 @@ describe("loadSubnetBurn", () => {
     globalThis.fetch = (async () => ({ ok: false })) as unknown as typeof fetch;
     try {
       await loadSubnetBurn(env, 42);
-      assert.equal(sawKey, "burn:42");
+      assert.equal(sawKey, "burn:42:failure:v1");
     } finally {
       globalThis.fetch = orig;
     }
@@ -299,7 +299,10 @@ describe("loadSubnetBurn", () => {
     globalThis.fetch = (async () => ({ ok: false })) as unknown as typeof fetch;
     try {
       await loadSubnetBurn(env, GOLDEN_NETUID);
-      assert.equal(putOptions!.expirationTtl, BURN_NEGATIVE_KV_TTL);
+      assert.equal(
+        putOptions!.expirationTtl,
+        Math.max(60, BURN_NEGATIVE_KV_TTL),
+      );
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/subnet-lease.test.ts
+++ b/tests/subnet-lease.test.ts
@@ -547,7 +547,10 @@ describe("loadSubnetLease", () => {
     globalThis.fetch = (async () => ({ ok: false })) as unknown as typeof fetch;
     try {
       await loadSubnetLease(env, 3);
-      assert.equal(putOptions!.expirationTtl, SUBNET_LEASE_NEGATIVE_KV_TTL);
+      assert.equal(
+        putOptions!.expirationTtl,
+        Math.max(60, SUBNET_LEASE_NEGATIVE_KV_TTL),
+      );
       assert.equal(SUBNET_LEASE_NEGATIVE_KV_TTL, 10);
     } finally {
       globalThis.fetch = orig;

--- a/tests/subnet-lock-state.test.ts
+++ b/tests/subnet-lock-state.test.ts
@@ -414,7 +414,10 @@ describe("the KV cache in front of the chain reads (#9335)", () => {
       rpc: async () => undefined,
       kv: kvBad,
     });
-    assert.equal(kvBad.puts.at(-1)?.ttl, LOCK_STATE_NEGATIVE_KV_TTL);
+    assert.equal(
+      kvBad.puts.at(-1)?.ttl,
+      Math.max(60, LOCK_STATE_NEGATIVE_KV_TTL),
+    );
     assert.ok(
       LOCK_STATE_NEGATIVE_KV_TTL < LOCK_STATE_KV_TTL,
       "a blip must clear sooner than a good board expires",

--- a/tests/subnet-recycled.test.ts
+++ b/tests/subnet-recycled.test.ts
@@ -247,7 +247,7 @@ describe("loadSubnetRecycled", () => {
     globalThis.fetch = (async () => ({ ok: false })) as unknown as typeof fetch;
     try {
       await loadSubnetRecycled(env, 42);
-      assert.equal(sawKey, "recycled:42");
+      assert.equal(sawKey, "recycled:42:failure:v1");
     } finally {
       globalThis.fetch = orig;
     }
@@ -305,7 +305,10 @@ describe("loadSubnetRecycled", () => {
     globalThis.fetch = (async () => ({ ok: false })) as unknown as typeof fetch;
     try {
       await loadSubnetRecycled(env, GOLDEN_NETUID);
-      assert.equal(putOptions!.expirationTtl, RECYCLED_NEGATIVE_KV_TTL);
+      assert.equal(
+        putOptions!.expirationTtl,
+        Math.max(60, RECYCLED_NEGATIVE_KV_TTL),
+      );
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/sudo-key.test.ts
+++ b/tests/sudo-key.test.ts
@@ -195,7 +195,10 @@ describe("loadSudoKey", () => {
     globalThis.fetch = (async () => ({ ok: false })) as unknown as typeof fetch;
     try {
       await loadSudoKey(env as unknown as Env);
-      assert.equal(putOptions!.expirationTtl, SUDO_KEY_NEGATIVE_KV_TTL);
+      assert.equal(
+        putOptions!.expirationTtl,
+        Math.max(60, SUDO_KEY_NEGATIVE_KV_TTL),
+      );
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/upgrade-radar-loaders.test.ts
+++ b/tests/upgrade-radar-loaders.test.ts
@@ -371,7 +371,9 @@ describe("loadUpgradeRadar", () => {
     expect(radar.pending_upgrade).toBe("unknown");
     expect(radar.testnet.spec_version).toBeNull();
     expect(radar.mainnet.spec_version).toBe(440);
-    expect(kv.puts.some((p) => p.key === UPGRADE_RADAR_CACHE_KEY)).toBe(true);
+    expect(
+      kv.puts.some((p) => p.key === `${UPGRADE_RADAR_CACHE_KEY}:failure:v1`),
+    ).toBe(true);
   });
 
   it("degrades to a live read when the cache is unreadable", async () => {


### PR DESCRIPTION
Cloudflare KV rejects the 10- and 30-second expiration values used by live-reader failure caches. Those rejected writes left repeated requests able to hit the unavailable source. A shared cache policy now persists failures for at least 60 seconds while enforcing each reader's original logical retry boundary.

Failure records use separate keys so a delayed failed read cannot overwrite a successful observation. Existing successful keys and response bodies are preserved; the randomness reader uses a versioned namespace for its 30-second logical success cache. Runtime/network checks, original observation timestamps, and unavailable-versus-empty behavior remain intact. Freshness endpoints continue reading the successful cache key so a failed attempt cannot mark a lane current. The shared policy covers 14 live-reader modules; authentication caches remain separately tracked.

Validation: provider-faithful tests exercise invalid-write rejection, logical and physical expiration, recovery, delayed failures, malformed records, network isolation, and all 15 reader entry points. Local lint, format, type checks, build, registry/schema/OpenAPI/types/docs validators, Worker handler checks, contract/UI-doc drift, public-safety and boundary checks passed. The full backend suite passed 22,708 tests across 992 files (11 skipped); changed runtime coverage is 100% across 88 executable lines and 124 branch arms.

Closes #12052
Refs #12029, #12012
