### PR TITLE
feat(data): accept atomic finalized basket captures

### DIFF
--- a/docs/root-basket-capture-receiver.md
+++ b/docs/root-basket-capture-receiver.md
@@ -1,0 +1,95 @@
+# Internal Root basket capture acceptance
+
+`POST /api/v1/internal/root-basket-capture-sync` accepts one complete
+`RootBasketCapture` observation. The edge forwards the request to the protected
+receiver. `ROOT_BASKET_CAPTURE_SYNC_SECRET` is optional: without it the receiver
+returns 503 and does not read the body or open storage. When configured, the
+`x-root-basket-capture-sync-token` header must match it. This delivery does not
+configure that secret, activate collection, schedule work, or expose a public
+basket read route.
+
+Apply migrations 0036 and 0037 before deploying the receiver. Its freshness
+classification includes the completion table, but has no scheduled arrival
+expectation until a producer is explicitly activated.
+
+## Acceptance bounds
+
+The receiver counts streamed bytes and rejects requests larger than **8,000,000
+bytes**, even if `Content-Length` is absent or understates the body. Invalid
+UTF-8, malformed JSON, missing parts, unsupported runtime/decoder versions,
+duplicate keys, inconsistent counts and broken cursor chains are rejected.
+Oversized input is rejected whole; it is never truncated into an observation.
+
+The initial work ceilings are **256 page receipts, 2,048 funds, and 32,768 total
+holding and target rows**. These limits and the byte cap are bounded defaults;
+they have **not been sized against production captures**. A future collector
+must measure complete capture sizes before activation and handle rejection
+without publishing a partial capture.
+
+Inserts use at most 1,000 rows per statement. Each batch uses four PostgreSQL
+parameters through a typed JSON recordset, independently of its column count.
+The bounds permit at most 41 statements inside the acceptance transaction,
+followed by one receipt-identity read. No external RPC calls run in the receiver.
+
+## Identity, completion and recovery
+
+The existing source identity is network genesis hash, finalized block hash and
+decoder version. A SHA-256 digest covers the schema-normalized observation:
+network label and genesis, finalized hash and height, runtime and API versions,
+decoder, metadata hash, index, every ordered page receipt, and every fund,
+holding, target and baseline value. Object construction order and fund/child
+array order do not alter the digest. Attempt UUID and start/finish timestamps
+are excluded so the same observation can be retried without rewriting the first
+accepted provenance.
+
+One producer-store connection holds a transaction-scoped source/decoder lock,
+checks replay identity, writes all row families, verifies persisted counts and
+cursor continuity, and inserts an immutable completion receipt. A completeness
+failure throws before commit. Completion freezes the observation and child
+rows. Child mutations lock their parent capture before checking completion;
+moving a child locks both parents in a stable order. This prevents a concurrent
+child mutation from committing after a completion check. The receipt-ID read
+after commit does not decide completeness.
+
+An identical retry returns the first accepted capture ID and digest with
+`replayed: true`; its attempt timestamps and acceptance time stay unchanged.
+Changed content at the same source identity, a reused attempt ID for another
+observation, an incomplete pre-existing observation, or a different finalized
+hash at the same height is a 409 conflict. Conflicting observations require
+investigation; retrying them cannot replace accepted data.
+
+If simultaneous captures reuse one attempt UUID across different network-genesis
+scopes, the losing transaction can initially return 503 from the UUID uniqueness
+constraint. It commits no data. Retrying that same observation after the winning
+commit resolves to 409; this first-response classification limit does not permit
+overwriting the accepted capture.
+
+The current pointer advances only to a greater finalized height within the same
+network-genesis/decoder scope. Valid older captures can be retained as history
+without regressing current data. A transaction failure rolls back all newly
+written rows and preserves the previous current capture.
+
+A 200 response contains `ok`, `capture_id`, `content_sha256` and `replayed`.
+Authentication failures return 401, invalid captures 400, acceptance-budget
+violations 413, and unavailable storage or unacknowledged writes 503. After a
+503 or an interrupted response, retry the same observation: even if the earlier
+transaction committed before its response was lost, replay resolves the
+original receipt. Receipt acceptance confirms persisted observations and their
+source metadata; it does not independently verify chain finality or valuation.
+
+## Local verification
+
+The portable PGlite tests execute both migrations and the same producer-store
+transaction statements used by the receiver. They cover exact quantities,
+batching, complete empty parts, stored-count/cursor corruption, rollback and
+immutable replay through the protected Worker and edge proxy.
+
+`tests/root-basket-capture-concurrency.test.ts` additionally uses PostgreSQL
+server tools discovered through `pg_config --bindir`. As a non-root user with
+those tools installed, it starts a disposable cluster on a temporary Unix
+socket with TCP disabled, then verifies actual advisory-lock contention between
+independent connections. Identical retries, conflicting data and source hashes,
+late/newer captures, a failed first writer, and concurrent child mutations are
+covered. The cluster is
+removed after the tests. Hosts without server tools explicitly skip these eleven
+cases; they still run the portable transaction and receiver suites.

--- a/migrations/neon/0037_root_basket_capture_completion.sql
+++ b/migrations/neon/0037_root_basket_capture_completion.sql
@@ -1,0 +1,148 @@
+-- Completion is verified in the same transaction as all observation writes.
+-- No reader or scheduled producer is enabled by this migration.
+CREATE TABLE IF NOT EXISTS root_basket_capture_completions (
+  capture_id UUID PRIMARY KEY REFERENCES root_basket_captures (capture_id),
+  content_sha256 root_basket_hash32 NOT NULL,
+  accepted_at_ms root_basket_u64 NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS root_basket_current (
+  network_genesis_hash root_basket_hash32 NOT NULL,
+  decoder_version TEXT NOT NULL,
+  capture_id UUID NOT NULL REFERENCES root_basket_capture_completions (capture_id),
+  PRIMARY KEY (network_genesis_hash, decoder_version)
+);
+
+CREATE OR REPLACE FUNCTION root_basket_preserve_completion() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' OR NEW IS DISTINCT FROM OLD THEN
+    RAISE EXCEPTION 'root basket completion is immutable' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS root_basket_completion_immutable ON root_basket_capture_completions;
+CREATE TRIGGER root_basket_completion_immutable
+  BEFORE UPDATE OR DELETE ON root_basket_capture_completions
+  FOR EACH ROW EXECUTE FUNCTION root_basket_preserve_completion();
+
+CREATE OR REPLACE FUNCTION root_basket_preserve_completed_observation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE id UUID; next_id UUID;
+BEGIN
+  id := CASE WHEN TG_OP = 'INSERT' THEN NEW.capture_id ELSE OLD.capture_id END;
+  next_id := CASE WHEN TG_OP = 'UPDATE' THEN NEW.capture_id ELSE id END;
+  -- Row mutation already locks a manifest itself. Child writes must take the
+  -- same parent lock as completion BEFORE checking the receipt, including both
+  -- parents in deterministic order when moving a child between captures.
+  IF TG_TABLE_NAME <> 'root_basket_captures' THEN
+    PERFORM capture_id FROM root_basket_captures
+      WHERE capture_id IN (id, next_id) ORDER BY capture_id FOR UPDATE;
+  END IF;
+  IF EXISTS (SELECT 1 FROM root_basket_capture_completions WHERE capture_id IN (id, next_id)) THEN
+    RAISE EXCEPTION 'completed root basket observation is immutable' USING ERRCODE = '23514';
+  END IF;
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+DECLARE table_name TEXT;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY['root_basket_captures', 'root_basket_capture_pages',
+    'root_basket_fund_snapshots', 'root_basket_holdings', 'root_basket_targets'] LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS root_basket_completed_immutable ON %I', table_name);
+    EXECUTE format('CREATE TRIGGER root_basket_completed_immutable BEFORE INSERT OR UPDATE OR DELETE ON %I
+      FOR EACH ROW EXECUTE FUNCTION root_basket_preserve_completed_observation()', table_name);
+  END LOOP;
+END;
+$$;
+
+-- Serialize captures within one source/decoder scope. An identical observation
+-- can arrive under another attempt ID; retain the first accepted provenance.
+CREATE OR REPLACE FUNCTION root_basket_check_replay(payload JSONB, digest root_basket_hash32)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE existing root_basket_captures%ROWTYPE; receipt root_basket_capture_completions%ROWTYPE;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    (payload->>'network_genesis_hash') || ':' || (payload->>'decoder_version'), 0));
+  IF EXISTS (SELECT 1 FROM root_basket_captures
+    WHERE capture_id = (payload->>'capture_id')::uuid
+      AND (network_genesis_hash <> payload->>'network_genesis_hash'
+        OR finalized_block_hash <> payload->>'finalized_block_hash'
+        OR decoder_version <> payload->>'decoder_version')) THEN
+    RAISE EXCEPTION 'ROOT_BASKET_CAPTURE_CONFLICT: attempt ID already belongs to another observation';
+  END IF;
+  IF EXISTS (SELECT 1 FROM root_basket_captures
+    WHERE network_genesis_hash = payload->>'network_genesis_hash'
+      AND decoder_version = payload->>'decoder_version'
+      AND finalized_block = (payload->>'finalized_block')::numeric
+      AND finalized_block_hash <> payload->>'finalized_block_hash') THEN
+    RAISE EXCEPTION 'ROOT_BASKET_CAPTURE_CONFLICT: finalized height has a different hash';
+  END IF;
+  SELECT * INTO existing FROM root_basket_captures
+    WHERE network_genesis_hash = payload->>'network_genesis_hash'
+      AND finalized_block_hash = payload->>'finalized_block_hash'
+      AND decoder_version = payload->>'decoder_version';
+  IF FOUND THEN
+    SELECT * INTO receipt FROM root_basket_capture_completions WHERE capture_id = existing.capture_id;
+    IF NOT FOUND OR receipt.content_sha256 <> digest THEN
+      RAISE EXCEPTION 'ROOT_BASKET_CAPTURE_CONFLICT: observation is incomplete or content differs';
+    END IF;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION root_basket_check_current() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE candidate root_basket_captures%ROWTYPE; previous_height NUMERIC;
+BEGIN
+  SELECT * INTO STRICT candidate FROM root_basket_captures WHERE capture_id = NEW.capture_id;
+  IF candidate.network_genesis_hash <> NEW.network_genesis_hash OR candidate.decoder_version <> NEW.decoder_version THEN
+    RAISE EXCEPTION 'root basket current scope mismatch' USING ERRCODE = '23514';
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    SELECT finalized_block INTO STRICT previous_height FROM root_basket_captures WHERE capture_id = OLD.capture_id;
+    IF NEW.network_genesis_hash <> OLD.network_genesis_hash OR NEW.decoder_version <> OLD.decoder_version
+      OR candidate.finalized_block < previous_height
+      OR (candidate.finalized_block = previous_height AND NEW.capture_id <> OLD.capture_id) THEN
+      RAISE EXCEPTION 'root basket current source order cannot regress' USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS root_basket_current_ordered ON root_basket_current;
+CREATE TRIGGER root_basket_current_ordered BEFORE INSERT OR UPDATE ON root_basket_current
+  FOR EACH ROW EXECUTE FUNCTION root_basket_check_current();
+
+CREATE OR REPLACE FUNCTION root_basket_complete_capture(id UUID, digest root_basket_hash32, accepted root_basket_u64)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE manifest root_basket_captures%ROWTYPE;
+BEGIN
+  SELECT * INTO STRICT manifest FROM root_basket_captures WHERE capture_id = id FOR UPDATE;
+  IF EXISTS (SELECT 1 FROM root_basket_capture_completions WHERE capture_id = id AND content_sha256 = digest) THEN
+    RETURN;
+  END IF;
+  IF (SELECT count(*) FROM root_basket_capture_pages WHERE capture_id = id) <> manifest.expected_pages
+    OR (SELECT count(*) FROM root_basket_fund_snapshots WHERE capture_id = id) <> manifest.expected_funds
+    OR EXISTS (SELECT 1 FROM root_basket_capture_pages p
+      LEFT JOIN root_basket_capture_pages previous ON previous.capture_id = p.capture_id AND previous.page_index = p.page_index - 1
+      WHERE p.capture_id = id AND (p.page_index >= manifest.expected_pages
+        OR (p.page_index = manifest.expected_pages - 1) <> (p.next_after IS NULL)
+        OR (p.page_index > 0 AND (previous.page_index IS NULL OR p.start_after IS DISTINCT FROM previous.next_after))
+        OR p.fund_count <> (SELECT count(*) FROM root_basket_fund_snapshots f WHERE f.capture_id = id AND f.page_index = p.page_index)))
+    OR EXISTS (SELECT 1 FROM root_basket_fund_snapshots f WHERE f.capture_id = id AND (
+      f.first_block > manifest.finalized_block
+      OR f.holdings_count <> (SELECT count(*) FROM root_basket_holdings h WHERE h.capture_id = id AND h.hotkey = f.hotkey)
+      OR f.targets_count <> (SELECT count(*) FROM root_basket_targets t WHERE t.capture_id = id AND t.hotkey = f.hotkey))) THEN
+    RAISE EXCEPTION 'root basket persisted capture is incomplete' USING ERRCODE = '23514';
+  END IF;
+  INSERT INTO root_basket_capture_completions VALUES (id, digest, accepted);
+  INSERT INTO root_basket_current VALUES (manifest.network_genesis_hash, manifest.decoder_version, id)
+    ON CONFLICT (network_genesis_hash, decoder_version) DO UPDATE SET capture_id = EXCLUDED.capture_id
+    WHERE (SELECT finalized_block FROM root_basket_captures WHERE capture_id = root_basket_current.capture_id) < manifest.finalized_block;
+END;
+$$;

--- a/src/root-basket-capture-sync.ts
+++ b/src/root-basket-capture-sync.ts
@@ -1,0 +1,110 @@
+import { RootBasketCaptureSchema } from "../schemas-src/root-basket-capture.ts";
+import { createProducerStore, type ProducerStore } from "./producer-store.ts";
+import { timingSafeEqual } from "./webhooks.ts";
+import {
+  rootBasketCaptureFits,
+  writeRootBasketCapture,
+} from "./root-basket-capture-write.ts";
+
+// Matches adjacent protected sync request caps. This initial bounded receiver
+// has not yet been sized against production captures; excess is rejected whole.
+export const ROOT_BASKET_CAPTURE_MAX_BYTES = 8_000_000;
+const TOKEN_HEADER = "x-root-basket-capture-sync-token";
+
+interface SyncEnv {
+  ROOT_BASKET_CAPTURE_SYNC_SECRET?: string;
+  HYPERDRIVE?: { connectionString: string };
+}
+
+export async function handleRootBasketCaptureSync(
+  request: Request,
+  env: SyncEnv,
+  deps: {
+    store?: ProducerStore;
+    now?: () => number;
+    onError?: (error: unknown) => Promise<unknown>;
+  } = {},
+): Promise<Response> {
+  const fail = (status: number, error: string) =>
+    Response.json({ error }, { status });
+  if (!env.ROOT_BASKET_CAPTURE_SYNC_SECRET)
+    return fail(503, "root basket capture sync is not provisioned");
+  if (
+    !timingSafeEqual(
+      request.headers.get(TOKEN_HEADER),
+      env.ROOT_BASKET_CAPTURE_SYNC_SECRET,
+    )
+  ) {
+    return fail(401, `provide a valid ${TOKEN_HEADER} header`);
+  }
+  const length = request.headers.get("content-length");
+  if (
+    length !== null &&
+    (!/^\d+$/.test(length) || Number(length) > ROOT_BASKET_CAPTURE_MAX_BYTES)
+  ) {
+    return fail(413, "root basket capture body exceeds byte limit");
+  }
+  if (!request.body)
+    return fail(400, "body must be a complete root basket capture");
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
+  let text = "";
+  let bytes = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > ROOT_BASKET_CAPTURE_MAX_BYTES) {
+        await reader.cancel().catch(() => {});
+        return fail(413, "root basket capture body exceeds byte limit");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+  } catch {
+    return fail(400, "root basket capture body could not be read");
+  } finally {
+    reader.releaseLock();
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return fail(400, "body must be JSON");
+  }
+  const parsed = RootBasketCaptureSchema.safeParse(body);
+  if (!parsed.success)
+    return fail(400, "body must be a complete root basket capture");
+  if (!rootBasketCaptureFits(parsed.data))
+    return fail(413, "root basket capture exceeds row limits");
+  if (!deps.store && !env.HYPERDRIVE?.connectionString)
+    return fail(503, "root basket capture store is unavailable");
+  const store =
+    deps.store ?? createProducerStore(env.HYPERDRIVE!.connectionString);
+  try {
+    const receipt = await writeRootBasketCapture(
+      store,
+      parsed.data,
+      (deps.now ?? Date.now)(),
+    );
+    return Response.json({ ok: true, ...receipt });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith("ROOT_BASKET_CAPTURE_CONFLICT:")
+    ) {
+      return fail(
+        409,
+        "root basket capture conflicts with an accepted observation",
+      );
+    }
+    await deps.onError?.(error).catch(() => {});
+    return fail(
+      503,
+      "root basket capture was not acknowledged; retry the same observation",
+    );
+  } finally {
+    await store.close();
+  }
+}

--- a/src/root-basket-capture-write.ts
+++ b/src/root-basket-capture-write.ts
@@ -1,0 +1,227 @@
+import { createHash } from "node:crypto";
+import type { z } from "zod";
+import { RootBasketCaptureSchema } from "../schemas-src/root-basket-capture.ts";
+import type { ProducerStatement, ProducerStore } from "./producer-store.ts";
+
+type Capture = z.infer<typeof RootBasketCaptureSchema>;
+
+// Receiver work ceilings, independent of the transport byte cap. These are
+// initial acceptance bounds, not a measurement of production capture sizes.
+export const ROOT_BASKET_CAPTURE_LIMITS = {
+  pages: 256,
+  funds: 2_048,
+  children: 32_768,
+} as const;
+const INSERT_BATCH_ROWS = 1_000;
+
+export function rootBasketCaptureFits(capture: Capture): boolean {
+  return (
+    capture.pages.length <= ROOT_BASKET_CAPTURE_LIMITS.pages &&
+    capture.funds.length <= ROOT_BASKET_CAPTURE_LIMITS.funds &&
+    capture.funds.reduce(
+      (n, fund) => n + fund.holdings.length + fund.targets.length,
+      0,
+    ) <= ROOT_BASKET_CAPTURE_LIMITS.children
+  );
+}
+
+/** Object field order and unordered fund/child arrays do not define identity.
+ * Attempt IDs/times are excluded; first accepted provenance remains immutable.
+ * Source height/hash, metadata, index, cursor receipts and all values are included.
+ */
+export function rootBasketCaptureDigest(capture: Capture): string {
+  const { capture_id, started_at_ms, finished_at_ms, ...observation } = capture;
+  void capture_id;
+  void started_at_ms;
+  void finished_at_ms;
+  const normalized = {
+    ...observation,
+    funds: [...capture.funds]
+      .sort((a, b) => a.hotkey.localeCompare(b.hotkey))
+      .map((fund) => ({
+        ...fund,
+        holdings: [...fund.holdings].sort((a, b) => a.netuid - b.netuid),
+        targets: [...fund.targets].sort((a, b) => a.netuid - b.netuid),
+      })),
+  };
+  // The schema has constructed every object in declared field order.
+  return `0x${createHash("sha256").update(JSON.stringify(normalized)).digest("hex")}`;
+}
+
+const SOURCE = `network_genesis_hash = $2 AND finalized_block_hash = $3 AND decoder_version = $4`;
+const CAPTURE_ID = `(SELECT capture_id FROM root_basket_captures WHERE ${SOURCE})`;
+const UNCOMPLETED = `NOT EXISTS (SELECT 1 FROM root_basket_capture_completions WHERE capture_id = ${CAPTURE_ID})`;
+
+/** Only fixed local table/column definitions reach this statement builder.
+ * Each batch spends four bind parameters regardless of its row/column count.
+ */
+function insertBatches(
+  capture: Capture,
+  table: string,
+  columns: readonly (readonly [string, string])[],
+  rows: readonly Record<string, unknown>[],
+): ProducerStatement[] {
+  const statements: ProducerStatement[] = [];
+  for (let start = 0; start < rows.length; start += INSERT_BATCH_ROWS) {
+    statements.push({
+      text: `INSERT INTO ${table} (capture_id, ${columns.map(([name]) => name).join(", ")})
+        SELECT ${CAPTURE_ID}, ${columns.map(([name]) => `r.${name}`).join(", ")}
+        FROM jsonb_to_recordset($1::jsonb) AS r(${columns.map(([name, type]) => `${name} ${type}`).join(", ")})
+        WHERE ${UNCOMPLETED}`,
+      values: [
+        JSON.stringify(rows.slice(start, start + INSERT_BATCH_ROWS)),
+        capture.network_genesis_hash,
+        capture.finalized_block_hash,
+        capture.decoder_version,
+      ],
+    });
+  }
+  return statements;
+}
+
+export async function writeRootBasketCapture(
+  store: ProducerStore,
+  input: unknown,
+  acceptedAtMs: number,
+): Promise<{ capture_id: string; content_sha256: string; replayed: boolean }> {
+  const capture = RootBasketCaptureSchema.parse(input);
+  if (!rootBasketCaptureFits(capture))
+    throw new Error("root basket capture exceeds row limits");
+  const digest = rootBasketCaptureDigest(capture);
+  const metadata = {
+    capture_id: capture.capture_id,
+    network: capture.network,
+    network_genesis_hash: capture.network_genesis_hash,
+    finalized_block_hash: capture.finalized_block_hash,
+    finalized_block: capture.finalized_block,
+    runtime_spec_version: capture.runtime_spec_version,
+    runtime_api_version: capture.runtime_api_version,
+    decoder_version: capture.decoder_version,
+    metadata_sha256: capture.metadata_sha256,
+    started_at_ms: capture.started_at_ms,
+    finished_at_ms: capture.finished_at_ms,
+    expected_pages: capture.expected_pages,
+    expected_funds: capture.expected_funds,
+    index_status: capture.index.status,
+    index_completed_block: capture.index.completed_block,
+    bag_index_q64_bits: capture.index.bag_q64_bits,
+    stake_index_q64_bits: capture.index.stake_q64_bits,
+  };
+  const statements: ProducerStatement[] = [
+    {
+      text: "SELECT root_basket_check_replay($1::jsonb, $2)",
+      values: [JSON.stringify(metadata), digest],
+    },
+    {
+      text: `INSERT INTO root_basket_captures (${Object.keys(metadata).join(", ")})
+        SELECT $1::uuid, $2::text, $3::text, $4::text, $5::numeric,
+          $6::numeric, $7::numeric, $8::text, $9::text, $10::numeric,
+          $11::numeric, $12::numeric, $13::numeric, $14::text, $15::numeric,
+          $16::numeric, $17::numeric
+        WHERE NOT EXISTS (SELECT 1 FROM root_basket_captures
+          WHERE network_genesis_hash = $3 AND finalized_block_hash = $4 AND decoder_version = $8)`,
+      values: Object.values(metadata),
+    },
+    ...insertBatches(
+      capture,
+      "root_basket_capture_pages",
+      [
+        ["page_index", "numeric"],
+        ["start_after", "text"],
+        ["next_after", "text"],
+        ["response_sha256", "text"],
+        ["fund_count", "numeric"],
+      ],
+      capture.pages,
+    ),
+    ...insertBatches(
+      capture,
+      "root_basket_fund_snapshots",
+      [
+        ["hotkey", "text"],
+        ["page_index", "numeric"],
+        ["shares_atomic", "numeric"],
+        ["spot_nav_rao", "numeric"],
+        ["realizable_nav_rao", "numeric"],
+        ["deposited_rao", "numeric"],
+        ["redeemed_rao", "numeric"],
+        ["raw_spot_price_q64_bits", "numeric"],
+        ["display_price_q64_bits", "numeric"],
+        ["display_shares_q64_bits", "numeric"],
+        ["stake_price_q64_bits", "numeric"],
+        ["staker_twr_q64_bits", "numeric"],
+        ["pending_entitlement_q64_bits", "numeric"],
+        ["provisional", "boolean"],
+        ["first_block", "numeric"],
+        ["price_divisor_q64_bits", "numeric"],
+        ["rate0_q32_bits", "numeric"],
+        ["tr_splice_q64_bits", "numeric"],
+        ["holdings_count", "numeric"],
+        ["targets_count", "numeric"],
+      ],
+      capture.funds.map(({ baseline, holdings, targets, ...fund }) => ({
+        ...fund,
+        ...baseline,
+        holdings_count: holdings.length,
+        targets_count: targets.length,
+      })),
+    ),
+    ...insertBatches(
+      capture,
+      "root_basket_holdings",
+      [
+        ["hotkey", "text"],
+        ["netuid", "numeric"],
+        ["quantity_atomic", "numeric"],
+        ["quantity_unit", "text"],
+        ["spot_value_rao", "numeric"],
+        ["realizable_value_rao", "numeric"],
+      ],
+      capture.funds.flatMap((fund) =>
+        fund.holdings.map((row) => ({ hotkey: fund.hotkey, ...row })),
+      ),
+    ),
+    ...insertBatches(
+      capture,
+      "root_basket_targets",
+      [
+        ["hotkey", "text"],
+        ["netuid", "numeric"],
+        ["weight", "numeric"],
+      ],
+      capture.funds.flatMap((fund) =>
+        fund.targets.map((row) => ({ hotkey: fund.hotkey, ...row })),
+      ),
+    ),
+    {
+      text: `SELECT root_basket_complete_capture(
+        (SELECT capture_id FROM root_basket_captures WHERE network_genesis_hash = $1
+          AND finalized_block_hash = $2 AND decoder_version = $3), $4, $5)`,
+      values: [
+        capture.network_genesis_hash,
+        capture.finalized_block_hash,
+        capture.decoder_version,
+        digest,
+        String(acceptedAtMs),
+      ],
+    },
+  ];
+  const result = await store.transaction(statements);
+  // Completeness was checked inside the transaction by a function that throws.
+  // This read only resolves the retained ID after an identical replay.
+  const receipt = await store.first<{ capture_id: string }>(
+    `SELECT capture_id FROM root_basket_captures WHERE network_genesis_hash = $1
+      AND finalized_block_hash = $2 AND decoder_version = $3`,
+    [
+      capture.network_genesis_hash,
+      capture.finalized_block_hash,
+      capture.decoder_version,
+    ],
+  );
+  if (!receipt) throw new Error("accepted root basket capture is absent");
+  return {
+    capture_id: receipt.capture_id,
+    content_sha256: digest,
+    replayed: result[1]!.changes === 0,
+  };
+}

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -762,6 +762,18 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     reason:
       "no child timestamp; no producer or published current view (#12019)",
   },
+  root_basket_capture_completions: {
+    column: "accepted_at_ms",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "protected capture receiver only; no scheduled producer (#12019)",
+  },
+  root_basket_current: {
+    column: "",
+    kind: "ms",
+    maxAgeMs: null,
+    reason: "capture pointer has no timestamp; no scheduled producer (#12019)",
+  },
 
   // Written by scripts/neon-migrate.ts, once per migration. The same "only
   // when a human acts" class as api_keys above.

--- a/tests/root-basket-capture-concurrency.test.ts
+++ b/tests/root-basket-capture-concurrency.test.ts
@@ -1,0 +1,368 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Client } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, test } from "vitest";
+import {
+  createProducerStore,
+  type ProducerStore,
+} from "../src/producer-store.ts";
+import {
+  rootBasketCaptureDigest,
+  writeRootBasketCapture,
+} from "../src/root-basket-capture-write.ts";
+import { RootBasketCaptureSchema } from "../schemas-src/root-basket-capture.ts";
+import { syntheticBasketCapture } from "./fixtures/root-basket-capture.ts";
+
+// PGlite exercises constraints and rollback in the companion suite but has one
+// connection. These real lock races use an ephemeral Unix-socket-only cluster:
+// no configured database, remote connection, persistent data or TCP listener.
+// Run with PostgreSQL server tools installed as a non-root user. Other hosts
+// explicitly skip these cases, while the portable PGlite suite always runs.
+const bindir = spawnSync("pg_config", ["--bindir"], {
+  encoding: "utf8",
+}).stdout?.trim();
+const available =
+  !!bindir &&
+  existsSync(path.join(bindir, "initdb")) &&
+  existsSync(path.join(bindir, "pg_ctl")) &&
+  process.getuid?.() !== 0;
+let directory: string;
+let admin: Client;
+const stores: ProducerStore[] = [];
+
+describe.skipIf(!available)(
+  "capture publication with concurrent PostgreSQL connections",
+  () => {
+    beforeAll(async () => {
+      directory = mkdtempSync(path.join(tmpdir(), "basket-race-"));
+      execFileSync(
+        path.join(bindir!, "initdb"),
+        [
+          "-D",
+          path.join(directory, "data"),
+          "-U",
+          "capture_test",
+          "-A",
+          "trust",
+          "--no-locale",
+        ],
+        { stdio: "ignore" },
+      );
+      execFileSync(
+        path.join(bindir!, "pg_ctl"),
+        [
+          "-D",
+          path.join(directory, "data"),
+          "-l",
+          path.join(directory, "server.log"),
+          "-o",
+          `-c listen_addresses='' -c unix_socket_directories='${directory}'`,
+          "-w",
+          "start",
+        ],
+        { stdio: "ignore" },
+      );
+      admin = new Client({
+        host: directory,
+        user: "capture_test",
+        database: "postgres",
+      });
+      await admin.connect();
+      for (const file of [
+        "0036_root_basket_observations.sql",
+        "0037_root_basket_capture_completion.sql",
+      ])
+        await admin.query(readFileSync(`migrations/neon/${file}`, "utf8"));
+    }, 30_000);
+    beforeEach(async () => {
+      await admin.query("TRUNCATE root_basket_captures CASCADE");
+    });
+    afterAll(async () => {
+      await Promise.all(stores.map((store) => store.close()));
+      await admin?.end();
+      if (directory) {
+        spawnSync(
+          path.join(bindir!, "pg_ctl"),
+          ["-D", path.join(directory, "data"), "-m", "immediate", "-w", "stop"],
+          { stdio: "ignore" },
+        );
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
+
+    function store(name: string, locked?: () => Promise<void>) {
+      const client = new Client({
+        host: directory,
+        user: "capture_test",
+        database: "postgres",
+        application_name: name,
+      });
+      const result = createProducerStore("unused-local-test", {
+        clientFactory: () => ({
+          connect: () => client.connect(),
+          end: () => client.end(),
+          query: async (sql, values) => {
+            const result = await client.query(sql, values);
+            if (sql.startsWith("SELECT root_basket_check_replay"))
+              await locked?.();
+            return result;
+          },
+        }),
+      });
+      stores.push(result);
+      return result;
+    }
+
+    async function assertWaiting(name: string, event = "advisory") {
+      for (let i = 0; i < 300; i++) {
+        const result = await admin.query(
+          "SELECT wait_event FROM pg_stat_activity WHERE application_name = $1",
+          [name],
+        );
+        if (result.rows[0]?.wait_event === event) return;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.fail(
+        "the second writer never waited on the source-scope transaction lock",
+      );
+    }
+
+    async function stageIncomplete(capture = syntheticBasketCapture()) {
+      // Model rows that predate the receiver: deliberately omit completion in
+      // fixture setup. The real receiver rejects this pre-existing partial state.
+      const underlying = store("fixture");
+      await writeRootBasketCapture(
+        {
+          ...underlying,
+          transaction: (statements) =>
+            underlying.transaction(
+              statements.filter(
+                (statement) =>
+                  !statement.text.startsWith(
+                    "SELECT root_basket_complete_capture",
+                  ),
+              ),
+            ),
+        },
+        capture,
+        3000,
+      );
+      return capture;
+    }
+
+    for (const mutation of ["update", "delete", "insert", "move"] as const) {
+      test(`a concurrent child ${mutation} cannot commit after completion`, async () => {
+        const capture = await stageIncomplete();
+        const other = {
+          ...structuredClone(capture),
+          capture_id: "00000000-0000-4000-8000-000000000002",
+          finalized_block_hash: `0x${"ee".repeat(32)}`,
+          finalized_block: "501",
+        };
+        if (mutation === "move") await stageIncomplete(other);
+        const completing = new Client({
+          host: directory,
+          user: "capture_test",
+          database: "postgres",
+        });
+        const mutating = new Client({
+          host: directory,
+          user: "capture_test",
+          database: "postgres",
+          application_name: "mutating",
+        });
+        await completing.connect();
+        await mutating.connect();
+        try {
+          await completing.query("BEGIN");
+          await completing.query(
+            "SELECT root_basket_complete_capture($1, $2, 3000)",
+            [
+              capture.capture_id,
+              rootBasketCaptureDigest(RootBasketCaptureSchema.parse(capture)),
+            ],
+          );
+          await mutating.query("BEGIN");
+          const sql =
+            mutation === "update"
+              ? "UPDATE root_basket_holdings SET quantity_atomic = 17 WHERE capture_id = $1"
+              : mutation === "delete"
+                ? "DELETE FROM root_basket_holdings WHERE capture_id = $1"
+                : mutation === "move"
+                  ? "UPDATE root_basket_holdings SET capture_id = $1 WHERE capture_id = $2"
+                  : "INSERT INTO root_basket_holdings VALUES ($1, $2, 51, 1, 'alpha_atomic', 1, 1)";
+          const values =
+            mutation === "move"
+              ? [capture.capture_id, other.capture_id]
+              : mutation === "insert"
+                ? [capture.capture_id, capture.funds[0]!.hotkey]
+                : [capture.capture_id];
+          const result = mutating.query(sql, values).then(
+            () => null,
+            (error: unknown) => error,
+          );
+          try {
+            await assertWaiting("mutating", "transactionid");
+          } finally {
+            await completing.query("COMMIT");
+          }
+          assert.match(
+            String(await result),
+            /completed root basket observation is immutable/,
+          );
+          await mutating.query("ROLLBACK");
+          const held = await admin.query(
+            "SELECT quantity_atomic::text AS quantity FROM root_basket_holdings WHERE capture_id = $1 AND netuid = 0",
+            [capture.capture_id],
+          );
+          assert.equal(held.rows[0].quantity, "1000000000");
+        } finally {
+          await completing.query("ROLLBACK");
+          await mutating.query("ROLLBACK");
+          await completing.end();
+          await mutating.end();
+        }
+      });
+    }
+
+    test("completion waits for an earlier child delete and rejects the now-incomplete rows", async () => {
+      const capture = await stageIncomplete();
+      const deleting = new Client({
+        host: directory,
+        user: "capture_test",
+        database: "postgres",
+      });
+      const completing = new Client({
+        host: directory,
+        user: "capture_test",
+        database: "postgres",
+        application_name: "completing",
+      });
+      await deleting.connect();
+      await completing.connect();
+      try {
+        await deleting.query("BEGIN");
+        await deleting.query(
+          "DELETE FROM root_basket_holdings WHERE capture_id = $1 AND netuid = 0",
+          [capture.capture_id],
+        );
+        const result = completing
+          .query("SELECT root_basket_complete_capture($1, $2, 3000)", [
+            capture.capture_id,
+            rootBasketCaptureDigest(RootBasketCaptureSchema.parse(capture)),
+          ])
+          .then(
+            () => null,
+            (error: unknown) => error,
+          );
+        try {
+          await assertWaiting("completing", "transactionid");
+        } finally {
+          await deleting.query("COMMIT");
+        }
+        assert.match(String(await result), /persisted capture is incomplete/);
+        assert.equal(
+          (
+            await admin.query(
+              "SELECT count(*)::int AS n FROM root_basket_capture_completions",
+            )
+          ).rows[0].n,
+          0,
+        );
+      } finally {
+        await deleting.query("ROLLBACK");
+        await deleting.end();
+        await completing.end();
+      }
+    });
+
+    for (const scenario of [
+      "identical",
+      "changed_content",
+      "same_height_hash",
+      "late_history",
+      "newer",
+      "first_rollback",
+    ] as const) {
+      test(`serializes ${scenario} without partial publication or current-pointer regression`, async () => {
+        const first = syntheticBasketCapture();
+        const second = {
+          ...structuredClone(first),
+          capture_id: "00000000-0000-4000-8000-000000000002",
+          started_at_ms: "4000",
+          finished_at_ms: "5000",
+        };
+        if (scenario === "changed_content")
+          second.metadata_sha256 = `0x${"ee".repeat(32)}`;
+        if (["same_height_hash", "late_history", "newer"].includes(scenario))
+          second.finalized_block_hash = `0x${"ee".repeat(32)}`;
+        if (scenario === "late_history") second.finalized_block = "499";
+        if (scenario === "newer") second.finalized_block = "501";
+        let release!: () => void;
+        let locked!: () => void;
+        const barrier = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const ready = new Promise<void>((resolve) => {
+          locked = resolve;
+        });
+        const firstWrite = writeRootBasketCapture(
+          store("first", async () => {
+            locked();
+            await barrier;
+            if (scenario === "first_rollback")
+              throw new Error("injected pre-insert failure");
+          }),
+          first,
+          3000,
+        );
+        await ready;
+        const secondWrite = writeRootBasketCapture(
+          store("second"),
+          second,
+          6000,
+        );
+        const results = Promise.allSettled([firstWrite, secondWrite]);
+        try {
+          await assertWaiting("second");
+        } finally {
+          release();
+        }
+        const [a, b] = await results;
+        const conflicting =
+          scenario === "changed_content" || scenario === "same_height_hash";
+        assert.equal(
+          a.status,
+          scenario === "first_rollback" ? "rejected" : "fulfilled",
+        );
+        assert.equal(b.status, conflicting ? "rejected" : "fulfilled");
+        if (b.status === "rejected")
+          assert.match(String(b.reason), /ROOT_BASKET_CAPTURE_CONFLICT/);
+        if (scenario === "identical" && b.status === "fulfilled") {
+          assert.equal(b.value.capture_id, first.capture_id);
+          assert.equal(b.value.replayed, true);
+        }
+        const current = await admin.query(
+          "SELECT capture_id FROM root_basket_current",
+        );
+        assert.equal(
+          current.rows[0].capture_id,
+          scenario === "newer" || scenario === "first_rollback"
+            ? second.capture_id
+            : first.capture_id,
+        );
+        const receipts = await admin.query(
+          "SELECT count(*)::int AS n FROM root_basket_capture_completions",
+        );
+        assert.equal(
+          receipts.rows[0].n,
+          scenario === "late_history" || scenario === "newer" ? 2 : 1,
+        );
+        await Promise.all(stores.splice(0).map((store) => store.close()));
+      });
+    }
+  },
+);

--- a/tests/root-basket-capture-concurrency.test.ts
+++ b/tests/root-basket-capture-concurrency.test.ts
@@ -4,11 +4,16 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Client } from "pg";
-import { afterAll, beforeAll, beforeEach, describe, test } from "vitest";
 import {
-  createProducerStore,
-  type ProducerStore,
-} from "../src/producer-store.ts";
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  test,
+  vi,
+} from "vitest";
+import { createProducerStore } from "../src/producer-store.ts";
 import {
   rootBasketCaptureDigest,
   writeRootBasketCapture,
@@ -31,7 +36,38 @@ const available =
   process.getuid?.() !== 0;
 let directory: string;
 let admin: Client;
-const stores: ProducerStore[] = [];
+const clients = new Set<Client>();
+const barriers = new Set<() => void>();
+
+function client(name: string) {
+  const connection = new Client({
+    host: directory,
+    user: "capture_test",
+    database: "postgres",
+    application_name: name,
+    // A server-side bound actually cancels blocked SQL; a client-side promise
+    // timeout could leave the transaction blocking the next test's TRUNCATE.
+    statement_timeout: 5_000,
+  });
+  clients.add(connection);
+  return connection;
+}
+
+async function closeClients() {
+  for (const release of barriers) release();
+  barriers.clear();
+  const pending = [...clients];
+  clients.clear();
+  // end() disconnects an active pg query and rolls back its transaction. Never
+  // enqueue ROLLBACK behind a blocked query or await the blocked client first.
+  const results = await Promise.allSettled(
+    pending.map((connection) => connection.end()),
+  );
+  const errors = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (errors.length) throw new AggregateError(errors, "closing race clients");
+}
 
 describe.skipIf(!available)(
   "capture publication with concurrent PostgreSQL connections",
@@ -69,6 +105,8 @@ describe.skipIf(!available)(
         host: directory,
         user: "capture_test",
         database: "postgres",
+        application_name: "observer",
+        statement_timeout: 5_000,
       });
       await admin.connect();
       for (const file of [
@@ -80,53 +118,66 @@ describe.skipIf(!available)(
     beforeEach(async () => {
       await admin.query("TRUNCATE root_basket_captures CASCADE");
     });
+    afterEach(closeClients);
     afterAll(async () => {
-      await Promise.all(stores.map((store) => store.close()));
-      await admin?.end();
-      if (directory) {
-        spawnSync(
-          path.join(bindir!, "pg_ctl"),
-          ["-D", path.join(directory, "data"), "-m", "immediate", "-w", "stop"],
-          { stdio: "ignore" },
-        );
-        rmSync(directory, { recursive: true, force: true });
+      try {
+        await closeClients();
+      } finally {
+        try {
+          await admin?.end();
+        } finally {
+          if (directory) {
+            spawnSync(
+              path.join(bindir!, "pg_ctl"),
+              [
+                "-D",
+                path.join(directory, "data"),
+                "-m",
+                "immediate",
+                "-w",
+                "stop",
+              ],
+              { stdio: "ignore" },
+            );
+            rmSync(directory, { recursive: true, force: true });
+          }
+        }
       }
     });
 
     function store(name: string, locked?: () => Promise<void>) {
-      const client = new Client({
-        host: directory,
-        user: "capture_test",
-        database: "postgres",
-        application_name: name,
-      });
+      const connection = client(name);
       const result = createProducerStore("unused-local-test", {
         clientFactory: () => ({
-          connect: () => client.connect(),
-          end: () => client.end(),
+          connect: () => connection.connect(),
+          end: () => connection.end(),
           query: async (sql, values) => {
-            const result = await client.query(sql, values);
+            const result = await connection.query(sql, values);
             if (sql.startsWith("SELECT root_basket_check_replay"))
               await locked?.();
             return result;
           },
         }),
       });
-      stores.push(result);
       return result;
     }
 
     async function assertWaiting(name: string, event = "advisory") {
       for (let i = 0; i < 300; i++) {
         const result = await admin.query(
-          "SELECT wait_event FROM pg_stat_activity WHERE application_name = $1",
+          "SELECT state, wait_event, pg_blocking_pids(pid) AS blockers, query FROM pg_stat_activity WHERE application_name = $1",
           [name],
         );
         if (result.rows[0]?.wait_event === event) return;
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        // Keep native lock coordination independent of shared-registry global
+        // timers. PostgreSQL advances this wait even if a test clock is frozen.
+        await admin.query("SELECT pg_sleep(0.01)");
       }
+      const activity = await admin.query(
+        "SELECT application_name, state, wait_event, pg_blocking_pids(pid) AS blockers, query FROM pg_stat_activity WHERE datname = current_database()",
+      );
       assert.fail(
-        "the second writer never waited on the source-scope transaction lock",
+        `expected ${name} to wait on ${event}: ${JSON.stringify(activity.rows)}`,
       );
     }
 
@@ -153,6 +204,101 @@ describe.skipIf(!available)(
       return capture;
     }
 
+    test("polling observes a later lock wait with frozen test timers", async () => {
+      const capture = await stageIncomplete();
+      const completing = client("completing");
+      const mutating = client("delayed-mutation");
+      await completing.connect();
+      await mutating.connect();
+      try {
+        await completing.query("BEGIN");
+        await completing.query(
+          "SELECT root_basket_complete_capture($1, $2, 3000)",
+          [
+            capture.capture_id,
+            rootBasketCaptureDigest(RootBasketCaptureSchema.parse(capture)),
+          ],
+        );
+        await mutating.query("BEGIN");
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        const waiting = assertWaiting("delayed-mutation", "transactionid");
+        // This observer query queues after the initial poll, proving it saw no
+        // lock wait before the mutation starts. A first-poll success cannot
+        // accidentally bypass the pacing path under test.
+        await admin.query("SELECT 1");
+        const result = mutating
+          .query(
+            "UPDATE root_basket_holdings SET quantity_atomic = 17 WHERE capture_id = $1",
+            [capture.capture_id],
+          )
+          .then(
+            () => null,
+            (error: unknown) => error,
+          );
+        await waiting;
+        await completing.query("COMMIT");
+        assert.match(
+          String(await result),
+          /completed root basket observation is immutable/,
+        );
+      } finally {
+        vi.useRealTimers();
+        await closeClients();
+      }
+    });
+
+    test("failed race cleanup disconnects a blocked mutation and releases the next reset", async () => {
+      const capture = await stageIncomplete();
+      const completing = client("completing");
+      const mutating = client("failed-mutation");
+      await completing.connect();
+      await mutating.connect();
+      let result: Promise<unknown> | undefined;
+      await assert.rejects(async () => {
+        try {
+          await completing.query("BEGIN");
+          await completing.query(
+            "SELECT root_basket_complete_capture($1, $2, 3000)",
+            [
+              capture.capture_id,
+              rootBasketCaptureDigest(RootBasketCaptureSchema.parse(capture)),
+            ],
+          );
+          await mutating.query("BEGIN");
+          result = mutating
+            .query("DELETE FROM root_basket_holdings WHERE capture_id = $1", [
+              capture.capture_id,
+            ])
+            .then(
+              () => null,
+              (error: unknown) => error,
+            );
+          await assertWaiting("failed-mutation", "transactionid");
+          assert.fail("injected race assertion failure");
+        } finally {
+          await closeClients();
+        }
+      }, /injected race assertion failure/);
+      assert.ok(await result, "the blocked mutation must be interrupted");
+      assert.equal(
+        (
+          await admin.query(
+            "SELECT count(*)::int AS n FROM root_basket_capture_completions",
+          )
+        ).rows[0].n,
+        0,
+      );
+      await admin.query("TRUNCATE root_basket_captures CASCADE");
+      assert.equal(
+        (
+          await admin.query(
+            "SELECT count(*)::int AS n FROM root_basket_captures",
+          )
+        ).rows[0].n,
+        0,
+      );
+    });
+
     for (const mutation of ["update", "delete", "insert", "move"] as const) {
       test(`a concurrent child ${mutation} cannot commit after completion`, async () => {
         const capture = await stageIncomplete();
@@ -163,17 +309,8 @@ describe.skipIf(!available)(
           finalized_block: "501",
         };
         if (mutation === "move") await stageIncomplete(other);
-        const completing = new Client({
-          host: directory,
-          user: "capture_test",
-          database: "postgres",
-        });
-        const mutating = new Client({
-          host: directory,
-          user: "capture_test",
-          database: "postgres",
-          application_name: "mutating",
-        });
+        const completing = client("completing");
+        const mutating = client("mutating");
         await completing.connect();
         await mutating.connect();
         try {
@@ -220,27 +357,15 @@ describe.skipIf(!available)(
           );
           assert.equal(held.rows[0].quantity, "1000000000");
         } finally {
-          await completing.query("ROLLBACK");
-          await mutating.query("ROLLBACK");
-          await completing.end();
-          await mutating.end();
+          await closeClients();
         }
       });
     }
 
     test("completion waits for an earlier child delete and rejects the now-incomplete rows", async () => {
       const capture = await stageIncomplete();
-      const deleting = new Client({
-        host: directory,
-        user: "capture_test",
-        database: "postgres",
-      });
-      const completing = new Client({
-        host: directory,
-        user: "capture_test",
-        database: "postgres",
-        application_name: "completing",
-      });
+      const deleting = client("deleting");
+      const completing = client("completing");
       await deleting.connect();
       await completing.connect();
       try {
@@ -273,9 +398,7 @@ describe.skipIf(!available)(
           0,
         );
       } finally {
-        await deleting.query("ROLLBACK");
-        await deleting.end();
-        await completing.end();
+        await closeClients();
       }
     });
 
@@ -306,6 +429,7 @@ describe.skipIf(!available)(
         const barrier = new Promise<void>((resolve) => {
           release = resolve;
         });
+        barriers.add(release);
         const ready = new Promise<void>((resolve) => {
           locked = resolve;
         });
@@ -319,7 +443,14 @@ describe.skipIf(!available)(
           first,
           3000,
         );
-        await ready;
+        // A writer failing before acquiring the lock must fail this test, not
+        // leave it waiting forever for a callback that will never run.
+        await Promise.race([
+          ready,
+          firstWrite.then(() => {
+            throw new Error("first writer completed without the lock barrier");
+          }),
+        ]);
         const secondWrite = writeRootBasketCapture(
           store("second"),
           second,
@@ -361,7 +492,7 @@ describe.skipIf(!available)(
           receipts.rows[0].n,
           scenario === "late_history" || scenario === "newer" ? 2 : 1,
         );
-        await Promise.all(stores.splice(0).map((store) => store.close()));
+        await closeClients();
       });
     }
   },

--- a/tests/root-basket-capture-sync.test.ts
+++ b/tests/root-basket-capture-sync.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, test, vi } from "vitest";
+import {
+  createProducerStore,
+  type ProducerStore,
+} from "../src/producer-store.ts";
+import {
+  handleRootBasketCaptureSync,
+  ROOT_BASKET_CAPTURE_MAX_BYTES,
+} from "../src/root-basket-capture-sync.ts";
+import { syntheticBasketCapture } from "./fixtures/root-basket-capture.ts";
+import { dataApiEnv } from "./helpers/worker-env.ts";
+
+const { driver } = vi.hoisted(() => ({
+  driver: { query: vi.fn(), close: vi.fn() },
+}));
+vi.mock("pg", () => ({
+  types: { setTypeParser() {} },
+  Client: class {
+    async connect() {}
+    async end() {
+      driver.close();
+    }
+    query(text: string, values: unknown[]) {
+      return driver.query(text, values);
+    }
+  },
+}));
+const { default: worker } = await import("../workers/data-api.ts");
+const { handleRequest } = await import("../workers/api.ts");
+const route =
+  "https://api.metagraph.sh/api/v1/internal/root-basket-capture-sync";
+const secret = "synthetic-receiver-test-token";
+const env = { ROOT_BASKET_CAPTURE_SYNC_SECRET: secret };
+const request = (
+  body: BodyInit | null = JSON.stringify(syntheticBasketCapture()),
+  headers: HeadersInit = {},
+) =>
+  new Request(route, {
+    method: "POST",
+    body,
+    headers: { "x-root-basket-capture-sync-token": secret, ...headers },
+    ...(body instanceof ReadableStream ? { duplex: "half" } : {}),
+  });
+let db: PGlite;
+beforeAll(async () => {
+  db = new PGlite();
+  for (const file of [
+    "0036_root_basket_observations.sql",
+    "0037_root_basket_capture_completion.sql",
+  ])
+    await db.exec(readFileSync(`migrations/neon/${file}`, "utf8"));
+});
+beforeEach(async () => {
+  await db.exec("TRUNCATE root_basket_captures CASCADE");
+  driver.query.mockClear();
+  driver.query.mockImplementation(async (text: string, values: unknown[]) => {
+    const result = await db.query(text, values);
+    return { rows: result.rows, rowCount: result.affectedRows ?? 0 };
+  });
+  driver.close.mockClear();
+});
+afterAll(async () => db.close());
+
+test("disabled and unauthorized receivers reject without reading a body or opening storage", async () => {
+  const invalidStream = () =>
+    new ReadableStream({
+      pull(controller) {
+        controller.error(new Error("body must not be read"));
+      },
+    });
+  assert.equal(
+    (await handleRootBasketCaptureSync(request(invalidStream()), {})).status,
+    503,
+  );
+  for (const token of ["", "incorrect"])
+    assert.equal(
+      (
+        await handleRootBasketCaptureSync(
+          request(invalidStream(), {
+            "x-root-basket-capture-sync-token": token,
+          }),
+          env,
+        )
+      ).status,
+      401,
+    );
+  assert.equal(driver.query.mock.calls.length, 0);
+});
+
+test("valid complete input still requires the explicitly configured store", async () => {
+  assert.equal((await handleRootBasketCaptureSync(request(), env)).status, 503);
+});
+
+test("declared and streamed byte limits reject whole, including a lying length and failed cancellation", async () => {
+  for (const length of ["invalid", String(ROOT_BASKET_CAPTURE_MAX_BYTES + 1)])
+    assert.equal(
+      (
+        await handleRootBasketCaptureSync(
+          request("{}", { "content-length": length }),
+          env,
+        )
+      ).status,
+      413,
+    );
+  for (const headers of [{}, { "content-length": "2" }] as Record<
+    string,
+    string
+  >[]) {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(ROOT_BASKET_CAPTURE_MAX_BYTES));
+        controller.enqueue(new Uint8Array(1));
+      },
+      cancel() {
+        throw new Error("disconnected sender");
+      },
+    });
+    assert.equal(
+      (await handleRootBasketCaptureSync(request(stream, headers), env)).status,
+      413,
+    );
+  }
+  assert.equal(driver.query.mock.calls.length, 0);
+});
+
+test("absent, invalid UTF-8, broken streams, invalid JSON and incomplete observations never write", async () => {
+  for (const body of [
+    null,
+    "not-json",
+    "{}",
+    new Uint8Array([0xff]),
+    new ReadableStream({
+      start(controller) {
+        controller.error(new Error("disconnected"));
+      },
+    }),
+  ])
+    assert.equal(
+      (await handleRootBasketCaptureSync(request(body), env)).status,
+      400,
+    );
+  assert.equal(driver.query.mock.calls.length, 0);
+});
+
+test("a valid observation exactly at the byte cap can be streamed across chunks", async () => {
+  // Legal JSON whitespace exercises the exact transport cap without changing content.
+  const text = JSON.stringify(syntheticBasketCapture());
+  const encoded = new TextEncoder().encode(
+    text + " ".repeat(ROOT_BASKET_CAPTURE_MAX_BYTES - text.length),
+  );
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded.subarray(0, 31));
+      controller.enqueue(encoded.subarray(31));
+      controller.close();
+    },
+  });
+  const response = await handleRootBasketCaptureSync(
+    request(stream, {
+      "content-length": String(ROOT_BASKET_CAPTURE_MAX_BYTES),
+    }),
+    env,
+    { store: createProducerStore("postgresql://example/db"), now: () => 3000 },
+  );
+  assert.equal(response.status, 200);
+  assert.equal(driver.close.mock.calls.length, 1);
+});
+
+test("too many complete page receipts hit the independent row budget", async () => {
+  const capture = syntheticBasketCapture();
+  capture.expected_pages = 257;
+  capture.expected_funds = 0;
+  capture.funds = [];
+  const cursor = (n: number) => `0x${n.toString(16).padStart(64, "0")}`;
+  capture.pages = Array.from({ length: 257 }, (_, i) => ({
+    ...capture.pages[0]!,
+    page_index: i,
+    start_after: i ? cursor(i) : null,
+    next_after: i === 256 ? null : cursor(i + 1),
+    fund_count: 0,
+  }));
+  assert.equal(
+    (await handleRootBasketCaptureSync(request(JSON.stringify(capture)), env))
+      .status,
+    413,
+  );
+  assert.equal(driver.query.mock.calls.length, 0);
+});
+
+test("the real protected worker route accepts, replays and rejects a conflict while closing every connection", async () => {
+  const workerEnv = dataApiEnv({
+    ...env,
+    HYPERDRIVE: { connectionString: "postgresql://example/db" },
+  });
+  const ctx = { waitUntil() {} } as unknown as ExecutionContext;
+  const first = await worker.fetch(request(), workerEnv, ctx);
+  assert.equal(first.status, 200);
+  assert.equal(((await first.json()) as { replayed: boolean }).replayed, false);
+  const replay = await worker.fetch(request(), workerEnv, ctx);
+  assert.equal(((await replay.json()) as { replayed: boolean }).replayed, true);
+  const changed = syntheticBasketCapture();
+  changed.metadata_sha256 = `0x${"ff".repeat(32)}`;
+  assert.equal(
+    (await worker.fetch(request(JSON.stringify(changed)), workerEnv, ctx))
+      .status,
+    409,
+  );
+  assert.equal(driver.close.mock.calls.length, 3);
+});
+
+test("failed storage is unacknowledged, reported and closed, with and without an error observer", async () => {
+  for (const withObserver of [false, true]) {
+    const error = withObserver
+      ? new Error("database disconnected")
+      : "connection unavailable";
+    const store = createProducerStore("postgresql://example/db");
+    driver.query.mockRejectedValueOnce(error);
+    const onError = vi.fn(async () => false);
+    const response = await handleRootBasketCaptureSync(request(), env, {
+      store,
+      ...(withObserver ? { onError } : {}),
+    });
+    assert.equal(response.status, 503);
+    assert.equal(onError.mock.calls.length, withObserver ? 1 : 0);
+  }
+  assert.equal(driver.close.mock.calls.length, 2);
+  const workerEnv = dataApiEnv({
+    ...env,
+    HYPERDRIVE: { connectionString: "postgresql://example/db" },
+  });
+  driver.query.mockRejectedValueOnce(new Error("database disconnected"));
+  assert.equal(
+    (
+      await worker.fetch(request(), workerEnv, {
+        waitUntil() {},
+      } as unknown as ExecutionContext)
+    ).status,
+    503,
+  );
+});
+
+test("a missing post-commit receipt is not reported as acknowledged", async () => {
+  const underlying = createProducerStore("postgresql://example/db");
+  const store: ProducerStore = { ...underlying, first: async () => null };
+  assert.equal(
+    (await handleRootBasketCaptureSync(request(), env, { store })).status,
+    503,
+  );
+});
+
+test("failed telemetry cannot mask the retry response or prevent connection cleanup", async () => {
+  driver.query.mockRejectedValueOnce(new Error("database disconnected"));
+  const response = await handleRootBasketCaptureSync(request(), env, {
+    store: createProducerStore("postgresql://example/db"),
+    onError: async () => {
+      throw new Error("telemetry unavailable");
+    },
+  });
+  assert.equal(response.status, 503);
+  assert.equal(driver.close.mock.calls.length, 1);
+});
+
+test("the edge proxy preserves body/token/status and refuses unbound or non-POST requests", async () => {
+  assert.equal((await handleRequest(request(), {} as Env, {})).status, 503);
+  const downstream = vi.fn(async (req: Request) => {
+    assert.equal(req.headers.get("x-root-basket-capture-sync-token"), secret);
+    assert.equal(await req.text(), "capture body");
+    return Response.json({ error: "conflicting observation" }, { status: 409 });
+  });
+  const proxyEnv = { DATA_API: { fetch: downstream } } as unknown as Env;
+  assert.equal(
+    (await handleRequest(request("capture body"), proxyEnv, {})).status,
+    409,
+  );
+  assert.equal(
+    (await handleRequest(new Request(route), proxyEnv, {})).status,
+    405,
+  );
+  assert.equal(downstream.mock.calls.length, 1);
+});

--- a/tests/root-basket-capture-write.test.ts
+++ b/tests/root-basket-capture-write.test.ts
@@ -1,0 +1,477 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, describe, test } from "vitest";
+import { RootBasketCaptureSchema } from "../schemas-src/root-basket-capture.ts";
+import {
+  createProducerStore,
+  type ProducerStoreClient,
+} from "../src/producer-store.ts";
+import {
+  rootBasketCaptureDigest,
+  rootBasketCaptureFits,
+  writeRootBasketCapture,
+} from "../src/root-basket-capture-write.ts";
+import { syntheticBasketCapture } from "./fixtures/root-basket-capture.ts";
+
+let pg: PGlite;
+const migrations = [
+  "0036_root_basket_observations.sql",
+  "0037_root_basket_capture_completion.sql",
+];
+const log: string[] = [];
+const makeStore = (intercept?: (text: string, values: unknown[]) => void) => {
+  const client: ProducerStoreClient = {
+    connect: async () => {},
+    end: async () => {},
+    query: async (text, values = []) => {
+      log.push(text);
+      intercept?.(text, values);
+      const result = await pg.query(text, values);
+      return { rows: result.rows, rowCount: result.affectedRows ?? 0 };
+    },
+  };
+  return createProducerStore("postgresql://example/db", {
+    clientFactory: () => client,
+  });
+};
+const count = async (table: string) =>
+  (await pg.query<{ n: number }>(`SELECT count(*)::int AS n FROM ${table}`))
+    .rows[0]!.n;
+const current = async () =>
+  (
+    await pg.query<{ capture_id: string }>(
+      "SELECT capture_id FROM root_basket_current",
+    )
+  ).rows[0]?.capture_id;
+const secondId = "00000000-0000-4000-8000-000000000002";
+const otherHash = `0x${"ee".repeat(32)}`;
+
+beforeAll(async () => {
+  pg = new PGlite();
+  for (const migration of migrations)
+    await pg.exec(readFileSync(`migrations/neon/${migration}`, "utf8"));
+});
+beforeEach(async () => {
+  await pg.exec("TRUNCATE root_basket_captures CASCADE");
+  log.length = 0;
+});
+afterAll(async () => pg.close());
+
+describe("atomic Root basket capture acceptance", () => {
+  test("persists every family before completion in one connection/transaction", async () => {
+    const capture = syntheticBasketCapture();
+    const result = await writeRootBasketCapture(makeStore(), capture, 3000);
+    assert.equal(result.capture_id, capture.capture_id);
+    assert.equal(result.replayed, false);
+    for (const [table, expected] of [
+      ["root_basket_captures", 1],
+      ["root_basket_capture_pages", 1],
+      ["root_basket_fund_snapshots", 1],
+      ["root_basket_holdings", 3],
+      ["root_basket_targets", 2],
+      ["root_basket_capture_completions", 1],
+    ] as const) {
+      assert.equal(await count(table), expected, table);
+    }
+    assert.equal(await current(), capture.capture_id);
+    assert.equal(log[0], "BEGIN");
+    assert.equal(log.at(-2), "COMMIT");
+    assert.ok(
+      log.findIndex((sql) => sql.includes("root_basket_complete_capture")) <
+        log.indexOf("COMMIT"),
+    );
+    const stored = (
+      await pg.query<{ bits: string }>(
+        "SELECT display_shares_q64_bits::text AS bits FROM root_basket_fund_snapshots",
+      )
+    ).rows[0]!;
+    assert.equal(stored.bits, capture.funds[0]!.display_shares_q64_bits);
+  });
+
+  test("reordered identical observations retain the accepted ID and original attempt timestamps", async () => {
+    const capture = syntheticBasketCapture();
+    const first = await writeRootBasketCapture(makeStore(), capture, 3000);
+    const retry = {
+      ...capture,
+      capture_id: secondId,
+      started_at_ms: "4000",
+      finished_at_ms: "5000",
+    };
+    retry.funds[0]!.holdings.reverse();
+    retry.funds[0]!.targets.reverse();
+    // Reverse object construction order recursively without dropping child fields.
+    const reverseObjects = (value: unknown): unknown =>
+      Array.isArray(value)
+        ? value.map(reverseObjects)
+        : value !== null && typeof value === "object"
+          ? Object.fromEntries(
+              Object.entries(value)
+                .reverse()
+                .map(([k, v]) => [k, reverseObjects(v)]),
+            )
+          : value;
+    const result = await writeRootBasketCapture(
+      makeStore(),
+      reverseObjects(retry),
+      6000,
+    );
+    assert.deepEqual(result, { ...first, replayed: true });
+    const row = (
+      await pg.query(
+        "SELECT started_at_ms::text, finished_at_ms::text, accepted_at_ms::text FROM root_basket_captures JOIN root_basket_capture_completions USING (capture_id)",
+      )
+    ).rows[0];
+    assert.deepEqual(row, {
+      started_at_ms: "1000",
+      finished_at_ms: "2000",
+      accepted_at_ms: "3000",
+    });
+    assert.equal(await count("root_basket_holdings"), 3);
+  });
+
+  for (const change of [
+    "value",
+    "receipt",
+    "metadata",
+    "index",
+    "height",
+    "network",
+    "attempt_id",
+    "same_height_hash",
+  ] as const) {
+    test(`rejects conflicting ${change} replay without changing the current capture`, async () => {
+      const capture = syntheticBasketCapture();
+      await writeRootBasketCapture(makeStore(), capture, 3000);
+      const conflict = structuredClone(capture);
+      if (change === "value")
+        conflict.funds[0]!.holdings[0]!.quantity_atomic = "123";
+      if (change === "receipt") conflict.pages[0]!.response_sha256 = otherHash;
+      if (change === "metadata") conflict.metadata_sha256 = otherHash;
+      if (change === "index") conflict.index.bag_q64_bits = "123";
+      if (change === "height") conflict.finalized_block = "501";
+      if (change === "network") conflict.network = "test";
+      if (change === "attempt_id") {
+        conflict.network_genesis_hash = otherHash;
+        conflict.finalized_block_hash = otherHash;
+      }
+      if (change === "same_height_hash") {
+        conflict.capture_id = secondId;
+        conflict.finalized_block_hash = otherHash;
+      }
+      await assert.rejects(
+        writeRootBasketCapture(makeStore(), conflict, 4000),
+        /ROOT_BASKET_CAPTURE_CONFLICT/,
+      );
+      assert.equal(await current(), capture.capture_id);
+      assert.equal(await count("root_basket_captures"), 1);
+    });
+  }
+
+  for (const table of [
+    "root_basket_captures",
+    "root_basket_capture_pages",
+    "root_basket_fund_snapshots",
+    "root_basket_holdings",
+    "root_basket_targets",
+    "root_basket_complete_capture",
+  ]) {
+    test(`a failure at ${table} rolls back all rows and retains the previous current capture`, async () => {
+      const previous = syntheticBasketCapture();
+      await writeRootBasketCapture(makeStore(), previous, 3000);
+      const next = {
+        ...previous,
+        capture_id: secondId,
+        finalized_block: "501",
+        finalized_block_hash: otherHash,
+      };
+      const store = makeStore((sql) => {
+        if (
+          sql.includes(table) &&
+          (sql.startsWith(`INSERT INTO ${table}`) ||
+            sql.startsWith("SELECT root_basket_complete_capture"))
+        )
+          throw new Error("injected stage failure");
+      });
+      await assert.rejects(
+        writeRootBasketCapture(store, next, 4000),
+        /injected stage failure/,
+      );
+      assert.equal(log.at(-1), "ROLLBACK");
+      assert.equal(await count("root_basket_captures"), 1);
+      assert.equal(await current(), previous.capture_id);
+    });
+  }
+
+  test("valid late historical captures do not replace the newest finalized observation", async () => {
+    const newest = syntheticBasketCapture();
+    await writeRootBasketCapture(makeStore(), newest, 3000);
+    const older = {
+      ...newest,
+      capture_id: secondId,
+      finalized_block: "499",
+      finalized_block_hash: otherHash,
+    };
+    await writeRootBasketCapture(makeStore(), older, 4000);
+    assert.equal(await count("root_basket_capture_completions"), 2);
+    assert.equal(await current(), newest.capture_id);
+    await assert.rejects(
+      pg.query("UPDATE root_basket_current SET capture_id = $1", [secondId]),
+      /source order cannot regress/,
+    );
+  });
+
+  test("an empty terminal capture publishes a verified empty observation", async () => {
+    const capture = syntheticBasketCapture();
+    capture.funds = [];
+    capture.expected_funds = 0;
+    capture.pages[0]!.fund_count = 0;
+    await writeRootBasketCapture(makeStore(), capture, 3000);
+    assert.equal(await count("root_basket_fund_snapshots"), 0);
+    assert.equal(await count("root_basket_capture_pages"), 1);
+    assert.equal(await current(), capture.capture_id);
+  });
+
+  test("SQL completeness throws before commit when a supposedly inserted child is absent", async () => {
+    const capture = syntheticBasketCapture();
+    let skipped = false;
+    const underlying = makeStore();
+    const store = {
+      ...underlying,
+      transaction: (statements: Parameters<typeof underlying.transaction>[0]) =>
+        underlying.transaction(
+          statements.filter((statement) => {
+            if (statement.text.startsWith("INSERT INTO root_basket_holdings")) {
+              skipped = true;
+              return false;
+            }
+            return true;
+          }),
+        ),
+    };
+    await assert.rejects(
+      writeRootBasketCapture(store, capture, 3000),
+      /persisted capture is incomplete/,
+    );
+    assert.equal(skipped, true);
+    assert.equal(await count("root_basket_captures"), 0);
+    assert.equal(await current(), undefined);
+  });
+
+  test("completed observations, receipts and additional children are immutable", async () => {
+    const capture = syntheticBasketCapture();
+    await writeRootBasketCapture(makeStore(), capture, 3000);
+    for (const table of [
+      "root_basket_captures",
+      "root_basket_capture_pages",
+      "root_basket_fund_snapshots",
+      "root_basket_holdings",
+      "root_basket_targets",
+      "root_basket_capture_completions",
+    ]) {
+      await assert.rejects(pg.query(`DELETE FROM ${table}`), /immutable/);
+      await assert.rejects(
+        pg.query(`UPDATE ${table} SET capture_id = $1`, [secondId]),
+        /immutable/,
+      );
+    }
+    await assert.rejects(
+      pg.query("INSERT INTO root_basket_targets VALUES ($1, $2, 51, 1)", [
+        capture.capture_id,
+        capture.funds[0]!.hotkey,
+      ]),
+      /immutable/,
+    );
+    await pg.exec(
+      readFileSync(
+        "migrations/neon/0037_root_basket_capture_completion.sql",
+        "utf8",
+      ),
+    );
+    assert.equal(await current(), capture.capture_id);
+  });
+
+  test("schema validation refuses missing pages and duplicate funds before opening a transaction", async () => {
+    const capture = syntheticBasketCapture();
+    capture.expected_pages = 2;
+    await assert.rejects(writeRootBasketCapture(makeStore(), capture, 3000));
+    assert.equal(log.length, 0);
+  });
+
+  test("validates the independent page budget before opening a transaction", async () => {
+    const capture = syntheticBasketCapture();
+    capture.expected_pages = 257;
+    capture.expected_funds = 0;
+    capture.funds = [];
+    const cursor = (n: number) => `0x${n.toString(16).padStart(64, "0")}`;
+    capture.pages = Array.from({ length: 257 }, (_, i) => ({
+      ...capture.pages[0]!,
+      page_index: i,
+      start_after: i ? cursor(i) : null,
+      next_after: i === 256 ? null : cursor(i + 1),
+      fund_count: 0,
+    }));
+    await assert.rejects(
+      writeRootBasketCapture(makeStore(), capture, 3000),
+      /exceeds row limits/,
+    );
+    assert.equal(log.length, 0);
+  });
+
+  test("batches multiple pages and funds under parameter limits while preserving order-independent replay", async () => {
+    const capture = syntheticBasketCapture();
+    const key = (n: number) => `0x${n.toString(16).padStart(64, "0")}`;
+    capture.expected_pages = 4;
+    capture.expected_funds = 1001;
+    capture.pages = Array.from({ length: 4 }, (_, i) => ({
+      ...capture.pages[0]!,
+      page_index: i,
+      start_after: i ? key(i) : null,
+      next_after: i === 3 ? null : key(i + 1),
+      fund_count: i === 3 ? 233 : 256,
+    }));
+    capture.funds = Array.from({ length: 1001 }, (_, i) => ({
+      ...capture.funds[0]!,
+      hotkey: key(i + 1),
+      page_index: Math.floor(i / 256),
+    }));
+    let batches = 0;
+    await writeRootBasketCapture(
+      makeStore((sql, values) => {
+        if (sql.includes("jsonb_to_recordset")) {
+          batches++;
+          assert.equal(values.length, 4);
+          assert.ok(JSON.parse(String(values[0])).length <= 1000);
+        }
+      }),
+      capture,
+      3000,
+    );
+    assert.equal(batches, 10); // 1 page, 2 funds, 4 holdings, 3 target batches.
+    assert.equal(await count("root_basket_fund_snapshots"), 1001);
+    const retry = {
+      ...capture,
+      capture_id: secondId,
+      funds: [...capture.funds].reverse(),
+    };
+    const result = await writeRootBasketCapture(makeStore(), retry, 4000);
+    assert.equal(result.replayed, true);
+    assert.equal(result.capture_id, capture.capture_id);
+  });
+
+  for (const corruption of [
+    "manifest_count",
+    "page_count",
+    "cursor",
+    "terminal",
+    "holdings_count",
+    "targets_count",
+    "baseline",
+  ] as const) {
+    test(`persisted ${corruption} corruption cannot acquire a completion receipt`, async () => {
+      const capture = syntheticBasketCapture();
+      capture.expected_pages = 2;
+      capture.pages[0]!.next_after = otherHash;
+      capture.pages.push({
+        ...capture.pages[0]!,
+        page_index: 1,
+        start_after: otherHash,
+        next_after: null,
+        fund_count: 0,
+      });
+      const store = makeStore((sql, values) => {
+        if (
+          corruption === "manifest_count" &&
+          sql.startsWith("INSERT INTO root_basket_captures")
+        )
+          values[12] = 2;
+        if (sql.startsWith("INSERT INTO root_basket_capture_pages")) {
+          const pages = JSON.parse(String(values[0]));
+          if (corruption === "page_count") pages[0].fund_count = 2;
+          if (corruption === "cursor")
+            pages[1].start_after = `0x${"dd".repeat(32)}`;
+          if (corruption === "terminal")
+            pages[1].next_after = `0x${"dd".repeat(32)}`;
+          values[0] = JSON.stringify(pages);
+        }
+        if (sql.startsWith("INSERT INTO root_basket_fund_snapshots")) {
+          const funds = JSON.parse(String(values[0]));
+          if (corruption === "holdings_count") funds[0].holdings_count++;
+          if (corruption === "targets_count") funds[0].targets_count++;
+          if (corruption === "baseline") funds[0].first_block = "501";
+          values[0] = JSON.stringify(funds);
+        }
+      });
+      await assert.rejects(
+        writeRootBasketCapture(store, capture, 3000),
+        /persisted capture is incomplete/,
+      );
+      assert.equal(await count("root_basket_captures"), 0);
+      assert.equal(await count("root_basket_capture_completions"), 0);
+    });
+  }
+
+  test("unpublished index and provisional baselines retain explicit nulls", async () => {
+    const capture = syntheticBasketCapture();
+    capture.index = {
+      status: "not_published",
+      completed_block: null,
+      bag_q64_bits: "18446744073709551616",
+      stake_q64_bits: "18446744073709551616",
+    };
+    capture.funds[0]!.baseline = {
+      provisional: true,
+      first_block: "0",
+      price_divisor_q64_bits: null,
+      rate0_q32_bits: null,
+      tr_splice_q64_bits: null,
+    };
+    capture.funds[0]!.holdings = [];
+    capture.funds[0]!.targets = [];
+    await writeRootBasketCapture(makeStore(), capture, 3000);
+    assert.equal(await count("root_basket_holdings"), 0);
+    const rows = (
+      await pg.query(
+        "SELECT price_divisor_q64_bits, index_completed_block FROM root_basket_fund_snapshots JOIN root_basket_captures USING (capture_id)",
+      )
+    ).rows;
+    assert.deepEqual(rows, [
+      { price_divisor_q64_bits: null, index_completed_block: null },
+    ]);
+  });
+
+  test("bounds row families independently of bytes and preserves every content-bearing field in the digest", () => {
+    const capture = RootBasketCaptureSchema.parse(syntheticBasketCapture());
+    assert.equal(rootBasketCaptureFits(capture), true);
+    assert.equal(
+      rootBasketCaptureFits({
+        ...capture,
+        pages: Array(257).fill(capture.pages[0]),
+      }),
+      false,
+    );
+    assert.equal(
+      rootBasketCaptureFits({
+        ...capture,
+        funds: Array(2049).fill(capture.funds[0]),
+      }),
+      false,
+    );
+    assert.equal(
+      rootBasketCaptureFits({
+        ...capture,
+        funds: [
+          {
+            ...capture.funds[0]!,
+            targets: Array(32769).fill({ netuid: 1, weight: 1 }),
+          },
+        ],
+      }),
+      false,
+    );
+    assert.notEqual(
+      rootBasketCaptureDigest(capture),
+      rootBasketCaptureDigest({ ...capture, finalized_block: "501" }),
+    );
+  });
+});

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -147,6 +147,12 @@ describe("TABLE_FRESHNESS coverage", () => {
           "utf8",
         ),
       );
+      await db.exec(
+        readFileSync(
+          "migrations/neon/0037_root_basket_capture_completion.sql",
+          "utf8",
+        ),
+      );
       const spec = Object.fromEntries(
         Object.entries(TABLE_FRESHNESS).filter(([table]) =>
           table.startsWith("root_basket_"),
@@ -158,7 +164,10 @@ describe("TABLE_FRESHNESS coverage", () => {
       await db.query(freshnessSql(swept, spec));
       const crossCheck = crossCheckSql(spec);
       if (crossCheck) await db.query(crossCheck);
-      assert.deepEqual(swept, ["root_basket_captures"]);
+      assert.deepEqual(swept, [
+        "root_basket_capture_completions",
+        "root_basket_captures",
+      ]);
     } finally {
       await db.close();
     }

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -4867,6 +4867,15 @@ async function handleHotkeyAlphaSyncProxy(request: Request, env: Env) {
   });
 }
 
+async function handleRootBasketCaptureSyncProxy(request: Request, env: Env) {
+  return proxyToDataApi(request, env, {
+    code: "root_basket_capture_sync_unavailable",
+    notBoundMessage: "The root basket capture sync tier is not bound.",
+    unreadableMessage:
+      "The root basket capture sync tier returned an unreadable response.",
+  });
+}
+
 // Proxies POST /api/v1/internal/poller-lane-health-sync -- the poller's own
 // tick outcomes (#9599). NOT a data lane: this is the DIAGNOSTIC channel, and
 // it exists because hotkey_alpha failed 95 seconds into every run for ten hours
@@ -5937,6 +5946,9 @@ async function dispatchRequest(request: Request, env: Env, ctx: Ctx = {}) {
   // scan POSTs here. Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/hotkey-alpha-sync") {
     return handleHotkeyAlphaSyncProxy(request, env);
+  }
+  if (url.pathname === "/api/v1/internal/root-basket-capture-sync") {
+    return handleRootBasketCaptureSyncProxy(request, env);
   }
   // The poller's own tick outcomes (#9599) -- the diagnostic channel, not a
   // data lane. Same DATA_API service binding.

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -18,6 +18,7 @@
 // they answered before the deletion -- see dispatchDataApiRequest's own note
 // for why that matters to the forward gate.
 import { DEFAULT_ACCOUNT_KIND, asAccountKind } from "../src/account-kind.ts";
+import { handleRootBasketCaptureSync } from "../src/root-basket-capture-sync.ts";
 import {
   accountBalanceSyncRowSchema,
   accountIdentitySyncRowSchema,
@@ -8831,6 +8832,15 @@ async function dispatchDataApiRequest(
       url.pathname === "/api/v1/internal/hotkey-alpha-sync"
     ) {
       return handleHotkeyAlphaSync(request, env, ctx);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/root-basket-capture-sync"
+    ) {
+      return handleRootBasketCaptureSync(request, env, {
+        onError: (error) =>
+          captureDataApiError(error, "root-basket-capture-sync", env),
+      });
     }
     if (
       request.method === "POST" &&

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -213,6 +213,8 @@ interface RuntimeSecretEnv {
   NEURON_DAILY_BACKFILL_SECRET?: string;
   NEURONS_SYNC_SECRET?: string;
   NOMINATOR_POSITIONS_SYNC_SECRET?: string;
+  /** Optional authentication for the bounded internal capture receiver. */
+  ROOT_BASKET_CAPTURE_SYNC_SECRET?: string;
   POSTHOG_EXCEPTION_STORM_WINDOW_MS?: string;
   POSTHOG_HOST?: string;
   POSTHOG_PROJECT_TOKEN?: string;


### PR DESCRIPTION
Accept complete finalized Root basket observations through an optional-secret internal receiver. One transaction checks persisted receipt/count continuity, freezes completed observations, makes identical replay idempotent, rejects conflicting source observations, and advances the current pointer only by finalized source height. Parent-row locking prevents concurrent child writes from committing after completion.

The initial limits are 8,000,000 streamed bytes, 256 receipts, 2,048 funds and 32,768 child rows, with 1,000-row typed JSON batches. These bounds are not yet sized against production captures. This change does not activate a collector or schedule, configure the optional secret, or expose a public basket read route.

Validation: build, typecheck, lint, format, migration sequence, schema/OpenAPI and contract drift, documentation, JSON binds, Worker type parity and public/private-boundary checks passed. Full backend coverage passed 996 files / 22,806 tests (11 skipped), with 100% coverage of changed runtime lines and branch arms. The final focused run passed 122 tests, including thirteen native PostgreSQL concurrency cases using a disposable local cluster.

Deployment prerequisite: apply migrations 0036 and 0037 before the receiver; the credentialed schema refresh follows the migrations and is reviewed separately. Keep the receiver disabled until its dedicated secret is explicitly configured. A concurrent attempt-UUID collision across different genesis scopes can initially return an unacknowledged 503; retry resolves the conflict to 409 without publishing the losing capture.

Closes #12064
Refs #12019
Refs #12012

The final test harness uses server-paced lock polling, bounded SQL and complete connection cleanup. The Ubuntu 24 / Node 22.23.2 / PostgreSQL 16 shared CI shard passed 299 files / 5,903 tests (11 skipped), with all thirteen native cases executed. A forced frozen-clock negative control fails with the old polling loop and passes with the new one; the original CI stall was not naturally reproduced. Runtime source and its full-suite coverage are unchanged by this test-only correction.
