### PR TITLE
fix(ui): preserve pending API key revocation state

### DIFF
--- a/apps/ui/src/components/metagraphed/api-keys-manager.tsx
+++ b/apps/ui/src/components/metagraphed/api-keys-manager.tsx
@@ -8,14 +8,11 @@ import { useWallet } from "@/hooks/use-wallet";
 import { useApiSession } from "@/hooks/use-api-session";
 import { toLinePoints } from "@/components/metagraphed/metric-history";
 import { WalletConnectPrompt } from "@/components/metagraphed/wallet-connect-button";
-
-interface ApiKeyRow {
-  key_id: string;
-  tier: string;
-  created_at: number;
-  revoked_at: number | null;
-  last_used_at: number | null;
-}
+import {
+  keyRevocationState,
+  reconcileApiKeys,
+  type ApiKeyRow,
+} from "@/lib/metagraphed/api-key-state";
 
 interface ApiKeyMinted {
   key: string;
@@ -94,6 +91,12 @@ function keyColumns(revoke: {
   return [
     { key: "id", label: "Key", kind: "identifier", value: (key) => key.key_id },
     {
+      key: "status",
+      label: "Status",
+      kind: "text",
+      value: (key) => (keyRevocationState(key) === "pending" ? "Revocation pending" : "Active"),
+    },
+    {
       key: "created",
       label: "Created",
       kind: "time",
@@ -110,16 +113,20 @@ function keyColumns(revoke: {
     {
       key: "revoke",
       label: "",
-      width: 110,
+      width: 150,
       align: "right",
       render: (key) => (
         <button
           type="button"
           onClick={() => revoke.mutate(key.key_id)}
-          disabled={revoke.isPending && revoke.variables === key.key_id}
-          className="mg-section-more"
+          disabled={revoke.isPending}
+          className="mg-section-more min-h-11 whitespace-normal"
         >
-          {revoke.isPending && revoke.variables === key.key_id ? "Revoking…" : "Revoke"}
+          {revoke.isPending && revoke.variables === key.key_id
+            ? "Revoking…"
+            : keyRevocationState(key) === "pending"
+              ? "Retry revocation"
+              : "Revoke"}
         </button>
       ),
     },
@@ -152,6 +159,7 @@ export function ApiKeysManager() {
             aria-label="API key management"
           >
             <ApiKeysPanel
+              key={apiSession.token}
               token={apiSession.token}
               tier={apiSession.tier}
               onSignOut={apiSession.signOut}
@@ -224,11 +232,12 @@ function ApiKeysPanel({
 
   const listQuery = useQuery({
     queryKey,
-    queryFn: async (): Promise<ApiKeyRow[]> => {
+    queryFn: async ({ signal }): Promise<ApiKeyRow[]> => {
       const res = await apiFetch<{ keys: ApiKeyRow[] }>("/api/v1/keys", {
+        signal,
         init: { headers: authHeaders(token) },
       });
-      return res.data.keys;
+      return reconcileApiKeys(res.data.keys, queryClient.getQueryData<ApiKeyRow[]>(queryKey));
     },
     retry: 0,
   });
@@ -249,11 +258,35 @@ function ApiKeysPanel({
         init: { method: "DELETE", headers: authHeaders(token) },
       });
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey }),
+    onSuccess: (_data, keyId) => {
+      queryClient.setQueryData<ApiKeyRow[]>(queryKey, (rows) =>
+        rows?.map((key) => (key.key_id === keyId ? { ...key, revocation_state: "revoked" } : key)),
+      );
+    },
+    onError: (error, keyId) => {
+      // The server has durably disabled local access. Preserve that known
+      // state even if the following list refresh is unavailable.
+      if (error instanceof ApiError && error.code === "KEY_REVOCATION_PENDING") {
+        queryClient.setQueryData<ApiKeyRow[]>(queryKey, (rows) =>
+          rows?.map((key) =>
+            key.key_id === keyId && keyRevocationState(key) !== "revoked"
+              ? { ...key, revocation_state: "pending" }
+              : key,
+          ),
+        );
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
   });
 
   const keys = listQuery.data ?? [];
-  const activeKeys = keys.filter((k) => !k.revoked_at);
+  const activeKeys = keys.filter((key) => keyRevocationState(key) === "active");
+  const visibleKeys = keys.filter((key) => keyRevocationState(key) !== "revoked");
+  const pendingKeys = visibleKeys.length - activeKeys.length;
+  const pendingRevocationError =
+    revokeMutation.isError &&
+    revokeMutation.error instanceof ApiError &&
+    revokeMutation.error.code === "KEY_REVOCATION_PENDING";
 
   const usageQuery = useQuery({
     queryKey: ["api-keys-usage", token],
@@ -354,30 +387,56 @@ function ApiKeysPanel({
       ) : null}
 
       <div className="space-y-2">
+        {revokeMutation.isError ? (
+          <div
+            role="alert"
+            className="border border-health-down/30 bg-health-down/5 p-3 text-13 text-health-down"
+          >
+            {describeApiError(revokeMutation.error)}
+          </div>
+        ) : null}
+        {pendingKeys > 0 && !pendingRevocationError ? (
+          <p className="text-13 text-ink-muted">
+            Access is disabled for keys with pending revocation. Retry to confirm revocation.
+          </p>
+        ) : null}
+        {listQuery.isError && listQuery.data !== undefined ? (
+          <ErrorState
+            error={listQuery.error}
+            onRetry={() => void listQuery.refetch()}
+            context="API keys"
+          />
+        ) : null}
         <DataTable
           id="api-keys"
-          rows={activeKeys}
+          rows={visibleKeys}
           columns={keyColumns(revokeMutation)}
           rowKey={(key) => key.key_id}
-          caption="Active keys"
+          caption="API keys"
           source="api-key"
           paginate={false}
           loading={listQuery.isPending}
           error={
-            listQuery.isError ? (
+            listQuery.isError && listQuery.data === undefined ? (
               <ErrorState
                 error={listQuery.error}
                 onRetry={() => void listQuery.refetch()}
-                context="active API keys"
+                context="API keys"
               />
             ) : undefined
           }
           empty={
-            !listQuery.isPending && !listQuery.isError ? (
+            !listQuery.isPending && listQuery.data !== undefined ? (
               <EmptyState title="No active keys" description="Generate one above to get started." />
             ) : undefined
           }
         />
+        {!listQuery.isPending && visibleKeys.length > 0 ? (
+          <p className="text-11 text-ink-muted" role="status">
+            {formatNumber(activeKeys.length)} active · {formatNumber(pendingKeys)} pending
+            revocation
+          </p>
+        ) : null}
       </div>
 
       {activeKeys.length > 0 ? (

--- a/apps/ui/src/lib/metagraphed/api-key-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/api-key-state.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { keyRevocationState, reconcileApiKeys, type ApiKeyRow } from "./api-key-state";
+
+const active: ApiKeyRow = {
+  key_id: "fixture-key",
+  tier: "pro",
+  created_at: 100,
+  revoked_at: null,
+  last_used_at: null,
+};
+
+describe("API key revocation evidence", () => {
+  it("accepts legacy rows and additive pending evidence without treating epoch zero as absent", () => {
+    expect(keyRevocationState(active)).toBe("active");
+    expect(
+      keyRevocationState({ ...active, revocation_requested_at: 0, revocation_state: "active" }),
+    ).toBe("pending");
+    expect(keyRevocationState({ ...active, revocation_state: "pending" })).toBe("pending");
+  });
+
+  it("gives confirmed revocation precedence over pending or active flags", () => {
+    expect(keyRevocationState({ ...active, revoked_at: 0, revocation_state: "pending" })).toBe(
+      "revoked",
+    );
+    expect(
+      keyRevocationState({ ...active, revocation_requested_at: 0, revocation_state: "revoked" }),
+    ).toBe("revoked");
+  });
+
+  it("retains pending and completed outcomes across stale lists while updating other metadata", () => {
+    const refreshed = { ...active, last_used_at: 200 };
+    for (const state of ["pending", "revoked"] as const) {
+      expect(reconcileApiKeys([refreshed], [{ ...active, revocation_state: state }])).toEqual([
+        { ...refreshed, revocation_state: state },
+      ]);
+    }
+    expect(
+      keyRevocationState(
+        reconcileApiKeys(
+          [{ ...active, revocation_state: "pending" }],
+          [{ ...active, revocation_state: "revoked" }],
+        )[0],
+      ),
+    ).toBe("revoked");
+  });
+
+  it("accepts stronger incoming evidence and isolates keys and fresh session caches", () => {
+    const pending = { ...active, revocation_state: "pending" as const };
+    const revoked = { ...active, revoked_at: 200 };
+    expect(reconcileApiKeys([revoked], [pending])).toEqual([revoked]);
+    const other = { ...active, key_id: "another-key" };
+    expect(reconcileApiKeys([other], [pending])).toEqual([other, pending]);
+    expect(reconcileApiKeys([active])).toEqual([active]);
+  });
+  it("keeps non-active evidence through a list that predates the key, without retaining absent active rows", () => {
+    for (const state of ["pending", "revoked"] as const) {
+      const known = { ...active, revocation_state: state };
+      const omitted = reconcileApiKeys([], [known, { ...active, key_id: "absent-active" }]);
+      expect(omitted).toEqual([known]);
+      expect(keyRevocationState(reconcileApiKeys([active], omitted)[0])).toBe(state);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/api-key-state.ts
+++ b/apps/ui/src/lib/metagraphed/api-key-state.ts
@@ -1,0 +1,36 @@
+export interface ApiKeyRow {
+  key_id: string;
+  tier: string;
+  created_at: number;
+  revoked_at: number | null;
+  revocation_requested_at?: number | null;
+  revocation_state?: "active" | "pending" | "revoked";
+  last_used_at: number | null;
+}
+
+export function keyRevocationState(key: ApiKeyRow): "active" | "pending" | "revoked" {
+  if (key.revoked_at != null || key.revocation_state === "revoked") return "revoked";
+  if (key.revocation_requested_at != null || key.revocation_state === "pending") return "pending";
+  return "active";
+}
+
+/** Revocation cannot be undone. A delayed list must not reverse a known outcome.
+ * Previous rows come only from the query cache for the same session token.
+ */
+export function reconcileApiKeys(incoming: ApiKeyRow[], previous: ApiKeyRow[] = []): ApiKeyRow[] {
+  const known = new Map(previous.map((key) => [key.key_id, keyRevocationState(key)]));
+  const next = incoming.map((key) => {
+    const before = known.get(key.key_id);
+    const current = keyRevocationState(key);
+    if (before === "revoked" || (before === "pending" && current === "active")) {
+      return { ...key, revocation_state: before };
+    }
+    return key;
+  });
+  // An older list can predate the key itself. Keep pending evidence and hidden
+  // completion records so a later stale active row cannot erase either outcome.
+  const present = new Set(incoming.map((key) => key.key_id));
+  return next.concat(
+    previous.filter((key) => !present.has(key.key_id) && keyRevocationState(key) !== "active"),
+  );
+}

--- a/apps/ui/tests/e2e/settings-state.spec.ts
+++ b/apps/ui/tests/e2e/settings-state.spec.ts
@@ -19,6 +19,7 @@ async function signInAsOwner(page: Page, connected = true) {
             accounts: {
               get: async () => [{ address, name: "Fixture account" }],
             },
+            signer: { signRaw: async () => ({ id: 1, signature: "0x00" }) },
           }),
         },
       };
@@ -216,7 +217,7 @@ test.describe("Settings record states", () => {
 
     const keys = page.locator("#keys");
     const alerts = page.locator("#alerts");
-    const keysError = keys.getByRole("alert").filter({ hasText: "Couldn't load active API keys" });
+    const keysError = keys.getByRole("alert").filter({ hasText: "Couldn't load API keys" });
     const triggersError = alerts
       .getByRole("alert")
       .filter({ hasText: "Couldn't load alert triggers" });
@@ -393,5 +394,379 @@ test.describe("Settings record states", () => {
     deliveriesAvailable = true;
     await deliveriesError.getByRole("button", { name: "Retry" }).click();
     await expect(alerts.getByText("No deliveries recorded yet", { exact: false })).toBeVisible();
+  });
+});
+
+test.describe("API-key revocation states", () => {
+  for (const width of [375, 1280]) {
+    test(`refreshes pending revocation after failure and completes a retry (${width}px)`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 812 });
+      await signInAsOwner(page);
+      let state: "active" | "pending" | "revoked" = "active";
+      let lists = 0;
+      let deletes = 0;
+      await page.route("**/api/v1/keys", async (route) => {
+        lists++;
+        await route.fulfill({
+          contentType: "application/json",
+          body: envelope({
+            keys: [
+              {
+                key_id: "key_fixture_revocation",
+                tier: "pro",
+                created_at: 1_784_000_000_000,
+                last_used_at: null,
+                revoked_at: state === "revoked" ? 1_784_000_100_000 : null,
+                // The first response deliberately has the older contract.
+                ...(state === "active"
+                  ? {}
+                  : { revocation_state: state, revocation_requested_at: 1_784_000_050_000 }),
+              },
+            ],
+          }),
+        });
+      });
+      await page.route("**/api/v1/keys/status", (route) =>
+        route.fulfill({ contentType: "application/json", body: envelope({ blocked: false }) }),
+      );
+      await page.route("**/api/v1/keys/usage", (route) =>
+        route.fulfill({
+          contentType: "application/json",
+          body: envelope({
+            window_days: 7,
+            tier: "pro",
+            quota: null,
+            days: [],
+            top_routes: [],
+            rejected_total: 0,
+          }),
+        }),
+      );
+      await page.route("**/api/v1/keys/key_fixture_revocation", async (route) => {
+        expect(route.request().method()).toBe("DELETE");
+        deletes++;
+        state = deletes === 1 ? "pending" : "revoked";
+        await route.fulfill({
+          status: deletes === 1 ? 502 : 200,
+          contentType: "application/json",
+          body:
+            deletes === 1
+              ? JSON.stringify({
+                  error: {
+                    code: "KEY_REVOCATION_PENDING",
+                    message: "Key access is disabled. Revocation confirmation is pending; retry.",
+                  },
+                  key_id: "key_fixture_revocation",
+                  revoked: false,
+                  revocation_state: "pending",
+                  access_disabled: true,
+                })
+              : envelope({ key_id: "key_fixture_revocation", revoked: true }),
+        });
+      });
+      await gotoThroughRestart(page, "/settings#keys");
+      const keys = page.locator("#keys");
+      await expect(
+        keys.getByText("1 active · 0 pending revocation", { exact: true }),
+      ).toBeVisible();
+      await keys.getByRole("button", { name: "Revoke", exact: true }).click();
+      await expect(
+        keys.getByRole("alert").filter({ hasText: "Key access is disabled." }),
+      ).toBeVisible();
+      await expect(keys.getByText("Revocation pending", { exact: true })).toBeVisible();
+      await expect(
+        keys.getByText("0 active · 1 pending revocation", { exact: true }),
+      ).toBeVisible();
+      expect(lists).toBeGreaterThanOrEqual(2);
+      const retry = keys.getByRole("button", { name: "Retry revocation", exact: true });
+      await expect(retry).toBeEnabled();
+      await retry.click();
+      await expect(keys.getByText("No active keys", { exact: true })).toBeVisible();
+      await expect(keys.getByText("Revocation pending", { exact: true })).toHaveCount(0);
+      await expect(
+        keys.getByRole("alert").filter({ hasText: "Key access is disabled." }),
+      ).toHaveCount(0);
+      expect(deletes).toBe(2);
+      expect(lists).toBeGreaterThanOrEqual(3);
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(
+        true,
+      );
+    });
+  }
+
+  for (const refresh of ["failed", "stale", "omitted"] as const) {
+    test(`preserves pending and completed revocation across ${refresh} list refreshes`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 375, height: 812 });
+      await signInAsOwner(page);
+      let deletes = 0;
+      let lists = 0;
+      await page.route("**/api/v1/keys", async (route) => {
+        lists++;
+        if (deletes > 0 && refresh === "failed")
+          return route.fulfill({ status: 503, body: "fixture unavailable" });
+        if (refresh === "omitted" && lists === 2) {
+          return route.fulfill({ contentType: "application/json", body: envelope({ keys: [] }) });
+        }
+        // Even after DELETE this endpoint deliberately returns an old active record.
+        await route.fulfill({
+          contentType: "application/json",
+          body: envelope({
+            keys: [
+              {
+                key_id: "key_fixture_refresh",
+                tier: "pro",
+                created_at: 1_784_000_000_000,
+                last_used_at: null,
+                revoked_at: null,
+              },
+            ],
+          }),
+        });
+      });
+      await page.route("**/api/v1/keys/status", (route) =>
+        route.fulfill({ contentType: "application/json", body: envelope({ blocked: false }) }),
+      );
+      await page.route("**/api/v1/keys/usage", (route) =>
+        route.fulfill({
+          contentType: "application/json",
+          body: envelope({
+            window_days: 7,
+            tier: "pro",
+            quota: null,
+            days: [],
+            top_routes: [],
+            rejected_total: 0,
+          }),
+        }),
+      );
+      await page.route("**/api/v1/keys/key_fixture_refresh", async (route) => {
+        deletes++;
+        await route.fulfill({
+          status: deletes === 1 ? 502 : 200,
+          contentType: "application/json",
+          body:
+            deletes === 1
+              ? JSON.stringify({
+                  error: {
+                    code: "KEY_REVOCATION_PENDING",
+                    message: "Key access is disabled. Revocation confirmation is pending; retry.",
+                  },
+                })
+              : envelope({ key_id: "key_fixture_refresh", revoked: true }),
+        });
+      });
+      await gotoThroughRestart(page, "/settings#keys");
+      const keys = page.locator("#keys");
+      await keys.getByRole("button", { name: "Revoke", exact: true }).click();
+      await expect(
+        keys.getByText("0 active · 1 pending revocation", { exact: true }),
+      ).toBeVisible();
+      const retry = keys.getByRole("button", { name: "Retry revocation", exact: true });
+      await expect(retry).toBeEnabled();
+      expect(lists).toBeGreaterThanOrEqual(2);
+      const error = keys.getByRole("alert").filter({ hasText: "Couldn't load API keys" });
+      if (refresh === "failed") await expect(error).toBeVisible();
+      await retry.click();
+      await expect(keys.getByText("No active keys", { exact: true })).toBeVisible();
+      await expect(keys.getByText("Revocation pending", { exact: true })).toHaveCount(0);
+      await expect(keys.getByRole("button", { name: "Revoke", exact: true })).toHaveCount(0);
+      expect(lists).toBeGreaterThanOrEqual(3);
+      if (refresh === "failed") {
+        await expect(error).toBeVisible();
+        await error.getByRole("button", { name: "Retry", exact: true }).click();
+        await expect.poll(() => lists).toBeGreaterThanOrEqual(4);
+        await expect(keys.getByText("No active keys", { exact: true })).toBeVisible();
+      }
+    });
+  }
+
+  test("does not claim disabled access after an unrelated revocation error", async ({ page }) => {
+    await signInAsOwner(page);
+    await page.route("**/api/v1/keys", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: envelope({
+          keys: [
+            {
+              key_id: "key_fixture_generic",
+              tier: "pro",
+              created_at: 1_784_000_000_000,
+              last_used_at: null,
+              revoked_at: null,
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/keys/status", (route) =>
+      route.fulfill({ contentType: "application/json", body: envelope({ blocked: false }) }),
+    );
+    await page.route("**/api/v1/keys/usage", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: envelope({
+          window_days: 7,
+          tier: "pro",
+          quota: null,
+          days: [],
+          top_routes: [],
+          rejected_total: 0,
+        }),
+      }),
+    );
+    await page.route("**/api/v1/keys/key_fixture_generic", (route) =>
+      route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { code: "UNAVAILABLE", message: "Revocation is unavailable. Try again." },
+        }),
+      }),
+    );
+    await gotoThroughRestart(page, "/settings#keys");
+    const keys = page.locator("#keys");
+    await keys.getByRole("button", { name: "Revoke", exact: true }).click();
+    await expect(
+      keys.getByRole("alert").filter({ hasText: "Revocation is unavailable." }),
+    ).toBeVisible();
+    await expect(keys.getByRole("button", { name: "Revoke", exact: true })).toBeEnabled();
+    await expect(keys.getByText("1 active · 0 pending revocation", { exact: true })).toBeVisible();
+    await expect(keys.getByText("Access is disabled", { exact: false })).toHaveCount(0);
+  });
+
+  test("treats timestamp-only pending keys as disabled and hides confirmed rows without loading usage", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await signInAsOwner(page);
+    let usageRequests = 0;
+    const pending = {
+      key_id: "key_fixture_pending",
+      tier: "pro",
+      created_at: 1_784_000_000_000,
+      last_used_at: null,
+      revoked_at: null,
+      revocation_requested_at: 0,
+    };
+    await page.route("**/api/v1/keys", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: envelope({
+          keys: [
+            pending,
+            {
+              ...pending,
+              key_id: "key_fixture_confirmed",
+              revoked_at: 0,
+              revocation_state: "pending",
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/keys/status", (route) =>
+      route.fulfill({ contentType: "application/json", body: envelope({ blocked: false }) }),
+    );
+    await page.route("**/api/v1/keys/usage", (route) => {
+      usageRequests++;
+      return route.fulfill({ status: 503 });
+    });
+    await gotoThroughRestart(page, "/settings#keys");
+    const keys = page.locator("#keys");
+    await expect(keys.getByText("0 active · 1 pending revocation", { exact: true })).toBeVisible();
+    const retry = keys.getByRole("button", { name: "Retry revocation", exact: true });
+    await expect(retry).toBeVisible();
+    await expect(keys.getByRole("button", { name: "Revoke", exact: true })).toHaveCount(0);
+    await expect(keys.getByText("key_fixture_confirmed", { exact: true })).toHaveCount(0);
+    expect(usageRequests).toBe(0);
+    const bounds = await retry.boundingBox();
+    expect(bounds?.height).toBeGreaterThanOrEqual(44);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(
+      true,
+    );
+  });
+  test("does not carry a previous session's pending state or error into a new session", async ({
+    page,
+  }) => {
+    await signInAsOwner(page);
+    const sessions: string[] = [];
+    await page.route("**/api/v1/keys", (route) => {
+      sessions.push(route.request().headers().authorization);
+      return route.fulfill({
+        contentType: "application/json",
+        body: envelope({
+          keys: [
+            {
+              key_id: "key_fixture_session",
+              tier: "pro",
+              created_at: 1_784_000_000_000,
+              last_used_at: null,
+              revoked_at: null,
+            },
+          ],
+        }),
+      });
+    });
+    await page.route("**/api/v1/keys/status", (route) =>
+      route.fulfill({ contentType: "application/json", body: envelope({ blocked: false }) }),
+    );
+    await page.route("**/api/v1/keys/usage", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: envelope({
+          window_days: 7,
+          tier: "pro",
+          quota: null,
+          days: [],
+          top_routes: [],
+          rejected_total: 0,
+        }),
+      }),
+    );
+    await page.route("**/api/v1/keys/key_fixture_session", (route) =>
+      route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            code: "KEY_REVOCATION_PENDING",
+            message: "Key access is disabled. Revocation confirmation is pending; retry.",
+          },
+        }),
+      }),
+    );
+    await page.route("**/api/v1/auth/wallet/challenge", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: envelope({ message: "Fixture challenge", expires_in_seconds: 60 }),
+      }),
+    );
+    await page.route("**/api/v1/auth/wallet/verify", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: envelope({
+          session_token: "fixture-second-session",
+          expires_in_seconds: 3600,
+          account: { ss58: OWNER, tier: "pro" },
+        }),
+      }),
+    );
+    await gotoThroughRestart(page, "/settings#keys");
+    const keys = page.locator("#keys");
+    await keys.getByRole("button", { name: "Revoke", exact: true }).click();
+    await expect(keys.getByRole("button", { name: "Retry revocation", exact: true })).toBeEnabled();
+    await keys.getByRole("button", { name: "Sign out", exact: true }).click();
+    await keys.getByRole("button", { name: "Sign in with wallet", exact: true }).click();
+    await expect(keys.getByText("1 active · 0 pending revocation", { exact: true })).toBeVisible();
+    await expect(keys.getByRole("button", { name: "Revoke", exact: true })).toBeEnabled();
+    await expect(
+      keys.getByRole("alert").filter({ hasText: "Key access is disabled." }),
+    ).toHaveCount(0);
+    expect(sessions).toContain("Bearer fixture-api-token");
+    expect(sessions).toContain("Bearer fixture-second-session");
   });
 });


### PR DESCRIPTION
Settings now keeps pending key revocations visible and retryable, excludes them from active-key counts, and preserves confirmed outcomes across failed or stale list refreshes. Session changes reset mutation state; older API responses remain supported. Ordinary errors do not claim that access has been disabled.

This is the compatible UI prerequisite for the separately staged revocation backend. Pending-state activation follows verified UI deployment.

Validation passed: 2,416 UI tests, 642 browser tests, 19 focused Settings browser cases, lint, typecheck, formatting, Worker fixture build, SSR content isolation and bundle budgets. Tests include failed refreshes, older lists that omit known keys, later stale active rows, retry completion, and session isolation. Homepage payload is 280/400 KiB gzip; docs and news are 60/70 and 51/70 KiB. Captures use synthetic local API/session responses; no live credentials or revocations were exercised.

Closes #12067
Refs #12030
Refs #12066
Refs #12012

## Visual evidence

Before source: `20040804971076402a90b545147e2c34cbc1edad`. After: `cebcab24eba930c4f393b4aafb999ce975524738`, including main `a19c4ce7453d37a39b5f887ca0ff0fb2eff866a7`. Fixed viewports; both themes are explicit. Existing active state versus pending state is shown below. Retry actions are at least 44px tall and all viewports fit without document overflow.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-1280-light-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-1280-light-active.png)<br><sub>active</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-light-pending.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-light-pending.png)<br><sub>pending and retryable</sub> |
| Desktop · dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-1280-dark-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-1280-dark-active.png)<br><sub>active</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-dark-pending.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-dark-pending.png)<br><sub>pending and retryable</sub> |
| Tablet · light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-768-light-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-768-light-active.png)<br><sub>active</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-light-pending.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-light-pending.png)<br><sub>pending and retryable</sub> |
| Tablet · dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-768-dark-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-768-dark-active.png)<br><sub>active</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-dark-pending.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-dark-pending.png)<br><sub>pending and retryable</sub> |
| Phone · light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-375-light-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-375-light-active.png)<br><sub>active</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-light-pending.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-light-pending.png)<br><sub>pending and retryable</sub> |
| Phone · dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-375-dark-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/before-375-dark-active.png)<br><sub>active</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-dark-pending.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-dark-pending.png)<br><sub>pending and retryable</sub> |

| State | Light | Dark |
|---|---|---|
| Desktop · active | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-light-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-light-active.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-dark-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-dark-active.png) |
| Desktop · refresh-error | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-light-refresh-error.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-light-refresh-error.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-dark-refresh-error.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-1280-dark-refresh-error.png) |
| Tablet · active | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-light-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-light-active.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-dark-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-dark-active.png) |
| Tablet · refresh-error | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-light-refresh-error.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-light-refresh-error.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-dark-refresh-error.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-768-dark-refresh-error.png) |
| Phone · active | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-light-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-light-active.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-dark-active.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-dark-active.png) |
| Phone · refresh-error | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-light-refresh-error-action.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-light-refresh-error-action.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-dark-refresh-error-action.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/e01dc3f291c825472fb41075f11a26c21c98957d/epic-12012/auth-revocation-ui/after-375-dark-refresh-error-action.png) |
