### PR TITLE
feat(policy): validate complete capture archive mappings

### DIFF
--- a/scripts/archive-policy-bundles.ts
+++ b/scripts/archive-policy-bundles.ts
@@ -1,0 +1,473 @@
+// Whole-capture representations have a different seam from same-name mirrors.
+// This checks declarations against committed metadata, never deployed coverage.
+export const BUNDLE_FAMILIES = [
+  "capture",
+  "pages",
+  "funds",
+  "holdings",
+  "targets",
+  "completion",
+] as const;
+type Family = (typeof BUNDLE_FAMILIES)[number];
+type Bounds = { min: number; max: number };
+type Value = { nullable: boolean } & (
+  | { kind: "string" | "boolean" | "decimal-string" }
+  | ({ kind: "integer" } & Bounds)
+);
+type Binding =
+  | {
+      kind: "path";
+      from: "row" | "capture" | "parent" | "receipt";
+      path: string;
+    }
+  | { kind: "array-length"; path: string };
+type ColumnRule = {
+  udt: string;
+  nullable: boolean;
+  // A versioned contract assertion, not something base `numeric` in a source
+  // snapshot proves. Unconstrained numeric values need decimal strings.
+  integerBounds?: Bounds;
+  binding: Binding;
+};
+type Receipt = { captureId: string; digest: string; acceptedAt: string };
+type FamilyRule = {
+  rows: string;
+  parent?: string;
+  columns: Record<string, ColumnRule>;
+  // Whole-capture totals can differ from per-parent array lengths. Bounds are
+  // explicit versioned contract assertions, including any global row cap.
+  count: { manifestPath: string; indexColumn: string; bounds: Bounds };
+};
+
+export interface BundleSourceColumn {
+  table: string;
+  column: string;
+  udt: string;
+  nullable: boolean;
+}
+export interface BundleCatalogColumn {
+  table: string;
+  column: string;
+  field_id: number;
+  type: string;
+  required: boolean;
+}
+export interface ArchiveBundleContract {
+  version: number;
+  capturePath: string;
+  receiptPath: string;
+  values: Record<string, Value>;
+  arrays: Record<string, Bounds>;
+  families: Record<Family, FamilyRule>;
+  receipt: Receipt;
+  index: {
+    fields: Omit<BundleCatalogColumn, "table">[];
+    receipt: Receipt;
+  };
+}
+export interface ArchiveBundleMapping {
+  contract: string;
+  version: number;
+  // The existing catalog snapshot is scoped to `chain` and keyed by bare table
+  // name. Another namespace needs snapshot support, not a guessed association.
+  namespace: "chain";
+  indexTable: string;
+  sources: Record<Family, string>;
+}
+
+const PATH = /^[a-z][a-z0-9_]*(?:\[\])?(?:\.[a-z][a-z0-9_]*(?:\[\])?)*$/;
+const NAME = /^[a-z][a-z0-9_]*$/;
+const isBounds = (bounds: Bounds): boolean =>
+  Number.isSafeInteger(bounds.min) &&
+  Number.isSafeInteger(bounds.max) &&
+  bounds.min <= bounds.max;
+const encloses = (outer: Bounds, inner: Bounds): boolean =>
+  outer.min <= inner.min && outer.max >= inner.max;
+const below = (path: string, base: string): boolean =>
+  path.startsWith(`${base}.`) && !path.slice(base.length).includes("[]");
+const childArray = (path: string, base: string): boolean =>
+  path.endsWith("[]") && below(path.slice(0, -2), base);
+
+function countFitsFamily(
+  contract: ArchiveBundleContract,
+  family: Family,
+  rule: FamilyRule,
+): boolean {
+  const bounds = rule.count.bounds;
+  if (!isBounds(bounds) || bounds.min < 0) return false;
+  if (family === "capture" || family === "completion")
+    return bounds.min === 1 && bounds.max === 1;
+  const array = contract.arrays[rule.rows];
+  const parent =
+    family === "holdings" || family === "targets"
+      ? contract.arrays[contract.families.funds?.rows]
+      : { min: 1, max: 1 };
+  if (
+    !array ||
+    !parent ||
+    !isBounds(array) ||
+    !isBounds(parent) ||
+    array.min < 0 ||
+    parent.min < 0
+  )
+    return false;
+  // BigInt avoids overflowing while comparing safe declared global limits
+  // against the product of two independently bounded arrays.
+  return (
+    BigInt(bounds.min) >= BigInt(array.min) * BigInt(parent.min) &&
+    BigInt(bounds.max) <= BigInt(array.max) * BigInt(parent.max)
+  );
+}
+
+function lossless(source: ColumnRule, value: Value): boolean {
+  if (source.nullable !== value.nullable) return false;
+  if (source.integerBounds && !isBounds(source.integerBounds)) return false;
+  if (value.kind === "integer" && !isBounds(value)) return false;
+  switch (source.udt) {
+    case "bool":
+      return value.kind === "boolean";
+    case "uuid":
+    case "text":
+    case "varchar":
+      return value.kind === "string";
+    case "numeric":
+      return (
+        value.kind === "decimal-string" ||
+        (value.kind === "integer" &&
+          source.integerBounds !== undefined &&
+          encloses(value, source.integerBounds))
+      );
+    case "int2":
+    case "int4": {
+      const width = source.udt === "int2" ? 16 : 32;
+      return (
+        value.kind === "decimal-string" ||
+        (value.kind === "integer" &&
+          encloses(value, {
+            min: -(2 ** (width - 1)),
+            max: 2 ** (width - 1) - 1,
+          }))
+      );
+    }
+    // A JS number cannot carry every int8. Do not widen the legacy mirror's
+    // numeric -> double rule to make an exact bundle declaration pass.
+    case "int8":
+      return value.kind === "decimal-string";
+    default:
+      return false;
+  }
+}
+
+function indexFits(
+  value: Value,
+  field: Omit<BundleCatalogColumn, "table">,
+): boolean {
+  if (!field.required || value.nullable) return false;
+  if (value.kind === "string" || value.kind === "decimal-string")
+    return field.type === "string";
+  if (value.kind === "boolean") return field.type === "boolean";
+  return (
+    value.kind === "integer" &&
+    isBounds(value) &&
+    (field.type === "long" ||
+      (field.type === "int" &&
+        value.min >= -(2 ** 31) &&
+        value.max <= 2 ** 31 - 1))
+  );
+}
+
+/**
+ * Pure metadata audit. Definitions describe a versioned representation;
+ * mappings associate that representation with actual source/catalog entities.
+ * An empty production mapping is not an archive declaration or debt exemption.
+ */
+export function validateArchiveBundles(input: {
+  source: readonly BundleSourceColumn[];
+  catalog: readonly BundleCatalogColumn[];
+  policies: Readonly<Record<string, string>>;
+  contracts: Readonly<Record<string, ArchiveBundleContract>>;
+  mappings: readonly ArchiveBundleMapping[];
+}): string[] {
+  const problems: string[] = [];
+  const declaredSources = new Set<string>();
+  const declaredIndexes = new Set<string>();
+  const usedContracts = new Set<string>();
+  for (const mapping of input.mappings) {
+    const label = `${mapping.contract} -> ${mapping.namespace}.${mapping.indexTable}`;
+    const fail = (message: string): void => {
+      problems.push(`${label}: ${message}`);
+    };
+    const contract = input.contracts[mapping.contract];
+    if (!contract) {
+      fail("unknown bundle contract");
+      continue;
+    }
+    usedContracts.add(mapping.contract);
+    if (contract.version !== 1 || mapping.version !== contract.version) {
+      fail("unsupported or incompatible bundle contract version");
+      continue;
+    }
+    if (mapping.namespace !== "chain" || !NAME.test(mapping.indexTable))
+      fail("unsupported catalog table identity");
+    if (declaredIndexes.has(mapping.indexTable))
+      fail("catalog table is assigned to more than one bundle mapping");
+    declaredIndexes.add(mapping.indexTable);
+    for (const [kind, keys] of [
+      ["contract families", Object.keys(contract.families)],
+      ["source families", Object.keys(mapping.sources)],
+    ] as const) {
+      const missing = BUNDLE_FAMILIES.filter(
+        (family) => !keys.includes(family),
+      );
+      const extra = keys.filter(
+        (key) => !BUNDLE_FAMILIES.some((family) => family === key),
+      );
+      if (missing.length || extra.length)
+        fail(
+          `${kind} must cover the complete group; missing [${missing}], extra [${extra}]`,
+        );
+    }
+    if (
+      !PATH.test(contract.capturePath) ||
+      contract.capturePath.includes("[]") ||
+      !PATH.test(contract.receiptPath) ||
+      contract.receiptPath.includes("[]") ||
+      contract.capturePath === contract.receiptPath
+    )
+      fail("capture and original receipt need distinct object paths");
+    const shape = new Map<string, string>();
+    const declareShape = (path: string, terminal: "value" | "object"): void => {
+      let parent = "";
+      const parts = path.split(".");
+      for (const [position, part] of parts.entries()) {
+        const array = part.endsWith("[]");
+        const key = `${parent}${array ? part.slice(0, -2) : part}`;
+        const kind = array
+          ? "array"
+          : position === parts.length - 1
+            ? terminal
+            : "object";
+        if (shape.has(key) && shape.get(key) !== kind)
+          fail(`conflicting bundle path shape: ${key}`);
+        shape.set(key, kind);
+        parent += `${part}.`;
+      }
+    };
+    declareShape(contract.capturePath, "object");
+    declareShape(contract.receiptPath, "object");
+    for (const [path, value] of Object.entries(contract.values)) {
+      if (
+        !PATH.test(path) ||
+        path.endsWith("[]") ||
+        (value.kind === "integer" && !isBounds(value))
+      )
+        fail(`invalid value path or integer bounds: ${path}`);
+      declareShape(path, "value");
+    }
+    for (const [path, array] of Object.entries(contract.arrays)) {
+      if (
+        !PATH.test(path) ||
+        !path.endsWith("[]") ||
+        !isBounds(array) ||
+        array.min < 0
+      )
+        fail(`invalid bounded array: ${path}`);
+      declareShape(path, "object");
+    }
+
+    const actualFields = input.catalog.filter(
+      (field) => field.table === mapping.indexTable,
+    );
+    if (!actualFields.length)
+      fail("index table is absent from the committed catalog snapshot");
+    const expectedNames = new Set<string>();
+    const expectedIds = new Set<number>();
+    const actualNames = new Set<string>();
+    const actualIds = new Set<number>();
+    for (const field of contract.index.fields) {
+      if (
+        !NAME.test(field.column) ||
+        !Number.isSafeInteger(field.field_id) ||
+        field.field_id < 1 ||
+        expectedNames.has(field.column) ||
+        expectedIds.has(field.field_id)
+      )
+        fail(`invalid or duplicate index field: ${field.column}`);
+      expectedNames.add(field.column);
+      expectedIds.add(field.field_id);
+      const actual = actualFields.find((item) => item.column === field.column);
+      if (
+        !actual ||
+        actual.field_id !== field.field_id ||
+        actual.type !== field.type ||
+        actual.required !== field.required
+      ) {
+        fail(
+          `index ${field.column} must have field ID ${field.field_id}, type ${field.type}, required=${field.required}`,
+        );
+      }
+    }
+    for (const field of actualFields) {
+      if (!expectedNames.has(field.column))
+        fail(`unmapped catalog column: ${field.column}`);
+      if (actualNames.has(field.column) || actualIds.has(field.field_id))
+        fail(`duplicate catalog field: ${field.column}`);
+      actualNames.add(field.column);
+      actualIds.add(field.field_id);
+    }
+    const countColumns = new Set<string>();
+    const countPaths = new Set<string>();
+    const rowPaths = new Set<string>();
+    for (const family of BUNDLE_FAMILIES) {
+      const rule = contract.families[family];
+      const table = mapping.sources[family];
+      if (!rule || !table) continue; // The complete-group error above owns this.
+      if (!NAME.test(table)) fail(`invalid source table for ${family}`);
+      if (declaredSources.has(table))
+        fail(`source table is mapped more than once: ${table}`);
+      declaredSources.add(table);
+      if (input.policies[table] !== "bundled")
+        fail(`${table} must explicitly use bundled policy`);
+      const source = input.source.filter((column) => column.table === table);
+      if (!source.length)
+        fail(`source table is absent from the committed snapshot: ${table}`);
+      const expectedParent =
+        family === "holdings" || family === "targets"
+          ? contract.families.funds?.rows
+          : contract.capturePath;
+      const objectFamily = family === "capture" || family === "completion";
+      const expectedObject =
+        family === "capture" ? contract.capturePath : contract.receiptPath;
+      if (
+        !PATH.test(rule.rows) ||
+        (objectFamily
+          ? rule.rows !== expectedObject
+          : !expectedParent ||
+            !childArray(rule.rows, expectedParent) ||
+            !contract.arrays[rule.rows]) ||
+        (!objectFamily && rule.parent !== expectedParent)
+      )
+        fail(`invalid row/parent path for ${family}`);
+      if (rowPaths.has(rule.rows))
+        fail(`row path is shared by different families: ${family}`);
+      rowPaths.add(rule.rows);
+
+      const sourceNames = new Set<string>();
+      for (const column of source) {
+        if (sourceNames.has(column.column))
+          fail(`duplicate source column: ${table}.${column.column}`);
+        sourceNames.add(column.column);
+        if (!rule.columns[column.column])
+          fail(`unmapped source column: ${table}.${column.column}`);
+      }
+      const projectionPaths = new Set<string>();
+      for (const [column, projection] of Object.entries(rule.columns)) {
+        const sourceColumn = source.find((item) => item.column === column);
+        if (!sourceColumn)
+          fail(`stale source column mapping: ${table}.${column}`);
+        else if (
+          sourceColumn.udt !== projection.udt ||
+          sourceColumn.nullable !== projection.nullable
+        )
+          fail(`source type/nullability changed: ${table}.${column}`);
+        const binding = projection.binding;
+        if (projectionPaths.has(binding.path))
+          fail(`different source columns share one value: ${table}.${column}`);
+        projectionPaths.add(binding.path);
+        let value: Value | undefined;
+        if (binding.kind === "array-length") {
+          const array = contract.arrays[binding.path];
+          if (!array || !childArray(binding.path, rule.rows))
+            fail(
+              `count must reference a declared child array: ${table}.${column}`,
+            );
+          else value = { kind: "integer", nullable: false, ...array };
+        } else {
+          const scope = {
+            row: rule.rows,
+            capture: contract.capturePath,
+            parent: rule.parent,
+            receipt: contract.receiptPath,
+          }[binding.from];
+          if (!scope || !below(binding.path, scope))
+            fail(`invalid ${binding.from} binding for ${table}.${column}`);
+          value = contract.values[binding.path];
+        }
+        if (!value)
+          fail(
+            `missing value definition for ${table}.${column}: ${binding.path}`,
+          );
+        else if (!lossless(projection, value))
+          fail(
+            `no lossless representation for ${table}.${column}; base numeric alone does not prove integer bounds`,
+          );
+      }
+      const count = contract.values[rule.count.manifestPath];
+      const indexField = contract.index.fields.find(
+        (field) => field.column === rule.count.indexColumn,
+      );
+      if (
+        !rule.count.manifestPath.startsWith("manifest.counts.") ||
+        !count ||
+        count.kind !== "integer" ||
+        count.nullable ||
+        !isBounds(count) ||
+        !countFitsFamily(contract, family, rule) ||
+        count.min !== rule.count.bounds.min ||
+        count.max !== rule.count.bounds.max ||
+        !indexField ||
+        !indexFits(count, indexField)
+      )
+        fail(`invalid original manifest/index count binding for ${family}`);
+      if (
+        countColumns.has(rule.count.indexColumn) ||
+        countPaths.has(rule.count.manifestPath)
+      )
+        fail(`count binding is shared by different families: ${family}`);
+      countColumns.add(rule.count.indexColumn);
+      countPaths.add(rule.count.manifestPath);
+    }
+    const receiptPaths = Object.values(contract.receipt);
+    if (
+      new Set(receiptPaths).size !== 3 ||
+      new Set(Object.values(contract.index.receipt)).size !== 3
+    )
+      fail("original receipt bindings must be distinct");
+    for (const role of ["captureId", "digest", "acceptedAt"] as const) {
+      const path = contract.receipt[role];
+      const value = contract.values[path];
+      const field = contract.index.fields.find(
+        (item) => item.column === contract.index.receipt[role],
+      );
+      const completion = contract.families.completion;
+      if (
+        !below(path, contract.receiptPath) ||
+        !value ||
+        !field ||
+        !indexFits(value, field) ||
+        !completion ||
+        !Object.values(completion.columns).some(
+          (column) =>
+            column.binding.kind === "path" &&
+            column.binding.from === "receipt" &&
+            column.binding.path === path,
+        )
+      ) {
+        fail(
+          `original completion receipt ${role} must bind source, bundle and required index field`,
+        );
+      }
+    }
+  }
+  for (const [table, policy] of Object.entries(input.policies)) {
+    if (policy === "bundled" && !declaredSources.has(table))
+      problems.push(`${table}: bundled policy has no complete bundle mapping`);
+  }
+  for (const name of Object.keys(input.contracts)) {
+    if (!usedContracts.has(name))
+      problems.push(
+        `${name}: bundle contract has no mapping; keep unprovisioned definitions in fixtures`,
+      );
+  }
+  return problems;
+}

--- a/scripts/validate-archive-policy.ts
+++ b/scripts/validate-archive-policy.ts
@@ -27,6 +27,13 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
+import {
+  validateArchiveBundles,
+  type ArchiveBundleContract,
+  type ArchiveBundleMapping,
+  type BundleSourceColumn,
+  type BundleCatalogColumn,
+} from "./archive-policy-bundles.ts";
 
 /**
  * What the archive does with each Neon table.
@@ -38,6 +45,10 @@ import { repoRoot } from "./lib.ts";
  *             This is a debt list, not a verdict: every entry is a table whose
  *             history is being kept only in the serving tier, where nothing
  *             promises to keep it. Tracked in metagraphed-infra#510.
+ *
+ * `bundled`   immutable row families preserved together in a verified complete
+ *             capture bundle, with a separately declared catalog index. Requires
+ *             an explicit whole-group mapping; not a same-name table mirror.
  *
  * `serving`   operational state that describes the SYSTEM rather than the
  *             chain: probe results, lane health, capture cursors, usage
@@ -56,7 +67,21 @@ import { repoRoot } from "./lib.ts";
  * `meta`      schema bookkeeping.
  */
 export type Policy =
-  "mirrored" | "pending" | "serving" | "sensitive" | "transient" | "meta";
+  | "mirrored"
+  | "pending"
+  | "bundled"
+  | "serving"
+  | "sensitive"
+  | "transient"
+  | "meta";
+
+// Support only (#12086). Actual mappings require credentialed catalog metadata
+// and deployed publication/read-back evidence. This pure metadata gate cannot
+// establish those runtime facts, and an authored declaration is not that proof.
+// Keep unprovisioned examples in tests; do not classify history to bypass debt.
+export const BUNDLE_CONTRACTS: Readonly<Record<string, ArchiveBundleContract>> =
+  {};
+export const BUNDLE_MAPPINGS: readonly ArchiveBundleMapping[] = [];
 
 export const POLICY: Readonly<Record<string, Policy>> = {
   // -- mirrored: the 18 tables the archive already holds -------------------
@@ -203,11 +228,22 @@ export function compare(tables: string[]): {
 function main(): void {
   const snapshot = JSON.parse(
     readFileSync(path.join(repoRoot, "generated/db/schema.json"), "utf8"),
-  ) as Column[];
+  ) as BundleSourceColumn[];
   const tables = neonTables(snapshot);
   const { unclassified, stale, pending } = compare(tables);
 
-  const problems: string[] = [];
+  const problems = validateArchiveBundles({
+    source: snapshot,
+    catalog: JSON.parse(
+      readFileSync(
+        path.join(repoRoot, "generated/lakehouse/schema.json"),
+        "utf8",
+      ),
+    ) as BundleCatalogColumn[],
+    policies: POLICY,
+    contracts: BUNDLE_CONTRACTS,
+    mappings: BUNDLE_MAPPINGS,
+  });
   if (unclassified.length) {
     problems.push(
       `${unclassified.length} Neon table(s) have no archive policy:\n  ` +
@@ -216,7 +252,8 @@ function main(): void {
         `\n     "mirrored" if the state mirror carries it, "pending" if it is` +
         `\n     chain history still owed an archive copy, "serving" if it` +
         `\n     describes the system rather than the chain, "sensitive" if it` +
-        `\n     must never be archived.`,
+        `\n     must never be archived. "bundled" requires a complete verified` +
+        `\n     capture mapping, actual catalog metadata and deployed evidence.`,
     );
   }
   if (stale.length) {

--- a/tests/archive-policy-bundles.test.ts
+++ b/tests/archive-policy-bundles.test.ts
@@ -1,0 +1,840 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BUNDLE_FAMILIES,
+  validateArchiveBundles,
+  type ArchiveBundleContract,
+  type ArchiveBundleMapping,
+  type BundleCatalogColumn,
+  type BundleSourceColumn,
+} from "../scripts/archive-policy-bundles.ts";
+
+type Rule = ArchiveBundleContract["families"]["capture"]["columns"][string];
+type Value = ArchiveBundleContract["values"][string];
+const text = (nullable = false): Value => ({ kind: "string", nullable });
+const decimal = (nullable = false): Value => ({
+  kind: "decimal-string",
+  nullable,
+});
+const integer = (min: number, max: number): Value => ({
+  kind: "integer",
+  nullable: false,
+  min,
+  max,
+});
+const path = (
+  udt: string,
+  from: "row" | "capture" | "parent" | "receipt",
+  value: string,
+  nullable = false,
+  integerBounds?: { min: number; max: number },
+): Rule => ({
+  udt,
+  nullable,
+  binding: { kind: "path", from, path: value },
+  ...(integerBounds ? { integerBounds } : {}),
+});
+const length = (value: string, min: number, max: number): Rule => ({
+  udt: "numeric",
+  nullable: false,
+  integerBounds: { min, max },
+  binding: { kind: "array-length", path: value },
+});
+
+function sourceTable(
+  table: string,
+  columns: [string, string, boolean][],
+): BundleSourceColumn[] {
+  return columns.map(([column, udt, nullable]) => ({
+    table,
+    column,
+    udt,
+    nullable,
+  }));
+}
+
+// Synthetic metadata only. Nothing in this fixture names a provisioned table
+// or constitutes a production policy, deployment receipt or coverage claim.
+function fixture() {
+  const source = [
+    ...sourceTable("fixture_capture", [
+      ["capture_id", "uuid", false],
+      ["height", "numeric", false],
+      ["page_count", "numeric", false],
+    ]),
+    ...sourceTable("fixture_pages", [
+      ["capture_id", "uuid", false],
+      ["page_index", "numeric", false],
+    ]),
+    ...sourceTable("fixture_funds", [
+      ["capture_id", "uuid", false],
+      ["hotkey", "text", false],
+      ["first_block", "numeric", true],
+      ["holdings_count", "numeric", false],
+      ["targets_count", "numeric", false],
+    ]),
+    ...sourceTable("fixture_holdings", [
+      ["capture_id", "uuid", false],
+      ["hotkey", "text", false],
+      ["netuid", "numeric", false],
+      ["quantity", "numeric", false],
+    ]),
+    ...sourceTable("fixture_targets", [
+      ["capture_id", "uuid", false],
+      ["hotkey", "text", false],
+      ["weight", "numeric", false],
+    ]),
+    ...sourceTable("fixture_completion", [
+      ["capture_id", "uuid", false],
+      ["digest", "text", false],
+      ["accepted_at", "numeric", false],
+    ]),
+  ];
+  const fields: ArchiveBundleContract["index"]["fields"] = [
+    ["schema_version", "int"],
+    ["network", "string"],
+    ["network_genesis_hash", "string"],
+    ["decoder_version", "string"],
+    ["capture_id", "string"],
+    ["finalized_block_hash", "string"],
+    ["finalized_block", "string"],
+    ["finalized_block_order", "string"],
+    ["runtime_spec_version", "long"],
+    ["runtime_api_version", "int"],
+    ["metadata_sha256", "string"],
+    ["started_at_ms", "string"],
+    ["finished_at_ms", "string"],
+    ["accepted_at_ms", "string"],
+    ["archived_at_ms", "string"],
+    ["content_sha256", "string"],
+    ["bundle_sha256", "string"],
+    ["bundle_key", "string"],
+    ["bundle_bytes", "int"],
+    ["manifest_sha256", "string"],
+    ["manifest_key", "string"],
+    ["capture_count", "int"],
+    ["page_count", "int"],
+    ["fund_count", "int"],
+    ["holding_count", "int"],
+    ["target_count", "int"],
+    ["completion_count", "int"],
+  ].map(([column, type], position) => ({
+    column: column!,
+    type: type!,
+    field_id: position + 1,
+    required: true,
+  }));
+  const contract: ArchiveBundleContract = {
+    version: 1,
+    capturePath: "capture",
+    receiptPath: "receipt",
+    values: {
+      "capture.capture_id": text(),
+      "capture.height": decimal(),
+      "capture.pages[].page_index": integer(0, 1),
+      "capture.funds[].hotkey": text(),
+      "capture.funds[].baseline.first_block": decimal(true),
+      "capture.funds[].holdings[].netuid": integer(0, 65535),
+      "capture.funds[].holdings[].quantity": decimal(),
+      "capture.funds[].targets[].weight": integer(0, 65535),
+      "receipt.capture_id": text(),
+      "receipt.digest": text(),
+      "receipt.accepted_at": decimal(),
+      "manifest.counts.captures": integer(1, 1),
+      "manifest.counts.pages": integer(1, 2),
+      "manifest.counts.funds": integer(0, 4),
+      "manifest.counts.holdings": integer(0, 32),
+      "manifest.counts.targets": integer(0, 32),
+      "manifest.counts.completions": integer(1, 1),
+    },
+    arrays: {
+      "capture.pages[]": { min: 1, max: 2 },
+      "capture.funds[]": { min: 0, max: 4 },
+      "capture.funds[].holdings[]": { min: 0, max: 8 },
+      "capture.funds[].targets[]": { min: 0, max: 8 },
+    },
+    families: {
+      capture: {
+        rows: "capture",
+        columns: {
+          capture_id: path("uuid", "row", "capture.capture_id"),
+          height: path("numeric", "row", "capture.height"),
+          page_count: length("capture.pages[]", 1, 2),
+        },
+        count: {
+          manifestPath: "manifest.counts.captures",
+          indexColumn: "capture_count",
+          bounds: { min: 1, max: 1 },
+        },
+      },
+      pages: {
+        rows: "capture.pages[]",
+        parent: "capture",
+        columns: {
+          capture_id: path("uuid", "capture", "capture.capture_id"),
+          page_index: path(
+            "numeric",
+            "row",
+            "capture.pages[].page_index",
+            false,
+            { min: 0, max: 1 },
+          ),
+        },
+        count: {
+          manifestPath: "manifest.counts.pages",
+          indexColumn: "page_count",
+          bounds: { min: 1, max: 2 },
+        },
+      },
+      funds: {
+        rows: "capture.funds[]",
+        parent: "capture",
+        columns: {
+          capture_id: path("uuid", "capture", "capture.capture_id"),
+          hotkey: path("text", "row", "capture.funds[].hotkey"),
+          first_block: path(
+            "numeric",
+            "row",
+            "capture.funds[].baseline.first_block",
+            true,
+          ),
+          holdings_count: length("capture.funds[].holdings[]", 0, 8),
+          targets_count: length("capture.funds[].targets[]", 0, 8),
+        },
+        count: {
+          manifestPath: "manifest.counts.funds",
+          indexColumn: "fund_count",
+          bounds: { min: 0, max: 4 },
+        },
+      },
+      holdings: {
+        rows: "capture.funds[].holdings[]",
+        parent: "capture.funds[]",
+        columns: {
+          capture_id: path("uuid", "capture", "capture.capture_id"),
+          hotkey: path("text", "parent", "capture.funds[].hotkey"),
+          netuid: path(
+            "numeric",
+            "row",
+            "capture.funds[].holdings[].netuid",
+            false,
+            { min: 0, max: 65535 },
+          ),
+          quantity: path(
+            "numeric",
+            "row",
+            "capture.funds[].holdings[].quantity",
+          ),
+        },
+        count: {
+          manifestPath: "manifest.counts.holdings",
+          indexColumn: "holding_count",
+          bounds: { min: 0, max: 32 },
+        },
+      },
+      targets: {
+        rows: "capture.funds[].targets[]",
+        parent: "capture.funds[]",
+        columns: {
+          capture_id: path("uuid", "capture", "capture.capture_id"),
+          hotkey: path("text", "parent", "capture.funds[].hotkey"),
+          weight: path(
+            "numeric",
+            "row",
+            "capture.funds[].targets[].weight",
+            false,
+            { min: 0, max: 65535 },
+          ),
+        },
+        count: {
+          manifestPath: "manifest.counts.targets",
+          indexColumn: "target_count",
+          bounds: { min: 0, max: 32 },
+        },
+      },
+      completion: {
+        rows: "receipt",
+        columns: {
+          capture_id: path("uuid", "receipt", "receipt.capture_id"),
+          digest: path("text", "receipt", "receipt.digest"),
+          accepted_at: path("numeric", "receipt", "receipt.accepted_at"),
+        },
+        count: {
+          manifestPath: "manifest.counts.completions",
+          indexColumn: "completion_count",
+          bounds: { min: 1, max: 1 },
+        },
+      },
+    },
+    receipt: {
+      captureId: "receipt.capture_id",
+      digest: "receipt.digest",
+      acceptedAt: "receipt.accepted_at",
+    },
+    index: {
+      fields,
+      receipt: {
+        captureId: "capture_id",
+        digest: "content_sha256",
+        acceptedAt: "accepted_at_ms",
+      },
+    },
+  };
+  const mapping: ArchiveBundleMapping = {
+    contract: "fixture-v1",
+    version: 1,
+    namespace: "chain",
+    indexTable: "fixture_index",
+    sources: {
+      capture: "fixture_capture",
+      pages: "fixture_pages",
+      funds: "fixture_funds",
+      holdings: "fixture_holdings",
+      targets: "fixture_targets",
+      completion: "fixture_completion",
+    },
+  };
+  const catalog: BundleCatalogColumn[] = fields.map((field) => ({
+    ...field,
+    table: "fixture_index",
+  }));
+  const policies: Record<string, string> = Object.fromEntries(
+    source.map((column) => [column.table, "bundled"]),
+  );
+  return {
+    source,
+    catalog,
+    policies,
+    contracts: { "fixture-v1": contract } as Record<
+      string,
+      ArchiveBundleContract
+    >,
+    mappings: [mapping],
+  };
+}
+
+type Fixture = ReturnType<typeof fixture>;
+const definition = (input: Fixture): ArchiveBundleContract =>
+  input.contracts["fixture-v1"]!;
+const association = (input: Fixture): ArchiveBundleMapping =>
+  input.mappings[0]!;
+
+describe("complete capture bundle archive mappings", () => {
+  test("validates complete families, source/header/parent paths, nested fields and original receipts", () => {
+    const input = fixture();
+    assert.deepEqual(validateArchiveBundles(input), []);
+    assert.equal(input.catalog.length, 27);
+    assert.equal(Object.keys(definition(input).families).length, 6);
+    assert.ok(input.catalog.every((field) => field.required));
+  });
+
+  test("empty child arrays remain represented by explicit zero-capable receipt counts", () => {
+    const input = fixture();
+    for (const family of ["funds", "holdings", "targets"] as const) {
+      const count =
+        definition(input).values[
+          definition(input).families[family].count.manifestPath
+        ];
+      assert.equal(count?.kind, "integer");
+      assert.ok(count && "min" in count && count.min === 0);
+    }
+    assert.deepEqual(validateArchiveBundles(input), []);
+  });
+
+  test("distinguishes per-parent array lengths from whole-capture counts and explicit global caps", () => {
+    const input = fixture();
+    const contract = definition(input);
+    assert.equal(contract.arrays["capture.funds[].holdings[]"]!.max, 8);
+    assert.equal(contract.families.holdings.count.bounds.max, 32);
+    assert.deepEqual(validateArchiveBundles(input), []);
+    // A smaller whole-capture cap is a separate contract assertion, not an
+    // inference from either the source numeric type or one parent's length.
+    contract.families.holdings.count.bounds.max = 12;
+    contract.values["manifest.counts.holdings"] = integer(0, 12);
+    assert.deepEqual(validateArchiveBundles(input), []);
+    contract.families.holdings.count.bounds.max = 33;
+    contract.values["manifest.counts.holdings"] = integer(0, 33);
+    assert.match(
+      validateArchiveBundles(input).join("\n"),
+      /count binding for holdings/,
+    );
+  });
+
+  test("rejects aliased columns, nested traversal and repeated index receipt roles", () => {
+    const aliased = fixture();
+    definition(aliased).families.capture.columns.height!.binding = {
+      kind: "path",
+      from: "row",
+      path: "capture.capture_id",
+    };
+    assert.match(
+      validateArchiveBundles(aliased).join("\n"),
+      /different source columns share one value/,
+    );
+    const nested = fixture();
+    definition(nested).families.capture.columns.page_count!.binding = {
+      kind: "array-length",
+      path: "capture.funds[].holdings[]",
+    };
+    assert.match(
+      validateArchiveBundles(nested).join("\n"),
+      /declared child array/,
+    );
+    const receipt = fixture();
+    definition(receipt).index.receipt.digest = "capture_id";
+    assert.match(
+      validateArchiveBundles(receipt).join("\n"),
+      /receipt bindings must be distinct/,
+    );
+  });
+
+  test("rejects scalar parents and inconsistent array/object path declarations", () => {
+    for (const path of [
+      "capture.height.units",
+      "capture.funds.hotkey",
+      "capture.funds",
+    ]) {
+      const input = fixture();
+      definition(input).values[path] = text();
+      assert.match(
+        validateArchiveBundles(input).join("\n"),
+        /conflicting bundle path shape/,
+        path,
+      );
+    }
+    const arrayValue = fixture();
+    definition(arrayValue).values["capture.funds[]"] = integer(0, 4);
+    assert.match(
+      validateArchiveBundles(arrayValue).join("\n"),
+      /invalid value path/,
+    );
+  });
+
+  test("does not infer a bundle policy, catalog table or deployment from definitions", () => {
+    const input = fixture();
+    input.mappings = [];
+    const problems = validateArchiveBundles(input);
+    assert.ok(
+      problems.some((problem) => problem.includes("contract has no mapping")),
+    );
+    assert.equal(
+      problems.filter((problem) =>
+        problem.includes("policy has no complete bundle mapping"),
+      ).length,
+      6,
+    );
+    assert.deepEqual(
+      validateArchiveBundles({
+        source: [],
+        catalog: [],
+        policies: {},
+        contracts: {},
+        mappings: [],
+      }),
+      [],
+    );
+  });
+
+  const failures: [string, (input: Fixture) => void, RegExp][] = [
+    [
+      "unknown contract",
+      (input) => {
+        association(input).contract = "missing";
+      },
+      /unknown bundle contract/,
+    ],
+    [
+      "unknown contract version",
+      (input) => {
+        definition(input).version = 2;
+      },
+      /unsupported.*version/,
+    ],
+    [
+      "incompatible mapping version",
+      (input) => {
+        association(input).version = 2;
+      },
+      /incompatible.*version/,
+    ],
+    [
+      "missing source family",
+      (input) => {
+        Reflect.deleteProperty(association(input).sources, "holdings");
+      },
+      /missing \[holdings\]/,
+    ],
+    [
+      "missing contract family",
+      (input) => {
+        Reflect.deleteProperty(definition(input).families, "completion");
+      },
+      /missing \[completion\]/,
+    ],
+    [
+      "extra family",
+      (input) => {
+        Object.assign(association(input).sources, {
+          current: "fixture_current",
+        });
+      },
+      /extra \[current\]/,
+    ],
+    [
+      "source table absent",
+      (input) => {
+        input.source = input.source.filter(
+          (column) => column.table !== "fixture_targets",
+        );
+      },
+      /source table is absent.*fixture_targets/,
+    ],
+    [
+      "new source column",
+      (input) => {
+        input.source.push({
+          table: "fixture_holdings",
+          column: "new_quantity",
+          udt: "numeric",
+          nullable: false,
+        });
+      },
+      /unmapped source column: fixture_holdings.new_quantity/,
+    ],
+    [
+      "stale source column",
+      (input) => {
+        input.source = input.source.filter(
+          (column) => column.column !== "height",
+        );
+      },
+      /stale source column mapping.*height/,
+    ],
+    [
+      "source type change",
+      (input) => {
+        input.source.find((column) => column.column === "quantity")!.udt =
+          "float8";
+      },
+      /source type\/nullability changed/,
+    ],
+    [
+      "source nullability change",
+      (input) => {
+        input.source.find(
+          (column) => column.column === "first_block",
+        )!.nullable = false;
+      },
+      /source type\/nullability changed/,
+    ],
+    [
+      "source duplicate metadata",
+      (input) => {
+        input.source.push({ ...input.source[0]! });
+      },
+      /duplicate source column/,
+    ],
+    [
+      "source claimed twice",
+      (input) => {
+        association(input).sources.targets = "fixture_holdings";
+      },
+      /source table is mapped more than once/,
+    ],
+    [
+      "sensitive source policy",
+      (input) => {
+        input.policies.fixture_holdings = "sensitive";
+      },
+      /must explicitly use bundled policy/,
+    ],
+    [
+      "nonexistent catalog",
+      (input) => {
+        input.catalog = [];
+      },
+      /index table is absent/,
+    ],
+    [
+      "dropped catalog column",
+      (input) => {
+        input.catalog = input.catalog.filter(
+          (field) => field.column !== "manifest_sha256",
+        );
+      },
+      /index manifest_sha256 must have field ID/,
+    ],
+    [
+      "changed field ID",
+      (input) => {
+        input.catalog[4]!.field_id = 99;
+      },
+      /index capture_id must have field ID 5/,
+    ],
+    [
+      "changed exact type",
+      (input) => {
+        input.catalog[8]!.type = "int";
+      },
+      /runtime_spec_version.*type long/,
+    ],
+    [
+      "changed requiredness",
+      (input) => {
+        input.catalog[13]!.required = false;
+      },
+      /accepted_at_ms.*required=true/,
+    ],
+    [
+      "extra catalog column",
+      (input) => {
+        input.catalog.push({
+          table: "fixture_index",
+          column: "extra",
+          field_id: 28,
+          type: "string",
+          required: true,
+        });
+      },
+      /unmapped catalog column: extra/,
+    ],
+    [
+      "duplicate catalog ID",
+      (input) => {
+        input.catalog[1]!.field_id = 1;
+      },
+      /duplicate catalog field/,
+    ],
+    [
+      "duplicate expected field",
+      (input) => {
+        definition(input).index.fields.push({
+          ...definition(input).index.fields[0]!,
+        });
+      },
+      /invalid or duplicate index field/,
+    ],
+    [
+      "duplicate catalog association",
+      (input) => {
+        input.mappings.push(structuredClone(association(input)));
+      },
+      /catalog table is assigned to more than one/,
+    ],
+    [
+      "unprovisioned definition",
+      (input) => {
+        input.contracts.unused = structuredClone(definition(input));
+      },
+      /unused: bundle contract has no mapping/,
+    ],
+    [
+      "missing value path",
+      (input) => {
+        Reflect.deleteProperty(definition(input).values, "capture.height");
+      },
+      /missing value definition.*height/,
+    ],
+    [
+      "wrong capture origin",
+      (input) => {
+        definition(input).families.holdings.columns.capture_id!.binding = {
+          kind: "path",
+          from: "row",
+          path: "capture.capture_id",
+        };
+      },
+      /invalid row binding/,
+    ],
+    [
+      "wrong parent origin",
+      (input) => {
+        definition(input).families.holdings.parent = "capture.pages[]";
+      },
+      /invalid row\/parent path/,
+    ],
+    [
+      "nullable wire value",
+      (input) => {
+        definition(input).values["capture.height"] = decimal(true);
+      },
+      /no lossless representation.*height/,
+    ],
+    [
+      "numeric falsely treated as bounded",
+      (input) => {
+        definition(input).values["capture.height"] = integer(0, 65535);
+      },
+      /base numeric alone does not prove integer bounds/,
+    ],
+    [
+      "integer range narrowed",
+      (input) => {
+        definition(input).values["capture.funds[].targets[].weight"] = integer(
+          0,
+          255,
+        );
+      },
+      /no lossless representation.*weight/,
+    ],
+    [
+      "unsafe declared integer bound",
+      (input) => {
+        definition(input).families.targets.columns.weight!.integerBounds!.max =
+          Number.MAX_SAFE_INTEGER + 1;
+      },
+      /no lossless representation.*weight/,
+    ],
+    [
+      "missing bounded array",
+      (input) => {
+        Reflect.deleteProperty(
+          definition(input).arrays,
+          "capture.funds[].holdings[]",
+        );
+      },
+      /count must reference a declared child array/,
+    ],
+    [
+      "count outside source family",
+      (input) => {
+        definition(input).families.funds.columns.holdings_count!.binding = {
+          kind: "array-length",
+          path: "capture.pages[]",
+        };
+      },
+      /count must reference a declared child array/,
+    ],
+    [
+      "missing original receipt source binding",
+      (input) => {
+        definition(input).families.completion.columns.accepted_at!.binding = {
+          kind: "path",
+          from: "row",
+          path: "receipt.accepted_at",
+        };
+      },
+      /original completion receipt acceptedAt/,
+    ],
+    [
+      "receipt bound to request metadata",
+      (input) => {
+        definition(input).receipt.acceptedAt = "request.generated_at";
+      },
+      /original completion receipt acceptedAt/,
+    ],
+    [
+      "missing receipt index field",
+      (input) => {
+        definition(input).index.receipt.digest = "missing";
+      },
+      /original completion receipt digest/,
+    ],
+    [
+      "repeated receipt roles",
+      (input) => {
+        definition(input).receipt.acceptedAt = "receipt.digest";
+      },
+      /receipt bindings must be distinct/,
+    ],
+    [
+      "count from wrong manifest path",
+      (input) => {
+        definition(input).families.capture.count.manifestPath =
+          "capture.height";
+      },
+      /original manifest\/index count binding/,
+    ],
+    [
+      "count binding shared",
+      (input) => {
+        definition(input).families.targets.count = {
+          ...definition(input).families.holdings.count,
+        };
+      },
+      /count binding is shared/,
+    ],
+    [
+      "count index uses float",
+      (input) => {
+        definition(input).index.fields.find(
+          (field) => field.column === "target_count",
+        )!.type = "double";
+      },
+      /original manifest\/index count binding for targets/,
+    ],
+    [
+      "nullable count index",
+      (input) => {
+        definition(input).index.fields.find(
+          (field) => field.column === "target_count",
+        )!.required = false;
+      },
+      /original manifest\/index count binding for targets/,
+    ],
+    [
+      "invalid path syntax",
+      (input) => {
+        definition(input).values["capture..height"] = decimal();
+      },
+      /invalid value path/,
+    ],
+    [
+      "invalid array bounds",
+      (input) => {
+        definition(input).arrays["capture.pages[]"]!.min = -1;
+      },
+      /invalid bounded array/,
+    ],
+  ];
+  for (const [name, mutate, expected] of failures) {
+    test(`rejects ${name}`, () => {
+      const input = fixture();
+      mutate(input);
+      assert.match(validateArchiveBundles(input).join("\n"), expected);
+    });
+  }
+
+  test("accepts exact primitive representations and rejects unknown/lossy source types", () => {
+    for (const [udt, value, valid] of [
+      ["bool", { kind: "boolean", nullable: false }, true],
+      ["varchar", text(), true],
+      ["int2", integer(-32768, 32767), true],
+      ["int4", integer(-(2 ** 31), 2 ** 31 - 1), true],
+      ["int8", decimal(), true],
+      ["int2", decimal(), true],
+      ["int4", decimal(), true],
+      ["int8", integer(0, Number.MAX_SAFE_INTEGER), false],
+      ["float8", decimal(), false],
+    ] as const) {
+      const input = fixture();
+      input.source.find((column) => column.column === "height")!.udt = udt;
+      definition(input).families.capture.columns.height!.udt = udt;
+      definition(input).values["capture.height"] = value;
+      const problems = validateArchiveBundles(input);
+      assert.equal(
+        problems.length === 0,
+        valid,
+        `${udt}: ${problems.join("\n")}`,
+      );
+    }
+  });
+
+  test("requires all six families even when a source table is empty", () => {
+    assert.deepEqual(BUNDLE_FAMILIES, [
+      "capture",
+      "pages",
+      "funds",
+      "holdings",
+      "targets",
+      "completion",
+    ]);
+    const input = fixture();
+    Reflect.deleteProperty(association(input).sources, "targets");
+    input.policies.fixture_targets = "transient";
+    assert.match(
+      validateArchiveBundles(input).join("\n"),
+      /complete group.*targets/,
+    );
+  });
+});

--- a/tests/archive-policy.test.ts
+++ b/tests/archive-policy.test.ts
@@ -6,6 +6,8 @@ import {
   PENDING_CEILING,
   compare,
   neonTables,
+  BUNDLE_CONTRACTS,
+  BUNDLE_MAPPINGS,
 } from "../scripts/validate-archive-policy.ts";
 
 describe("archive policy", () => {
@@ -68,6 +70,7 @@ describe("archive policy", () => {
     const kinds = new Set([
       "mirrored",
       "pending",
+      "bundled",
       "serving",
       "sensitive",
       "transient",
@@ -83,5 +86,12 @@ describe("archive policy", () => {
       neonTables([{ table: "b" }, { table: "a" }, { table: "b" }]),
       ["a", "b"],
     );
+  });
+
+  test("bundle support adds no production archive or table declaration", () => {
+    assert.deepEqual(BUNDLE_CONTRACTS, {});
+    assert.deepEqual(BUNDLE_MAPPINGS, []);
+    assert.equal(Object.values(POLICY).includes("bundled"), false);
+    assert.equal(PENDING_CEILING, 0);
   });
 });


### PR DESCRIPTION
The archive policy needs to describe immutable row families preserved together in a complete capture bundle. This adds typed, versioned mappings and a pure metadata validator for complete family/source-column coverage, header and parent keys, nested values, bounded counts, original completion receipts, and exact catalog field IDs, types and requiredness. Conflicting JSON shapes and lossy numeric representations fail with actionable diagnostics.

Production bundle declarations remain empty. Existing policy entries, generated snapshots and the zero pending-debt ceiling stay unchanged. A mapping declaration is not deployed publication proof; #12061 remains blocked on its actual catalog and archive prerequisites.

Validation:

- Final focused tests: 60 passed (51 helper tests and 9 policy tests). Helper coverage: 98.44% lines, 97% branches, 100% functions.
- Full backend coverage before the final path-shape check: 1,002 files, 22,935 tests passed, 11 skipped. The final helper and integration tests were rerun with focused coverage after that change.
- Build, lint, formatting, typecheck, registry validation, archive-policy CLI, store/schema drift, exports, modules, public safety and whitespace checks passed.

Closes #12086. Refs #12072, #12081, #12061, #12012.
