### PR TITLE
fix(auth): preserve short negative cache lifetimes

### DIFF
--- a/docs/auth-lookup-cache.md
+++ b/docs/auth-lookup-cache.md
@@ -1,0 +1,44 @@
+# Authentication lookup cache lifetimes
+
+API-key verification and OAuth account-tier lookups share a small envelope
+policy in `src/auth-lookup-cache.ts`. Workers KV requires an `expirationTtl`
+of at least 60 seconds. Both lookups retain their existing 30-second negative
+retry lifetime inside the record while storing it for 60 seconds.
+
+| Lookup               | Positive lifetime | Negative lifetime | Physical negative TTL |
+| -------------------- | ----------------- | ----------------- | --------------------- |
+| API-key verification | 1,800 seconds     | 30 seconds        | 60 seconds            |
+| OAuth account tier   | 300 seconds       | 30 seconds        | 60 seconds            |
+
+Readers reject an envelope at its exact logical expiry, regardless of whether
+KV still returns its physical entry. Invalid versions, timestamps, lifetimes,
+or `found` flags also cause a fresh lookup. Record fields and public response
+bodies remain unchanged. A KV read failure falls through to the service
+binding; a write failure retains that lookup's result. Lookup failures use
+the existing negative result and retry policy.
+
+The envelope is written under `api-key-lookup:v2:<sha256>` or
+`oauth-account-tier:v2:<account-id>`. API keys remain locally SHA-256 hashed
+in storage keys; raw credentials are never included in these cache values.
+Legacy namespaces are ignored so a rolling deployment cannot interpret an
+envelope as a raw identity record. Their existing entries expire normally.
+This version change causes one cold lookup per identity at rollout.
+
+Both outcomes replace the same key. An observed rejection can therefore
+replace a previously stored grant, and a later successful lookup can replace
+a negative answer. Unlike observational RPC caches, authentication lookups
+do not give successful answers precedence over rejections. Lifetimes start
+when the lookup completes and the envelope is constructed. Concurrent
+lookups retain completion-order writes; timestamps do not establish which
+authorization observation is newer at its source.
+
+This change does not add atomic ordering or immediate revocation. Workers KV
+is eventually consistent and concurrent writes remain last-write-wins.
+A valid API-key verification may be reused for its existing 30-minute
+lifetime; the negative lifetime only controls retries after a rejection has
+actually been observed. Account blocks, rate limits, and quota checks remain
+the responsibility of each request path, outside the identity cache. An
+account block is distinct from revoking an individual API key.
+
+Provider references: [KV write parameters and concurrent writes](https://developers.cloudflare.com/kv/api/write-key-value-pairs/)
+and [KV consistency](https://developers.cloudflare.com/kv/concepts/how-kv-works/).

--- a/src/api-key-validation.ts
+++ b/src/api-key-validation.ts
@@ -22,15 +22,23 @@
 // accepting eventual consistency for identity/revocation (NOT rate-limiting;
 // see src/unkey-client.ts's header for why that stays live/uncached), and a
 // longer TTL directly cuts how often verifyKey() gets called, keeping usage
-// comfortably inside Unkey's free tier. A revoked/disabled/not-found/garbage
-// key gets a SHORT TTL (30s) instead -- this falls straight out of caching
-// by `record.valid` rather than being a separate rule, and it's a genuinely
-// better property than one flat TTL would give: revocation propagates fast
-// (≤30s) precisely because a just-revoked key is, correctly, no longer
-// "valid" the moment it's checked.
+// comfortably inside Unkey's free tier. An observed rejection is reused for
+// only 30s before retrying. This does NOT bound revocation propagation: an
+// already-cached valid identity can remain reusable for its full 30-minute
+// TTL. Account blocklist and request rate/quota checks run separately.
+import {
+  authLookupCacheWrite,
+  readAuthLookupCache,
+} from "./auth-lookup-cache.ts";
+
 export const API_KEY_LOOKUP_KV_TTL = 1800; // 30 min
 export const API_KEY_LOOKUP_NEGATIVE_KV_TTL = 30;
 export const API_KEY_LOOKUP_TOKEN_HEADER = "x-api-key-lookup-token";
+
+const CACHE_POLICY = {
+  positiveTtlSeconds: API_KEY_LOOKUP_KV_TTL,
+  negativeTtlSeconds: API_KEY_LOOKUP_NEGATIVE_KV_TTL,
+};
 
 // Loose, not an exact-length assertion -- Unkey's own random-suffix
 // charset/length isn't a contract this codebase hard-codes. Just enough to
@@ -56,7 +64,7 @@ async function hashKeyForCache(bareKey: string): Promise<string> {
 }
 
 function cacheKeyFor(hash: string): string {
-  return `api-key-lookup:${hash}`;
+  return `api-key-lookup:v2:${hash}`;
 }
 
 export interface ApiKeyLookupRecord {
@@ -113,8 +121,11 @@ async function lookupApiKey(
   const cacheKey = cacheKeyFor(await hashKeyForCache(bareKey));
   if (kv?.get) {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
-      if (cached) return cached as ApiKeyLookupRecord;
+      const cached = readAuthLookupCache(
+        await kv.get(cacheKey, { type: "json" }),
+        CACHE_POLICY,
+      );
+      if (cached) return cached;
     } catch {
       // KV read failure is non-fatal -- fall through to the live lookup.
     }
@@ -123,10 +134,9 @@ async function lookupApiKey(
   const payload = await lookupViaDataApi(env, bareKey);
   if (kv?.put) {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: payload.found
-          ? API_KEY_LOOKUP_KV_TTL
-          : API_KEY_LOOKUP_NEGATIVE_KV_TTL,
+      const entry = authLookupCacheWrite(payload, CACHE_POLICY);
+      await kv.put(cacheKey, entry.value, {
+        expirationTtl: entry.expirationTtl,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/src/auth-lookup-cache.ts
+++ b/src/auth-lookup-cache.ts
@@ -1,0 +1,64 @@
+import { recordOrNull } from "./read-store.ts";
+
+interface AuthLookupCachePolicy {
+  positiveTtlSeconds: number;
+  negativeTtlSeconds: number;
+}
+
+/** Auth answers share one key: an observed rejection must replace a grant.
+ * KV is eventually consistent and concurrent writes remain last-write-wins;
+ * these timestamps bound reuse, not the ordering of authorization decisions.
+ * Versioned reader namespaces keep these envelopes isolated from legacy code.
+ */
+export function authLookupCacheWrite<T extends { found: boolean }>(
+  record: T,
+  policy: AuthLookupCachePolicy,
+): { value: string; expirationTtl: number } {
+  const ttl = record.found
+    ? policy.positiveTtlSeconds
+    : policy.negativeTtlSeconds;
+  const cachedAt = Date.now();
+  return {
+    value: JSON.stringify({
+      auth_lookup_cache_version: 1,
+      cached_at_ms: cachedAt,
+      expires_at_ms: cachedAt + ttl * 1000,
+      record,
+    }),
+    // Workers KV rejects expirationTtl below 60 seconds. The envelope retains
+    // the shorter logical retry lifetime even while its physical entry exists.
+    expirationTtl: Math.max(60, ttl),
+  };
+}
+
+export function readAuthLookupCache(
+  value: unknown,
+  policy: AuthLookupCachePolicy,
+): ({ found: boolean } & Record<string, unknown>) | null {
+  const envelope = recordOrNull(value);
+  if (envelope?.auth_lookup_cache_version !== 1) return null;
+  const record = recordOrNull(envelope.record);
+  if (!record || typeof record.found !== "boolean") return null;
+  const cachedAt = envelope.cached_at_ms;
+  const expiresAt = envelope.expires_at_ms;
+  if (
+    typeof cachedAt !== "number" ||
+    !Number.isSafeInteger(cachedAt) ||
+    typeof expiresAt !== "number" ||
+    !Number.isSafeInteger(expiresAt)
+  ) {
+    return null;
+  }
+  const ttl = record.found
+    ? policy.positiveTtlSeconds
+    : policy.negativeTtlSeconds;
+  const now = Date.now();
+  if (
+    cachedAt > now ||
+    expiresAt <= now ||
+    expiresAt - cachedAt !== ttl * 1000
+  ) {
+    return null;
+  }
+  return { ...record, found: record.found };
+}

--- a/src/oauth-account-tier.ts
+++ b/src/oauth-account-tier.ts
@@ -31,21 +31,29 @@
 //
 // ## WHY THE TTL IS SHORTER THAN THE KEY CACHE'S
 //
-// api-key-validation.ts caches a valid key for 30 minutes, which is right for
-// its job: that cache exists to keep `verifyKey()` call volume down, and key
-// REVOCATION has its own faster path (the blocklist, on its own short TTL). No
-// such second path exists for a tier change, so this cache's TTL *is* the
-// upgrade latency. Five minutes keeps the read cheap while keeping "I paid and
-// nothing happened" inside the window a person will sit through.
+// api-key-validation.ts caches a valid key for 30 minutes to keep
+// `verifyKey()` call volume down. Its separate account blocklist does not
+// invalidate an individual key's cached verification. This tier cache uses
+// five minutes so subscription changes can be observed sooner. KV remains
+// eventually consistent; these TTLs bound local reuse, not global visibility.
 
 import { API_KEY_LOOKUP_TOKEN_HEADER } from "./api-key-validation.ts";
+import {
+  authLookupCacheWrite,
+  readAuthLookupCache,
+} from "./auth-lookup-cache.ts";
 
-/** How long a resolved tier is cached. This is the upgrade latency -- see the
- * header for why it is not the key cache's 30 minutes. */
+/** How long a resolved tier can be reused locally -- see the header for why
+ * it is not the key cache's 30 minutes. */
 export const OAUTH_ACCOUNT_TIER_KV_TTL = 300; // 5 min
 /** How long "no such account" is cached. Short, so an account that appears
  * (or a lookup that failed transiently) is not denied for a full TTL. */
 export const OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL = 30;
+
+const CACHE_POLICY = {
+  positiveTtlSeconds: OAUTH_ACCOUNT_TIER_KV_TTL,
+  negativeTtlSeconds: OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
+};
 
 export interface OAuthAccountTierRecord {
   found: boolean;
@@ -53,7 +61,7 @@ export interface OAuthAccountTierRecord {
 }
 
 function cacheKeyFor(accountId: number): string {
-  return `oauth-account-tier:${accountId}`;
+  return `oauth-account-tier:v2:${accountId}`;
 }
 
 /**
@@ -115,9 +123,9 @@ async function lookupViaDataApi(
 /**
  * The current tier for an OAuth-authenticated account, KV-cache-fronted.
  *
- * Returns `{ found: false }` for an unreadable id, an unknown account, or any
- * upstream/KV failure -- one shape for every "we cannot say", so the caller has
- * exactly one branch to take and it is the safe one.
+ * Returns `{ found: false }` for an unreadable id, an unknown account, or an
+ * upstream failure. KV failures fall through to the lookup or retain its
+ * result, so cache availability does not itself decide authorization.
  */
 export async function resolveOAuthAccountTier(
   env: Env,
@@ -130,8 +138,11 @@ export async function resolveOAuthAccountTier(
   const cacheKey = cacheKeyFor(accountId);
   if (kv?.get) {
     try {
-      const cached = await kv.get(cacheKey, { type: "json" });
-      if (cached) return cached as OAuthAccountTierRecord;
+      const cached = readAuthLookupCache(
+        await kv.get(cacheKey, { type: "json" }),
+        CACHE_POLICY,
+      );
+      if (cached) return cached;
     } catch {
       // KV read failure is non-fatal -- fall through to the live lookup.
     }
@@ -140,10 +151,9 @@ export async function resolveOAuthAccountTier(
   const payload = await lookupViaDataApi(env, accountId);
   if (kv?.put) {
     try {
-      await kv.put(cacheKey, JSON.stringify(payload), {
-        expirationTtl: payload.found
-          ? OAUTH_ACCOUNT_TIER_KV_TTL
-          : OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
+      const entry = authLookupCacheWrite(payload, CACHE_POLICY);
+      await kv.put(cacheKey, entry.value, {
+        expirationTtl: entry.expirationTtl,
       });
     } catch {
       // KV write failure is non-fatal.

--- a/tests/auth-lookup-cache.test.ts
+++ b/tests/auth-lookup-cache.test.ts
@@ -1,0 +1,377 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import {
+  authLookupCacheWrite,
+  readAuthLookupCache,
+} from "../src/auth-lookup-cache.ts";
+import { validateApiKey } from "../src/api-key-validation.ts";
+import { resolveOAuthAccountTier } from "../src/oauth-account-tier.ts";
+import { applyTieredRateLimit } from "../workers/tiered-rate-limit.ts";
+import { mockEnv } from "./row-type.ts";
+
+const NOW = 1_800_000_000_000;
+const RAW_KEY = "mg_cache_lifetime_regression_fixture";
+const POLICY = { positiveTtlSeconds: 300, negativeTtlSeconds: 30 };
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(NOW);
+});
+afterEach(() => vi.useRealTimers());
+
+// Enforce Workers KV's real minimum and physical expiry. A negative entry
+// remains readable at 30 seconds so the application's logical guard must work.
+function providerKv() {
+  const store = new Map<string, { value: string; expiresAt: number }>();
+  const puts: { key: string; value: string; expirationTtl: number }[] = [];
+  return {
+    store,
+    puts,
+    get: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      return entry && entry.expiresAt > Date.now()
+        ? JSON.parse(entry.value)
+        : null;
+    }),
+    put: vi.fn(
+      async (
+        key: string,
+        value: string,
+        options: { expirationTtl: number },
+      ) => {
+        assert.ok(options.expirationTtl >= 60, "KV rejects TTLs below 60s");
+        puts.push({ key, value, ...options });
+        store.set(key, {
+          value,
+          expiresAt: Date.now() + options.expirationTtl * 1000,
+        });
+      },
+    ),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("auth cache envelope validation", () => {
+  test.each([true, false])(
+    "retains the original record for found=%s",
+    (found) => {
+      const record = { found, tier: null, accountId: "7", code: "DISABLED" };
+      const entry = authLookupCacheWrite(record, POLICY);
+      assert.equal(entry.expirationTtl, found ? 300 : 60);
+      assert.deepEqual(
+        readAuthLookupCache(JSON.parse(entry.value), POLICY),
+        record,
+      );
+    },
+  );
+
+  const valid = {
+    auth_lookup_cache_version: 1,
+    cached_at_ms: NOW,
+    expires_at_ms: NOW + 30_000,
+    record: { found: false },
+  };
+  test.each([
+    null,
+    [],
+    "garbage",
+    {},
+    { found: true },
+    { ...valid, auth_lookup_cache_version: 2 },
+    { ...valid, record: null },
+    { ...valid, record: [] },
+    { ...valid, record: { found: "true", tier: "paid" } },
+    { ...valid, cached_at_ms: "1800000000000" },
+    { ...valid, cached_at_ms: 1.5 },
+    { ...valid, cached_at_ms: Number.NaN },
+    { ...valid, cached_at_ms: Number.MAX_SAFE_INTEGER + 1 },
+    { ...valid, expires_at_ms: "1800000030000" },
+    { ...valid, expires_at_ms: Number.POSITIVE_INFINITY },
+    { ...valid, cached_at_ms: NOW + 1 },
+    { ...valid, expires_at_ms: NOW },
+    { ...valid, expires_at_ms: NOW - 1 },
+    { ...valid, expires_at_ms: NOW + 60_000 },
+    { ...valid, record: { found: true } },
+  ])("treats malformed or expired cache data as a miss (%#)", (value) => {
+    assert.equal(readAuthLookupCache(value, POLICY), null);
+  });
+});
+
+const MODES = [
+  {
+    name: "API key",
+    prefix: "api-key-lookup",
+    positiveTtl: 1800,
+    lookup: (env: Env) => validateApiKey(env, RAW_KEY),
+    positive: { valid: true, tier: "paid", accountId: "7" },
+    negative: { valid: false, code: "DISABLED" },
+    positiveResult: { ok: true, tier: "paid", accountId: "7" },
+    negativeResult: { ok: false, code: "key_revoked" },
+    failedResult: { ok: false, code: "invalid_key" },
+  },
+  {
+    name: "OAuth account tier",
+    prefix: "oauth-account-tier",
+    positiveTtl: 300,
+    lookup: (env: Env) => resolveOAuthAccountTier(env, 7),
+    positive: { found: true, tier: "paid" },
+    negative: { found: false },
+    positiveResult: { found: true, tier: "paid" },
+    negativeResult: { found: false },
+    failedResult: { found: false },
+  },
+];
+
+for (const mode of MODES) {
+  function harness() {
+    const kv = providerKv();
+    const fetch = vi.fn(async () => Response.json(mode.negative));
+    const env = mockEnv({
+      METAGRAPH_CONTROL: kv,
+      API_KEY_LOOKUP_INTERNAL_TOKEN: "test-lookup-token",
+      DATA_API: { fetch },
+    });
+    return { kv, fetch, env };
+  }
+
+  describe(`${mode.name} cache lifetime`, () => {
+    test("persists negatives for 60s but retries exactly at 30s and recovers", async () => {
+      const { kv, fetch, env } = harness();
+      assert.deepEqual(await mode.lookup(env), mode.negativeResult);
+      assert.equal(kv.puts[0]!.expirationTtl, 60);
+      fetch.mockImplementation(async () => Response.json(mode.positive));
+      vi.setSystemTime(NOW + 29_999);
+      assert.deepEqual(await mode.lookup(env), mode.negativeResult);
+      assert.equal(fetch.mock.calls.length, 1);
+      vi.setSystemTime(NOW + 30_000);
+      assert.ok(
+        await kv.get(kv.puts[0]!.key),
+        "physical negative still exists",
+      );
+      assert.deepEqual(await mode.lookup(env), mode.positiveResult);
+      assert.equal(fetch.mock.calls.length, 2);
+      assert.equal(kv.puts[1]!.expirationTtl, mode.positiveTtl);
+      assert.equal(kv.puts[0]!.key, kv.puts[1]!.key);
+    });
+
+    test("preserves positive TTL and rechecks a rejection at its exact boundary", async () => {
+      const { kv, fetch, env } = harness();
+      fetch.mockImplementationOnce(async () => Response.json(mode.positive));
+      assert.deepEqual(await mode.lookup(env), mode.positiveResult);
+      assert.equal(kv.puts[0]!.expirationTtl, mode.positiveTtl);
+      vi.setSystemTime(NOW + mode.positiveTtl * 1000 - 1);
+      assert.deepEqual(await mode.lookup(env), mode.positiveResult);
+      assert.equal(fetch.mock.calls.length, 1);
+      vi.setSystemTime(NOW + mode.positiveTtl * 1000);
+      assert.deepEqual(await mode.lookup(env), mode.negativeResult);
+      assert.equal(fetch.mock.calls.length, 2);
+    });
+
+    test("rejects malformed envelopes and ignores legacy raw cache namespaces", async () => {
+      const { kv, fetch, env } = harness();
+      await mode.lookup(env);
+      const key = kv.puts[0]!.key;
+      assert.ok(key.startsWith(`${mode.prefix}:v2:`));
+      assert.ok(!key.includes(RAW_KEY));
+      assert.ok(!kv.puts[0]!.value.includes(RAW_KEY));
+      kv.store.clear();
+      kv.store.set(key.replace(":v2:", ":"), {
+        value: JSON.stringify({ found: true, tier: "paid", accountId: "7" }),
+        expiresAt: NOW + 1_800_000,
+      });
+      assert.deepEqual(await mode.lookup(env), mode.negativeResult);
+      kv.store.set(key, {
+        value: JSON.stringify({
+          auth_lookup_cache_version: 1,
+          cached_at_ms: NOW,
+          expires_at_ms: NOW + 30_000,
+          record: { found: "true", tier: "paid" },
+        }),
+        expiresAt: NOW + 60_000,
+      });
+      assert.deepEqual(await mode.lookup(env), mode.negativeResult);
+      assert.equal(fetch.mock.calls.length, 3);
+    });
+
+    test.each(["throw", "non-ok", "malformed JSON"])(
+      "retries upstream failure (%s) after the logical negative lifetime",
+      async (failure) => {
+        const { kv, fetch, env } = harness();
+        fetch.mockImplementationOnce(async () => {
+          if (failure === "throw") throw new Error("lookup unavailable");
+          return new Response("invalid JSON", {
+            status: failure === "non-ok" ? 503 : 200,
+          });
+        });
+        assert.deepEqual(await mode.lookup(env), mode.failedResult);
+        assert.equal(kv.puts[0]!.expirationTtl, 60);
+        fetch.mockImplementation(async () => Response.json(mode.positive));
+        vi.setSystemTime(NOW + 30_000);
+        assert.deepEqual(await mode.lookup(env), mode.positiveResult);
+      },
+    );
+
+    test.each(["negative", "positive"])(
+      "keeps completion-order replacement when a delayed %s arrives last",
+      async (last) => {
+        const { kv, fetch, env } = harness();
+        const first = deferred<Response>();
+        const second = deferred<Response>();
+        const startedFirst = deferred<void>();
+        const startedSecond = deferred<void>();
+        fetch.mockImplementationOnce(() => {
+          startedFirst.resolve();
+          return first.promise;
+        });
+        fetch.mockImplementationOnce(() => {
+          startedSecond.resolve();
+          return second.promise;
+        });
+        const pendingFirst = mode.lookup(env);
+        await startedFirst.promise;
+        const pendingSecond = mode.lookup(env);
+        await startedSecond.promise;
+        second.resolve(
+          Response.json(last === "negative" ? mode.positive : mode.negative),
+        );
+        await pendingSecond;
+        vi.setSystemTime(NOW + 20_000);
+        first.resolve(
+          Response.json(last === "negative" ? mode.negative : mode.positive),
+        );
+        await pendingFirst;
+        assert.deepEqual(
+          await mode.lookup(env),
+          last === "negative" ? mode.negativeResult : mode.positiveResult,
+        );
+        assert.equal(kv.store.size, 1, "no permanent success preference");
+        assert.equal(fetch.mock.calls.length, 2);
+        if (last === "negative") {
+          fetch.mockImplementation(async () => Response.json(mode.positive));
+          vi.setSystemTime(NOW + 49_999);
+          assert.deepEqual(await mode.lookup(env), mode.negativeResult);
+          vi.setSystemTime(NOW + 50_000);
+          assert.deepEqual(await mode.lookup(env), mode.positiveResult);
+        }
+      },
+    );
+
+    test("cache failures preserve live authorization results", async () => {
+      const { kv, fetch, env } = harness();
+      kv.get.mockRejectedValue(new Error("read unavailable"));
+      kv.put.mockRejectedValue(new Error("write unavailable"));
+      assert.deepEqual(await mode.lookup(env), mode.negativeResult);
+      fetch.mockImplementation(async () => Response.json(mode.positive));
+      assert.deepEqual(await mode.lookup(env), mode.positiveResult);
+      assert.equal(fetch.mock.calls.length, 2);
+    });
+  });
+}
+
+test("account and credential identities remain isolated in a shared KV", async () => {
+  const kv = providerKv();
+  const fetch = vi.fn(async (request: Request) => {
+    const input = (await request.json()) as {
+      account_id?: number;
+      key?: string;
+    };
+    return Response.json(
+      input.account_id
+        ? { found: input.account_id === 7, tier: "paid" }
+        : { valid: input.key === RAW_KEY, tier: "free", accountId: "7" },
+    );
+  });
+  const env = mockEnv({
+    METAGRAPH_CONTROL: kv,
+    API_KEY_LOOKUP_INTERNAL_TOKEN: "test-token",
+    DATA_API: { fetch },
+  });
+  assert.deepEqual(await validateApiKey(env, RAW_KEY), {
+    ok: true,
+    tier: "free",
+    accountId: "7",
+  });
+  assert.deepEqual(await validateApiKey(env, `${RAW_KEY}_other`), {
+    ok: false,
+    code: "invalid_key",
+  });
+  assert.deepEqual(await resolveOAuthAccountTier(env, 7), {
+    found: true,
+    tier: "paid",
+  });
+  assert.deepEqual(await resolveOAuthAccountTier(env, 8), { found: false });
+  assert.equal(kv.store.size, 4);
+  assert.equal(fetch.mock.calls.length, 4);
+});
+
+test("OAuth tier upgrades and downgrades refresh without changing identity", async () => {
+  const kv = providerKv();
+  let tier = "free";
+  const env = mockEnv({
+    METAGRAPH_CONTROL: kv,
+    API_KEY_LOOKUP_INTERNAL_TOKEN: "test-token",
+    DATA_API: { fetch: async () => Response.json({ found: true, tier }) },
+  });
+  for (const [elapsed, nextTier] of [
+    [0, "free"],
+    [300_000, "paid"],
+    [600_000, "free"],
+  ] as const) {
+    tier = nextTier;
+    vi.setSystemTime(NOW + elapsed);
+    assert.deepEqual(await resolveOAuthAccountTier(env, 7), {
+      found: true,
+      tier,
+    });
+  }
+  assert.equal(kv.store.size, 1);
+});
+
+test("a cached identity still undergoes each request's account block and rate checks", async () => {
+  const kv = providerKv();
+  const fetch = vi.fn(async () =>
+    Response.json({ valid: true, tier: "free", accountId: "7" }),
+  );
+  const limit = vi.fn(async () => ({ success: true }));
+  const env = mockEnv({
+    METAGRAPH_CONTROL: kv,
+    API_KEY_LOOKUP_INTERNAL_TOKEN: "test-token",
+    DATA_API: { fetch },
+    TEST_KEYED_LIMITER: { limit },
+  });
+  const policy = { envVar: "TEST_KEYED_LIMITER", limit: 60, windowSeconds: 60 };
+  const config = { anonymous: policy, keyed: policy, keyPrefix: "test" };
+  const request = new Request("https://api.metagraph.sh/api/v1/chain-events", {
+    headers: { Authorization: `Bearer ${RAW_KEY}` },
+  });
+  assert.equal(
+    (await applyTieredRateLimit(request, env, config)).allowed,
+    true,
+  );
+  assert.equal(
+    (await applyTieredRateLimit(request, env, config)).allowed,
+    true,
+  );
+  assert.equal(fetch.mock.calls.length, 1);
+  assert.equal(limit.mock.calls.length, 2);
+  kv.store.set("api-key-blocklist", {
+    value: JSON.stringify({
+      blocks: [
+        { accountId: 7, accountKind: "rpc", reasonCode: "abuse_manual" },
+      ],
+    }),
+    expiresAt: NOW + 60_000,
+  });
+  const blocked = await applyTieredRateLimit(request, env, config);
+  assert.equal(blocked.allowed, false);
+  assert.equal(blocked.block?.blocked, true);
+  assert.equal(fetch.mock.calls.length, 1);
+  assert.equal(limit.mock.calls.length, 2);
+});

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -10,6 +10,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { handleMcpRequest } from "../src/mcp-server.ts";
+import { authLookupCacheWrite } from "../src/auth-lookup-cache.ts";
+import {
+  API_KEY_LOOKUP_KV_TTL,
+  API_KEY_LOOKUP_NEGATIVE_KV_TTL,
+} from "../src/api-key-validation.ts";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.ts";
 import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import type { Row } from "./row-type.ts";
@@ -2331,9 +2336,14 @@ describe("surface credential store (#9009)", () => {
     const hash = [...new Uint8Array(digest)]
       .map((byte) => byte.toString(16).padStart(2, "0"))
       .join("");
-    env.store.set(`api-key-lookup:${hash}`, {
-      value: JSON.stringify({ found: true, tier: "free", accountId: 7 }),
-    });
+    const identity = { found: true, tier: "free", accountId: 7 };
+    env.store.set(
+      `api-key-lookup:v2:${hash}`,
+      authLookupCacheWrite(identity, {
+        positiveTtlSeconds: API_KEY_LOOKUP_KV_TTL,
+        negativeTtlSeconds: API_KEY_LOOKUP_NEGATIVE_KV_TTL,
+      }),
+    );
 
     // Registered through the OAuth door as account 7…
     await callAs(

--- a/tests/oauth-account-tier.test.ts
+++ b/tests/oauth-account-tier.test.ts
@@ -4,6 +4,7 @@
 // tests/tiered-rate-limit.test.ts mocks them.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { authLookupCacheWrite } from "../src/auth-lookup-cache.ts";
 import {
   OAUTH_ACCOUNT_TIER_KV_TTL,
   OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
@@ -142,13 +143,13 @@ describe("resolveOAuthAccountTier", () => {
       { METAGRAPH_CONTROL: kv },
     );
     await resolveOAuthAccountTier(env, 42);
-    assert.deepEqual(kv.puts, [
-      {
-        key: "oauth-account-tier:42",
-        value: JSON.stringify({ found: true, tier: "paid" }),
-        options: { expirationTtl: OAUTH_ACCOUNT_TIER_KV_TTL },
-      },
-    ]);
+    assert.equal(kv.puts.length, 1);
+    assert.equal(kv.puts[0]!.key, "oauth-account-tier:v2:42");
+    assert.equal(kv.puts[0]!.options?.expirationTtl, OAUTH_ACCOUNT_TIER_KV_TTL);
+    assert.deepEqual(JSON.parse(kv.puts[0]!.value).record, {
+      found: true,
+      tier: "paid",
+    });
     // Second call is served from cache -- no second round trip.
     assert.deepEqual(await resolveOAuthAccountTier(env, 42), {
       found: true,
@@ -161,9 +162,11 @@ describe("resolveOAuthAccountTier", () => {
     const kv = createFakeKv();
     const { env } = envWith({ found: false }, { METAGRAPH_CONTROL: kv });
     await resolveOAuthAccountTier(env, 42);
+    assert.equal(kv.puts[0]!.options?.expirationTtl, 60);
+    const envelope = JSON.parse(kv.puts[0]!.value);
     assert.equal(
-      kv.puts[0]!.options?.expirationTtl,
-      OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
+      envelope.expires_at_ms - envelope.cached_at_ms,
+      OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL * 1000,
     );
     assert.ok(
       OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL < OAUTH_ACCOUNT_TIER_KV_TTL,
@@ -172,16 +175,22 @@ describe("resolveOAuthAccountTier", () => {
   });
 
   test("the tier TTL is short enough to be a tolerable upgrade latency", () => {
-    // This cache's TTL *is* how long a paid upgrade takes to be honoured --
-    // there is no second fast path the way the blocklist is for key
-    // revocation. Pinned so it cannot drift up to the key cache's 30 minutes
-    // without someone deciding to.
+    // Pin local tier reuse so it cannot drift up to the key cache's
+    // 30 minutes without a deliberate policy change.
     assert.ok(OAUTH_ACCOUNT_TIER_KV_TTL <= 300);
   });
 
   test("serves a cached answer without calling upstream at all", async () => {
     const kv = createFakeKv({
-      "oauth-account-tier:9": { found: true, tier: "paid" },
+      "oauth-account-tier:v2:9": JSON.parse(
+        authLookupCacheWrite(
+          { found: true, tier: "paid" },
+          {
+            positiveTtlSeconds: OAUTH_ACCOUNT_TIER_KV_TTL,
+            negativeTtlSeconds: OAUTH_ACCOUNT_TIER_NEGATIVE_KV_TTL,
+          },
+        ).value,
+      ),
     });
     const { env, requests } = envWith(
       { found: true, tier: "free" },


### PR DESCRIPTION
## Summary

Authentication lookup misses used a 30-second Workers KV expiration, below the provider's 60-second minimum. Keep their intended 30-second logical retry window in a validated envelope while persisting negative answers for 60 seconds. API-key and OAuth tier positive lifetimes remain 1,800 and 300 seconds respectively.

Use versioned namespaces, retain hashed API-key cache identifiers, and refresh malformed or expired entries. Positive and negative answers continue replacing the same key in completion order. Existing account block, rate-limit, quota, and response behavior is preserved. Document cache consistency and retry limits accurately.

Closes #12059
Refs #12029

## Validation

- Provider-faithful regressions cover the 60-second physical minimum, exact 30-second retry boundary, recovery, unchanged positive lifetimes, identity isolation, malformed/legacy records, overlapping lookups, tier changes, disabled keys, storage/upstream failures, and downstream account block/rate checks.
- Focused authentication and request suites: 325 passed.
- Full backend coverage: 993 files, 22,751 passed, 11 skipped; 100% changed runtime coverage (28 executable lines and 25 branch arms).
- Build, lint, formatting, typecheck, registry/schema/OpenAPI/type/contract checks, documentation drift checks, export/module checks, private/boundary checks, Worker runtime tests, and public-safety scan passed.

No public API schema or generated artifact changes. The namespace change causes a fresh lookup for existing identities during rollout; concurrent KV operations remain eventually consistent.
